### PR TITLE
[VL] Refine log plan/split json into one line

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -103,7 +103,7 @@ void parseLocalFileNodes(
     const auto& localFile = localFiles[i];
     const auto& fileList = localFile.items();
 
-    splitInfos.push_back(std::move(parseScanSplitInfo(fileList)));
+    splitInfos.push_back(parseScanSplitInfo(fileList));
   }
 
   planConverter->setSplitInfos(std::move(splitInfos));

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -53,9 +53,8 @@ void VeloxRuntime::parsePlan(
   taskInfo_ = taskInfo;
   if (debugModeEnabled_) {
     try {
-      auto jsonPlan = substraitFromPbToJson("Plan", data, size, dumpFile);
-      LOG(INFO) << std::string(50, '#') << " received substrait::Plan:";
-      LOG(INFO) << taskInfo_ << std::endl << jsonPlan;
+      auto planJson = substraitFromPbToJson("Plan", data, size, dumpFile);
+      LOG(INFO) << std::string(50, '#') << " received substrait::Plan: " << taskInfo_ << std::endl << planJson;
     } catch (const std::exception& e) {
       LOG(WARNING) << "Error converting Substrait plan to JSON: " << e.what();
     }
@@ -67,9 +66,9 @@ void VeloxRuntime::parsePlan(
 void VeloxRuntime::parseSplitInfo(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) {
   if (debugModeEnabled_) {
     try {
-      auto jsonPlan = substraitFromPbToJson("ReadRel.LocalFiles", data, size, dumpFile);
-      LOG(INFO) << std::string(50, '#') << " received substrait::ReadRel.LocalFiles:";
-      LOG(INFO) << std::endl << jsonPlan;
+      auto splitJson = substraitFromPbToJson("ReadRel.LocalFiles", data, size, dumpFile);
+      LOG(INFO) << std::string(50, '#') << " received substrait::ReadRel.LocalFiles: " << taskInfo_ << std::endl
+                << splitJson;
     } catch (const std::exception& e) {
       LOG(WARNING) << "Error converting Substrait plan to JSON: " << e.what();
     }

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -522,7 +522,7 @@ std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig()
   std::unordered_map<std::string, std::string> configs = {};
   // The semantics of reading as lower case is opposite with case-sensitive.
   configs[velox::connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession] =
-      veloxCfg_->get<bool>(kCaseSensitive, false) == false ? "true" : "false";
+      !veloxCfg_->get<bool>(kCaseSensitive, false) ? "true" : "false";
   configs[velox::connector::hive::HiveConfig::kPartitionPathAsLowerCaseSession] = "false";
   configs[velox::connector::hive::HiveConfig::kArrowBridgeTimestampUnit] = "6";
   configs[velox::connector::hive::HiveConfig::kMaxPartitionsPerWritersSession] =

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -151,8 +151,8 @@ std::vector<std::string> SubstraitParser::makeNames(const std::string& prefix, i
   return names;
 }
 
-std::string SubstraitParser::makeNodeName(int node_id, int col_idx) {
-  return fmt::format("n{}_{}", node_id, col_idx);
+std::string SubstraitParser::makeNodeName(int nodeId, int colIdx) {
+  return fmt::format("n{}_{}", nodeId, colIdx);
 }
 
 int SubstraitParser::getIdxFromNodeName(const std::string& nodeName) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -659,7 +659,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
               makeLocationHandle(writePath),
               dwio::common::FileFormat::PARQUET, // Currently only support parquet format.
               compressionCodec)),
-      (partitionedKey.size() > 0) ? true : false,
+      (!partitionedKey.empty()),
       exec::TableWriteTraits::outputType(nullptr),
       connector::CommitStrategy::kNoCommit,
       childNode);
@@ -2005,13 +2005,13 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
     // Not equal.
     if (filterInfo.notValue_) {
       filters[common::Subfield(inputName)] =
-          std::move(std::make_unique<common::BoolValue>(!filterInfo.notValue_.value().value<bool>(), nullAllowed));
+          std::make_unique<common::BoolValue>(!filterInfo.notValue_.value().value<bool>(), nullAllowed);
     } else if (rangeSize == 0) {
       // IsNull/IsNotNull.
       if (!nullAllowed) {
-        filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNotNull>());
+        filters[common::Subfield(inputName)] = std::make_unique<common::IsNotNull>();
       } else if (isNull) {
-        filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNull>());
+        filters[common::Subfield(inputName)] = std::make_unique<common::IsNull>();
       } else {
         VELOX_NYI("Only IsNotNull and IsNull are supported in constructSubfieldFilters when no other filter ranges.");
       }
@@ -2020,15 +2020,15 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
       // Equal.
       auto value = filterInfo.lowerBounds_[0].value().value<bool>();
       VELOX_CHECK(value == filterInfo.upperBounds_[0].value().value<bool>(), "invalid state of bool equal");
-      filters[common::Subfield(inputName)] = std::move(std::make_unique<common::BoolValue>(value, nullAllowed));
+      filters[common::Subfield(inputName)] = std::make_unique<common::BoolValue>(value, nullAllowed);
     }
   } else if constexpr (KIND == facebook::velox::TypeKind::ARRAY || KIND == facebook::velox::TypeKind::MAP) {
     // Only IsNotNull and IsNull are supported for array and map types.
     if (rangeSize == 0) {
       if (!nullAllowed) {
-        filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNotNull>());
+        filters[common::Subfield(inputName)] = std::make_unique<common::IsNotNull>();
       } else if (isNull) {
-        filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNull>());
+        filters[common::Subfield(inputName)] = std::make_unique<common::IsNull>();
       } else {
         VELOX_NYI(
             "Only IsNotNull and IsNull are supported in constructSubfieldFilters for input type '{}'.",
@@ -2082,9 +2082,9 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
     // Handle null filtering.
     if (rangeSize == 0) {
       if (!nullAllowed) {
-        filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNotNull>());
+        filters[common::Subfield(inputName)] = std::make_unique<common::IsNotNull>();
       } else if (isNull) {
-        filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNull>());
+        filters[common::Subfield(inputName)] = std::make_unique<common::IsNull>();
       } else {
         VELOX_NYI("Only IsNotNull and IsNull are supported in constructSubfieldFilters when no other filter ranges.");
       }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -648,8 +648,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   try {
     for (const auto& expr : groupByExprs) {
       auto expression = exprConverter_->toVeloxExpr(expr, rowType);
-      auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-      if (expr_field == nullptr) {
+      auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+      if (exprField == nullptr) {
         LOG_VALIDATION_MSG("Only field is supported for partition key in Window Operator!");
         return false;
       } else {
@@ -681,8 +681,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
     if (sort.has_expr()) {
       try {
         auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
-        auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-        if (!expr_field) {
+        auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+        if (!exprField) {
           LOG_VALIDATION_MSG("in windowRel, the sorting key in Sort Operator only support field.");
           return false;
         }
@@ -739,8 +739,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
     if (sort.has_expr()) {
       try {
         auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
-        auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-        if (!expr_field) {
+        auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+        if (!exprField) {
           LOG_VALIDATION_MSG("in SortRel, the sorting key in Sort Operator only support field.");
           return false;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refine log plan/split json into one line, it helps filter json output quickly when multi task running.

Before
```
I0312 12:32:11.865212 1787198 VeloxRuntime.cc:57] ################################################## received substrait::Plan:
I0312 12:32:11.865226 1787198 VeloxRuntime.cc:58] [Stage: 0 TID: 0]
{"relations":[{"root":{"input":{"read":{"common":{"direct":{}},"baseSchema":{"names":["id","dt"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}}]},"columnTypes":["NORMAL_COL","NORMAL_COL"]},"advancedExtension":{"optimization":{"@type":"/google.protobuf.StringValue","value":"isMergeTree=0\n"}}}},"names":["id#0","dt#1","id#0","dt#1"]}}]}
```

After
```
I0312 15:25:13.993911 3130302 VeloxRuntime.cc:57] ################################################## received substrait::Plan: [Stage: 0 TID: 0]
{"relations":[{"root":{"input":{"read":{"common":{"direct":{}},"baseSchema":{"names":["id","dt"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}}]},"columnTypes":["NORMAL_COL","NORMAL_COL"]},"advancedExtension":{"optimization":{"@type":"/google.protobuf.StringValue","value":"isMergeTree=0\n"}}}},"names":["id#0","dt#1","id#0","dt#1"]}}]}
```

Fix some warnings reported by IDE.