### PR TITLE
[GLUTEN-4013][CH] Improve evict action control strategy in shuffle write

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHShuffleSplitterJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHShuffleSplitterJniWrapper.java
@@ -32,6 +32,7 @@ public class CHShuffleSplitterJniWrapper {
       int subDirsPerLocalDir,
       boolean preferSpill,
       long spillThreshold,
+      long offHeapSize,
       String hashAlgorithm,
       boolean throwIfMemoryExceed,
       boolean flushBlockBufferBeforeEvict) {
@@ -49,6 +50,7 @@ public class CHShuffleSplitterJniWrapper {
         subDirsPerLocalDir,
         preferSpill,
         spillThreshold,
+        offHeapSize,
         hashAlgorithm,
         throwIfMemoryExceed,
         flushBlockBufferBeforeEvict);
@@ -61,6 +63,7 @@ public class CHShuffleSplitterJniWrapper {
       int bufferSize,
       String codec,
       long spillThreshold,
+      long offHeapSize,
       String hashAlgorithm,
       Object pusher,
       boolean throwIfMemoryExceed,
@@ -75,6 +78,7 @@ public class CHShuffleSplitterJniWrapper {
         bufferSize,
         codec,
         spillThreshold,
+        offHeapSize,
         hashAlgorithm,
         pusher,
         throwIfMemoryExceed,
@@ -95,6 +99,7 @@ public class CHShuffleSplitterJniWrapper {
       int subDirsPerLocalDir,
       boolean preferSpill,
       long spillThreshold,
+      long offHeapSize,
       String hashAlgorithm,
       boolean throwIfMemoryExceed,
       boolean flushBlockBufferBeforeEvict);
@@ -109,6 +114,7 @@ public class CHShuffleSplitterJniWrapper {
       int bufferSize,
       String codec,
       long spillThreshold,
+      long offHeapSize,
       String hashAlgorithm,
       Object pusher,
       boolean throwIfMemoryExceed,

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -129,6 +129,13 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       ".runtime_config.max_source_concatenate_bytes"
   val GLUTEN_MAX_SHUFFLE_READ_BYTES_DEFAULT = -1
 
+  // Enable this, shuffle write will evict in memory data actively, not rely on the vanilla memory
+  // manager.
+  val GLUTEN_ENABLE_SHUFFLE_ACTIVE_SPILL: String =
+    GlutenConfig.GLUTEN_CONFIG_PREFIX + CHBackend.BACKEND_NAME +
+      ".enable.shuffle.active.spill"
+  val GLUTEN_ENABLE_SHUFFLE_ACTIVE_SPILL_DEFAULT = true
+
   def affinityMode: String = {
     SparkEnv.get.conf
       .get(
@@ -270,6 +277,11 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   def maxShuffleReadBytes(): Long = {
     SparkEnv.get.conf
       .getLong(GLUTEN_MAX_SHUFFLE_READ_BYTES, GLUTEN_MAX_SHUFFLE_READ_BYTES_DEFAULT)
+  }
+
+  def enableShuffleActiveSpill(): Boolean = {
+    SparkEnv.get.conf
+      .getBoolean(GLUTEN_ENABLE_SHUFFLE_ACTIVE_SPILL, GLUTEN_ENABLE_SHUFFLE_ACTIVE_SPILL_DEFAULT)
   }
 
   override def supportWriteFilesExec(

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -59,6 +59,7 @@ class CHColumnarShuffleWriter[K, V](
   private val flushBlockBufferBeforeEvict =
     GlutenConfig.getConf.chColumnarFlushBlockBufferBeforeEvict
   private val spillThreshold = GlutenConfig.getConf.chColumnarShuffleSpillThreshold
+  private val offHeapSize = GlutenConfig.getConf.offHeapMemorySize
   private val jniWrapper = new CHShuffleSplitterJniWrapper
   // Are we in the process of stopping? Because map tasks can call stop() with success = true
   // and then call stop() with success = false if they get an exception, we want to make sure
@@ -106,6 +107,7 @@ class CHColumnarShuffleWriter[K, V](
         subDirsPerLocalDir,
         preferSpill,
         spillThreshold,
+        offHeapSize,
         CHBackendSettings.shuffleHashAlgorithm,
         throwIfMemoryExceed,
         flushBlockBufferBeforeEvict

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -55,6 +55,7 @@
 #include <Poco/Logger.h>
 #include <Poco/Util/MapConfiguration.h>
 #include <Common/BitHelpers.h>
+#include <Common/CurrentThread.h>
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/CurrentThread.h>
 #include <Common/GlutenSignalHandler.h>
@@ -305,7 +306,10 @@ size_t PODArrayUtil::adjustMemoryEfficientSize(size_t n)
     }
     else
     {
-        padded_n = rounded_n - padding_n;    
+        if (rounded_n < padding_n)
+            padded_n = rounded_n;
+        else
+            padded_n = rounded_n - padding_n;
     }
     return padded_n;
 }
@@ -876,5 +880,4 @@ UInt64 MemoryUtil::getMemoryRSS()
     fclose(fp);
     return rss * sysconf(_SC_PAGESIZE);
 }
-
 }

--- a/cpp-ch/local-engine/Shuffle/CachedShuffleWriter.h
+++ b/cpp-ch/local-engine/Shuffle/CachedShuffleWriter.h
@@ -29,6 +29,9 @@ class PartitionWriter;
 class LocalPartitionWriter;
 class CelebornPartitionWriter;
 
+/// For CachedShuffleWriter, both `spark.gluten.sql.columnar.backend.ch.spillThreshold` and
+/// `spark.memory.offHeap.size` could control the evict action. In most cases, you don't need to
+/// set `spark.gluten.sql.columnar.backend.ch.spillThreshold`.
 class CachedShuffleWriter : public ShuffleWriterBase
 {
 public:

--- a/cpp-ch/local-engine/Shuffle/PartitionWriter.h
+++ b/cpp-ch/local-engine/Shuffle/PartitionWriter.h
@@ -95,6 +95,8 @@ protected:
 
     /// Only valid in celeborn partition writer
     size_t last_partition_id;
+
+    bool needEvictPartitions(size_t cached_bytes);
 };
 
 class LocalPartitionWriter : public PartitionWriter

--- a/cpp-ch/local-engine/Shuffle/ShuffleSplitter.h
+++ b/cpp-ch/local-engine/Shuffle/ShuffleSplitter.h
@@ -46,6 +46,7 @@ struct SplitOptions
     std::string compress_method = "zstd";
     int compress_level;
     size_t spill_threshold = 300 * 1024 * 1024;
+    size_t max_offheap_size = 0;
     std::string hash_algorithm;
     bool throw_if_memory_exceed = true;
     /// Whether to flush partition_block_buffer in PartitionWriter before evict.
@@ -55,7 +56,7 @@ struct SplitOptions
 class ColumnsBuffer
 {
 public:
-    ColumnsBuffer(size_t prefer_buffer_size = 8192);
+    ColumnsBuffer(size_t max_offheap_size_ = 0);
     ~ColumnsBuffer() = default;
 
     void add(DB::Block & columns, int start, int end);
@@ -78,7 +79,8 @@ public:
 private:
     DB::MutableColumns accumulated_columns;
     DB::Block header;
-    size_t prefer_buffer_size;
+    size_t prefer_buffer_size = 0;
+    size_t max_offheap_size = 0;
 };
 using ColumnsBufferPtr = std::shared_ptr<ColumnsBuffer>;
 

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -638,6 +638,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHShuffleSplitterJniWrapper_nat
     jint num_sub_dirs,
     jboolean prefer_spill,
     jlong spill_threshold,
+    jlong max_offheap_size,
     jstring hash_algorithm,
     jboolean throw_if_memory_exceed,
     jboolean flush_block_buffer_before_evict)
@@ -682,6 +683,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHShuffleSplitterJniWrapper_nat
         .out_exprs = out_exprs,
         .compress_method = jstring2string(env, codec),
         .spill_threshold = static_cast<size_t>(spill_threshold),
+        .max_offheap_size = static_cast<size_t>(max_offheap_size),
         .hash_algorithm = jstring2string(env, hash_algorithm),
         .throw_if_memory_exceed = static_cast<bool>(throw_if_memory_exceed),
         .flush_block_buffer_before_evict = static_cast<bool>(flush_block_buffer_before_evict)};
@@ -707,6 +709,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHShuffleSplitterJniWrapper_nat
     jint split_size,
     jstring codec,
     jlong spill_threshold,
+    jlong max_offheap_size,
     jstring hash_algorithm,
     jobject pusher,
     jboolean throw_if_memory_exceed,
@@ -743,6 +746,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHShuffleSplitterJniWrapper_nat
         .out_exprs = out_exprs,
         .compress_method = jstring2string(env, codec),
         .spill_threshold = static_cast<size_t>(spill_threshold),
+        .max_offheap_size = static_cast<size_t>(max_offheap_size),
         .hash_algorithm = jstring2string(env, hash_algorithm),
         .throw_if_memory_exceed = static_cast<bool>(throw_if_memory_exceed),
         .flush_block_buffer_before_evict = static_cast<bool>(flush_block_buffer_before_evict)};

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornHashBasedColumnarShuffleWriter.scala
@@ -62,7 +62,11 @@ class CHCelebornHashBasedColumnarShuffleWriter[K, V](
       handleEmptyIterator()
       return
     }
-
+    val maxOffHeapMemory = if (CHBackendSettings.enableShuffleActiveSpill) {
+      GlutenConfig.getConf.offHeapMemorySize
+    } else {
+      0
+    }
     if (nativeShuffleWriter == -1L) {
       nativeShuffleWriter = jniWrapper.makeForRSS(
         dep.nativePartitioning,
@@ -71,6 +75,7 @@ class CHCelebornHashBasedColumnarShuffleWriter[K, V](
         nativeBufferSize,
         customizedCompressCodec,
         GlutenConfig.getConf.chColumnarShuffleSpillThreshold,
+        maxOffHeapMemory,
         CHBackendSettings.shuffleHashAlgorithm,
         celebornPartitionPusher,
         GlutenConfig.getConf.chColumnarThrowIfMemoryExceed,


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #4013

1. Allows the reserved space of columns to be adaptively adjusted
2. No longer rely on spark's memory manager to trigger spill, improving the stability.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

