### PR TITLE
[GLUTEN-4502][VL] Allow TIMESTAMP & complex types in cast expression

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -274,10 +274,6 @@ bool SubstraitToVeloxPlanValidator::validateCast(
     case TypeKind::VARBINARY:
       LOG_VALIDATION_MSG("Invalid input type in casting: ARRAY/MAP/ROW/VARBINARY.");
       return false;
-    case TypeKind::TIMESTAMP: {
-      LOG_VALIDATION_MSG("Casting from TIMESTAMP is not supported or has incorrect result.");
-      return false;
-    }
     default: {
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is just an attempt to offload cast with such types involved to velox. Maybe, at least, we still need to block nested complex types. 

(Fixes: #4502)

## How was this patch tested?

Existing tests & new test.

