### PR TITLE
[GLUTEN-4866][VL] Avoid convert column name according to case sensitivity config

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -282,11 +282,8 @@ void WholeStageResultIterator::constructPartitionColumns(
     std::unordered_map<std::string, std::optional<std::string>>& partitionKeys,
     const std::unordered_map<std::string, std::string>& map) {
   for (const auto& partitionColumn : map) {
-    auto key = partitionColumn.first;
+    const auto key = partitionColumn.first;
     const auto value = partitionColumn.second;
-    if (!veloxCfg_->get<bool>(kCaseSensitive, false)) {
-      folly::toLowerAscii(key);
-    }
     if (value == kHiveDefaultPartition) {
       partitionKeys[key] = std::nullopt;
     } else {
@@ -520,9 +517,6 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
 
 std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig() {
   std::unordered_map<std::string, std::string> configs = {};
-  // The semantics of reading as lower case is opposite with case-sensitive.
-  configs[velox::connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession] =
-      veloxCfg_->get<bool>(kCaseSensitive, false) == false ? "true" : "false";
   configs[velox::connector::hive::HiveConfig::kPartitionPathAsLowerCaseSession] = "false";
   configs[velox::connector::hive::HiveConfig::kArrowBridgeTimestampUnit] = "6";
   configs[velox::connector::hive::HiveConfig::kMaxPartitionsPerWritersSession] =

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -23,7 +23,7 @@
 
 namespace gluten {
 
-TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType, bool asLowerCase) {
+TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType) {
   switch (substraitType.kind_case()) {
     case ::substrait::Type::KindCase::kBool:
       return BOOLEAN();
@@ -51,24 +51,21 @@ TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType, bool 
       std::vector<TypePtr> types;
       std::vector<std::string> names;
       for (int i = 0; i < structTypes.size(); i++) {
-        types.emplace_back(parseType(structTypes[i], asLowerCase));
-        std::string fieldName = nameProvided ? structNames[i] : "col_" + std::to_string(i);
-        if (asLowerCase) {
-          folly::toLowerAscii(fieldName);
-        }
+        types.emplace_back(parseType(structTypes[i]));
+        auto fieldName = nameProvided ? structNames[i] : "col_" + std::to_string(i);
         names.emplace_back(fieldName);
       }
       return ROW(std::move(names), std::move(types));
     }
     case ::substrait::Type::KindCase::kList: {
       const auto& fieldType = substraitType.list().type();
-      return ARRAY(parseType(fieldType, asLowerCase));
+      return ARRAY(parseType(fieldType));
     }
     case ::substrait::Type::KindCase::kMap: {
       const auto& sMap = substraitType.map();
       const auto& keyType = sMap.key();
       const auto& valueType = sMap.value();
-      return MAP(parseType(keyType, asLowerCase), parseType(valueType, asLowerCase));
+      return MAP(parseType(keyType), parseType(valueType));
     }
     case ::substrait::Type::KindCase::kUserDefined:
       // We only support UNKNOWN type to handle the null literal whose type is
@@ -90,7 +87,7 @@ TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType, bool 
   }
 }
 
-std::vector<TypePtr> SubstraitParser::parseNamedStruct(const ::substrait::NamedStruct& namedStruct, bool asLowerCase) {
+std::vector<TypePtr> SubstraitParser::parseNamedStruct(const ::substrait::NamedStruct& namedStruct) {
   // Note that "names" are not used.
 
   // Parse Struct.
@@ -99,7 +96,7 @@ std::vector<TypePtr> SubstraitParser::parseNamedStruct(const ::substrait::NamedS
   std::vector<TypePtr> typeList;
   typeList.reserve(substraitTypes.size());
   for (const auto& type : substraitTypes) {
-    typeList.emplace_back(parseType(type, asLowerCase));
+    typeList.emplace_back(parseType(type));
   }
   return typeList;
 }

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -37,15 +37,13 @@ namespace gluten {
 class SubstraitParser {
  public:
   /// Used to parse Substrait NamedStruct.
-  static std::vector<facebook::velox::TypePtr> parseNamedStruct(
-      const ::substrait::NamedStruct& namedStruct,
-      bool asLowerCase = false);
+  static std::vector<facebook::velox::TypePtr> parseNamedStruct(const ::substrait::NamedStruct& namedStruct);
 
   /// Used to parse partition columns from Substrait NamedStruct.
   static std::vector<bool> parsePartitionColumns(const ::substrait::NamedStruct& namedStruct);
 
   /// Parse Substrait Type to Velox type.
-  static facebook::velox::TypePtr parseType(const ::substrait::Type& substraitType, bool asLowerCase = false);
+  static facebook::velox::TypePtr parseType(const ::substrait::Type& substraitType);
 
   /// Parse Substrait ReferenceSegment.
   static int32_t parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment);

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1045,21 +1045,13 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   std::vector<std::string> colNameList;
   std::vector<TypePtr> veloxTypeList;
   std::vector<bool> isPartitionColumns;
-  // Convert field names into lower case when not case-sensitive.
-  std::shared_ptr<const facebook::velox::Config> veloxCfg =
-      std::make_shared<const facebook::velox::core::MemConfigMutable>(confMap_);
-  bool asLowerCase = !veloxCfg->get<bool>(kCaseSensitive, false);
   if (readRel.has_base_schema()) {
     const auto& baseSchema = readRel.base_schema();
     colNameList.reserve(baseSchema.names().size());
     for (const auto& name : baseSchema.names()) {
-      std::string fieldName = name;
-      if (asLowerCase) {
-        folly::toLowerAscii(fieldName);
-      }
-      colNameList.emplace_back(fieldName);
+      colNameList.emplace_back(name);
     }
-    veloxTypeList = SubstraitParser::parseNamedStruct(baseSchema, asLowerCase);
+    veloxTypeList = SubstraitParser::parseNamedStruct(baseSchema);
     isPartitionColumns = SubstraitParser::parsePartitionColumns(baseSchema);
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -23,13 +23,12 @@ import io.glutenproject.utils.SubstraitPlanPrinterUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import io.substrait.proto.{NamedStruct, Type}
 
-import java.util.{ArrayList => JArrayList, List => JList, Locale}
+import java.util.{ArrayList => JArrayList, List => JList}
 
 import scala.collection.JavaConverters._
 
@@ -46,8 +45,7 @@ object ConverterUtils extends Logging {
   }
 
   def normalizeColName(name: String): String = {
-    val caseSensitive = SQLConf.get.caseSensitiveAnalysis
-    if (caseSensitive) name else name.toLowerCase(Locale.ROOT)
+    name
   }
 
   def getShortAttributeName(attr: Attribute): String = {

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -678,9 +678,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Migration from INT96 to TIMESTAMP_MICROS timestamp type")
     .exclude("SPARK-10365 timestamp written and read as INT64 - TIMESTAMP_MICROS")
     .exclude("SPARK-36182: read TimestampNTZ as TimestampLTZ")
-    // new added in spark-3.3 and need fix later, random failure may caused by memory free
-    .exclude("SPARK-39833: pushed filters with project without filter columns")
-    .exclude("SPARK-39833: pushed filters with count()")
     // Rewrite because the filter after datasource is not needed.
     .exclude(
       "SPARK-26677: negated null-safe equality comparison should not filter matched row groups")


### PR DESCRIPTION
## What changes were proposed in this pull request?



(Fixes: #4866)

## How was this patch tested?

Enable `SPARK-39833: pushed filters with project without filter columns` and `SPARK-39833: pushed filters with count()`