### PR TITLE
[CORE] Support pull out aggregate pre-project in LogicalPlan

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -18,6 +18,7 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.execution._
 import io.glutenproject.expression._
+import io.glutenproject.extension.AddExtraOptimizations
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
 
 import org.apache.spark.ShuffleDependency
@@ -275,6 +276,14 @@ trait SparkPlanExecApi {
    * @return
    */
   def genExtendedAnalyzers(): List[SparkSession => Rule[LogicalPlan]]
+
+  /**
+   * Generate extended CheckRules. Currently only for Velox backend.
+   *
+   * @return
+   */
+  def genExtendedCheckRules(): List[SparkSession => LogicalPlan => Unit] =
+    List(AddExtraOptimizations)
 
   /**
    * Generate extended Optimizers. Currently only for Velox backend.

--- a/gluten-core/src/main/scala/io/glutenproject/extension/AddExtraOptimizations.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/AddExtraOptimizations.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension
+
+import io.glutenproject.extension.logical.LogicalPullOutPreProject
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+import scala.reflect.ClassTag
+
+/**
+ * Some rules need to be applied at the end of all Spark logical optimizers. This rule helps to add
+ * logical optimizer to the experimental extra optimizations that will be applied in the end.
+ */
+case class AddExtraOptimizations(sparkSession: SparkSession) extends (LogicalPlan => Unit) {
+
+  override def apply(plan: LogicalPlan): Unit = {
+
+    def addIfNotExists[T <: Rule[LogicalPlan]](rule: T)(implicit tag: ClassTag[T]): Unit = {
+      if (!sparkSession.experimental.extraOptimizations.exists(_.getClass == tag.runtimeClass)) {
+        sparkSession.experimental.extraOptimizations ++= Seq(rule)
+      }
+    }
+
+    addIfNotExists(LogicalPullOutPreProject(sparkSession))
+  }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/OthersExtensionOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/OthersExtensionOverrides.scala
@@ -27,6 +27,9 @@ object OthersExtensionOverrides extends GlutenSparkExtensionsInjector {
       .genExtendedAnalyzers()
       .foreach(extensions.injectResolutionRule)
     BackendsApiManager.getSparkPlanExecApiInstance
+      .genExtendedCheckRules()
+      .foreach(extensions.injectCheckRule)
+    BackendsApiManager.getSparkPlanExecApiInstance
       .genExtendedOptimizers()
       .foreach(extensions.injectOptimizerRule)
     BackendsApiManager.getSparkPlanExecApiInstance

--- a/gluten-core/src/main/scala/io/glutenproject/extension/logical/LogicalPullOutPreProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/logical/LogicalPullOutPreProject.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension.logical
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.sql.shims.SparkShimLoader
+import io.glutenproject.utils.{LogicalPlanSelector, PullOutProjectHelper}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{AGGREGATE, FILTER}
+import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
+
+import scala.collection.mutable
+
+/**
+ * Pulling out pre-projects in the logical plan can reduce the number of pre-projects in some cases.
+ * For example, in agg operation that include distinct, we can reduce two expression evaluations and
+ * pre-project if we pull out project at logical side. Additionally, for operations like joins that
+ * may require adding broadcast exchanges or sort operations in the child plans, handling them in
+ * the logical plan can be simpler. However, logical rules may not be able to handle all scenarios,
+ * so we still need physical rules to handle any remaining cases.
+ */
+case class LogicalPullOutPreProject(session: SparkSession)
+  extends Rule[LogicalPlan]
+  with PullOutProjectHelper {
+
+  private def needsPreProject(plan: LogicalPlan): Boolean = plan match {
+    case Aggregate(groupingExpressions, aggregateExpressions, _) =>
+      groupingExpressions.exists(isNotAttribute) ||
+      aggregateExpressions.exists(_.find {
+        case ae: AggregateExpression
+            if ae.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
+          // We cannot pull out the children of TypedAggregateExpression to pre-project,
+          // and Gluten cannot support TypedAggregateExpression.
+          false
+        case ae: AggregateExpression
+            if ae.filter.exists(isNotAttribute) || ae.aggregateFunction.children.exists(
+              isNotAttributeAndLiteral) =>
+          true
+        case _ => false
+      }.isDefined)
+    case _ => false
+  }
+
+  private def transformAgg(agg: Aggregate): LogicalPlan = {
+    val expressionMap = new mutable.HashMap[Expression, NamedExpression]()
+
+    // Handle groupingExpressions.
+    val newGroupingExpressions =
+      agg.groupingExpressions.toIndexedSeq.map(replaceExpressionWithAttribute(_, expressionMap))
+
+    // Handle aggregateExpressions
+    val newAggregateExpressions = agg.aggregateExpressions.toIndexedSeq.map {
+      _.transformDown {
+        case ae: AggregateExpression => rewriteAggregateExpression(ae, expressionMap)
+
+        case a: Alias if expressionMap.contains(a.child.canonicalized) =>
+          val findAlias = expressionMap(a.child.canonicalized)
+          if (a.semanticEquals(findAlias)) {
+            // We need to preserve the Alias in AggregateExpressions, but when the Alias
+            // in groupingExpressions and aggExpressions are consistent, we can replace
+            // them with the corresponding Attribute, because the name hasn't changed.
+            findAlias.toAttribute
+          } else {
+            a.withNewChildren(Seq(findAlias.toAttribute))
+          }
+
+        case e if expressionMap.contains(e.canonicalized) =>
+          expressionMap(e.canonicalized).toAttribute
+      }
+    }
+
+    agg.copy(
+      groupingExpressions = newGroupingExpressions,
+      aggregateExpressions = newAggregateExpressions.asInstanceOf[Seq[NamedExpression]],
+      child =
+        Project(eliminateProjectList(agg.child.outputSet, expressionMap.values.toSeq), agg.child)
+    )
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = LogicalPlanSelector.maybe(session, plan) {
+    if (GlutenConfig.getConf.enableAnsiMode) {
+      // Gluten not support Ansi Mode, not pull out pre-project
+      return plan
+    }
+    plan.transformUpWithPruning(_.containsAnyPattern(AGGREGATE, FILTER)) {
+      case filter: Filter
+          if SparkShimLoader.getSparkShims.needsPreProjectForBloomFilterAgg(filter)(
+            needsPreProject) =>
+        SparkShimLoader.getSparkShims.addPreProjectForBloomFilter(filter)(transformAgg)
+
+      case agg: Aggregate if needsPreProject(agg) =>
+        transformAgg(agg)
+    }
+  }
+}

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -451,6 +451,10 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-36656: Do not collapse projects with correlate scalar subqueries")
     .exclude("Merge non-correlated scalar subqueries from different parent plans")
     .exclude("Merge non-correlated scalar subqueries with conflicting names")
+    // exclude as pre-project change the number of reused subquery in plan
+    .exclude("Merge non-correlated scalar subqueries in a subquery")
+    .exclude("Merge non-correlated scalar subqueries from different levels")
+    .exclude(GLUTEN_TEST + "Merge non-correlated scalar subqueries from different parent plans")
   enableSuite[GlutenTypedImperativeAggregateSuite]
   enableSuite[GlutenUnwrapCastInComparisonEndToEndSuite].exclude("cases when literal is max")
   enableSuite[GlutenXPathFunctionsSuite]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1120,6 +1120,10 @@ class VeloxTestSettings extends BackendTestSettings {
     )
     // exclude as it checks spark plan
     .exclude("SPARK-36280: Remove redundant aliases after RewritePredicateSubquery")
+    // exclude as pre-project change the number of reused subquery in plan
+    .exclude("Merge non-correlated scalar subqueries in a subquery")
+    .exclude("Merge non-correlated scalar subqueries from different levels")
+    .exclude("Merge non-correlated scalar subqueries from different parent plans")
   enableSuite[GlutenTypedImperativeAggregateSuite]
   enableSuite[GlutenUnwrapCastInComparisonEndToEndSuite]
     // Rewrite with NaN test cases excluded.

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSubquerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSubquerySuite.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql
 
 import io.glutenproject.execution.{FileSourceScanExecTransformer, WholeStageTransformer}
 
+import org.apache.spark.sql.execution.{ReusedSubqueryExec, SubqueryExec}
+import org.apache.spark.sql.internal.SQLConf
+
 class GlutenSubquerySuite extends SubquerySuite with GlutenSQLTestsTrait {
 
   // Test Canceled: IntegratedUDFTestUtils.shouldTestPythonUDFs was false
@@ -50,6 +53,126 @@ class GlutenSubquerySuite extends SubquerySuite with GlutenSQLTestsTrait {
             .exists(_.files.exists(_.getPath.toString.contains("p=0")))
         case _ => false
       })
+    }
+  }
+
+  // InsertPreProject rule will move subquery from aggregate to pre-project. The
+  // reused subquery appeared double times in partial and final aggregation in the past.
+  // But now it appears only in pre-project. ClickHouse pull out pre-project in
+  // columnar, its subqueryIds.size is same as vanilla Spark.
+
+  testGluten("Merge non-correlated scalar subqueries in a subquery") {
+    Seq(false, true).foreach {
+      enableAQE =>
+        withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+          val df = sql("""
+                         |SELECT (
+                         |  SELECT
+                         |    SUM(
+                         |      (SELECT avg(key) FROM testData) +
+                         |      (SELECT sum(key) FROM testData) +
+                         |      (SELECT count(distinct key) FROM testData))
+                         |   FROM testData
+                         |)
+          """.stripMargin)
+
+          checkAnswer(df, Row(520050.0) :: Nil)
+
+          val plan = df.queryExecution.executedPlan
+          val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+          val reusedSubqueryIds = collectWithSubqueries(plan) {
+            case rs: ReusedSubqueryExec => rs.child.id
+          }
+
+          if (enableAQE) {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          } else {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          }
+        }
+    }
+  }
+
+  testGluten("Merge non-correlated scalar subqueries from different levels") {
+    Seq(false, true).foreach {
+      enableAQE =>
+        withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+          val df = sql("""
+                         |SELECT
+                         |  (SELECT avg(key) FROM testData),
+                         |  (
+                         |    SELECT
+                         |      SUM(
+                         |        (SELECT sum(key) FROM testData)
+                         |      )
+                         |    FROM testData
+                         |  )
+          """.stripMargin)
+
+          checkAnswer(df, Row(50.5, 505000) :: Nil)
+
+          val plan = df.queryExecution.executedPlan
+          val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+          val reusedSubqueryIds = collectWithSubqueries(plan) {
+            case rs: ReusedSubqueryExec => rs.child.id
+          }
+
+          assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+          assert(
+            reusedSubqueryIds.size == 1,
+            "Missing or unexpected reused ReusedSubqueryExec in the plan")
+        }
+    }
+  }
+
+  testGluten("Merge non-correlated scalar subqueries from different parent plans") {
+    Seq(false, true).foreach {
+      enableAQE =>
+        withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+          val df = sql("""
+                         |SELECT
+                         |  (
+                         |    SELECT
+                         |      SUM(
+                         |        (SELECT avg(key) FROM testData)
+                         |      )
+                         |    FROM testData
+                         |  ),
+                         |  (
+                         |    SELECT
+                         |      SUM(
+                         |        (SELECT sum(key) FROM testData)
+                         |      )
+                         |    FROM testData
+                         |  )
+          """.stripMargin)
+
+          checkAnswer(df, Row(5050.0, 505000) :: Nil)
+
+          val plan = df.queryExecution.executedPlan
+          val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+          val reusedSubqueryIds = collectWithSubqueries(plan) {
+            case rs: ReusedSubqueryExec => rs.child.id
+          }
+
+          if (enableAQE) {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          } else {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          }
+        }
     }
   }
 }

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -449,6 +449,10 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-36656: Do not collapse projects with correlate scalar subqueries")
     .exclude("Merge non-correlated scalar subqueries from different parent plans")
     .exclude("Merge non-correlated scalar subqueries with conflicting names")
