### PR TITLE
[VL] Fix wrong plan equality due to case class inheritance

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -19,12 +19,12 @@ package io.glutenproject.execution
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
-import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExecShim, FileScan}
@@ -32,24 +32,54 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import java.util.Objects
-
 /**
  * Columnar Based BatchScanExec. Although keyGroupedPartitioning is not used, it cannot be deleted,
  * it can make BatchScanExecTransformer contain a constructor with the same parameters as
  * Spark-3.3's BatchScanExec. Otherwise, the corresponding constructor will not be found when
  * calling TreeNode.makeCopy and will fail to copy this node during transformation.
  */
-class BatchScanExecTransformer(
-    output: Seq[AttributeReference],
-    @transient scan: Scan,
-    runtimeFilters: Seq[Expression],
-    keyGroupedPartitioning: Option[Seq[Expression]] = None,
-    ordering: Option[Seq[SortOrder]] = None,
-    @transient table: Table,
-    commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
-    applyPartialClustering: Boolean = false,
-    replicatePartitions: Boolean = false)
+
+case class BatchScanExecTransformer(
+    override val output: Seq[AttributeReference],
+    @transient override val scan: Scan,
+    override val runtimeFilters: Seq[Expression],
+    override val keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    override val ordering: Option[Seq[SortOrder]] = None,
+    @transient override val table: Table,
+    override val commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
+    override val applyPartialClustering: Boolean = false,
+    override val replicatePartitions: Boolean = false)
+  extends BatchScanExecTransformerBase(
+    output,
+    scan,
+    runtimeFilters,
+    keyGroupedPartitioning,
+    ordering,
+    table,
+    commonPartitionValues,
+    applyPartialClustering,
+    replicatePartitions) {
+
+  override def doCanonicalize(): BatchScanExecTransformer = {
+    this.copy(
+      output = output.map(QueryPlan.normalizeExpressions(_, output)),
+      runtimeFilters = QueryPlan.normalizePredicates(
+        runtimeFilters.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral)),
+        output)
+    )
+  }
+}
+
+abstract class BatchScanExecTransformerBase(
+    override val output: Seq[AttributeReference],
+    @transient override val scan: Scan,
+    override val runtimeFilters: Seq[Expression],
+    override val keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    override val ordering: Option[Seq[SortOrder]] = None,
+    @transient override val table: Table,
+    override val commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
+    override val applyPartialClustering: Boolean = false,
+    override val replicatePartitions: Boolean = false)
   extends BatchScanExecShim(output, scan, runtimeFilters, table = table)
   with BasicScanExecTransformer {
 
@@ -58,7 +88,7 @@ class BatchScanExecTransformer(
     BackendsApiManager.getMetricsApiInstance.genBatchScanTransformerMetrics(sparkContext)
 
   // Similar to the problem encountered in https://github.com/oap-project/gluten/pull/3184,
-  // we cannot add member variables to BatchScanExecTransformer, which inherits from case
+  // we cannot add member variables to BatchScanExecTransformerBase, which inherits from case
   // class. Otherwise, we will encounter an issue where makeCopy cannot find a constructor
   // with the corresponding number of parameters.
   // The workaround is to add a mutable list to pass in pushdownFilters.
@@ -107,16 +137,6 @@ class BatchScanExecTransformer(
     doExecuteColumnarInternal()
   }
 
-  override def equals(other: Any): Boolean = other match {
-    case that: BatchScanExecTransformer =>
-      that.canEqual(this) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = Objects.hash(batch, runtimeFilters)
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[BatchScanExecTransformer]
-
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genBatchScanTransformerMetricsUpdater(metrics)
 
@@ -129,15 +149,5 @@ class BatchScanExecTransformer(
     case "DwrfScan" => ReadFileFormat.DwrfReadFormat
     case "ClickHouseScan" => ReadFileFormat.MergeTreeReadFormat
     case _ => ReadFileFormat.UnknownFormat
-  }
-
-  override def doCanonicalize(): BatchScanExecTransformer = {
-    val canonicalized = super.doCanonicalize()
-    new BatchScanExecTransformer(
-      canonicalized.output,
-      canonicalized.scan,
-      canonicalized.runtimeFilters,
-      table = SparkShimLoader.getSparkShims.getBatchScanExecTable(canonicalized)
-    )
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/DataSourceScanTransformerRegister.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/DataSourceScanTransformerRegister.scala
@@ -45,14 +45,14 @@ trait DataSourceScanTransformerRegister {
 
   def createDataSourceTransformer(
       batchScan: FileSourceScanExec,
-      newPartitionFilters: Seq[Expression]): FileSourceScanExecTransformer = {
+      newPartitionFilters: Seq[Expression]): FileSourceScanExecTransformerBase = {
     throw new UnsupportedOperationException(
       "This should not be called, please implement this method in child class.");
   }
 
   def createDataSourceV2Transformer(
       batchScan: BatchScanExec,
-      newPartitionFilters: Seq[Expression]): BatchScanExecTransformer = {
+      newPartitionFilters: Seq[Expression]): BatchScanExecTransformerBase = {
     throw new UnsupportedOperationException(
       "This should not be called, please implement this method in child class.");
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -24,6 +24,7 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, PlanExpression}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.FileSourceScanExecShim
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
@@ -32,15 +33,53 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.collection.BitSet
 
-class FileSourceScanExecTransformer(
+case class FileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
-    output: Seq[Attribute],
+    override val output: Seq[Attribute],
+    override val requiredSchema: StructType,
+    override val partitionFilters: Seq[Expression],
+    override val optionalBucketSet: Option[BitSet],
+    override val optionalNumCoalescedBuckets: Option[Int],
+    override val dataFilters: Seq[Expression],
+    override val tableIdentifier: Option[TableIdentifier],
+    override val disableBucketedScan: Boolean = false)
+  extends FileSourceScanExecTransformerBase(
+    relation,
+    output,
+    requiredSchema,
+    partitionFilters,
+    optionalBucketSet,
+    optionalNumCoalescedBuckets,
+    dataFilters,
+    tableIdentifier,
+    disableBucketedScan) {
+
+  override def doCanonicalize(): FileSourceScanExecTransformer = {
+    FileSourceScanExecTransformer(
+      relation,
+      output.map(QueryPlan.normalizeExpressions(_, output)),
+      requiredSchema,
+      QueryPlan.normalizePredicates(
+        filterUnusedDynamicPruningExpressions(partitionFilters),
+        output),
+      optionalBucketSet,
+      optionalNumCoalescedBuckets,
+      QueryPlan.normalizePredicates(dataFilters, output),
+      None,
+      disableBucketedScan
+    )
+  }
+}
+
+abstract class FileSourceScanExecTransformerBase(
+    @transient override val relation: HadoopFsRelation,
+    override val output: Seq[Attribute],
     requiredSchema: StructType,
     partitionFilters: Seq[Expression],
     optionalBucketSet: Option[BitSet],
     optionalNumCoalescedBuckets: Option[Int],
     dataFilters: Seq[Expression],
-    override val tableIdentifier: Option[TableIdentifier],
+    tableIdentifier: Option[TableIdentifier],
     disableBucketedScan: Boolean = false)
   extends FileSourceScanExecShim(
     relation,
@@ -59,6 +98,8 @@ class FileSourceScanExecTransformer(
     BackendsApiManager.getMetricsApiInstance
       .genFileSourceScanTransformerMetrics(sparkContext)
       .filter(m => !driverMetricsAlias.contains(m._1)) ++ driverMetricsAlias
+
+  def getPartitionFilters(): Seq[Expression] = partitionFilters
 
   override def filterExprs(): Seq[Expression] = dataFilters
 
@@ -82,16 +123,6 @@ class FileSourceScanExecTransformer(
   override def getInputFilePathsInternal: Seq[String] = {
     relation.location.inputFiles.toSeq
   }
-
-  override def equals(other: Any): Boolean = other match {
-    case that: FileSourceScanExecTransformer =>
-      that.canEqual(this) && super.equals(that)
-    case _ => false
-  }
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSourceScanExecTransformer]
-
-  override def hashCode(): Int = super.hashCode()
 
   override protected def doValidateInternal(): ValidationResult = {
     if (hasMetadataColumns) {
@@ -148,24 +179,9 @@ class FileSourceScanExecTransformer(
       case "CSVFileFormat" => ReadFileFormat.TextReadFormat
       case _ => ReadFileFormat.UnknownFormat
     }
-
-  override def doCanonicalize(): FileSourceScanExecTransformer = {
-    val canonicalized = super.doCanonicalize()
-    new FileSourceScanExecTransformer(
-      canonicalized.relation,
-      canonicalized.output,
-      canonicalized.requiredSchema,
-      canonicalized.partitionFilters,
-      canonicalized.optionalBucketSet,
-      canonicalized.optionalNumCoalescedBuckets,
-      canonicalized.dataFilters,
-      canonicalized.tableIdentifier,
-      canonicalized.disableBucketedScan
-    )
-  }
 }
 
-object FileSourceScanExecTransformer {
+object FileSourceScanExecTransformerBase {
   private def isDynamicPruningFilter(e: Expression): Boolean =
     e.find(_.isInstanceOf[PlanExpression[_]]).isDefined
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -89,8 +89,6 @@ abstract class HashAggregateExecBaseTransformer(
     }
   }
 
-  // override def canEqual(that: Any): Boolean = false
-
   override def simpleString(maxFields: Int): String = toString(verbose = false, maxFields)
 
   protected def checkType(dataType: DataType): Boolean = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
@@ -37,7 +37,7 @@ object ScanTransformerFactory {
   def createFileSourceScanTransformer(
       scanExec: FileSourceScanExec,
       allPushDownFilters: Option[Seq[Expression]] = None,
-      validation: Boolean = false): FileSourceScanExecTransformer = {
+      validation: Boolean = false): FileSourceScanExecTransformerBase = {
     // transform BroadcastExchangeExec to ColumnarBroadcastExchangeExec in partitionFilters
     val newPartitionFilters = if (validation) {
       scanExec.partitionFilters
@@ -69,7 +69,7 @@ object ScanTransformerFactory {
 
   private def lookupBatchScanTransformer(
       batchScanExec: BatchScanExec,
-      newPartitionFilters: Seq[Expression]): BatchScanExecTransformer = {
+      newPartitionFilters: Seq[Expression]): BatchScanExecTransformerBase = {
     val scan = batchScanExec.scan
     lookupDataSourceScanTransformer(scan.getClass.getName) match {
       case Some(clz) =>

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/MiscColumnarRules.scala
@@ -413,7 +413,7 @@ object MiscColumnarRules {
           transformer
         } else {
           logDebug(s"Columnar Processing for ${plan.getClass} is currently unsupported.")
-          val newSource = plan.copy(partitionFilters = transformer.partitionFilters)
+          val newSource = plan.copy(partitionFilters = transformer.getPartitionFilters())
           TransformHints.tagNotTransformable(newSource, validationResult.reason.get)
           newSource
         }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -409,7 +409,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               val transformer =
                 ScanTransformerFactory
                   .createBatchScanTransformer(plan, validation = true)
-                  .asInstanceOf[BatchScanExecTransformer]
+                  .asInstanceOf[BasicScanExecTransformer]
               transformer.doValidate().tagOnFallback(plan)
             }
           }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -25,13 +25,14 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSeq, Expression}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer._
 import org.apache.spark.sql.hive.client.HiveClientImpl
-import org.apache.spark.sql.hive.execution.HiveTableScanExec
+import org.apache.spark.sql.hive.execution.{AbstractHiveTableScanExec, HiveTableScanExec}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
@@ -43,11 +44,11 @@ import org.apache.hadoop.mapred.TextInputFormat
 
 import java.net.URI
 
-class HiveTableScanExecTransformer(
+case class HiveTableScanExecTransformer(
     requestedAttributes: Seq[Attribute],
     relation: HiveTableRelation,
     partitionPruningPred: Seq[Expression])(session: SparkSession)
-  extends HiveTableScanExec(requestedAttributes, relation, partitionPruningPred)(session)
+  extends AbstractHiveTableScanExec(requestedAttributes, relation, partitionPruningPred)(session)
   with BasicScanExecTransformer {
 
   @transient override lazy val metrics: Map[String, SQLMetric] =
@@ -167,22 +168,13 @@ class HiveTableScanExecTransformer(
 
   override def nodeName: String = s"NativeScan hive ${relation.tableMeta.qualifiedName}"
 
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[HiveTableScanExecTransformer]
-
-  override def equals(other: Any): Boolean = other match {
-    case that: HiveTableScanExecTransformer =>
-      that.canEqual(this) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
   override def doCanonicalize(): HiveTableScanExecTransformer = {
-    val canonicalized = super.doCanonicalize()
-    new HiveTableScanExecTransformer(
-      canonicalized.requestedAttributes,
-      canonicalized.relation,
-      canonicalized.partitionPruningPred)(canonicalized.session)
+    val input: AttributeSeq = relation.output
+    HiveTableScanExecTransformer(
+      requestedAttributes.map(QueryPlan.normalizeExpressions(_, input)),
+      relation.canonicalized.asInstanceOf[HiveTableRelation],
+      QueryPlan.normalizePredicates(partitionPruningPred, input)
+    )(sparkSession)
   }
 }
 

--- a/gluten-delta/src/main/scala/io/glutenproject/execution/DeltaScanTransformer.scala
+++ b/gluten-delta/src/main/scala/io/glutenproject/execution/DeltaScanTransformer.scala
@@ -21,22 +21,23 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
 
-class DeltaScanTransformer(
+case class DeltaScanTransformer(
     @transient override val relation: HadoopFsRelation,
-    output: Seq[Attribute],
-    requiredSchema: StructType,
-    partitionFilters: Seq[Expression],
-    optionalBucketSet: Option[BitSet],
-    optionalNumCoalescedBuckets: Option[Int],
-    dataFilters: Seq[Expression],
+    override val output: Seq[Attribute],
+    override val requiredSchema: StructType,
+    override val partitionFilters: Seq[Expression],
+    override val optionalBucketSet: Option[BitSet],
+    override val optionalNumCoalescedBuckets: Option[Int],
+    override val dataFilters: Seq[Expression],
     override val tableIdentifier: Option[TableIdentifier],
-    disableBucketedScan: Boolean = false)
-  extends FileSourceScanExecTransformer(
+    override val disableBucketedScan: Boolean = false)
+  extends FileSourceScanExecTransformerBase(
     relation,
     output,
     requiredSchema,
@@ -58,6 +59,21 @@ class DeltaScanTransformer(
     super.doValidateInternal()
   }
 
+  override def doCanonicalize(): DeltaScanTransformer = {
+    DeltaScanTransformer(
+      relation,
+      output.map(QueryPlan.normalizeExpressions(_, output)),
+      requiredSchema,
+      QueryPlan.normalizePredicates(
+        filterUnusedDynamicPruningExpressions(partitionFilters),
+        output),
+      optionalBucketSet,
+      optionalNumCoalescedBuckets,
+      QueryPlan.normalizePredicates(dataFilters, output),
+      None,
+      disableBucketedScan
+    )
+  }
 }
 
 object DeltaScanTransformer {

--- a/gluten-delta/src/main/scala/io/glutenproject/execution/DeltaScanTransformerProvider.scala
+++ b/gluten-delta/src/main/scala/io/glutenproject/execution/DeltaScanTransformerProvider.scala
@@ -25,7 +25,7 @@ class DeltaScanTransformerProvider extends DataSourceScanTransformerRegister {
 
   override def createDataSourceTransformer(
       batchScan: FileSourceScanExec,
-      newPartitionFilters: Seq[Expression]): FileSourceScanExecTransformer = {
+      newPartitionFilters: Seq[Expression]): FileSourceScanExecTransformerBase = {
     DeltaScanTransformer(batchScan, newPartitionFilters)
   }
 }

--- a/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxDeltaSuite.scala
+++ b/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxDeltaSuite.scala
@@ -117,7 +117,7 @@ class VeloxDeltaSuite extends WholeStageTransformerSuite {
                    |""".stripMargin)
       val df1 = runQueryAndCompare("select * from delta_pf where name = 'v1'") { _ => }
       val deltaScanTransformer = df1.queryExecution.executedPlan.collect {
-        case f: FileSourceScanExecTransformer => f
+        case f: DeltaScanTransformer => f
       }.head
       // No data filters as only partition filters exist
       assert(deltaScanTransformer.filterExprs().size == 0)

--- a/gluten-iceberg/src/main/scala/io/glutenproject/execution/IcebergTransformerProvider.scala
+++ b/gluten-iceberg/src/main/scala/io/glutenproject/execution/IcebergTransformerProvider.scala
@@ -25,7 +25,7 @@ class IcebergTransformerProvider extends DataSourceScanTransformerRegister {
 
   override def createDataSourceV2Transformer(
       batchScan: BatchScanExec,
-      newPartitionFilters: Seq[Expression]): BatchScanExecTransformer = {
+      newPartitionFilters: Seq[Expression]): BatchScanExecTransformerBase = {
     IcebergScanTransformer(batchScan, newPartitionFilters)
   }
 }

--- a/gluten-ut/common/src/test/scala/io/glutenproject/utils/BackendTestSettings.scala
+++ b/gluten-ut/common/src/test/scala/io/glutenproject/utils/BackendTestSettings.scala
@@ -127,7 +127,7 @@ abstract class BackendTestSettings {
       this
     }
 
-    def disableByReason(reason: String): SuiteSettings = {
+    def disable(reason: String): SuiteSettings = {
       disableReason = disableReason match {
         case Some(r) => throw new IllegalArgumentException("Disable reason already set: " + r)
         case None => Some(reason)

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -326,6 +326,10 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("UDF input_file_name()")
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
     .exclude("SPARK-35669: special char in CSV header with filter pushdown")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support partition pruning")
     .excludeGlutenTest("Spark native readers should respect spark.sql.caseSensitive - parquet")
     .excludeGlutenTest("SPARK-25237 compute correct input metrics in FileScanRDD")
   enableSuite[GlutenFileScanSuite]
@@ -975,6 +979,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("partitioning reporting")
     .exclude("SPARK-33267: push down with condition 'in (..., null)' should not throw NPE")
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("Fallback Parquet V2 to V1")
   enableSuite[GlutenLocalScanSuite]
   enableSuite[GlutenSupportsCatalogOptionsSuite]
   enableSuite[GlutenTableCapabilityCheckSuite]
@@ -1465,6 +1471,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("Enabling/disabling ignoreCorruptFiles")
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcSourceSuite]
     .exclude("SPARK-24322 Fix incorrect workaround for bug in java.sql.Timestamp")
     .exclude("SPARK-31238: compatibility with Spark 2.4 in reading dates")
@@ -1472,6 +1483,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-31284: compatibility with Spark 2.4 in reading timestamps")
     .exclude("SPARK-31284, SPARK-31423: rebasing timestamps in write")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
     .excludeGlutenTest("SPARK-31238: compatibility with Spark 2.4 in reading dates")
     .excludeGlutenTest("SPARK-31238, SPARK-31423: rebasing dates in write")
     .excludeGlutenTest("SPARK-31284: compatibility with Spark 2.4 in reading timestamps")
@@ -1483,6 +1496,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("Enabling/disabling ignoreCorruptFiles")
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcV1SchemaPruningSuite]
     .exclude(
       "Spark vectorized reader - without partition data column - select only top-level fields")
@@ -1668,6 +1686,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("Enabling/disabling ignoreCorruptFiles")
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcV2SchemaPruningSuite]
     .exclude("Spark vectorized reader - without partition data column - select a single complex field from a map entry and its parent map entry")
     .exclude("Spark vectorized reader - with partition data column - select a single complex field from a map entry and its parent map entry")
@@ -2120,6 +2143,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-32767 Bucket join should work if SHUFFLE_PARTITIONS larger than bucket number")
     .exclude("bucket coalescing eliminates shuffle")
     .exclude("bucket coalescing is not satisfied")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("disable bucketing when the output doesn't contain all bucketing columns")
     .exclude(
       "bucket coalescing is applied when join expressions match with partitioning expressions")
   enableSuite[GlutenBucketedWriteWithoutHiveSupportSuite]
@@ -2128,6 +2153,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("create a table, drop it and create another one with the same name")
   enableSuite[GlutenDDLSourceLoadSuite]
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .disable(
+      "DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type")
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
   enableSuite[GlutenExternalCommandRunnerSuite]
   enableSuite[GlutenFilteredScanSuite]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -379,6 +379,10 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Return correct results when data columns overlap with partition " +
       "columns (nested data)")
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support partition pruning")
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
     .excludeByPrefix("SPARK-35675")
@@ -982,6 +986,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataSourceV2SQLSessionCatalogSuite]
   enableSuite[GlutenDataSourceV2SQLSuite]
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("Fallback Parquet V2 to V1")
   enableSuite[GlutenLocalScanSuite]
   enableSuite[GlutenSupportsCatalogOptionsSuite]
   enableSuite[GlutenTableCapabilityCheckSuite]
@@ -1008,6 +1014,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-32767 Bucket join should work if SHUFFLE_PARTITIONS larger than bucket number")
     .exclude("bucket coalescing eliminates shuffle")
     .exclude("bucket coalescing is not satisfied")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("disable bucketing when the output doesn't contain all bucketing columns")
     .excludeByPrefix("bucket coalescing is applied when join expressions match")
   enableSuite[GlutenBucketedWriteWithoutHiveSupportSuite]
   enableSuite[GlutenCreateTableAsSelectSuite]
@@ -1016,6 +1024,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("create a table, drop it and create another one with the same name")
   enableSuite[GlutenDDLSourceLoadSuite]
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .disable(
+      "DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type")
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
   enableSuite[GlutenExternalCommandRunnerSuite]
   enableSuite[GlutenFilteredScanSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
@@ -438,7 +438,12 @@ abstract class GlutenDynamicPartitionPruningV1Suite extends GlutenDynamicPartiti
             find(plan) {
               case s: FileSourceScanExec =>
                 s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
+              case s: FileSourceScanExecTransformer =>
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
               case s: BatchScanExec =>
+                // we use f1 col for v2 tables due to schema pruning
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
+              case s: BatchScanExecTransformer =>
                 // we use f1 col for v2 tables due to schema pruning
                 s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
               case _ => false

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV1SchemaPruningSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV1SchemaPruningSuite.scala
@@ -16,8 +16,31 @@
  */
 package org.apache.spark.sql.execution.datasources.orc
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import io.glutenproject.execution.FileSourceScanExecTransformer
+
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.tags.ExtendedSQLTest
 
 @ExtendedSQLTest
-class GlutenOrcV1SchemaPruningSuite extends OrcV1SchemaPruningSuite with GlutenSQLTestsBaseTrait {}
+class GlutenOrcV1SchemaPruningSuite extends OrcV1SchemaPruningSuite with GlutenSQLTestsBaseTrait {
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case scan: FileSourceScanExec => scan.requiredSchema
+        case scan: FileSourceScanExecTransformer => scan.requiredSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
+}

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -339,6 +339,10 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("Option recursiveFileLookup: disable partition inferring")
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
     .exclude("SPARK-35669: special char in CSV header with filter pushdown")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support partition pruning")
     .excludeGlutenTest("Spark native readers should respect spark.sql.caseSensitive - parquet")
     .excludeGlutenTest("SPARK-25237 compute correct input metrics in FileScanRDD")
     .excludeGlutenTest("Option recursiveFileLookup: disable partition inferring")
@@ -994,6 +998,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-33267: push down with condition 'in (..., null)' should not throw NPE")
   enableSuite[GlutenDeleteFromTableSuite]
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("Fallback Parquet V2 to V1")
   enableSuite[GlutenKeyGroupedPartitioningSuite]
     .exclude("partitioned join: number of buckets mismatch should trigger shuffle")
     .exclude("partitioned join: only one side reports partitioning")
@@ -1322,6 +1328,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcSourceSuite]
     .exclude("SPARK-24322 Fix incorrect workaround for bug in java.sql.Timestamp")
     .exclude("SPARK-31238: compatibility with Spark 2.4 in reading dates")
@@ -1330,6 +1341,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-31284, SPARK-31423: rebasing timestamps in write")
     .exclude("SPARK-36663: OrcUtils.toCatalystSchema should correctly handle a column name which consists of only numbers")
     .exclude("SPARK-37812: Reuse result row when deserializing a struct")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
     .excludeGlutenTest("SPARK-31238: compatibility with Spark 2.4 in reading dates")
     .excludeGlutenTest("SPARK-31238, SPARK-31423: rebasing dates in write")
     .excludeGlutenTest("SPARK-31284: compatibility with Spark 2.4 in reading timestamps")
@@ -1342,6 +1355,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcV1SchemaPruningSuite]
     .exclude(
       "Spark vectorized reader - without partition data column - select only top-level fields")
@@ -1528,6 +1546,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcV2SchemaPruningSuite]
     .exclude("Spark vectorized reader - without partition data column - select a single complex field from a map entry and its parent map entry")
     .exclude("Spark vectorized reader - with partition data column - select a single complex field from a map entry and its parent map entry")
@@ -2025,6 +2048,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-32767 Bucket join should work if SHUFFLE_PARTITIONS larger than bucket number")
     .exclude("bucket coalescing eliminates shuffle")
     .exclude("bucket coalescing is not satisfied")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("disable bucketing when the output doesn't contain all bucketing columns")
     .exclude(
       "bucket coalescing is applied when join expressions match with partitioning expressions")
   enableSuite[GlutenBucketedWriteWithoutHiveSupportSuite]
@@ -2033,6 +2058,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("create a table, drop it and create another one with the same name")
   enableSuite[GlutenDDLSourceLoadSuite]
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .disable(
+      "DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type")
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
   enableSuite[GlutenExternalCommandRunnerSuite]
   enableSuite[GlutenFilteredScanSuite]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -56,6 +56,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("partitioning reporting")
   enableSuite[GlutenDeleteFromTableSuite]
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("Fallback Parquet V2 to V1")
   enableSuite[GlutenKeyGroupedPartitioningSuite]
     // NEW SUITE: disable as they check vanilla spark plan
     .exclude("partitioned join: number of buckets mismatch should trigger shuffle")
@@ -877,6 +879,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-32767 Bucket join should work if SHUFFLE_PARTITIONS larger than bucket number")
     .exclude("bucket coalescing eliminates shuffle")
     .exclude("bucket coalescing is not satisfied")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("disable bucketing when the output doesn't contain all bucketing columns")
     .excludeByPrefix("bucket coalescing is applied when join expressions match")
   enableSuite[GlutenBucketedWriteWithoutHiveSupportSuite]
   enableSuite[GlutenCreateTableAsSelectSuite]
@@ -885,6 +889,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("create a table, drop it and create another one with the same name")
   enableSuite[GlutenDDLSourceLoadSuite]
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .disable(
+      "DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type")
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
   enableSuite[GlutenExternalCommandRunnerSuite]
   enableSuite[GlutenFilteredScanSuite]
@@ -1056,6 +1062,10 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-37585: test input metrics for DSV2 with output limits")
     // Unknown. Need to investigate.
     .exclude("SPARK-30362: test input metrics for DSV2")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support partition pruning")
   enableSuite[GlutenFileScanSuite]
   enableSuite[GlutenGeneratorFunctionSuite]
   enableSuite[GlutenInjectRuntimeFilterSuite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
@@ -443,7 +443,12 @@ abstract class GlutenDynamicPartitionPruningV1Suite extends GlutenDynamicPartiti
             find(plan) {
               case s: FileSourceScanExec =>
                 s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
+              case s: FileSourceScanExecTransformer =>
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
               case s: BatchScanExec =>
+                // we use f1 col for v2 tables due to schema pruning
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
+              case s: BatchScanExecTransformer =>
                 // we use f1 col for v2 tables due to schema pruning
                 s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
               case _ => false

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV2SchemaPruningSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV2SchemaPruningSuite.scala
@@ -16,7 +16,12 @@
  */
 package org.apache.spark.sql.execution.datasources.orc
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import io.glutenproject.execution.BatchScanExecTransformer
+
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -25,4 +30,23 @@ class GlutenOrcV2SchemaPruningSuite extends OrcV2SchemaPruningSuite with GlutenS
   // disable column reader for nested type
   override protected val vectorizedReaderNestedEnabledKey: String =
     SQLConf.PARQUET_VECTORIZED_READER_NESTED_COLUMN_ENABLED.key + "_DISABLED"
+
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case BatchScanExec(_, scan: OrcScan, _, _) => scan.readDataSchema
+        case BatchScanExecTransformer(_, scan: OrcScan, _, _, _, _, _, _, _) => scan.readDataSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetSchemaPruningSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetSchemaPruningSuite.scala
@@ -15,8 +15,14 @@
  * limitations under the License.
  */
 package org.apache.spark.sql.execution.datasources.parquet
+import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer}
+
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -30,6 +36,25 @@ class GlutenParquetV1SchemaPruningSuite
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.memory.offHeap.size", "3g")
   }
+
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case scan: FileSourceScanExec => scan.requiredSchema
+        case scan: FileSourceScanExecTransformer => scan.requiredSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
 }
 
 @ExtendedSQLTest
@@ -40,5 +65,24 @@ class GlutenParquetV2SchemaPruningSuite
     SQLConf.PARQUET_VECTORIZED_READER_NESTED_COLUMN_ENABLED.key + "_DISABLED"
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.memory.offHeap.size", "3g")
+  }
+
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case scan: BatchScanExec => scan.scan.asInstanceOf[ParquetScan].readDataSchema
+        case scan: BatchScanExecTransformer => scan.scan.asInstanceOf[ParquetScan].readDataSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.FileSourceScanExecTransformer
+import io.glutenproject.execution.FileSourceScanExecTransformerBase
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
@@ -27,17 +27,17 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
 
 /** Test for customer column rules */
-class TestFileSourceScanExecTransformer(
-    @transient relation: HadoopFsRelation,
-    output: Seq[Attribute],
-    requiredSchema: StructType,
-    partitionFilters: Seq[Expression],
-    optionalBucketSet: Option[BitSet],
-    optionalNumCoalescedBuckets: Option[Int],
-    dataFilters: Seq[Expression],
-    tableIdentifier: Option[TableIdentifier],
-    disableBucketedScan: Boolean = false)
-  extends FileSourceScanExecTransformer(
+case class TestFileSourceScanExecTransformer(
+    @transient override val relation: HadoopFsRelation,
+    override val output: Seq[Attribute],
+    override val requiredSchema: StructType,
+    override val partitionFilters: Seq[Expression],
+    override val optionalBucketSet: Option[BitSet],
+    override val optionalNumCoalescedBuckets: Option[Int],
+    override val dataFilters: Seq[Expression],
+    override val tableIdentifier: Option[TableIdentifier],
+    override val disableBucketedScan: Boolean = false)
+  extends FileSourceScanExecTransformerBase(
     relation,
     output,
     requiredSchema,

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -337,6 +337,12 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("Option recursiveFileLookup: disable partition inferring")
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
     .exclude("SPARK-35669: special char in CSV header with filter pushdown")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support partition pruning")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-41017: filter pushdown with nondeterministic predicates")
     .excludeGlutenTest("Spark native readers should respect spark.sql.caseSensitive - parquet")
     .excludeGlutenTest("SPARK-25237 compute correct input metrics in FileScanRDD")
     .excludeGlutenTest("Option recursiveFileLookup: disable partition inferring")
@@ -772,6 +778,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-33267: push down with condition 'in (..., null)' should not throw NPE")
   enableSuite[GlutenDeleteFromTableSuite]
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("Fallback Parquet V2 to V1")
   enableSuite[GlutenKeyGroupedPartitioningSuite]
     .exclude("partitioned join: number of buckets mismatch should trigger shuffle")
     .exclude("partitioned join: only one side reports partitioning")
@@ -1099,6 +1107,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcSourceSuite]
     .exclude("SPARK-24322 Fix incorrect workaround for bug in java.sql.Timestamp")
     .exclude("SPARK-31238: compatibility with Spark 2.4 in reading dates")
@@ -1107,6 +1120,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-31284, SPARK-31423: rebasing timestamps in write")
     .exclude("SPARK-36663: OrcUtils.toCatalystSchema should correctly handle a column name which consists of only numbers")
     .exclude("SPARK-37812: Reuse result row when deserializing a struct")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
     .excludeGlutenTest("SPARK-31238: compatibility with Spark 2.4 in reading dates")
     .excludeGlutenTest("SPARK-31238, SPARK-31423: rebasing dates in write")
     .excludeGlutenTest("SPARK-31284: compatibility with Spark 2.4 in reading timestamps")
@@ -1119,6 +1134,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcV1SchemaPruningSuite]
     .exclude(
       "Spark vectorized reader - without partition data column - select only top-level fields")
@@ -1305,6 +1325,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-27160 Predicate pushdown correctness on DecimalType for ORC")
     .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core")
     .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude(
+      "SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column")
   enableSuite[GlutenOrcV2SchemaPruningSuite]
     .exclude("Spark vectorized reader - without partition data column - select a single complex field from a map entry and its parent map entry")
     .exclude("Spark vectorized reader - with partition data column - select a single complex field from a map entry and its parent map entry")
@@ -1802,6 +1827,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-32767 Bucket join should work if SHUFFLE_PARTITIONS larger than bucket number")
     .exclude("bucket coalescing eliminates shuffle")
     .exclude("bucket coalescing is not satisfied")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("disable bucketing when the output doesn't contain all bucketing columns")
     .exclude(
       "bucket coalescing is applied when join expressions match with partitioning expressions")
   enableSuite[GlutenBucketedWriteWithoutHiveSupportSuite]
@@ -1810,6 +1837,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("create a table, drop it and create another one with the same name")
   enableSuite[GlutenDDLSourceLoadSuite]
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .disable(
+      "DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type")
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
   enableSuite[GlutenExternalCommandRunnerSuite]
   enableSuite[GlutenFilteredScanSuite]

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -58,6 +58,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("ordering and partitioning reporting")
   enableSuite[GlutenDeleteFromTableSuite]
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("Fallback Parquet V2 to V1")
   enableSuite[GlutenKeyGroupedPartitioningSuite]
     // NEW SUITE: disable as they check vanilla spark plan
     .exclude("partitioned join: number of buckets mismatch should trigger shuffle")
@@ -871,6 +873,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-32767 Bucket join should work if SHUFFLE_PARTITIONS larger than bucket number")
     .exclude("bucket coalescing eliminates shuffle")
     .exclude("bucket coalescing is not satisfied")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("disable bucketing when the output doesn't contain all bucketing columns")
     .excludeByPrefix("bucket coalescing is applied when join expressions match")
   enableSuite[GlutenBucketedWriteWithoutHiveSupportSuite]
   enableSuite[GlutenCreateTableAsSelectSuite]
@@ -879,6 +883,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("create a table, drop it and create another one with the same name")
   enableSuite[GlutenDDLSourceLoadSuite]
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .disable(
+      "DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type")
   enableSuite[GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
   enableSuite[GlutenExternalCommandRunnerSuite]
   enableSuite[GlutenFilteredScanSuite]
@@ -1056,6 +1062,12 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-37585: test input metrics for DSV2 with output limits")
     // TODO(yuan): fix the input bytes on ORC code path
     .exclude("SPARK-30362: test input metrics for DSV2")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("File source v2: support partition pruning")
+    // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
+    .exclude("SPARK-41017: filter pushdown with nondeterministic predicates")
   enableSuite[GlutenFileScanSuite]
   enableSuite[GlutenGeneratorFunctionSuite]
   enableSuite[GlutenInjectRuntimeFilterSuite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
@@ -475,7 +475,12 @@ abstract class GlutenDynamicPartitionPruningV1Suite extends GlutenDynamicPartiti
             find(plan) {
               case s: FileSourceScanExec =>
                 s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
+              case s: FileSourceScanExecTransformer =>
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
               case s: BatchScanExec =>
+                // we use f1 col for v2 tables due to schema pruning
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
+              case s: BatchScanExecTransformer =>
                 // we use f1 col for v2 tables due to schema pruning
                 s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
               case _ => false
@@ -486,6 +491,7 @@ abstract class GlutenDynamicPartitionPruningV1Suite extends GlutenDynamicPartiti
 
         def getDriverMetrics(plan: SparkPlan, key: String): Option[SQLMetric] = plan match {
           case fs: FileSourceScanExec => fs.driverMetrics.get(key)
+          case fs: FileSourceScanExecTransformer => fs.driverMetrics.get(key)
           case _ => None
         }
 
@@ -609,6 +615,7 @@ class GlutenDynamicPartitionPruningV1SuiteAEOff
 
         def getDriverMetrics(plan: SparkPlan, key: String): Option[SQLMetric] = plan match {
           case fs: FileSourceScanExec => fs.driverMetrics.get(key)
+          case fs: FileSourceScanExecTransformer => fs.driverMetrics.get(key)
           case _ => None
         }
 

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV2SchemaPruningSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV2SchemaPruningSuite.scala
@@ -16,7 +16,12 @@
  */
 package org.apache.spark.sql.execution.datasources.orc
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import io.glutenproject.execution.BatchScanExecTransformer
+
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -25,4 +30,23 @@ class GlutenOrcV2SchemaPruningSuite extends OrcV2SchemaPruningSuite with GlutenS
   // disable column reader for nested type
   override protected val vectorizedReaderNestedEnabledKey: String =
     SQLConf.PARQUET_VECTORIZED_READER_NESTED_COLUMN_ENABLED.key + "_DISABLED"
+
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case BatchScanExec(_, scan: OrcScan, _, _, _, _, _, _, _) => scan.readDataSchema
+        case BatchScanExecTransformer(_, scan: OrcScan, _, _, _, _, _, _, _) => scan.readDataSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
 }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetSchemaPruningSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetSchemaPruningSuite.scala
@@ -15,8 +15,14 @@
  * limitations under the License.
  */
 package org.apache.spark.sql.execution.datasources.parquet
+import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer}
+
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -30,6 +36,25 @@ class GlutenParquetV1SchemaPruningSuite
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.memory.offHeap.size", "3g")
   }
+
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case scan: FileSourceScanExec => scan.requiredSchema
+        case scan: FileSourceScanExecTransformer => scan.requiredSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
 }
 
 @ExtendedSQLTest
@@ -40,5 +65,24 @@ class GlutenParquetV2SchemaPruningSuite
     SQLConf.PARQUET_VECTORIZED_READER_NESTED_COLUMN_ENABLED.key + "_DISABLED"
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.memory.offHeap.size", "3g")
+  }
+
+  override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case scan: BatchScanExec => scan.scan.asInstanceOf[ParquetScan].readDataSchema
+        case scan: BatchScanExecTransformer => scan.scan.asInstanceOf[ParquetScan].readDataSchema
+      }
+    assert(
+      fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings"
+    )
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
   }
 }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.FileSourceScanExecTransformer
+import io.glutenproject.execution.FileSourceScanExecTransformerBase
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
@@ -27,17 +27,17 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
 
 /** Test for customer column rules */
-class TestFileSourceScanExecTransformer(
-    @transient relation: HadoopFsRelation,
-    output: Seq[Attribute],
-    requiredSchema: StructType,
-    partitionFilters: Seq[Expression],
-    optionalBucketSet: Option[BitSet],
-    optionalNumCoalescedBuckets: Option[Int],
-    dataFilters: Seq[Expression],
-    tableIdentifier: Option[TableIdentifier],
-    disableBucketedScan: Boolean = false)
-  extends FileSourceScanExecTransformer(
+case class TestFileSourceScanExecTransformer(
+    @transient override val relation: HadoopFsRelation,
+    override val output: Seq[Attribute],
+    override val requiredSchema: StructType,
+    override val partitionFilters: Seq[Expression],
+    override val optionalBucketSet: Option[BitSet],
+    override val optionalNumCoalescedBuckets: Option[Int],
+    override val dataFilters: Seq[Expression],
+    override val tableIdentifier: Option[TableIdentifier],
+    override val disableBucketedScan: Boolean = false)
+  extends FileSourceScanExecTransformerBase(
     relation,
     output,
     requiredSchema,

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -1,12 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.execution
 
-import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
-import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -16,32 +30,45 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
 
+import org.apache.hadoop.fs.Path
+
 import java.util.concurrent.TimeUnit._
+
 import scala.collection.mutable.HashMap
+
 /**
  * Physical plan node for scanning data from HadoopFsRelations.
  *
- * @param relation The file-based relation to scan.
- * @param output Output attributes of the scan, including data attributes and partition attributes.
- * @param requiredSchema Required schema of the underlying relation, excluding partition columns.
- * @param partitionFilters Predicates to use for partition pruning.
- * @param optionalBucketSet Bucket ids for bucket pruning.
- * @param optionalNumCoalescedBuckets Number of coalesced buckets.
- * @param dataFilters Filters on non-partition columns.
- * @param tableIdentifier Identifier for the table in the metastore.
- * @param disableBucketedScan Disable bucketed scan based on physical query plan, see rule
- *                            [[DisableUnnecessaryBucketedScan]] for details.
+ * @param relation
+ *   The file-based relation to scan.
+ * @param output
+ *   Output attributes of the scan, including data attributes and partition attributes.
+ * @param requiredSchema
+ *   Required schema of the underlying relation, excluding partition columns.
+ * @param partitionFilters
+ *   Predicates to use for partition pruning.
+ * @param optionalBucketSet
+ *   Bucket ids for bucket pruning.
+ * @param optionalNumCoalescedBuckets
+ *   Number of coalesced buckets.
+ * @param dataFilters
+ *   Filters on non-partition columns.
+ * @param tableIdentifier
+ *   Identifier for the table in the metastore.
+ * @param disableBucketedScan
+ *   Disable bucketed scan based on physical query plan, see rule [[DisableUnnecessaryBucketedScan]]
+ *   for details.
  */
-case class AbstractFileSourceScanExec(
-                               @transient relation: HadoopFsRelation,
-                               output: Seq[Attribute],
-                               requiredSchema: StructType,
-                               partitionFilters: Seq[Expression],
-                               optionalBucketSet: Option[BitSet],
-                               optionalNumCoalescedBuckets: Option[Int],
-                               dataFilters: Seq[Expression],
-                               tableIdentifier: Option[TableIdentifier],
-                               disableBucketedScan: Boolean = false)
+abstract class AbstractFileSourceScanExec(
+    @transient relation: HadoopFsRelation,
+    output: Seq[Attribute],
+    requiredSchema: StructType,
+    partitionFilters: Seq[Expression],
+    optionalBucketSet: Option[BitSet],
+    optionalNumCoalescedBuckets: Option[Int],
+    dataFilters: Seq[Expression],
+    tableIdentifier: Option[TableIdentifier],
+    disableBucketedScan: Boolean = false)
   extends DataSourceScanExec {
 
   // Note that some vals referring the file-based relation are lazy intentionally
@@ -67,13 +94,15 @@ case class AbstractFileSourceScanExec(
   private lazy val driverMetrics: HashMap[String, Long] = HashMap.empty
 
   /**
-   * Send the driver-side metrics. Before calling this function, selectedPartitions has
-   * been initialized. See SPARK-26327 for more details.
+   * Send the driver-side metrics. Before calling this function, selectedPartitions has been
+   * initialized. See SPARK-26327 for more details.
    */
   private def sendDriverMetrics(): Unit = {
     driverMetrics.foreach(e => metrics(e._1).add(e._2))
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,
+    SQLMetrics.postDriverMetricUpdates(
+      sparkContext,
+      executionId,
       metrics.filter(e => driverMetrics.contains(e._1)).values.toSeq)
   }
 
@@ -84,11 +113,10 @@ case class AbstractFileSourceScanExec(
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
     val ret =
-      relation.location.listFiles(
-        partitionFilters.filterNot(isDynamicPruningFilter), dataFilters)
+      relation.location.listFiles(partitionFilters.filterNot(isDynamicPruningFilter), dataFilters)
     setFilesNumAndSizeMetric(ret, true)
-    val timeTakenMs = NANOSECONDS.toMillis(
-      (System.nanoTime() - startTime) + optimizerMetadataTimeNs)
+    val timeTakenMs =
+      NANOSECONDS.toMillis((System.nanoTime() - startTime) + optimizerMetadataTimeNs)
     driverMetrics("metadataTime") = timeTakenMs
     ret
   }.toArray
@@ -104,11 +132,14 @@ case class AbstractFileSourceScanExec(
       // call the file index for the files matching all filters except dynamic partition filters
       val predicate = dynamicPartitionFilters.reduce(And)
       val partitionColumns = relation.partitionSchema
-      val boundPredicate = Predicate.create(predicate.transform {
-        case a: AttributeReference =>
-          val index = partitionColumns.indexWhere(a.name == _.name)
-          BoundReference(index, partitionColumns(index).dataType, nullable = true)
-      }, Nil)
+      val boundPredicate = Predicate.create(
+        predicate.transform {
+          case a: AttributeReference =>
+            val index = partitionColumns.indexWhere(a.name == _.name)
+            BoundReference(index, partitionColumns(index).dataType, nullable = true)
+        },
+        Nil
+      )
       val ret = selectedPartitions.filter(p => boundPredicate.eval(p.values))
       setFilesNumAndSizeMetric(ret, false)
       val timeTakenMs = (System.nanoTime() - startTime) / 1000 / 1000
@@ -132,8 +163,10 @@ case class AbstractFileSourceScanExec(
 
   // exposed for testing
   lazy val bucketedScan: Boolean = {
-    if (relation.sparkSession.sessionState.conf.bucketingEnabled && relation.bucketSpec.isDefined
-      && !disableBucketedScan) {
+    if (
+      relation.sparkSession.sessionState.conf.bucketingEnabled && relation.bucketSpec.isDefined
+      && !disableBucketedScan
+    ) {
       val spec = relation.bucketSpec.get
       val bucketColumns = spec.bucketColumnNames.flatMap(n => toAttribute(n))
       bucketColumns.size == spec.bucketColumnNames.size
@@ -222,44 +255,48 @@ case class AbstractFileSourceScanExec(
         "PartitionFilters" -> seqToString(partitionFilters),
         "PushedFilters" -> seqToString(pushedDownFilters),
         "DataFilters" -> seqToString(dataFilters),
-        "Location" -> locationDesc)
+        "Location" -> locationDesc
+      )
 
     // TODO(SPARK-32986): Add bucketed scan info in explain output of AbstractFileSourceScanExec
     if (bucketedScan) {
-      relation.bucketSpec.map { spec =>
-        val numSelectedBuckets = optionalBucketSet.map { b =>
-          b.cardinality()
-        } getOrElse {
-          spec.numBuckets
+      relation.bucketSpec
+        .map {
+          spec =>
+            val numSelectedBuckets = optionalBucketSet.map(b => b.cardinality()).getOrElse {
+              spec.numBuckets
+            }
+            metadata + ("SelectedBucketsCount" ->
+              (s"$numSelectedBuckets out of ${spec.numBuckets}" +
+                optionalNumCoalescedBuckets.map(b => s" (Coalesced to $b)").getOrElse("")))
         }
-        metadata + ("SelectedBucketsCount" ->
-          (s"$numSelectedBuckets out of ${spec.numBuckets}" +
-            optionalNumCoalescedBuckets.map { b => s" (Coalesced to $b)"}.getOrElse("")))
-      } getOrElse {
-        metadata
-      }
+        .getOrElse {
+          metadata
+        }
     } else {
       metadata
     }
   }
 
   override def verboseStringWithOperatorId(): String = {
-    val metadataStr = metadata.toSeq.sorted.filterNot {
-      case (_, value) if (value.isEmpty || value.equals("[]")) => true
-      case (key, _) if (key.equals("DataFilters") || key.equals("Format")) => true
-      case (_, _) => false
-    }.map {
-      case (key, _) if (key.equals("Location")) =>
-        val location = relation.location
-        val numPaths = location.rootPaths.length
-        val abbreviatedLocation = if (numPaths <= 1) {
-          location.rootPaths.mkString("[", ", ", "]")
-        } else {
-          "[" + location.rootPaths.head + s", ... ${numPaths - 1} entries]"
-        }
-        s"$key: ${location.getClass.getSimpleName} ${redact(abbreviatedLocation)}"
-      case (key, value) => s"$key: ${redact(value)}"
-    }
+    val metadataStr = metadata.toSeq.sorted
+      .filterNot {
+        case (_, value) if (value.isEmpty || value.equals("[]")) => true
+        case (key, _) if (key.equals("DataFilters") || key.equals("Format")) => true
+        case (_, _) => false
+      }
+      .map {
+        case (key, _) if (key.equals("Location")) =>
+          val location = relation.location
+          val numPaths = location.rootPaths.length
+          val abbreviatedLocation = if (numPaths <= 1) {
+            location.rootPaths.mkString("[", ", ", "]")
+          } else {
+            "[" + location.rootPaths.head + s", ... ${numPaths - 1} entries]"
+          }
+          s"$key: ${location.getClass.getSimpleName} ${redact(abbreviatedLocation)}"
+        case (key, value) => s"$key: ${redact(value)}"
+      }
 
     s"""
        |$formattedNodeName
@@ -277,10 +314,14 @@ case class AbstractFileSourceScanExec(
         requiredSchema = requiredSchema,
         filters = pushedDownFilters,
         options = relation.options,
-        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options))
+        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options)
+      )
 
     val readRDD = if (bucketedScan) {
-      createBucketedReadRDD(relation.bucketSpec.get, readFile, dynamicallySelectedPartitions,
+      createBucketedReadRDD(
+        relation.bucketSpec.get,
+        readFile,
+        dynamicallySelectedPartitions,
         relation)
     } else {
       createReadRDD(readFile, dynamicallySelectedPartitions, relation)
@@ -295,16 +336,18 @@ case class AbstractFileSourceScanExec(
 
   /** SQL metrics generated only for scans using dynamic partition pruning. */
   private lazy val staticMetrics = if (partitionFilters.exists(isDynamicPruningFilter)) {
-    Map("staticFilesNum" -> SQLMetrics.createMetric(sparkContext, "static number of files read"),
-      "staticFilesSize" -> SQLMetrics.createSizeMetric(sparkContext, "static size of files read"))
+    Map(
+      "staticFilesNum" -> SQLMetrics.createMetric(sparkContext, "static number of files read"),
+      "staticFilesSize" -> SQLMetrics.createSizeMetric(sparkContext, "static size of files read")
+    )
   } else {
     Map.empty[String, SQLMetric]
   }
 
   /** Helper for computing total number and size of files in selected partitions. */
   private def setFilesNumAndSizeMetric(
-                                        partitions: Seq[PartitionDirectory],
-                                        static: Boolean): Unit = {
+      partitions: Seq[PartitionDirectory],
+      static: Boolean): Unit = {
     val filesNum = partitions.map(_.files.size.toLong).sum
     val filesSize = partitions.map(_.files.map(_.getLen).sum).sum
     if (!static || !partitionFilters.exists(isDynamicPruningFilter)) {
@@ -337,131 +380,152 @@ case class AbstractFileSourceScanExec(
       Map(
         "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions read"),
         "pruningTime" ->
-          SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time"))
+          SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time")
+      )
     } else {
       Map.empty[String, SQLMetric]
     }
   } ++ staticMetrics
 
-  protected override def doExecute(): RDD[InternalRow] = {
+  override protected def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     if (needsUnsafeRowConversion) {
-      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-        val toUnsafe = UnsafeProjection.create(schema)
-        toUnsafe.initialize(index)
-        iter.map { row =>
-          numOutputRows += 1
-          toUnsafe(row)
-        }
+      inputRDD.mapPartitionsWithIndexInternal {
+        (index, iter) =>
+          val toUnsafe = UnsafeProjection.create(schema)
+          toUnsafe.initialize(index)
+          iter.map {
+            row =>
+              numOutputRows += 1
+              toUnsafe(row)
+          }
       }
     } else {
-      inputRDD.mapPartitionsInternal { iter =>
-        iter.map { row =>
-          numOutputRows += 1
-          row
-        }
+      inputRDD.mapPartitionsInternal {
+        iter =>
+          iter.map {
+            row =>
+              numOutputRows += 1
+              row
+          }
       }
     }
   }
 
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val numOutputRows = longMetric("numOutputRows")
     val scanTime = longMetric("scanTime")
-    inputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal { batches =>
-      new Iterator[ColumnarBatch] {
+    inputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal {
+      batches =>
+        new Iterator[ColumnarBatch] {
 
-        override def hasNext: Boolean = {
-          // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
-          val startNs = System.nanoTime()
-          val res = batches.hasNext
-          scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
-          res
-        }
+          override def hasNext: Boolean = {
+            // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
+            val startNs = System.nanoTime()
+            val res = batches.hasNext
+            scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+            res
+          }
 
-        override def next(): ColumnarBatch = {
-          val batch = batches.next()
-          numOutputRows += batch.numRows()
-          batch
+          override def next(): ColumnarBatch = {
+            val batch = batches.next()
+            numOutputRows += batch.numRows()
+            batch
+          }
         }
-      }
     }
   }
 
   override val nodeNamePrefix: String = "File"
 
   /**
-   * Create an RDD for bucketed reads.
-   * The non-bucketed variant of this function is [[createReadRDD]].
+   * Create an RDD for bucketed reads. The non-bucketed variant of this function is
+   * [[createReadRDD]].
    *
    * The algorithm is pretty simple: each RDD partition being returned should include all the files
    * with the same bucket id from all the given Hive partitions.
    *
-   * @param bucketSpec the bucketing spec.
-   * @param readFile a function to read each (part of a) file.
-   * @param selectedPartitions Hive-style partition that are part of the read.
-   * @param fsRelation [[HadoopFsRelation]] associated with the read.
+   * @param bucketSpec
+   *   the bucketing spec.
+   * @param readFile
+   *   a function to read each (part of a) file.
+   * @param selectedPartitions
+   *   Hive-style partition that are part of the read.
+   * @param fsRelation
+   *   [[HadoopFsRelation]] associated with the read.
    */
   private def createBucketedReadRDD(
-                                     bucketSpec: BucketSpec,
-                                     readFile: (PartitionedFile) => Iterator[InternalRow],
-                                     selectedPartitions: Array[PartitionDirectory],
-                                     fsRelation: HadoopFsRelation): RDD[InternalRow] = {
+      bucketSpec: BucketSpec,
+      readFile: (PartitionedFile) => Iterator[InternalRow],
+      selectedPartitions: Array[PartitionDirectory],
+      fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     logInfo(s"Planning with ${bucketSpec.numBuckets} buckets")
     val filesGroupedToBuckets =
-      selectedPartitions.flatMap { p =>
-        p.files.map { f =>
-          PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values)
+      selectedPartitions
+        .flatMap {
+          p => p.files.map(f => PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values))
         }
-      }.groupBy { f =>
-        BucketingUtils
-          .getBucketId(new Path(f.filePath).getName)
-          .getOrElse(throw new IllegalStateException(s"Invalid bucket file ${f.filePath}"))
-      }
+        .groupBy {
+          f =>
+            BucketingUtils
+              .getBucketId(new Path(f.filePath).getName)
+              .getOrElse(throw new IllegalStateException(s"Invalid bucket file ${f.filePath}"))
+        }
 
     val prunedFilesGroupedToBuckets = if (optionalBucketSet.isDefined) {
       val bucketSet = optionalBucketSet.get
-      filesGroupedToBuckets.filter {
-        f => bucketSet.get(f._1)
-      }
+      filesGroupedToBuckets.filter(f => bucketSet.get(f._1))
     } else {
       filesGroupedToBuckets
     }
 
-    val filePartitions = optionalNumCoalescedBuckets.map { numCoalescedBuckets =>
-      logInfo(s"Coalescing to ${numCoalescedBuckets} buckets")
-      val coalescedBuckets = prunedFilesGroupedToBuckets.groupBy(_._1 % numCoalescedBuckets)
-      Seq.tabulate(numCoalescedBuckets) { bucketId =>
-        val partitionedFiles = coalescedBuckets.get(bucketId).map {
-          _.values.flatten.toArray
-        }.getOrElse(Array.empty)
-        FilePartition(bucketId, partitionedFiles)
+    val filePartitions = optionalNumCoalescedBuckets
+      .map {
+        numCoalescedBuckets =>
+          logInfo(s"Coalescing to $numCoalescedBuckets buckets")
+          val coalescedBuckets = prunedFilesGroupedToBuckets.groupBy(_._1 % numCoalescedBuckets)
+          Seq.tabulate(numCoalescedBuckets) {
+            bucketId =>
+              val partitionedFiles = coalescedBuckets
+                .get(bucketId)
+                .map {
+                  _.values.flatten.toArray
+                }
+                .getOrElse(Array.empty)
+              FilePartition(bucketId, partitionedFiles)
+          }
       }
-    }.getOrElse {
-      Seq.tabulate(bucketSpec.numBuckets) { bucketId =>
-        FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
+      .getOrElse {
+        Seq.tabulate(bucketSpec.numBuckets) {
+          bucketId =>
+            FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
+        }
       }
-    }
 
     new FileScanRDD(fsRelation.sparkSession, readFile, filePartitions)
   }
 
   /**
-   * Create an RDD for non-bucketed reads.
-   * The bucketed variant of this function is [[createBucketedReadRDD]].
+   * Create an RDD for non-bucketed reads. The bucketed variant of this function is
+   * [[createBucketedReadRDD]].
    *
-   * @param readFile a function to read each (part of a) file.
-   * @param selectedPartitions Hive-style partition that are part of the read.
-   * @param fsRelation [[HadoopFsRelation]] associated with the read.
+   * @param readFile
+   *   a function to read each (part of a) file.
+   * @param selectedPartitions
+   *   Hive-style partition that are part of the read.
+   * @param fsRelation
+   *   [[HadoopFsRelation]] associated with the read.
    */
   private def createReadRDD(
-                             readFile: (PartitionedFile) => Iterator[InternalRow],
-                             selectedPartitions: Array[PartitionDirectory],
-                             fsRelation: HadoopFsRelation): RDD[InternalRow] = {
+      readFile: (PartitionedFile) => Iterator[InternalRow],
+      selectedPartitions: Array[PartitionDirectory],
+      fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
     val maxSplitBytes =
       FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions)
-    logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-      s"open cost is considered as scanning $openCostInBytes bytes.")
+    logInfo(
+      s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+        s"open cost is considered as scanning $openCostInBytes bytes.")
 
     // Filter files with bucket pruning if possible
     val bucketingEnabled = fsRelation.sparkSession.sessionState.conf.bucketingEnabled
@@ -473,27 +537,31 @@ case class AbstractFileSourceScanExec(
         _ => true
     }
 
-    val splitFiles = selectedPartitions.flatMap { partition =>
-      partition.files.flatMap { file =>
-        // getPath() is very expensive so we only want to call it once in this block:
-        val filePath = file.getPath
+    val splitFiles = selectedPartitions
+      .flatMap {
+        partition =>
+          partition.files.flatMap {
+            file =>
+              // getPath() is very expensive so we only want to call it once in this block:
+              val filePath = file.getPath
 
-        if (shouldProcess(filePath)) {
-          val isSplitable = relation.fileFormat.isSplitable(
-            relation.sparkSession, relation.options, filePath)
-          PartitionedFileUtil.splitFiles(
-            sparkSession = relation.sparkSession,
-            file = file,
-            filePath = filePath,
-            isSplitable = isSplitable,
-            maxSplitBytes = maxSplitBytes,
-            partitionValues = partition.values
-          )
-        } else {
-          Seq.empty
-        }
+              if (shouldProcess(filePath)) {
+                val isSplitable =
+                  relation.fileFormat.isSplitable(relation.sparkSession, relation.options, filePath)
+                PartitionedFileUtil.splitFiles(
+                  sparkSession = relation.sparkSession,
+                  file = file,
+                  filePath = filePath,
+                  isSplitable = isSplitable,
+                  maxSplitBytes = maxSplitBytes,
+                  partitionValues = partition.values
+                )
+              } else {
+                Seq.empty
+              }
+          }
       }
-    }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+      .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
 
     val partitions =
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
@@ -503,22 +571,8 @@ case class AbstractFileSourceScanExec(
 
   // Filters unused DynamicPruningExpression expressions - one which has been replaced
   // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
-  private def filterUnusedDynamicPruningExpressions(
-                                                     predicates: Seq[Expression]): Seq[Expression] = {
+  protected def filterUnusedDynamicPruningExpressions(
+      predicates: Seq[Expression]): Seq[Expression] = {
     predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
-  }
-
-  override def doCanonicalize(): AbstractFileSourceScanExec = {
-    AbstractFileSourceScanExec(
-      relation,
-      output.map(QueryPlan.normalizeExpressions(_, output)),
-      requiredSchema,
-      QueryPlan.normalizePredicates(
-        filterUnusedDynamicPruningExpressions(partitionFilters), output),
-      optionalBucketSet,
-      optionalNumCoalescedBuckets,
-      QueryPlan.normalizePredicates(dataFilters, output),
-      None,
-      disableBucketedScan)
   }
 }

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -29,17 +29,17 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.mutable
 
-class FileSourceScanExecShim(
-    @transient relation: HadoopFsRelation,
-    output: Seq[Attribute],
-    requiredSchema: StructType,
-    partitionFilters: Seq[Expression],
-    optionalBucketSet: Option[BitSet],
-    optionalNumCoalescedBuckets: Option[Int],
-    dataFilters: Seq[Expression],
-    tableIdentifier: Option[TableIdentifier],
-    disableBucketedScan: Boolean = false)
-  extends FileSourceScanExec(
+abstract class FileSourceScanExecShim(
+    @transient val relation: HadoopFsRelation,
+    val output: Seq[Attribute],
+    val requiredSchema: StructType,
+    val partitionFilters: Seq[Expression],
+    val optionalBucketSet: Option[BitSet],
+    val optionalNumCoalescedBuckets: Option[Int],
+    val dataFilters: Seq[Expression],
+    val tableIdentifier: Option[TableIdentifier],
+    val disableBucketedScan: Boolean = false)
+  extends AbstractFileSourceScanExec(
     relation,
     output,
     requiredSchema,
@@ -52,16 +52,6 @@ class FileSourceScanExecShim(
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map()
-
-  override def equals(other: Any): Boolean = other match {
-    case that: FileSourceScanExecShim =>
-      (that.canEqual(this)) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSourceScanExecShim]
 
   def hasMetadataColumns: Boolean = false
 

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
@@ -27,17 +27,17 @@ import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class BatchScanExecShim(
-    output: Seq[AttributeReference],
-    @transient scan: Scan,
-    runtimeFilters: Seq[Expression],
-    keyGroupedPartitioning: Option[Seq[Expression]] = None,
-    ordering: Option[Seq[SortOrder]] = None,
-    @transient table: Table,
-    commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
-    applyPartialClustering: Boolean = false,
-    replicatePartitions: Boolean = false)
-  extends BatchScanExec(output, scan, runtimeFilters) {
+abstract class BatchScanExecShim(
+    val output: Seq[AttributeReference],
+    @transient val scan: Scan,
+    override val runtimeFilters: Seq[Expression],
+    val keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    val ordering: Option[Seq[SortOrder]] = None,
+    @transient val table: Table,
+    val commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
+    val applyPartialClustering: Boolean = false,
+    val replicatePartitions: Boolean = false)
+  extends AbstractBatchScanExec(output, scan, runtimeFilters) {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map()
@@ -45,16 +45,6 @@ class BatchScanExecShim(
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     throw new UnsupportedOperationException("Need to implement this method")
   }
-
-  override def equals(other: Any): Boolean = other match {
-    case that: BatchScanExecShim =>
-      (that.canEqual(this)) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[BatchScanExecShim]
 
   // to comply v3.3. and v3.2, change return type from Seq[InputPartition] to current
   @transient protected lazy val filteredPartitions: Seq[Seq[InputPartition]] = {

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.CastSupport
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.hive._
+import org.apache.spark.sql.hive.client.HiveClientImpl
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BooleanType, DataType}
+import org.apache.spark.util.Utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
+import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.serde.serdeConstants
+import org.apache.hadoop.hive.serde2.objectinspector._
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils
+
+import scala.collection.JavaConverters._
+
+/**
+ * The Hive table scan operator. Column and partition pruning are both handled.
+ *
+ * @param requestedAttributes
+ *   Attributes to be fetched from the Hive table.
+ * @param relation
+ *   The Hive table be scanned.
+ * @param partitionPruningPred
+ *   An optional partition pruning predicate for partitioned table.
+ */
+abstract private[hive] class AbstractHiveTableScanExec(
+    requestedAttributes: Seq[Attribute],
+    relation: HiveTableRelation,
+    partitionPruningPred: Seq[Expression])(@transient protected val sparkSession: SparkSession)
+  extends LeafExecNode
+  with CastSupport {
+
+  require(
+    partitionPruningPred.isEmpty || relation.isPartitioned,
+    "Partition pruning predicates only supported for partitioned tables.")
+
+  override def conf: SQLConf = sparkSession.sessionState.conf
+
+  override def nodeName: String = s"Scan hive ${relation.tableMeta.qualifiedName}"
+
+  override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+
+  override def producedAttributes: AttributeSet = outputSet ++
+    AttributeSet(partitionPruningPred.flatMap(_.references))
+
+  private val originalAttributes = AttributeMap(relation.output.map(a => a -> a))
+
+  override val output: Seq[Attribute] = {
+    // Retrieve the original attributes based on expression ID so that capitalization matches.
+    requestedAttributes.map(originalAttributes)
+  }
+
+  // Bind all partition key attribute references in the partition pruning predicate for later
+  // evaluation.
+  private lazy val boundPruningPred = partitionPruningPred.reduceLeftOption(And).map {
+    pred =>
+      require(
+        pred.dataType == BooleanType,
+        s"Data type of predicate $pred must be ${BooleanType.catalogString} rather than " +
+          s"${pred.dataType.catalogString}.")
+
+      BindReferences.bindReference(pred, relation.partitionCols)
+  }
+
+  @transient private lazy val hiveQlTable = HiveClientImpl.toHiveTable(relation.tableMeta)
+  @transient private lazy val tableDesc = new TableDesc(
+    hiveQlTable.getInputFormatClass,
+    hiveQlTable.getOutputFormatClass,
+    hiveQlTable.getMetadata)
+
+  // Create a local copy of hadoopConf,so that scan specific modifications should not impact
+  // other queries
+  @transient private lazy val hadoopConf = {
+    val c = sparkSession.sessionState.newHadoopConf()
+    // append columns ids and names before broadcast
+    addColumnMetadataToConf(c)
+    c
+  }
+
+  @transient private lazy val hadoopReader =
+    new HadoopTableReader(output, relation.partitionCols, tableDesc, sparkSession, hadoopConf)
+
+  private def castFromString(value: String, dataType: DataType) = {
+    cast(Literal(value), dataType).eval(null)
+  }
+
+  private def addColumnMetadataToConf(hiveConf: Configuration): Unit = {
+    // Specifies needed column IDs for those non-partitioning columns.
+    val columnOrdinals = AttributeMap(relation.dataCols.zipWithIndex)
+    val neededColumnIDs = output.flatMap(columnOrdinals.get).map(o => o: Integer)
+    val neededColumnNames = output.filter(columnOrdinals.contains).map(_.name)
+
+    HiveShim.appendReadColumns(hiveConf, neededColumnIDs, neededColumnNames)
+
+    val deserializer = tableDesc.getDeserializerClass.getConstructor().newInstance()
+    deserializer.initialize(hiveConf, tableDesc.getProperties)
+
+    // Specifies types and object inspectors of columns to be scanned.
+    val structOI = ObjectInspectorUtils
+      .getStandardObjectInspector(deserializer.getObjectInspector, ObjectInspectorCopyOption.JAVA)
+      .asInstanceOf[StructObjectInspector]
+
+    val columnTypeNames = structOI.getAllStructFieldRefs.asScala
+      .map(_.getFieldObjectInspector)
+      .map(TypeInfoUtils.getTypeInfoFromObjectInspector(_).getTypeName)
+      .mkString(",")
+
+    hiveConf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeNames)
+    hiveConf.set(serdeConstants.LIST_COLUMNS, relation.dataCols.map(_.name).mkString(","))
+  }
+
+  /**
+   * Prunes partitions not involve the query plan.
+   *
+   * @param partitions
+   *   All partitions of the relation.
+   * @return
+   *   Partitions that are involved in the query plan.
+   */
+  private[hive] def prunePartitions(partitions: Seq[HivePartition]): Seq[HivePartition] = {
+    boundPruningPred match {
+      case None => partitions
+      case Some(shouldKeep) =>
+        partitions.filter {
+          part =>
+            val dataTypes = relation.partitionCols.map(_.dataType)
+            val castedValues = part.getValues.asScala
+              .zip(dataTypes)
+              .map { case (value, dataType) => castFromString(value, dataType) }
+
+            // Only partitioned values are needed here, since the predicate has already been
+            // bound to partition key attribute references.
+            val row = InternalRow.fromSeq(castedValues.toSeq)
+            shouldKeep.eval(row).asInstanceOf[Boolean]
+        }
+    }
+  }
+
+  @transient lazy val prunedPartitions: Seq[HivePartition] = {
+    if (relation.prunedPartitions.nonEmpty) {
+      val hivePartitions =
+        relation.prunedPartitions.get.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+      if (partitionPruningPred.forall(!ExecSubqueryExpression.hasSubquery(_))) {
+        hivePartitions
+      } else {
+        prunePartitions(hivePartitions)
+      }
+    } else {
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        rawPartitions
+      } else {
+        prunePartitions(rawPartitions)
+      }
+    }
+  }
+
+  // exposed for tests
+  @transient lazy val rawPartitions: Seq[HivePartition] = {
+    val prunedPartitions =
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        // Retrieve the original attributes based on expression ID so that capitalization matches.
+        val normalizedFilters = partitionPruningPred.map(_.transform {
+          case a: AttributeReference => originalAttributes(a)
+        })
+        sparkSession.sessionState.catalog
+          .listPartitionsByFilter(relation.tableMeta.identifier, normalizedFilters)
+      } else {
+        sparkSession.sessionState.catalog.listPartitions(relation.tableMeta.identifier)
+      }
+    prunedPartitions.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    // Using dummyCallSite, as getCallSite can turn out to be expensive with
+    // multiple partitions.
+    val rdd = if (!relation.isPartitioned) {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForTable(hiveQlTable)
+      }
+    } else {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForPartitionedTable(prunedPartitions)
+      }
+    }
+    val numOutputRows = longMetric("numOutputRows")
+    // Avoid to serialize MetastoreRelation because schema is lazy. (see SPARK-15649)
+    val outputSchema = schema
+    rdd.mapPartitionsWithIndexInternal {
+      (index, iter) =>
+        val proj = UnsafeProjection.create(outputSchema)
+        proj.initialize(index)
+        iter.map {
+          r =>
+            numOutputRows += 1
+            proj(r)
+        }
+    }
+  }
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(sparkSession)
+}

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -14,60 +14,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql.execution
-import java.util.concurrent.TimeUnit._
-
-import scala.collection.mutable.HashMap
-
-import org.apache.commons.lang3.StringUtils
-import org.apache.hadoop.fs.Path
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
-import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
-import org.apache.spark.sql.execution.datasources.v2.PushedDownOperators
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
 
+import org.apache.hadoop.fs.Path
+
+import java.util.concurrent.TimeUnit._
+
+import scala.collection.mutable.HashMap
 
 /**
  * Physical plan node for scanning data from HadoopFsRelations.
  *
- * @param relation The file-based relation to scan.
- * @param output Output attributes of the scan, including data attributes and partition attributes.
- * @param requiredSchema Required schema of the underlying relation, excluding partition columns.
- * @param partitionFilters Predicates to use for partition pruning.
- * @param optionalBucketSet Bucket ids for bucket pruning.
- * @param optionalNumCoalescedBuckets Number of coalesced buckets.
- * @param dataFilters Filters on non-partition columns.
- * @param tableIdentifier Identifier for the table in the metastore.
- * @param disableBucketedScan Disable bucketed scan based on physical query plan, see rule
- *                            [[DisableUnnecessaryBucketedScan]] for details.
+ * @param relation
+ *   The file-based relation to scan.
+ * @param output
+ *   Output attributes of the scan, including data attributes and partition attributes.
+ * @param requiredSchema
+ *   Required schema of the underlying relation, excluding partition columns.
+ * @param partitionFilters
+ *   Predicates to use for partition pruning.
+ * @param optionalBucketSet
+ *   Bucket ids for bucket pruning.
+ * @param optionalNumCoalescedBuckets
+ *   Number of coalesced buckets.
+ * @param dataFilters
+ *   Filters on non-partition columns.
+ * @param tableIdentifier
+ *   Identifier for the table in the metastore.
+ * @param disableBucketedScan
+ *   Disable bucketed scan based on physical query plan, see rule [[DisableUnnecessaryBucketedScan]]
+ *   for details.
  */
-case class AbstractFileSourceScanExec(
-                               @transient relation: HadoopFsRelation,
-                               output: Seq[Attribute],
-                               requiredSchema: StructType,
-                               partitionFilters: Seq[Expression],
-                               optionalBucketSet: Option[BitSet],
-                               optionalNumCoalescedBuckets: Option[Int],
-                               dataFilters: Seq[Expression],
-                               tableIdentifier: Option[TableIdentifier],
-                               disableBucketedScan: Boolean = false)
+abstract class AbstractFileSourceScanExec(
+    @transient override val relation: HadoopFsRelation,
+    override val output: Seq[Attribute],
+    requiredSchema: StructType,
+    partitionFilters: Seq[Expression],
+    optionalBucketSet: Option[BitSet],
+    optionalNumCoalescedBuckets: Option[Int],
+    dataFilters: Seq[Expression],
+    override val tableIdentifier: Option[TableIdentifier],
+    disableBucketedScan: Boolean = false)
   extends DataSourceScanExec {
 
   lazy val metadataColumns: Seq[AttributeReference] =
@@ -88,24 +90,29 @@ case class AbstractFileSourceScanExec(
   }
 
   override def vectorTypes: Option[Seq[String]] =
-    relation.fileFormat.vectorTypes(
-      requiredSchema = requiredSchema,
-      partitionSchema = relation.partitionSchema,
-      relation.sparkSession.sessionState.conf).map { vectorTypes =>
-      // for column-based file format, append metadata column's vector type classes if any
-      vectorTypes ++ Seq.fill(metadataColumns.size)(classOf[ConstantColumnVector].getName)
-    }
+    relation.fileFormat
+      .vectorTypes(
+        requiredSchema = requiredSchema,
+        partitionSchema = relation.partitionSchema,
+        relation.sparkSession.sessionState.conf)
+      .map {
+        vectorTypes =>
+          // for column-based file format, append metadata column's vector type classes if any
+          vectorTypes ++ Seq.fill(metadataColumns.size)(classOf[ConstantColumnVector].getName)
+      }
 
   private lazy val driverMetrics: HashMap[String, Long] = HashMap.empty
 
   /**
-   * Send the driver-side metrics. Before calling this function, selectedPartitions has
-   * been initialized. See SPARK-26327 for more details.
+   * Send the driver-side metrics. Before calling this function, selectedPartitions has been
+   * initialized. See SPARK-26327 for more details.
    */
   private def sendDriverMetrics(): Unit = {
     driverMetrics.foreach(e => metrics(e._1).add(e._2))
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,
+    SQLMetrics.postDriverMetricUpdates(
+      sparkContext,
+      executionId,
       metrics.filter(e => driverMetrics.contains(e._1)).values.toSeq)
   }
 
@@ -116,11 +123,10 @@ case class AbstractFileSourceScanExec(
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
     val ret =
-      relation.location.listFiles(
-        partitionFilters.filterNot(isDynamicPruningFilter), dataFilters)
+      relation.location.listFiles(partitionFilters.filterNot(isDynamicPruningFilter), dataFilters)
     setFilesNumAndSizeMetric(ret, true)
-    val timeTakenMs = NANOSECONDS.toMillis(
-      (System.nanoTime() - startTime) + optimizerMetadataTimeNs)
+    val timeTakenMs =
+      NANOSECONDS.toMillis((System.nanoTime() - startTime) + optimizerMetadataTimeNs)
     driverMetrics("metadataTime") = timeTakenMs
     ret
   }.toArray
@@ -136,11 +142,14 @@ case class AbstractFileSourceScanExec(
       // call the file index for the files matching all filters except dynamic partition filters
       val predicate = dynamicPartitionFilters.reduce(And)
       val partitionColumns = relation.partitionSchema
-      val boundPredicate = Predicate.create(predicate.transform {
-        case a: AttributeReference =>
-          val index = partitionColumns.indexWhere(a.name == _.name)
-          BoundReference(index, partitionColumns(index).dataType, nullable = true)
-      }, Nil)
+      val boundPredicate = Predicate.create(
+        predicate.transform {
+          case a: AttributeReference =>
+            val index = partitionColumns.indexWhere(a.name == _.name)
+            BoundReference(index, partitionColumns(index).dataType, nullable = true)
+        },
+        Nil
+      )
       val ret = selectedPartitions.filter(p => boundPredicate.eval(p.values))
       setFilesNumAndSizeMetric(ret, false)
       val timeTakenMs = (System.nanoTime() - startTime) / 1000 / 1000
@@ -164,8 +173,10 @@ case class AbstractFileSourceScanExec(
 
   // exposed for testing
   lazy val bucketedScan: Boolean = {
-    if (relation.sparkSession.sessionState.conf.bucketingEnabled && relation.bucketSpec.isDefined
-      && !disableBucketedScan) {
+    if (
+      relation.sparkSession.sessionState.conf.bucketingEnabled && relation.bucketSpec.isDefined
+      && !disableBucketedScan
+    ) {
       val spec = relation.bucketSpec.get
       val bucketColumns = spec.bucketColumnNames.flatMap(n => toAttribute(n))
       bucketColumns.size == spec.bucketColumnNames.size
@@ -240,10 +251,12 @@ case class AbstractFileSourceScanExec(
     // `dataFilters` should not include any metadata col filters
     // because the metadata struct has been flatted in FileSourceStrategy
     // and thus metadata col filters are invalid to be pushed down
-    dataFilters.filterNot(_.references.exists {
-      case FileSourceMetadataAttribute(_) => true
-      case _ => false
-    }).flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
+    dataFilters
+      .filterNot(_.references.exists {
+        case FileSourceMetadataAttribute(_) => true
+        case _ => false
+      })
+      .flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
   }
 
   override lazy val metadata: Map[String, String] = {
@@ -260,49 +273,54 @@ case class AbstractFileSourceScanExec(
         "PartitionFilters" -> seqToString(partitionFilters),
         "PushedFilters" -> seqToString(pushedDownFilters),
         "DataFilters" -> seqToString(dataFilters),
-        "Location" -> locationDesc)
+        "Location" -> locationDesc
+      )
 
-    relation.bucketSpec.map { spec =>
-      val bucketedKey = "Bucketed"
-      if (bucketedScan) {
-        val numSelectedBuckets = optionalBucketSet.map { b =>
-          b.cardinality()
-        } getOrElse {
-          spec.numBuckets
-        }
-        metadata ++ Map(
-          bucketedKey -> "true",
-          "SelectedBucketsCount" -> (s"$numSelectedBuckets out of ${spec.numBuckets}" +
-            optionalNumCoalescedBuckets.map { b => s" (Coalesced to $b)"}.getOrElse("")))
-      } else if (!relation.sparkSession.sessionState.conf.bucketingEnabled) {
-        metadata + (bucketedKey -> "false (disabled by configuration)")
-      } else if (disableBucketedScan) {
-        metadata + (bucketedKey -> "false (disabled by query planner)")
-      } else {
-        metadata + (bucketedKey -> "false (bucket column(s) not read)")
+    relation.bucketSpec
+      .map {
+        spec =>
+          val bucketedKey = "Bucketed"
+          if (bucketedScan) {
+            val numSelectedBuckets = optionalBucketSet.map(b => b.cardinality()).getOrElse {
+              spec.numBuckets
+            }
+            metadata ++ Map(
+              bucketedKey -> "true",
+              "SelectedBucketsCount" -> (s"$numSelectedBuckets out of ${spec.numBuckets}" +
+                optionalNumCoalescedBuckets.map(b => s" (Coalesced to $b)").getOrElse(""))
+            )
+          } else if (!relation.sparkSession.sessionState.conf.bucketingEnabled) {
+            metadata + (bucketedKey -> "false (disabled by configuration)")
+          } else if (disableBucketedScan) {
+            metadata + (bucketedKey -> "false (disabled by query planner)")
+          } else {
+            metadata + (bucketedKey -> "false (bucket column(s) not read)")
+          }
       }
-    } getOrElse {
-      metadata
-    }
+      .getOrElse {
+        metadata
+      }
   }
 
   override def verboseStringWithOperatorId(): String = {
-    val metadataStr = metadata.toSeq.sorted.filterNot {
-      case (_, value) if (value.isEmpty || value.equals("[]")) => true
-      case (key, _) if (key.equals("DataFilters") || key.equals("Format")) => true
-      case (_, _) => false
-    }.map {
-      case (key, _) if (key.equals("Location")) =>
-        val location = relation.location
-        val numPaths = location.rootPaths.length
-        val abbreviatedLocation = if (numPaths <= 1) {
-          location.rootPaths.mkString("[", ", ", "]")
-        } else {
-          "[" + location.rootPaths.head + s", ... ${numPaths - 1} entries]"
-        }
-        s"$key: ${location.getClass.getSimpleName} ${redact(abbreviatedLocation)}"
-      case (key, value) => s"$key: ${redact(value)}"
-    }
+    val metadataStr = metadata.toSeq.sorted
+      .filterNot {
+        case (_, value) if (value.isEmpty || value.equals("[]")) => true
+        case (key, _) if (key.equals("DataFilters") || key.equals("Format")) => true
+        case (_, _) => false
+      }
+      .map {
+        case (key, _) if (key.equals("Location")) =>
+          val location = relation.location
+          val numPaths = location.rootPaths.length
+          val abbreviatedLocation = if (numPaths <= 1) {
+            location.rootPaths.mkString("[", ", ", "]")
+          } else {
+            "[" + location.rootPaths.head + s", ... ${numPaths - 1} entries]"
+          }
+          s"$key: ${location.getClass.getSimpleName} ${redact(abbreviatedLocation)}"
+        case (key, value) => s"$key: ${redact(value)}"
+      }
 
     s"""
        |$formattedNodeName
@@ -320,10 +338,14 @@ case class AbstractFileSourceScanExec(
         requiredSchema = requiredSchema,
         filters = pushedDownFilters,
         options = relation.options,
-        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options))
+        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options)
+      )
 
     val readRDD = if (bucketedScan) {
-      createBucketedReadRDD(relation.bucketSpec.get, readFile, dynamicallySelectedPartitions,
+      createBucketedReadRDD(
+        relation.bucketSpec.get,
+        readFile,
+        dynamicallySelectedPartitions,
         relation)
     } else {
       createReadRDD(readFile, dynamicallySelectedPartitions, relation)
@@ -338,16 +360,18 @@ case class AbstractFileSourceScanExec(
 
   /** SQL metrics generated only for scans using dynamic partition pruning. */
   private lazy val staticMetrics = if (partitionFilters.exists(isDynamicPruningFilter)) {
-    Map("staticFilesNum" -> SQLMetrics.createMetric(sparkContext, "static number of files read"),
-      "staticFilesSize" -> SQLMetrics.createSizeMetric(sparkContext, "static size of files read"))
+    Map(
+      "staticFilesNum" -> SQLMetrics.createMetric(sparkContext, "static number of files read"),
+      "staticFilesSize" -> SQLMetrics.createSizeMetric(sparkContext, "static size of files read")
+    )
   } else {
     Map.empty[String, SQLMetric]
   }
 
   /** Helper for computing total number and size of files in selected partitions. */
   private def setFilesNumAndSizeMetric(
-                                        partitions: Seq[PartitionDirectory],
-                                        static: Boolean): Unit = {
+      partitions: Seq[PartitionDirectory],
+      static: Boolean): Unit = {
     val filesNum = partitions.map(_.files.size.toLong).sum
     val filesSize = partitions.map(_.files.map(_.getLen).sum).sum
     if (!static || !partitionFilters.exists(isDynamicPruningFilter)) {
@@ -380,132 +404,157 @@ case class AbstractFileSourceScanExec(
       Map(
         "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions read"),
         "pruningTime" ->
-          SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time"))
+          SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time")
+      )
     } else {
       Map.empty[String, SQLMetric]
     }
   } ++ staticMetrics
 
-  protected override def doExecute(): RDD[InternalRow] = {
+  override protected def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     if (needsUnsafeRowConversion) {
-      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-        val toUnsafe = UnsafeProjection.create(schema)
-        toUnsafe.initialize(index)
-        iter.map { row =>
-          numOutputRows += 1
-          toUnsafe(row)
-        }
+      inputRDD.mapPartitionsWithIndexInternal {
+        (index, iter) =>
+          val toUnsafe = UnsafeProjection.create(schema)
+          toUnsafe.initialize(index)
+          iter.map {
+            row =>
+              numOutputRows += 1
+              toUnsafe(row)
+          }
       }
     } else {
-      inputRDD.mapPartitionsInternal { iter =>
-        iter.map { row =>
-          numOutputRows += 1
-          row
-        }
+      inputRDD.mapPartitionsInternal {
+        iter =>
+          iter.map {
+            row =>
+              numOutputRows += 1
+              row
+          }
       }
     }
   }
 
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val numOutputRows = longMetric("numOutputRows")
     val scanTime = longMetric("scanTime")
-    inputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal { batches =>
-      new Iterator[ColumnarBatch] {
+    inputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal {
+      batches =>
+        new Iterator[ColumnarBatch] {
 
-        override def hasNext: Boolean = {
-          // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
-          val startNs = System.nanoTime()
-          val res = batches.hasNext
-          scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
-          res
-        }
+          override def hasNext: Boolean = {
+            // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
+            val startNs = System.nanoTime()
+            val res = batches.hasNext
+            scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+            res
+          }
 
-        override def next(): ColumnarBatch = {
-          val batch = batches.next()
-          numOutputRows += batch.numRows()
-          batch
+          override def next(): ColumnarBatch = {
+            val batch = batches.next()
+            numOutputRows += batch.numRows()
+            batch
+          }
         }
-      }
     }
   }
 
   override val nodeNamePrefix: String = "File"
 
   /**
-   * Create an RDD for bucketed reads.
-   * The non-bucketed variant of this function is [[createReadRDD]].
+   * Create an RDD for bucketed reads. The non-bucketed variant of this function is
+   * [[createReadRDD]].
    *
    * The algorithm is pretty simple: each RDD partition being returned should include all the files
    * with the same bucket id from all the given Hive partitions.
    *
-   * @param bucketSpec the bucketing spec.
-   * @param readFile a function to read each (part of a) file.
-   * @param selectedPartitions Hive-style partition that are part of the read.
-   * @param fsRelation [[HadoopFsRelation]] associated with the read.
+   * @param bucketSpec
+   *   the bucketing spec.
+   * @param readFile
+   *   a function to read each (part of a) file.
+   * @param selectedPartitions
+   *   Hive-style partition that are part of the read.
+   * @param fsRelation
+   *   [[HadoopFsRelation]] associated with the read.
    */
   private def createBucketedReadRDD(
-                                     bucketSpec: BucketSpec,
-                                     readFile: (PartitionedFile) => Iterator[InternalRow],
-                                     selectedPartitions: Array[PartitionDirectory],
-                                     fsRelation: HadoopFsRelation): RDD[InternalRow] = {
+      bucketSpec: BucketSpec,
+      readFile: (PartitionedFile) => Iterator[InternalRow],
+      selectedPartitions: Array[PartitionDirectory],
+      fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     logInfo(s"Planning with ${bucketSpec.numBuckets} buckets")
     val filesGroupedToBuckets =
-      selectedPartitions.flatMap { p =>
-        p.files.map { f =>
-          PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values)
+      selectedPartitions
+        .flatMap {
+          p => p.files.map(f => PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values))
         }
-      }.groupBy { f =>
-        BucketingUtils
-          .getBucketId(new Path(f.filePath).getName)
-          .getOrElse(throw QueryExecutionErrors.invalidBucketFile(f.filePath))
-      }
+        .groupBy {
+          f =>
+            BucketingUtils
+              .getBucketId(new Path(f.filePath).getName)
+              .getOrElse(throw QueryExecutionErrors.invalidBucketFile(f.filePath))
+        }
 
     val prunedFilesGroupedToBuckets = if (optionalBucketSet.isDefined) {
       val bucketSet = optionalBucketSet.get
-      filesGroupedToBuckets.filter {
-        f => bucketSet.get(f._1)
-      }
+      filesGroupedToBuckets.filter(f => bucketSet.get(f._1))
     } else {
       filesGroupedToBuckets
     }
 
-    val filePartitions = optionalNumCoalescedBuckets.map { numCoalescedBuckets =>
-      logInfo(s"Coalescing to ${numCoalescedBuckets} buckets")
-      val coalescedBuckets = prunedFilesGroupedToBuckets.groupBy(_._1 % numCoalescedBuckets)
-      Seq.tabulate(numCoalescedBuckets) { bucketId =>
-        val partitionedFiles = coalescedBuckets.get(bucketId).map {
-          _.values.flatten.toArray
-        }.getOrElse(Array.empty)
-        FilePartition(bucketId, partitionedFiles)
+    val filePartitions = optionalNumCoalescedBuckets
+      .map {
+        numCoalescedBuckets =>
+          logInfo(s"Coalescing to $numCoalescedBuckets buckets")
+          val coalescedBuckets = prunedFilesGroupedToBuckets.groupBy(_._1 % numCoalescedBuckets)
+          Seq.tabulate(numCoalescedBuckets) {
+            bucketId =>
+              val partitionedFiles = coalescedBuckets
+                .get(bucketId)
+                .map {
+                  _.values.flatten.toArray
+                }
+                .getOrElse(Array.empty)
+              FilePartition(bucketId, partitionedFiles)
+          }
       }
-    }.getOrElse {
-      Seq.tabulate(bucketSpec.numBuckets) { bucketId =>
-        FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
+      .getOrElse {
+        Seq.tabulate(bucketSpec.numBuckets) {
+          bucketId =>
+            FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
+        }
       }
-    }
 
-    new FileScanRDD(fsRelation.sparkSession, readFile, filePartitions,
-      new StructType(requiredSchema.fields ++ fsRelation.partitionSchema.fields), metadataColumns)
+    new FileScanRDD(
+      fsRelation.sparkSession,
+      readFile,
+      filePartitions,
+      new StructType(requiredSchema.fields ++ fsRelation.partitionSchema.fields),
+      metadataColumns)
   }
 
   /**
-   * Create an RDD for non-bucketed reads.
-   * The bucketed variant of this function is [[createBucketedReadRDD]].
+   * Create an RDD for non-bucketed reads. The bucketed variant of this function is
+   * [[createBucketedReadRDD]].
    *
-   * @param readFile a function to read each (part of a) file.
-   * @param selectedPartitions Hive-style partition that are part of the read.
-   * @param fsRelation [[HadoopFsRelation]] associated with the read.
+   * @param readFile
+   *   a function to read each (part of a) file.
+   * @param selectedPartitions
+   *   Hive-style partition that are part of the read.
+   * @param fsRelation
+   *   [[HadoopFsRelation]] associated with the read.
    */
   private def createReadRDD(
-                             readFile: (PartitionedFile) => Iterator[InternalRow],
-                             selectedPartitions: Array[PartitionDirectory],
-                             fsRelation: HadoopFsRelation): RDD[InternalRow] = {
+      readFile: (PartitionedFile) => Iterator[InternalRow],
+      selectedPartitions: Array[PartitionDirectory],
+      fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
     val maxSplitBytes =
       FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions)
-    logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-      s"open cost is considered as scanning $openCostInBytes bytes.")
+    logInfo(
+      s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+        s"open cost is considered as scanning $openCostInBytes bytes.")
 
     // Filter files with bucket pruning if possible
     val bucketingEnabled = fsRelation.sparkSession.sessionState.conf.bucketingEnabled
@@ -517,53 +566,47 @@ case class AbstractFileSourceScanExec(
         _ => true
     }
 
-    val splitFiles = selectedPartitions.flatMap { partition =>
-      partition.files.flatMap { file =>
-        // getPath() is very expensive so we only want to call it once in this block:
-        val filePath = file.getPath
+    val splitFiles = selectedPartitions
+      .flatMap {
+        partition =>
+          partition.files.flatMap {
+            file =>
+              // getPath() is very expensive so we only want to call it once in this block:
+              val filePath = file.getPath
 
-        if (shouldProcess(filePath)) {
-          val isSplitable = relation.fileFormat.isSplitable(
-            relation.sparkSession, relation.options, filePath)
-          PartitionedFileUtil.splitFiles(
-            sparkSession = relation.sparkSession,
-            file = file,
-            filePath = filePath,
-            isSplitable = isSplitable,
-            maxSplitBytes = maxSplitBytes,
-            partitionValues = partition.values
-          )
-        } else {
-          Seq.empty
-        }
+              if (shouldProcess(filePath)) {
+                val isSplitable =
+                  relation.fileFormat.isSplitable(relation.sparkSession, relation.options, filePath)
+                PartitionedFileUtil.splitFiles(
+                  sparkSession = relation.sparkSession,
+                  file = file,
+                  filePath = filePath,
+                  isSplitable = isSplitable,
+                  maxSplitBytes = maxSplitBytes,
+                  partitionValues = partition.values
+                )
+              } else {
+                Seq.empty
+              }
+          }
       }
-    }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+      .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
 
     val partitions =
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
 
-    new FileScanRDD(fsRelation.sparkSession, readFile, partitions,
-      new StructType(requiredSchema.fields ++ fsRelation.partitionSchema.fields), metadataColumns)
+    new FileScanRDD(
+      fsRelation.sparkSession,
+      readFile,
+      partitions,
+      new StructType(requiredSchema.fields ++ fsRelation.partitionSchema.fields),
+      metadataColumns)
   }
 
   // Filters unused DynamicPruningExpression expressions - one which has been replaced
   // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
-  private def filterUnusedDynamicPruningExpressions(
-                                                     predicates: Seq[Expression]): Seq[Expression] = {
+  protected def filterUnusedDynamicPruningExpressions(
+      predicates: Seq[Expression]): Seq[Expression] = {
     predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
-  }
-
-  override def doCanonicalize(): AbstractFileSourceScanExec = {
-    AbstractFileSourceScanExec(
-      relation,
-      output.map(QueryPlan.normalizeExpressions(_, output)),
-      requiredSchema,
-      QueryPlan.normalizePredicates(
-        filterUnusedDynamicPruningExpressions(partitionFilters), output),
-      optionalBucketSet,
-      optionalNumCoalescedBuckets,
-      QueryPlan.normalizePredicates(dataFilters, output),
-      None,
-      disableBucketedScan)
   }
 }

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -30,17 +30,17 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.mutable
 
-class FileSourceScanExecShim(
-    @transient relation: HadoopFsRelation,
-    output: Seq[Attribute],
-    requiredSchema: StructType,
-    partitionFilters: Seq[Expression],
-    optionalBucketSet: Option[BitSet],
-    optionalNumCoalescedBuckets: Option[Int],
-    dataFilters: Seq[Expression],
-    tableIdentifier: Option[TableIdentifier],
-    disableBucketedScan: Boolean = false)
-  extends FileSourceScanExec(
+abstract class FileSourceScanExecShim(
+    @transient override val relation: HadoopFsRelation,
+    override val output: Seq[Attribute],
+    val requiredSchema: StructType,
+    val partitionFilters: Seq[Expression],
+    val optionalBucketSet: Option[BitSet],
+    val optionalNumCoalescedBuckets: Option[Int],
+    val dataFilters: Seq[Expression],
+    override val tableIdentifier: Option[TableIdentifier],
+    val disableBucketedScan: Boolean = false)
+  extends AbstractFileSourceScanExec(
     relation,
     output,
     requiredSchema,
@@ -53,16 +53,6 @@ class FileSourceScanExecShim(
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map()
-
-  override def equals(other: Any): Boolean = other match {
-    case that: FileSourceScanExecShim =>
-      (that.canEqual(this)) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSourceScanExecShim]
 
   def hasMetadataColumns: Boolean = metadataColumns.nonEmpty
 

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AbstractBatchScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AbstractBatchScanExec.scala
@@ -14,27 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, SinglePartition}
-import org.apache.spark.sql.catalyst.util.InternalRowSet
-import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, PartitionReaderFactory, Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowSet}
+import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 
 import com.google.common.base.Objects
 
 /** Physical plan node for scanning a batch of data from a data source v2. */
-case class AbstractBatchScanExec(
+abstract class AbstractBatchScanExec(
     output: Seq[AttributeReference],
     @transient scan: Scan,
-    runtimeFilters: Seq[Expression],
+    val runtimeFilters: Seq[Expression],
     keyGroupedPartitioning: Option[Seq[Expression]] = None)
   extends DataSourceV2ScanExecBase {
 
@@ -121,15 +118,6 @@ case class AbstractBatchScanExec(
         supportsColumnar,
         customMetrics)
     }
-  }
-
-  override def doCanonicalize(): AbstractBatchScanExec = {
-    this.copy(
-      output = output.map(QueryPlan.normalizeExpressions(_, output)),
-      runtimeFilters = QueryPlan.normalizePredicates(
-        runtimeFilters.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral)),
-        output)
-    )
   }
 
   override def simpleString(maxFields: Int): String = {

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.CastSupport
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.hive._
+import org.apache.spark.sql.hive.client.HiveClientImpl
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BooleanType, DataType}
+import org.apache.spark.util.Utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
+import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.serde.serdeConstants
+import org.apache.hadoop.hive.serde2.objectinspector._
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils
+
+import scala.collection.JavaConverters._
+
+/**
+ * The Hive table scan operator. Column and partition pruning are both handled.
+ *
+ * @param requestedAttributes
+ *   Attributes to be fetched from the Hive table.
+ * @param relation
+ *   The Hive table be scanned.
+ * @param partitionPruningPred
+ *   An optional partition pruning predicate for partitioned table.
+ */
+abstract private[hive] class AbstractHiveTableScanExec(
+    requestedAttributes: Seq[Attribute],
+    relation: HiveTableRelation,
+    partitionPruningPred: Seq[Expression])(@transient protected val sparkSession: SparkSession)
+  extends LeafExecNode
+  with CastSupport {
+
+  require(
+    partitionPruningPred.isEmpty || relation.isPartitioned,
+    "Partition pruning predicates only supported for partitioned tables.")
+
+  override def conf: SQLConf = sparkSession.sessionState.conf
+
+  override def nodeName: String = s"Scan hive ${relation.tableMeta.qualifiedName}"
+
+  override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+
+  override def producedAttributes: AttributeSet = outputSet ++
+    AttributeSet(partitionPruningPred.flatMap(_.references))
+
+  private val originalAttributes = AttributeMap(relation.output.map(a => a -> a))
+
+  override val output: Seq[Attribute] = {
+    // Retrieve the original attributes based on expression ID so that capitalization matches.
+    requestedAttributes.map(originalAttributes)
+  }
+
+  // Bind all partition key attribute references in the partition pruning predicate for later
+  // evaluation.
+  private lazy val boundPruningPred = partitionPruningPred.reduceLeftOption(And).map {
+    pred =>
+      require(
+        pred.dataType == BooleanType,
+        s"Data type of predicate $pred must be ${BooleanType.catalogString} rather than " +
+          s"${pred.dataType.catalogString}.")
+
+      BindReferences.bindReference(pred, relation.partitionCols)
+  }
+
+  @transient private lazy val hiveQlTable = HiveClientImpl.toHiveTable(relation.tableMeta)
+  @transient private lazy val tableDesc = new TableDesc(
+    hiveQlTable.getInputFormatClass,
+    hiveQlTable.getOutputFormatClass,
+    hiveQlTable.getMetadata)
+
+  // Create a local copy of hadoopConf,so that scan specific modifications should not impact
+  // other queries
+  @transient private lazy val hadoopConf = {
+    val c = sparkSession.sessionState.newHadoopConf()
+    // append columns ids and names before broadcast
+    addColumnMetadataToConf(c)
+    c
+  }
+
+  @transient private lazy val hadoopReader =
+    new HadoopTableReader(output, relation.partitionCols, tableDesc, sparkSession, hadoopConf)
+
+  private def castFromString(value: String, dataType: DataType) = {
+    cast(Literal(value), dataType).eval(null)
+  }
+
+  private def addColumnMetadataToConf(hiveConf: Configuration): Unit = {
+    // Specifies needed column IDs for those non-partitioning columns.
+    val columnOrdinals = AttributeMap(relation.dataCols.zipWithIndex)
+    val neededColumnIDs = output.flatMap(columnOrdinals.get).map(o => o: Integer)
+    val neededColumnNames = output.filter(columnOrdinals.contains).map(_.name)
+
+    HiveShim.appendReadColumns(hiveConf, neededColumnIDs, neededColumnNames)
+
+    val deserializer = tableDesc.getDeserializerClass.getConstructor().newInstance()
+    deserializer.initialize(hiveConf, tableDesc.getProperties)
+
+    // Specifies types and object inspectors of columns to be scanned.
+    val structOI = ObjectInspectorUtils
+      .getStandardObjectInspector(deserializer.getObjectInspector, ObjectInspectorCopyOption.JAVA)
+      .asInstanceOf[StructObjectInspector]
+
+    val columnTypeNames = structOI.getAllStructFieldRefs.asScala
+      .map(_.getFieldObjectInspector)
+      .map(TypeInfoUtils.getTypeInfoFromObjectInspector(_).getTypeName)
+      .mkString(",")
+
+    hiveConf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeNames)
+    hiveConf.set(serdeConstants.LIST_COLUMNS, relation.dataCols.map(_.name).mkString(","))
+  }
+
+  /**
+   * Prunes partitions not involve the query plan.
+   *
+   * @param partitions
+   *   All partitions of the relation.
+   * @return
+   *   Partitions that are involved in the query plan.
+   */
+  private[hive] def prunePartitions(partitions: Seq[HivePartition]): Seq[HivePartition] = {
+    boundPruningPred match {
+      case None => partitions
+      case Some(shouldKeep) =>
+        partitions.filter {
+          part =>
+            val dataTypes = relation.partitionCols.map(_.dataType)
+            val castedValues = part.getValues.asScala
+              .zip(dataTypes)
+              .map { case (value, dataType) => castFromString(value, dataType) }
+
+            // Only partitioned values are needed here, since the predicate has
+            // already been bound to partition key attribute references.
+            val row = InternalRow.fromSeq(castedValues.toSeq)
+            shouldKeep.eval(row).asInstanceOf[Boolean]
+        }
+    }
+  }
+
+  @transient lazy val prunedPartitions: Seq[HivePartition] = {
+    if (relation.prunedPartitions.nonEmpty) {
+      val hivePartitions =
+        relation.prunedPartitions.get.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+      if (partitionPruningPred.forall(!ExecSubqueryExpression.hasSubquery(_))) {
+        hivePartitions
+      } else {
+        prunePartitions(hivePartitions)
+      }
+    } else {
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        rawPartitions
+      } else {
+        prunePartitions(rawPartitions)
+      }
+    }
+  }
+
+  // exposed for tests
+  @transient lazy val rawPartitions: Seq[HivePartition] = {
+    val prunedPartitions =
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        // Retrieve the original attributes based on expression ID so that capitalization matches.
+        val normalizedFilters = partitionPruningPred.map(_.transform {
+          case a: AttributeReference => originalAttributes(a)
+        })
+        sparkSession.sessionState.catalog
+          .listPartitionsByFilter(relation.tableMeta.identifier, normalizedFilters)
+      } else {
+        sparkSession.sessionState.catalog.listPartitions(relation.tableMeta.identifier)
+      }
+    prunedPartitions.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    // Using dummyCallSite, as getCallSite can turn out to be expensive with
+    // multiple partitions.
+    val rdd = if (!relation.isPartitioned) {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForTable(hiveQlTable)
+      }
+    } else {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForPartitionedTable(prunedPartitions)
+      }
+    }
+    val numOutputRows = longMetric("numOutputRows")
+    // Avoid to serialize MetastoreRelation because schema is lazy. (see SPARK-15649)
+    val outputSchema = schema
+    rdd.mapPartitionsWithIndexInternal {
+      (index, iter) =>
+        val proj = UnsafeProjection.create(outputSchema)
+        proj.initialize(index)
+        iter.map {
+          r =>
+            numOutputRows += 1
+            proj(r)
+        }
+    }
+  }
+
+  // Filters unused DynamicPruningExpression expressions - one which has been replaced
+  // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
+  private def filterUnusedDynamicPruningExpressions(
+      predicates: Seq[Expression]): Seq[Expression] = {
+    predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
+  }
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(sparkSession)
+}

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -1,54 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.execution
-
-import java.util.concurrent.TimeUnit._
-
-import org.apache.commons.lang3.StringUtils
-import org.apache.hadoop.fs.Path
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{FileSourceOptions, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, UnknownPartitioning}
-import org.apache.spark.sql.catalyst.util.{truncatedString, CaseInsensitiveMap}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat => ParquetSource}
-import org.apache.spark.sql.execution.datasources.v2.PushedDownOperators
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
-import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.BitSet
+
+import org.apache.hadoop.fs.Path
+
+import java.util.concurrent.TimeUnit._
 
 /**
  * Physical plan node for scanning data from HadoopFsRelations.
  *
- * @param relation The file-based relation to scan.
- * @param output Output attributes of the scan, including data attributes and partition attributes.
- * @param requiredSchema Required schema of the underlying relation, excluding partition columns.
- * @param partitionFilters Predicates to use for partition pruning.
- * @param optionalBucketSet Bucket ids for bucket pruning.
- * @param optionalNumCoalescedBuckets Number of coalesced buckets.
- * @param dataFilters Filters on non-partition columns.
- * @param tableIdentifier Identifier for the table in the metastore.
- * @param disableBucketedScan Disable bucketed scan based on physical query plan, see rule
- *                            [[DisableUnnecessaryBucketedScan]] for details.
+ * @param relation
+ *   The file-based relation to scan.
+ * @param output
+ *   Output attributes of the scan, including data attributes and partition attributes.
+ * @param requiredSchema
+ *   Required schema of the underlying relation, excluding partition columns.
+ * @param partitionFilters
+ *   Predicates to use for partition pruning.
+ * @param optionalBucketSet
+ *   Bucket ids for bucket pruning.
+ * @param optionalNumCoalescedBuckets
+ *   Number of coalesced buckets.
+ * @param dataFilters
+ *   Filters on non-partition columns.
+ * @param tableIdentifier
+ *   Identifier for the table in the metastore.
+ * @param disableBucketedScan
+ *   Disable bucketed scan based on physical query plan, see rule [[DisableUnnecessaryBucketedScan]]
+ *   for details.
  */
-case class AbstractFileSourceScanExec(
-                               @transient override val relation: HadoopFsRelation,
-                               override val output: Seq[Attribute],
-                               override val requiredSchema: StructType,
-                               override val partitionFilters: Seq[Expression],
-                               override val optionalBucketSet: Option[BitSet],
-                               override val optionalNumCoalescedBuckets: Option[Int],
-                               override val dataFilters: Seq[Expression],
-                               override val tableIdentifier: Option[TableIdentifier],
-                               override val disableBucketedScan: Boolean = false)
+abstract class AbstractFileSourceScanExec(
+    @transient override val relation: HadoopFsRelation,
+    override val output: Seq[Attribute],
+    override val requiredSchema: StructType,
+    override val partitionFilters: Seq[Expression],
+    override val optionalBucketSet: Option[BitSet],
+    override val optionalNumCoalescedBuckets: Option[Int],
+    override val dataFilters: Seq[Expression],
+    override val tableIdentifier: Option[TableIdentifier],
+    override val disableBucketedScan: Boolean = false)
   extends FileSourceScanLike {
 
   // Note that some vals referring the file-based relation are lazy intentionally
@@ -59,7 +75,7 @@ case class AbstractFileSourceScanExec(
     val requiredWholeStageCodegenSettings =
       conf.wholeStageEnabled && !WholeStageCodegenExec.isTooManyFields(conf, schema)
     requiredWholeStageCodegenSettings &&
-      relation.fileFormat.supportBatch(relation.sparkSession, schema)
+    relation.fileFormat.supportBatch(relation.sparkSession, schema)
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {
@@ -81,10 +97,14 @@ case class AbstractFileSourceScanExec(
         requiredSchema = requiredSchema,
         filters = pushedDownFilters,
         options = options,
-        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options))
+        hadoopConf = relation.sparkSession.sessionState.newHadoopConfWithOptions(relation.options)
+      )
 
     val readRDD = if (bucketedScan) {
-      createBucketedReadRDD(relation.bucketSpec.get, readFile, dynamicallySelectedPartitions,
+      createBucketedReadRDD(
+        relation.bucketSpec.get,
+        readFile,
+        dynamicallySelectedPartitions,
         relation)
     } else {
       createReadRDD(readFile, dynamicallySelectedPartitions, relation)
@@ -97,127 +117,152 @@ case class AbstractFileSourceScanExec(
     inputRDD :: Nil
   }
 
-  protected override def doExecute(): RDD[InternalRow] = {
+  override protected def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     if (needsUnsafeRowConversion) {
-      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-        val toUnsafe = UnsafeProjection.create(schema)
-        toUnsafe.initialize(index)
-        iter.map { row =>
-          numOutputRows += 1
-          toUnsafe(row)
-        }
+      inputRDD.mapPartitionsWithIndexInternal {
+        (index, iter) =>
+          val toUnsafe = UnsafeProjection.create(schema)
+          toUnsafe.initialize(index)
+          iter.map {
+            row =>
+              numOutputRows += 1
+              toUnsafe(row)
+          }
       }
     } else {
-      inputRDD.mapPartitionsInternal { iter =>
-        iter.map { row =>
-          numOutputRows += 1
-          row
-        }
+      inputRDD.mapPartitionsInternal {
+        iter =>
+          iter.map {
+            row =>
+              numOutputRows += 1
+              row
+          }
       }
     }
   }
 
-  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val numOutputRows = longMetric("numOutputRows")
     val scanTime = longMetric("scanTime")
-    inputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal { batches =>
-      new Iterator[ColumnarBatch] {
+    inputRDD.asInstanceOf[RDD[ColumnarBatch]].mapPartitionsInternal {
+      batches =>
+        new Iterator[ColumnarBatch] {
 
-        override def hasNext: Boolean = {
-          // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
-          val startNs = System.nanoTime()
-          val res = batches.hasNext
-          scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
-          res
-        }
+          override def hasNext: Boolean = {
+            // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
+            val startNs = System.nanoTime()
+            val res = batches.hasNext
+            scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+            res
+          }
 
-        override def next(): ColumnarBatch = {
-          val batch = batches.next()
-          numOutputRows += batch.numRows()
-          batch
+          override def next(): ColumnarBatch = {
+            val batch = batches.next()
+            numOutputRows += batch.numRows()
+            batch
+          }
         }
-      }
     }
   }
 
   override val nodeNamePrefix: String = "File"
 
   /**
-   * Create an RDD for bucketed reads.
-   * The non-bucketed variant of this function is [[createReadRDD]].
+   * Create an RDD for bucketed reads. The non-bucketed variant of this function is
+   * [[createReadRDD]].
    *
    * The algorithm is pretty simple: each RDD partition being returned should include all the files
    * with the same bucket id from all the given Hive partitions.
    *
-   * @param bucketSpec the bucketing spec.
-   * @param readFile a function to read each (part of a) file.
-   * @param selectedPartitions Hive-style partition that are part of the read.
-   * @param fsRelation [[HadoopFsRelation]] associated with the read.
+   * @param bucketSpec
+   *   the bucketing spec.
+   * @param readFile
+   *   a function to read each (part of a) file.
+   * @param selectedPartitions
+   *   Hive-style partition that are part of the read.
+   * @param fsRelation
+   *   [[HadoopFsRelation]] associated with the read.
    */
   private def createBucketedReadRDD(
-                                     bucketSpec: BucketSpec,
-                                     readFile: (PartitionedFile) => Iterator[InternalRow],
-                                     selectedPartitions: Array[PartitionDirectory],
-                                     fsRelation: HadoopFsRelation): RDD[InternalRow] = {
+      bucketSpec: BucketSpec,
+      readFile: (PartitionedFile) => Iterator[InternalRow],
+      selectedPartitions: Array[PartitionDirectory],
+      fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     logInfo(s"Planning with ${bucketSpec.numBuckets} buckets")
     val filesGroupedToBuckets =
-      selectedPartitions.flatMap { p =>
-        p.files.map { f =>
-          PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values)
+      selectedPartitions
+        .flatMap {
+          p => p.files.map(f => PartitionedFileUtil.getPartitionedFile(f, f.getPath, p.values))
         }
-      }.groupBy { f =>
-        BucketingUtils
-          .getBucketId(f.toPath.getName)
-          .getOrElse(throw QueryExecutionErrors.invalidBucketFile(f.urlEncodedPath))
-      }
+        .groupBy {
+          f =>
+            BucketingUtils
+              .getBucketId(f.toPath.getName)
+              .getOrElse(throw QueryExecutionErrors.invalidBucketFile(f.urlEncodedPath))
+        }
 
     val prunedFilesGroupedToBuckets = if (optionalBucketSet.isDefined) {
       val bucketSet = optionalBucketSet.get
-      filesGroupedToBuckets.filter {
-        f => bucketSet.get(f._1)
-      }
+      filesGroupedToBuckets.filter(f => bucketSet.get(f._1))
     } else {
       filesGroupedToBuckets
     }
 
-    val filePartitions = optionalNumCoalescedBuckets.map { numCoalescedBuckets =>
-      logInfo(s"Coalescing to ${numCoalescedBuckets} buckets")
-      val coalescedBuckets = prunedFilesGroupedToBuckets.groupBy(_._1 % numCoalescedBuckets)
-      Seq.tabulate(numCoalescedBuckets) { bucketId =>
-        val partitionedFiles = coalescedBuckets.get(bucketId).map {
-          _.values.flatten.toArray
-        }.getOrElse(Array.empty)
-        FilePartition(bucketId, partitionedFiles)
+    val filePartitions = optionalNumCoalescedBuckets
+      .map {
+        numCoalescedBuckets =>
+          logInfo(s"Coalescing to $numCoalescedBuckets buckets")
+          val coalescedBuckets = prunedFilesGroupedToBuckets.groupBy(_._1 % numCoalescedBuckets)
+          Seq.tabulate(numCoalescedBuckets) {
+            bucketId =>
+              val partitionedFiles = coalescedBuckets
+                .get(bucketId)
+                .map {
+                  _.values.flatten.toArray
+                }
+                .getOrElse(Array.empty)
+              FilePartition(bucketId, partitionedFiles)
+          }
       }
-    }.getOrElse {
-      Seq.tabulate(bucketSpec.numBuckets) { bucketId =>
-        FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
+      .getOrElse {
+        Seq.tabulate(bucketSpec.numBuckets) {
+          bucketId =>
+            FilePartition(bucketId, prunedFilesGroupedToBuckets.getOrElse(bucketId, Array.empty))
+        }
       }
-    }
 
-    new FileScanRDD(fsRelation.sparkSession, readFile, filePartitions,
+    new FileScanRDD(
+      fsRelation.sparkSession,
+      readFile,
+      filePartitions,
       new StructType(requiredSchema.fields ++ fsRelation.partitionSchema.fields),
-      fileConstantMetadataColumns, new FileSourceOptions(CaseInsensitiveMap(relation.options)))
+      fileConstantMetadataColumns,
+      new FileSourceOptions(CaseInsensitiveMap(relation.options))
+    )
   }
 
   /**
-   * Create an RDD for non-bucketed reads.
-   * The bucketed variant of this function is [[createBucketedReadRDD]].
+   * Create an RDD for non-bucketed reads. The bucketed variant of this function is
+   * [[createBucketedReadRDD]].
    *
-   * @param readFile a function to read each (part of a) file.
-   * @param selectedPartitions Hive-style partition that are part of the read.
-   * @param fsRelation [[HadoopFsRelation]] associated with the read.
+   * @param readFile
+   *   a function to read each (part of a) file.
+   * @param selectedPartitions
+   *   Hive-style partition that are part of the read.
+   * @param fsRelation
+   *   [[HadoopFsRelation]] associated with the read.
    */
   private def createReadRDD(
-                             readFile: (PartitionedFile) => Iterator[InternalRow],
-                             selectedPartitions: Array[PartitionDirectory],
-                             fsRelation: HadoopFsRelation): RDD[InternalRow] = {
+      readFile: (PartitionedFile) => Iterator[InternalRow],
+      selectedPartitions: Array[PartitionDirectory],
+      fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
     val maxSplitBytes =
       FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions)
-    logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-      s"open cost is considered as scanning $openCostInBytes bytes.")
+    logInfo(
+      s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+        s"open cost is considered as scanning $openCostInBytes bytes.")
 
     // Filter files with bucket pruning if possible
     val bucketingEnabled = fsRelation.sparkSession.sessionState.conf.bucketingEnabled
@@ -229,57 +274,54 @@ case class AbstractFileSourceScanExec(
         _ => true
     }
 
-    val splitFiles = selectedPartitions.flatMap { partition =>
-      partition.files.flatMap { file =>
-        // getPath() is very expensive so we only want to call it once in this block:
-        val filePath = file.getPath
+    val splitFiles = selectedPartitions
+      .flatMap {
+        partition =>
+          partition.files.flatMap {
+            file =>
+              // getPath() is very expensive so we only want to call it once in this block:
+              val filePath = file.getPath
 
-        if (shouldProcess(filePath)) {
-          val isSplitable = relation.fileFormat.isSplitable(
-            relation.sparkSession, relation.options, filePath) &&
-            // SPARK-39634: Allow file splitting in combination with row index generation once
-            // the fix for PARQUET-2161 is available.
-            !RowIndexUtil.isNeededForSchema(requiredSchema)
-          PartitionedFileUtil.splitFiles(
-            sparkSession = relation.sparkSession,
-            file = file,
-            filePath = filePath,
-            isSplitable = isSplitable,
-            maxSplitBytes = maxSplitBytes,
-            partitionValues = partition.values
-          )
-        } else {
-          Seq.empty
-        }
+              if (shouldProcess(filePath)) {
+                val isSplitable = relation.fileFormat.isSplitable(
+                  relation.sparkSession,
+                  relation.options,
+                  filePath) &&
+                  // SPARK-39634: Allow file splitting in combination with row index generation once
+                  // the fix for PARQUET-2161 is available.
+                  !RowIndexUtil.isNeededForSchema(requiredSchema)
+                PartitionedFileUtil.splitFiles(
+                  sparkSession = relation.sparkSession,
+                  file = file,
+                  filePath = filePath,
+                  isSplitable = isSplitable,
+                  maxSplitBytes = maxSplitBytes,
+                  partitionValues = partition.values
+                )
+              } else {
+                Seq.empty
+              }
+          }
       }
-    }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+      .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
 
     val partitions =
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
 
-    new FileScanRDD(fsRelation.sparkSession, readFile, partitions,
+    new FileScanRDD(
+      fsRelation.sparkSession,
+      readFile,
+      partitions,
       new StructType(requiredSchema.fields ++ fsRelation.partitionSchema.fields),
-      fileConstantMetadataColumns, new FileSourceOptions(CaseInsensitiveMap(relation.options)))
+      fileConstantMetadataColumns,
+      new FileSourceOptions(CaseInsensitiveMap(relation.options))
+    )
   }
 
   // Filters unused DynamicPruningExpression expressions - one which has been replaced
   // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
-  private def filterUnusedDynamicPruningExpressions(
-                                                     predicates: Seq[Expression]): Seq[Expression] = {
+  protected def filterUnusedDynamicPruningExpressions(
+      predicates: Seq[Expression]): Seq[Expression] = {
     predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
-  }
-
-  override def doCanonicalize(): AbstractFileSourceScanExec = {
-    AbstractFileSourceScanExec(
-      relation,
-      output.map(QueryPlan.normalizeExpressions(_, output)),
-      requiredSchema,
-      QueryPlan.normalizePredicates(
-        filterUnusedDynamicPruningExpressions(partitionFilters), output),
-      optionalBucketSet,
-      optionalNumCoalescedBuckets,
-      QueryPlan.normalizePredicates(dataFilters, output),
-      None,
-      disableBucketedScan)
   }
 }

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
 
-class FileSourceScanExecShim(
+abstract class FileSourceScanExecShim(
     @transient relation: HadoopFsRelation,
     output: Seq[Attribute],
     requiredSchema: StructType,
@@ -36,7 +36,7 @@ class FileSourceScanExecShim(
     dataFilters: Seq[Expression],
     tableIdentifier: Option[TableIdentifier],
     disableBucketedScan: Boolean = false)
-  extends FileSourceScanExec(
+  extends AbstractFileSourceScanExec(
     relation,
     output,
     requiredSchema,
@@ -54,16 +54,6 @@ class FileSourceScanExecShim(
     case FileSourceConstantMetadataAttribute(attr) => attr
     case FileSourceGeneratedMetadataAttribute(attr) => attr
   }
-
-  override def equals(other: Any): Boolean = other match {
-    case that: FileSourceScanExecShim =>
-      (that.canEqual(this)) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSourceScanExecShim]
 
   def hasMetadataColumns: Boolean = metadataColumns.nonEmpty
 

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.CastSupport
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.hive._
+import org.apache.spark.sql.hive.client.HiveClientImpl
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BooleanType, DataType}
+import org.apache.spark.util.Utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.ql.io.{DelegateSymlinkTextInputFormat, SymlinkTextInputFormat}
+import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
+import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.serde.serdeConstants
+import org.apache.hadoop.hive.serde2.objectinspector._
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils
+import org.apache.hadoop.mapred.InputFormat
+
+import scala.collection.JavaConverters._
+
+/**
+ * The Hive table scan operator. Column and partition pruning are both handled.
+ *
+ * @param requestedAttributes
+ *   Attributes to be fetched from the Hive table.
+ * @param relation
+ *   The Hive table be scanned.
+ * @param partitionPruningPred
+ *   An optional partition pruning predicate for partitioned table.
+ */
+abstract private[hive] class AbstractHiveTableScanExec(
+    requestedAttributes: Seq[Attribute],
+    relation: HiveTableRelation,
+    partitionPruningPred: Seq[Expression])(@transient protected val sparkSession: SparkSession)
+  extends LeafExecNode
+  with CastSupport {
+
+  require(
+    partitionPruningPred.isEmpty || relation.isPartitioned,
+    "Partition pruning predicates only supported for partitioned tables.")
+
+  override def conf: SQLConf = sparkSession.sessionState.conf
+
+  override def nodeName: String = s"Scan hive ${relation.tableMeta.qualifiedName}"
+
+  override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+
+  override def producedAttributes: AttributeSet = outputSet ++
+    AttributeSet(partitionPruningPred.flatMap(_.references))
+
+  private val originalAttributes = AttributeMap(relation.output.map(a => a -> a))
+
+  override val output: Seq[Attribute] = {
+    // Retrieve the original attributes based on expression ID so that capitalization matches.
+    requestedAttributes.map(originalAttributes)
+  }
+
+  // Bind all partition key attribute references in the partition pruning predicate for later
+  // evaluation.
+  private lazy val boundPruningPred = partitionPruningPred.reduceLeftOption(And).map {
+    pred =>
+      require(
+        pred.dataType == BooleanType,
+        s"Data type of predicate $pred must be ${BooleanType.catalogString} rather than " +
+          s"${pred.dataType.catalogString}.")
+
+      BindReferences.bindReference(pred, relation.partitionCols)
+  }
+
+  @transient private lazy val hiveQlTable = HiveClientImpl.toHiveTable(relation.tableMeta)
+  @transient private lazy val tableDesc = new TableDesc(
+    getInputFormat(hiveQlTable.getInputFormatClass, conf),
+    hiveQlTable.getOutputFormatClass,
+    hiveQlTable.getMetadata)
+
+  // Create a local copy of hadoopConf,so that scan specific modifications should not impact
+  // other queries
+  @transient private lazy val hadoopConf = {
+    val c = sparkSession.sessionState.newHadoopConf()
+    // append columns ids and names before broadcast
+    addColumnMetadataToConf(c)
+    c
+  }
+
+  @transient private lazy val hadoopReader =
+    new HadoopTableReader(output, relation.partitionCols, tableDesc, sparkSession, hadoopConf)
+
+  private def castFromString(value: String, dataType: DataType) = {
+    cast(Literal(value), dataType).eval(null)
+  }
+
+  private def addColumnMetadataToConf(hiveConf: Configuration): Unit = {
+    // Specifies needed column IDs for those non-partitioning columns.
+    val columnOrdinals = AttributeMap(relation.dataCols.zipWithIndex)
+    val neededColumnIDs = output.flatMap(columnOrdinals.get).map(o => o: Integer)
+    val neededColumnNames = output.filter(columnOrdinals.contains).map(_.name)
+
+    HiveShim.appendReadColumns(hiveConf, neededColumnIDs, neededColumnNames)
+
+    val deserializer = tableDesc.getDeserializerClass.getConstructor().newInstance()
+    deserializer.initialize(hiveConf, tableDesc.getProperties)
+
+    // Specifies types and object inspectors of columns to be scanned.
+    val structOI = ObjectInspectorUtils
+      .getStandardObjectInspector(deserializer.getObjectInspector, ObjectInspectorCopyOption.JAVA)
+      .asInstanceOf[StructObjectInspector]
+
+    val columnTypeNames = structOI.getAllStructFieldRefs.asScala
+      .map(_.getFieldObjectInspector)
+      .map(TypeInfoUtils.getTypeInfoFromObjectInspector(_).getTypeName)
+      .mkString(",")
+
+    hiveConf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeNames)
+    hiveConf.set(serdeConstants.LIST_COLUMNS, relation.dataCols.map(_.name).mkString(","))
+  }
+
+  /**
+   * Prunes partitions not involve the query plan.
+   *
+   * @param partitions
+   *   All partitions of the relation.
+   * @return
+   *   Partitions that are involved in the query plan.
+   */
+  private[hive] def prunePartitions(partitions: Seq[HivePartition]): Seq[HivePartition] = {
+    boundPruningPred match {
+      case None => partitions
+      case Some(shouldKeep) =>
+        partitions.filter {
+          part =>
+            val dataTypes = relation.partitionCols.map(_.dataType)
+            val castedValues = part.getValues.asScala
+              .zip(dataTypes)
+              .map { case (value, dataType) => castFromString(value, dataType) }
+
+            // Only partitioned values are needed here, since the predicate has
+            // already been bound to partition key attribute references.
+            val row = InternalRow.fromSeq(castedValues.toSeq)
+            shouldKeep.eval(row).asInstanceOf[Boolean]
+        }
+    }
+  }
+
+  @transient lazy val prunedPartitions: Seq[HivePartition] = {
+    if (relation.prunedPartitions.nonEmpty) {
+      val hivePartitions =
+        relation.prunedPartitions.get.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+      if (partitionPruningPred.forall(!ExecSubqueryExpression.hasSubquery(_))) {
+        hivePartitions
+      } else {
+        prunePartitions(hivePartitions)
+      }
+    } else {
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        rawPartitions
+      } else {
+        prunePartitions(rawPartitions)
+      }
+    }
+  }
+
+  // exposed for tests
+  @transient lazy val rawPartitions: Seq[HivePartition] = {
+    val prunedPartitions =
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        // Retrieve the original attributes based on expression ID so that capitalization matches.
+        val normalizedFilters = partitionPruningPred.map(_.transform {
+          case a: AttributeReference => originalAttributes(a)
+        })
+        sparkSession.sessionState.catalog
+          .listPartitionsByFilter(relation.tableMeta.identifier, normalizedFilters)
+      } else {
+        sparkSession.sessionState.catalog.listPartitions(relation.tableMeta.identifier)
+      }
+    prunedPartitions.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    // Using dummyCallSite, as getCallSite can turn out to be expensive with
+    // multiple partitions.
+    val rdd = if (!relation.isPartitioned) {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForTable(hiveQlTable)
+      }
+    } else {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForPartitionedTable(prunedPartitions)
+      }
+    }
+    val numOutputRows = longMetric("numOutputRows")
+    // Avoid to serialize MetastoreRelation because schema is lazy. (see SPARK-15649)
+    val outputSchema = schema
+    rdd.mapPartitionsWithIndexInternal {
+      (index, iter) =>
+        val proj = UnsafeProjection.create(outputSchema)
+        proj.initialize(index)
+        iter.map {
+          r =>
+            numOutputRows += 1
+            proj(r)
+        }
+    }
+  }
+
+  // Filters unused DynamicPruningExpression expressions - one which has been replaced
+  // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
+  private def filterUnusedDynamicPruningExpressions(
+      predicates: Seq[Expression]): Seq[Expression] = {
+    predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
+  }
+
+  // Optionally returns a delegate input format based on the provided input format class.
+  // This is currently used to replace SymlinkTextInputFormat with DelegateSymlinkTextInputFormat
+  // in order to fix SPARK-40815.
+  private def getInputFormat(
+      inputFormatClass: Class[_ <: InputFormat[_, _]],
+      conf: SQLConf): Class[_ <: InputFormat[_, _]] = {
+    if (
+      inputFormatClass == classOf[SymlinkTextInputFormat] &&
+      conf != null && conf.getConf(HiveUtils.USE_DELEGATE_FOR_SYMLINK_TEXT_INPUT_FORMAT)
+    ) {
+      classOf[DelegateSymlinkTextInputFormat]
+    } else {
+      inputFormatClass
+    }
+  }
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(sparkSession)
+}

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
 
-class FileSourceScanExecShim(
+abstract class FileSourceScanExecShim(
     @transient relation: HadoopFsRelation,
     output: Seq[Attribute],
     requiredSchema: StructType,
@@ -36,7 +36,7 @@ class FileSourceScanExecShim(
     dataFilters: Seq[Expression],
     tableIdentifier: Option[TableIdentifier],
     disableBucketedScan: Boolean = false)
-  extends FileSourceScanExec(
+  extends AbstractFileSourceScanExec(
     relation,
     output,
     requiredSchema,
@@ -56,16 +56,6 @@ class FileSourceScanExecShim(
   }
 
   protected lazy val driverMetricsAlias = driverMetrics
-
-  override def equals(other: Any): Boolean = other match {
-    case that: FileSourceScanExecShim =>
-      (that.canEqual(this)) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSourceScanExecShim]
 
   def hasMetadataColumns: Boolean = metadataColumns.nonEmpty
 

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
@@ -30,12 +31,15 @@ import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class BatchScanExecShim(
+abstract class BatchScanExecShim(
     output: Seq[AttributeReference],
     @transient scan: Scan,
     runtimeFilters: Seq[Expression],
-    @transient table: Table)
-  extends BatchScanExec(output, scan, runtimeFilters, table = table) {
+    @transient val table: Table,
+    val commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
+    val applyPartialClustering: Boolean = false,
+    val replicatePartitions: Boolean = false)
+  extends AbstractBatchScanExec(output, scan, runtimeFilters, table = table) {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map()
@@ -43,16 +47,6 @@ class BatchScanExecShim(
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     throw new UnsupportedOperationException("Need to implement this method")
   }
-
-  override def equals(other: Any): Boolean = other match {
-    case that: BatchScanExecShim =>
-      (that.canEqual(this)) && super.equals(that)
-    case _ => false
-  }
-
-  override def hashCode(): Int = super.hashCode()
-
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[BatchScanExecShim]
 
   @transient protected lazy val filteredPartitions: Seq[Seq[InputPartition]] = {
     val dataSourceFilters = runtimeFilters.flatMap {

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.CastSupport
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.hive._
+import org.apache.spark.sql.hive.client.HiveClientImpl
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BooleanType, DataType}
+import org.apache.spark.util.Utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.ql.io.{DelegateSymlinkTextInputFormat, SymlinkTextInputFormat}
+import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
+import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.serde.serdeConstants
+import org.apache.hadoop.hive.serde2.objectinspector._
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils
+import org.apache.hadoop.mapred.InputFormat
+
+import scala.collection.JavaConverters._
+
+/**
+ * The Hive table scan operator. Column and partition pruning are both handled.
+ *
+ * @param requestedAttributes
+ *   Attributes to be fetched from the Hive table.
+ * @param relation
+ *   The Hive table be scanned.
+ * @param partitionPruningPred
+ *   An optional partition pruning predicate for partitioned table.
+ */
+abstract private[hive] class AbstractHiveTableScanExec(
+    requestedAttributes: Seq[Attribute],
+    relation: HiveTableRelation,
+    partitionPruningPred: Seq[Expression])(@transient protected val sparkSession: SparkSession)
+  extends LeafExecNode
+  with CastSupport {
+
+  require(
+    partitionPruningPred.isEmpty || relation.isPartitioned,
+    "Partition pruning predicates only supported for partitioned tables.")
+
+  override def conf: SQLConf = sparkSession.sessionState.conf
+
+  override def nodeName: String = s"Scan hive ${relation.tableMeta.qualifiedName}"
+
+  override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+
+  override def producedAttributes: AttributeSet = outputSet ++
+    AttributeSet(partitionPruningPred.flatMap(_.references))
+
+  private val originalAttributes = AttributeMap(relation.output.map(a => a -> a))
+
+  override val output: Seq[Attribute] = {
+    // Retrieve the original attributes based on expression ID so that capitalization matches.
+    requestedAttributes.map(originalAttributes)
+  }
+
+  // Bind all partition key attribute references in the partition pruning predicate for later
+  // evaluation.
+  private lazy val boundPruningPred = partitionPruningPred.reduceLeftOption(And).map {
+    pred =>
+      require(
+        pred.dataType == BooleanType,
+        s"Data type of predicate $pred must be ${BooleanType.catalogString} rather than " +
+          s"${pred.dataType.catalogString}.")
+
+      BindReferences.bindReference(pred, relation.partitionCols)
+  }
+
+  @transient private lazy val hiveQlTable = HiveClientImpl.toHiveTable(relation.tableMeta)
+  @transient private lazy val tableDesc = new TableDesc(
+    getInputFormat(hiveQlTable.getInputFormatClass, conf),
+    hiveQlTable.getOutputFormatClass,
+    hiveQlTable.getMetadata)
+
+  // Create a local copy of hadoopConf,so that scan specific modifications should not impact
+  // other queries
+  @transient private lazy val hadoopConf = {
+    val c = sparkSession.sessionState.newHadoopConf()
+    // append columns ids and names before broadcast
+    addColumnMetadataToConf(c)
+    c
+  }
+
+  @transient private lazy val hadoopReader =
+    new HadoopTableReader(output, relation.partitionCols, tableDesc, sparkSession, hadoopConf)
+
+  private def castFromString(value: String, dataType: DataType) = {
+    cast(Literal(value), dataType).eval(null)
+  }
+
+  private def addColumnMetadataToConf(hiveConf: Configuration): Unit = {
+    // Specifies needed column IDs for those non-partitioning columns.
+    val columnOrdinals = AttributeMap(relation.dataCols.zipWithIndex)
+    val neededColumnIDs = output.flatMap(columnOrdinals.get).map(o => o: Integer)
+    val neededColumnNames = output.filter(columnOrdinals.contains).map(_.name)
+
+    HiveShim.appendReadColumns(hiveConf, neededColumnIDs, neededColumnNames)
+
+    val deserializer = tableDesc.getDeserializerClass.getConstructor().newInstance()
+    deserializer.initialize(hiveConf, tableDesc.getProperties)
+
+    // Specifies types and object inspectors of columns to be scanned.
+    val structOI = ObjectInspectorUtils
+      .getStandardObjectInspector(deserializer.getObjectInspector, ObjectInspectorCopyOption.JAVA)
+      .asInstanceOf[StructObjectInspector]
+
+    val columnTypeNames = structOI.getAllStructFieldRefs.asScala
+      .map(_.getFieldObjectInspector)
+      .map(TypeInfoUtils.getTypeInfoFromObjectInspector(_).getTypeName)
+      .mkString(",")
+
+    hiveConf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeNames)
+    hiveConf.set(serdeConstants.LIST_COLUMNS, relation.dataCols.map(_.name).mkString(","))
+  }
+
+  /**
+   * Prunes partitions not involve the query plan.
+   *
+   * @param partitions
+   *   All partitions of the relation.
+   * @return
+   *   Partitions that are involved in the query plan.
+   */
+  private[hive] def prunePartitions(partitions: Seq[HivePartition]): Seq[HivePartition] = {
+    boundPruningPred match {
+      case None => partitions
+      case Some(shouldKeep) =>
+        partitions.filter {
+          part =>
+            val dataTypes = relation.partitionCols.map(_.dataType)
+            val castedValues = part.getValues.asScala
+              .zip(dataTypes)
+              .map { case (value, dataType) => castFromString(value, dataType) }
+
+            // Only partitioned values are needed here, since the predicate has
+            // already been bound to partition key attribute references.
+            val row = InternalRow.fromSeq(castedValues.toSeq)
+            shouldKeep.eval(row).asInstanceOf[Boolean]
+        }
+    }
+  }
+
+  @transient lazy val prunedPartitions: Seq[HivePartition] = {
+    if (relation.prunedPartitions.nonEmpty) {
+      val hivePartitions =
+        relation.prunedPartitions.get.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+      if (partitionPruningPred.forall(!ExecSubqueryExpression.hasSubquery(_))) {
+        hivePartitions
+      } else {
+        prunePartitions(hivePartitions)
+      }
+    } else {
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        rawPartitions
+      } else {
+        prunePartitions(rawPartitions)
+      }
+    }
+  }
+
+  // exposed for tests
+  @transient lazy val rawPartitions: Seq[HivePartition] = {
+    val prunedPartitions =
+      if (
+        sparkSession.sessionState.conf.metastorePartitionPruning &&
+        partitionPruningPred.nonEmpty
+      ) {
+        // Retrieve the original attributes based on expression ID so that capitalization matches.
+        val normalizedFilters = partitionPruningPred.map(_.transform {
+          case a: AttributeReference => originalAttributes(a)
+        })
+        sparkSession.sessionState.catalog
+          .listPartitionsByFilter(relation.tableMeta.identifier, normalizedFilters)
+      } else {
+        sparkSession.sessionState.catalog.listPartitions(relation.tableMeta.identifier)
+      }
+    prunedPartitions.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    // Using dummyCallSite, as getCallSite can turn out to be expensive with
+    // multiple partitions.
+    val rdd = if (!relation.isPartitioned) {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForTable(hiveQlTable)
+      }
+    } else {
+      Utils.withDummyCallSite(sparkContext) {
+        hadoopReader.makeRDDForPartitionedTable(prunedPartitions)
+      }
+    }
+    val numOutputRows = longMetric("numOutputRows")
+    // Avoid to serialize MetastoreRelation because schema is lazy. (see SPARK-15649)
+    val outputSchema = schema
+    rdd.mapPartitionsWithIndexInternal {
+      (index, iter) =>
+        val proj = UnsafeProjection.create(outputSchema)
+        proj.initialize(index)
+        iter.map {
+          r =>
+            numOutputRows += 1
+            proj(r)
+        }
+    }
+  }
+
+  // Filters unused DynamicPruningExpression expressions - one which has been replaced
+  // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
+  private def filterUnusedDynamicPruningExpressions(
+      predicates: Seq[Expression]): Seq[Expression] = {
+    predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
+  }
+
+  // Optionally returns a delegate input format based on the provided input format class.
+  // This is currently used to replace SymlinkTextInputFormat with DelegateSymlinkTextInputFormat
+  // in order to fix SPARK-40815.
+  private def getInputFormat(
+      inputFormatClass: Class[_ <: InputFormat[_, _]],
+      conf: SQLConf): Class[_ <: InputFormat[_, _]] = {
+    if (
+      inputFormatClass == classOf[SymlinkTextInputFormat] &&
+      conf != null && conf.getConf(HiveUtils.USE_DELEGATE_FOR_SYMLINK_TEXT_INPUT_FORMAT)
+    ) {
+      classOf[DelegateSymlinkTextInputFormat]
+    } else {
+      inputFormatClass
+    }
+  }
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(sparkSession)
+}


### PR DESCRIPTION
We had some case classes inheriting Spark's case class `BatchScanExec` or `FileSourceScanExec` or `HiveTableScanExec`. The case class inheritance is usually considered a bad practice since it breaks case class's equality convention.

The patch will fix the issue by putting Vanilla spark's code as abstract classes into shim layers.

Another pending [PR](https://github.com/apache/incubator-gluten/pull/4888) would require for this change so as the test of this patch, along with all the existing UTs.


The following UTs will be disabled for this path since they are based on vanilla Spark's non-overridable code that checks against  exact scan class types:


```
File source v2: support passing data filters to FileScan without partitionFilters
File source v2: support partition pruning
disable bucketing when the output doesn't contain all bucketing columns
Fallback Parquet V2 to V1
Aggregates with no groupby over tables having 1 BUCKET, return multiple rows
SPARK-32859: disable unnecessary bucketed table scan - other operators test
SPARK-32859: disable unnecessary bucketed table scan - multiple bucketed columns test
SPARK-32859: disable unnecessary bucketed table scan - multiple joins test
SPARK-32859: disable unnecessary bucketed table scan - basic test
```