### PR TITLE
[GLUTEN-4326][CH] Fix unsupported operator ShuffleQueryStage for BroadcastRelation

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
+import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.datasources.{FileFormat, WriteFilesExec}
 import org.apache.spark.sql.execution.datasources.GlutenWriterColumnarRules.NativeWritePostRule
 import org.apache.spark.sql.execution.datasources.v1.ClickHouseFileIndex
@@ -305,6 +305,9 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
             // when aqe is open
             // TODO: remove this after pushdowning preprojection
             wrapChild(r)
+          // This case may happen when AQE is enabled but CoalesceShufflePartitions rule is disabled
+          case s: ShuffleQueryStageExec =>
+            wrapChild(s)
           case r2c: RowToCHNativeColumnarExec =>
             wrapChild(r2c)
           case union: UnionExecTransformer =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When AQE is enabled but `spark.sql.adaptive.coalescePartitions.enabled` is false, AQE converts shj to bhj in runtime but the `ShuffleQueryStageExec` of shj has been generated, which causes the exception `java.lang.UnsupportedOperationException: Not supported operator ShuffleQueryStage for BroadcastRelation` when `createBroadcastRelation` for it.

(Fixes: \#4326)

## How was this patch tested?

manual tests, ut seems not easy to construct.