+    // exclude as pre-project change the number of reused subquery in plan
+    .exclude("Merge non-correlated scalar subqueries in a subquery")
+    .exclude("Merge non-correlated scalar subqueries from different levels")
+    .exclude(GLUTEN_TEST + "Merge non-correlated scalar subqueries from different parent plans")
   enableSuite[GlutenTypedImperativeAggregateSuite]
   enableSuite[GlutenUnwrapCastInComparisonEndToEndSuite].exclude("cases when literal is max")
   enableSuite[GlutenXPathFunctionsSuite]

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1132,6 +1132,10 @@ class VeloxTestSettings extends BackendTestSettings {
     )
     // exclude as it checks spark plan
     .exclude("SPARK-36280: Remove redundant aliases after RewritePredicateSubquery")
+    // exclude as pre-project change the number of reused subquery in plan
+    .exclude("Merge non-correlated scalar subqueries in a subquery")
+    .exclude("Merge non-correlated scalar subqueries from different levels")
+    .exclude("Merge non-correlated scalar subqueries from different parent plans")
   enableSuite[GlutenTypedImperativeAggregateSuite]
   enableSuite[GlutenUnwrapCastInComparisonEndToEndSuite]
     // Rewrite with NaN test cases excluded.

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSubquerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSubquerySuite.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql
 
 import io.glutenproject.execution.{FileSourceScanExecTransformer, WholeStageTransformer}
 
