### PR TITLE
[GLUTEN-4926][CELEBORN] `CelebornShuffleManager` should remove `shuffleId` from `columnarShuffleIds` after unregistering shuffle

### DIFF
--- a/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -242,7 +242,11 @@ public class CelebornShuffleManager implements ShuffleManager {
   @Override
   public boolean unregisterShuffle(int shuffleId) {
     if (columnarShuffleIds.contains(shuffleId)) {
-      return columnarShuffleManager().unregisterShuffle(shuffleId);
+      if (columnarShuffleManager().unregisterShuffle(shuffleId)) {
+        return columnarShuffleIds.remove(shuffleId);
+      } else {
+        return false;
+      }
     }
     if (appUniqueId == null) {
       return true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CelebornShuffleManager` removes `shuffleId` from `columnarShuffleIds` after unregistering shuffle.

Fixes: #4926 

## How was this patch tested?

integration tests.