### PR TITLE
[VL] Enable force-spill in shuffle for debugging purpose

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -58,6 +58,7 @@ const std::string kShuffleCompressionCodec = "spark.gluten.sql.columnar.shuffle.
 const std::string kShuffleCompressionCodecBackend = "spark.gluten.sql.columnar.shuffle.codecBackend";
 const std::string kQatBackendName = "qat";
 const std::string kIaaBackendName = "iaa";
+const std::string kForceSpillThreshold = "spark.shuffle.spill.numElementsForceSpillThreshold";
 
 std::unordered_map<std::string, std::string> parseConfMap(JNIEnv* env, jbyteArray configArray);
 

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -180,11 +180,11 @@ static inline arrow::Compression::type getCompressionType(JNIEnv* env, jstring c
   return compressionType;
 }
 
-static inline gluten::CodecBackend getCodecBackend(JNIEnv* env, jstring codecJstr) {
-  if (codecJstr == nullptr) {
+static inline gluten::CodecBackend getCodecBackend(JNIEnv* env, jstring codecBackendJstr) {
+  if (codecBackendJstr == nullptr) {
     return gluten::CodecBackend::NONE;
   }
-  auto codecBackend = jStringToCString(env, codecJstr);
+  auto codecBackend = jStringToCString(env, codecBackendJstr);
   if (codecBackend == "qat") {
     return gluten::CodecBackend::QAT;
   } else if (codecBackend == "iaa") {

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -821,12 +821,17 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     throw gluten::GlutenException(std::string("Short partitioning name can't be null"));
   }
 
+  int32_t forceSpillThreshold = kDefaultForceSpillThreshold;
+  if (auto iter = ctx->getConfMap().find(kForceSpillThreshold); iter != ctx->getConfMap().end()) {
+    forceSpillThreshold = std::stoi(iter->second);
+  }
+
   auto shuffleWriterOptions = ShuffleWriterOptions{
       .bufferSize = bufferSize,
       .bufferReallocThreshold = reallocThreshold,
       .partitioning = gluten::toPartitioning(jStringToCString(env, partitioningNameJstr)),
       .startPartitionId = startPartitionId,
-  };
+      .forceSpillThreshold = forceSpillThreshold};
 
   auto partitionWriterOptions = PartitionWriterOptions{
       .mergeBufferSize = mergeBufferSize,

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -219,7 +219,10 @@ class LocalPartitionWriter::PayloadMerger {
   uint32_t totalCachedRows() {
     return std::accumulate(
         partitionMergePayload_.begin(), partitionMergePayload_.end(), 0u, [](uint32_t sum, const auto& elem) {
-          return sum + elem.second->numRows();
+          if (elem.second) {
+            return sum + elem.second->numRows();
+          }
+          return sum;
         });
   }
 

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -69,6 +69,8 @@ class LocalPartitionWriter : public PartitionWriter {
   // 3. After stop() called,
   arrow::Status reclaimFixedSize(int64_t size, int64_t* actual) override;
 
+  uint32_t cachedRows() override;
+
   class LocalSpiller;
 
   class PayloadMerger;

--- a/cpp/core/shuffle/Options.h
+++ b/cpp/core/shuffle/Options.h
@@ -31,6 +31,7 @@ static constexpr int32_t kDefaultBufferAlignment = 64;
 static constexpr double kDefaultBufferReallocThreshold = 0.25;
 static constexpr double kDefaultMergeBufferThreshold = 0.25;
 static constexpr bool kEnableBufferedWrite = true;
+static constexpr int32_t kDefaultForceSpillThreshold = std::numeric_limits<int32_t>::max();
 
 enum PartitionWriterType { kLocal, kCeleborn };
 
@@ -45,8 +46,7 @@ struct ShuffleWriterOptions {
   double bufferReallocThreshold = kDefaultBufferReallocThreshold;
   Partitioning partitioning = Partitioning::kRoundRobin;
   int32_t startPartitionId = 0;
-
-  int32_t forceSpillThreshold = std::numeric_limits<int32_t>::max();
+  int32_t forceSpillThreshold = kDefaultForceSpillThreshold;
 };
 
 struct PartitionWriterOptions {

--- a/cpp/core/shuffle/Options.h
+++ b/cpp/core/shuffle/Options.h
@@ -44,9 +44,9 @@ struct ShuffleWriterOptions {
   int32_t bufferSize = kDefaultShuffleWriterBufferSize;
   double bufferReallocThreshold = kDefaultBufferReallocThreshold;
   Partitioning partitioning = Partitioning::kRoundRobin;
-  int64_t taskAttemptId = -1;
   int32_t startPartitionId = 0;
-  int64_t threadId = -1;
+
+  int32_t forceSpillThreshold = std::numeric_limits<int32_t>::max();
 };
 
 struct PartitionWriterOptions {

--- a/cpp/core/shuffle/PartitionWriter.h
+++ b/cpp/core/shuffle/PartitionWriter.h
@@ -49,6 +49,8 @@ class PartitionWriter : public Reclaimable {
       bool reuseBuffers,
       bool hasComplexType) = 0;
 
+  virtual uint32_t cachedRows() = 0;
+
   uint64_t cachedPayloadSize() {
     return payloadPool_->bytes_allocated();
   }

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
@@ -75,4 +75,8 @@ arrow::Status CelebornPartitionWriter::evict(
       partitionId, reinterpret_cast<char*>(const_cast<uint8_t*>(buffer->data())), buffer->size());
   return arrow::Status::OK();
 }
+
+uint32_t CelebornPartitionWriter::cachedRows() {
+  return 0;
+}
 } // namespace gluten

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.h
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.h
@@ -48,6 +48,8 @@ class CelebornPartitionWriter final : public RemotePartitionWriter {
 
   arrow::Status stop(ShuffleWriterMetrics* metrics) override;
 
+  uint32_t cachedRows() override;
+
  private:
   void init();
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -305,6 +305,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Result<uint32_t> partitionBufferSizeAfterShrink(uint32_t partitionId) const;
 
+  arrow::Status spillIfNeeded();
+
   SplitState splitState_{kInit};
 
   EvictState evictState_{kEvictable};

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -503,6 +503,8 @@ object GlutenConfig {
       COLUMNAR_VELOX_BLOOM_FILTER_EXPECTED_NUM_ITEMS.key,
       COLUMNAR_VELOX_BLOOM_FILTER_NUM_BITS.key,
       COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS.key,
+      // shuffle config
+      "spark.shuffle.spill.numElementsForceSpillThreshold",
       // s3 config
       SPARK_S3_ACCESS_KEY,
       SPARK_S3_SECRET_KEY,


### PR DESCRIPTION
Enable Spark's configuration `spark.shuffle.spill.numElementsForceSpillThreshold` to force spilling in shuffle writer.