+import org.apache.spark.sql.execution.{ReusedSubqueryExec, SubqueryExec}
+import org.apache.spark.sql.internal.SQLConf
+
 class GlutenSubquerySuite extends SubquerySuite with GlutenSQLTestsTrait {
 
   // Test Canceled: IntegratedUDFTestUtils.shouldTestPythonUDFs was false
@@ -50,6 +53,126 @@ class GlutenSubquerySuite extends SubquerySuite with GlutenSQLTestsTrait {
             .exists(_.files.exists(_.getPath.toString.contains("p=0")))
         case _ => false
       })
+    }
+  }
+
+  // InsertPreProject rule will move subquery from aggregate to pre-project. The
+  // reused subquery appeared double times in partial and final aggregation in the past.
+  // But now it appears only in pre-project. ClickHouse pull out pre-project in
+  // columnar, its subqueryIds.size is same as vanilla Spark.
+
+  testGluten("Merge non-correlated scalar subqueries in a subquery") {
+    Seq(false, true).foreach {
+      enableAQE =>
+        withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+          val df = sql("""
+                         |SELECT (
+                         |  SELECT
+                         |    SUM(
+                         |      (SELECT avg(key) FROM testData) +
+                         |      (SELECT sum(key) FROM testData) +
+                         |      (SELECT count(distinct key) FROM testData))
+                         |   FROM testData
+                         |)
+          """.stripMargin)
+
+          checkAnswer(df, Row(520050.0) :: Nil)
+
+          val plan = df.queryExecution.executedPlan
+          val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+          val reusedSubqueryIds = collectWithSubqueries(plan) {
+            case rs: ReusedSubqueryExec => rs.child.id
+          }
+
+          if (enableAQE) {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          } else {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          }
+        }
+    }
+  }
+
+  testGluten("Merge non-correlated scalar subqueries from different levels") {
+    Seq(false, true).foreach {
+      enableAQE =>
+        withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+          val df = sql("""
+                         |SELECT
+                         |  (SELECT avg(key) FROM testData),
+                         |  (
+                         |    SELECT
+                         |      SUM(
+                         |        (SELECT sum(key) FROM testData)
+                         |      )
+                         |    FROM testData
+                         |  )
+          """.stripMargin)
+
+          checkAnswer(df, Row(50.5, 505000) :: Nil)
+
+          val plan = df.queryExecution.executedPlan
+          val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+          val reusedSubqueryIds = collectWithSubqueries(plan) {
+            case rs: ReusedSubqueryExec => rs.child.id
+          }
+
+          assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+          assert(
+            reusedSubqueryIds.size == 1,
+            "Missing or unexpected reused ReusedSubqueryExec in the plan")
+        }
+    }
+  }
+
+  testGluten("Merge non-correlated scalar subqueries from different parent plans") {
+    Seq(false, true).foreach {
+      enableAQE =>
+        withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+          val df = sql("""
+                         |SELECT
+                         |  (
+                         |    SELECT
+                         |      SUM(
+                         |        (SELECT avg(key) FROM testData)
+                         |      )
+                         |    FROM testData
+                         |  ),
+                         |  (
+                         |    SELECT
+                         |      SUM(
+                         |        (SELECT sum(key) FROM testData)
+                         |      )
+                         |    FROM testData
+                         |  )
+          """.stripMargin)
+
+          checkAnswer(df, Row(5050.0, 505000) :: Nil)
+
+          val plan = df.queryExecution.executedPlan
+          val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+          val reusedSubqueryIds = collectWithSubqueries(plan) {
+            case rs: ReusedSubqueryExec => rs.child.id
+          }
+
+          if (enableAQE) {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          } else {
+            assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+            assert(
+              reusedSubqueryIds.size == 2,
+              "Missing or unexpected reused ReusedSubqueryExec in the plan")
+          }
+        }
     }
   }
 }

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.Distribution
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
@@ -90,7 +91,13 @@ trait SparkShims {
   def hasBloomFilterAggregate(
       agg: org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec): Boolean
 
+  def needsPreProjectForBloomFilterAgg(filter: org.apache.spark.sql.catalyst.plans.logical.Filter)(
+      needsPreProject: LogicalPlan => Boolean): Boolean
+
   def extractSubPlanFromMightContain(expr: Expression): Option[SparkPlan]
+
+  def addPreProjectForBloomFilter(filter: org.apache.spark.sql.catalyst.plans.logical.Filter)(
+      transformAgg: Aggregate => LogicalPlan): LogicalPlan
 
   def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = (plan.limit, 0)
 

--- a/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClusteredDistribution}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
@@ -111,7 +112,13 @@ class Spark32Shims extends SparkShims {
   override def hasBloomFilterAggregate(
       agg: org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec): Boolean = false
 
+  override def needsPreProjectForBloomFilterAgg(filter: Filter)(
+      needsPreProject: LogicalPlan => Boolean): Boolean = false
+
   override def extractSubPlanFromMightContain(expr: Expression): Option[SparkPlan] = None
+
+  override def addPreProjectForBloomFilter(filter: Filter)(
+      transformAgg: Aggregate => LogicalPlan): LogicalPlan = filter
 
   override def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = {
     List(session => GlutenParquetWriterInjects.getInstance().getExtendedColumnarPostRule(session))

--- a/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
+import org.apache.spark.sql.catalyst.optimizer.{ColumnPruning, ConstantFolding}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
@@ -46,7 +48,7 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 
 import org.apache.hadoop.fs.Path
 
-class Spark33Shims extends SparkShims {
+class Spark33Shims extends SparkShims with PredicateHelper {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
 
   override def getDistribution(
@@ -139,6 +141,18 @@ class Spark33Shims extends SparkShims {
       expr => expr.aggregateFunction.isInstanceOf[BloomFilterAggregate])
   }
 
+  override def needsPreProjectForBloomFilterAgg(filter: Filter)(
+      needsPreProject: LogicalPlan => Boolean): Boolean = {
+    splitConjunctivePredicates(filter.condition).exists {
+      case _ @BloomFilterMightContain(sub: ScalarSubquery, _) =>
+        sub.plan.exists {
+          case agg: Aggregate => needsPreProject(agg)
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
   override def extractSubPlanFromMightContain(expr: Expression): Option[SparkPlan] = {
     expr match {
       case mc @ BloomFilterMightContain(sub: org.apache.spark.sql.execution.ScalarSubquery, _) =>
@@ -149,6 +163,19 @@ class Spark33Shims extends SparkShims {
         Some(sub.plan)
       case _ => None
     }
+  }
+
+  override def addPreProjectForBloomFilter(filter: Filter)(
+      transformAgg: Aggregate => LogicalPlan): LogicalPlan = {
+    val newConditions = splitConjunctivePredicates(filter.condition).map {
+      case bloom @ BloomFilterMightContain(sub: ScalarSubquery, _) =>
+        val newSubqueryPlan = sub.plan.transform {
+          case agg: Aggregate => ConstantFolding(ColumnPruning(transformAgg(agg)))
+        }
+        bloom.copy(bloomFilterExpression = sub.copy(plan = newSubqueryPlan))
+      case other => other
+    }
+    filter.copy(condition = newConditions.reduceLeft(And))
   }
 
   private def invalidBucketFile(path: String): Throwable = {

--- a/shims/spark34/src/main/scala/io/glutenproject/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/io/glutenproject/sql/shims/spark34/Spark34Shims.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
+import org.apache.spark.sql.catalyst.optimizer.{ColumnPruning, ConstantFolding}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
@@ -43,7 +45,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
 
-class Spark34Shims extends SparkShims {
+class Spark34Shims extends SparkShims with PredicateHelper {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
 
   override def getDistribution(
@@ -137,6 +139,18 @@ class Spark34Shims extends SparkShims {
       expr => expr.aggregateFunction.isInstanceOf[BloomFilterAggregate])
   }
 
+  override def needsPreProjectForBloomFilterAgg(filter: Filter)(
+      needsPreProject: LogicalPlan => Boolean): Boolean = {
+    splitConjunctivePredicates(filter.condition).exists {
+      case _ @BloomFilterMightContain(sub: ScalarSubquery, _) =>
+        sub.plan.exists {
+          case agg: Aggregate => needsPreProject(agg)
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
   override def extractSubPlanFromMightContain(expr: Expression): Option[SparkPlan] = {
     expr match {
       case mc @ BloomFilterMightContain(sub: org.apache.spark.sql.execution.ScalarSubquery, _) =>
@@ -147,6 +161,19 @@ class Spark34Shims extends SparkShims {
         Some(sub.plan)
       case _ => None
     }
+  }
+
+  override def addPreProjectForBloomFilter(filter: Filter)(
+      transformAgg: Aggregate => LogicalPlan): LogicalPlan = {
+    val newConditions = splitConjunctivePredicates(filter.condition).map {
+      case bloom @ BloomFilterMightContain(sub: ScalarSubquery, _) =>
+        val newSubPlan = sub.plan.transform {
+          case agg: Aggregate => ConstantFolding(ColumnPruning(transformAgg(agg)))
+        }
+        bloom.copy(bloomFilterExpression = sub.copy(plan = newSubPlan))
+      case other => other
+    }
+    filter.copy(condition = newConditions.reduceLeft(And))
   }
 
   // https://issues.apache.org/jira/browse/SPARK-40400


### PR DESCRIPTION
## What changes were proposed in this pull request?

As we discussed in https://github.com/oap-project/gluten/discussions/4308, pulling out pre-projects in the logical plan can reduce the number of  expression evaluations and pre-projects in some cases, thereby improving performance to a certain extent. However, it is not always convenient to handle this in the logical plan. Therefore, we first introduced a physical rule to pull out projects. Now, we are introducing a logical plan rule again to process parts that can be handled in the logical plan, leveraging the advantages of pulling out pre-projects in the logical plan.

## How was this patch tested?

Exists CI.

