### PR TITLE
[CORE] Refactor the inheritance relationship of joins

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -301,7 +301,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       condition: Option[Expression],
       left: SparkPlan,
       right: SparkPlan,
-      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExecTransformer =
+      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExecTransformerBase =
     CHBroadcastHashJoinExecTransformer(
       leftKeys,
       rightKeys,

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
@@ -88,7 +88,7 @@ case class CHBroadcastHashJoinExecTransformer(
     left: SparkPlan,
     right: SparkPlan,
     isNullAwareAntiJoin: Boolean)
-  extends BroadcastHashJoinExecTransformer(
+  extends BroadcastHashJoinExecTransformerBase(
     leftKeys,
     rightKeys,
     joinType,

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -162,7 +162,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         df =>
           assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
           val bhjRes = collect(df.queryExecution.executedPlan) {
-            case bhj: BroadcastHashJoinExecTransformer => bhj
+            case bhj: BroadcastHashJoinExecTransformerBase => bhj
           }
           assert(bhjRes.isEmpty)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableColumnarShuffleSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableColumnarShuffleSuite.scala
@@ -77,7 +77,7 @@ class GlutenClickHouseTPCHNullableColumnarShuffleSuite extends GlutenClickHouseT
       runTPCHQuery(5) {
         df =>
           val bhjRes = df.queryExecution.executedPlan.collect {
-            case bhj: BroadcastHashJoinExecTransformer => bhj
+            case bhj: BroadcastHashJoinExecTransformerBase => bhj
           }
           assert(bhjRes.isEmpty)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -77,7 +77,7 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
       runTPCHQuery(5) {
         df =>
           val bhjRes = df.queryExecution.executedPlan.collect {
-            case bhj: BroadcastHashJoinExecTransformer => bhj
+            case bhj: BroadcastHashJoinExecTransformerBase => bhj
           }
           assert(bhjRes.isEmpty)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQESuite.scala
@@ -96,7 +96,7 @@ class GlutenClickHouseTPCHParquetAQESuite
         df =>
           assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
           val bhjRes = collect(df.queryExecution.executedPlan) {
-            case bhj: BroadcastHashJoinExecTransformer => bhj
+            case bhj: BroadcastHashJoinExecTransformerBase => bhj
           }
           assert(bhjRes.isEmpty)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -249,7 +249,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       runTPCHQuery(5) {
         df =>
           val bhjRes = df.queryExecution.executedPlan.collect {
-            case bhj: BroadcastHashJoinExecTransformer => bhj
+            case bhj: BroadcastHashJoinExecTransformerBase => bhj
           }
           assert(bhjRes.isEmpty)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
@@ -87,7 +87,7 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
       runTPCHQuery(5) {
         df =>
           val bhjRes = df.queryExecution.executedPlan.collect {
-            case bhj: BroadcastHashJoinExecTransformer => bhj
+            case bhj: BroadcastHashJoinExecTransformerBase => bhj
           }
           assert(bhjRes.isEmpty)
       }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -267,8 +267,8 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
       condition: Option[Expression],
       left: SparkPlan,
       right: SparkPlan,
-      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExecTransformer =
-    GlutenBroadcastHashJoinExecTransformer(
+      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExecTransformerBase =
+    BroadcastHashJoinExecTransformer(
       leftKeys,
       rightKeys,
       joinType,

--- a/backends-velox/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
@@ -153,7 +153,7 @@ case class ShuffledHashJoinExecTransformer(
     copy(left = newLeft, right = newRight)
 }
 
-case class GlutenBroadcastHashJoinExecTransformer(
+case class BroadcastHashJoinExecTransformer(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
     joinType: JoinType,
@@ -162,7 +162,7 @@ case class GlutenBroadcastHashJoinExecTransformer(
     left: SparkPlan,
     right: SparkPlan,
     isNullAwareAntiJoin: Boolean)
-  extends BroadcastHashJoinExecTransformer(
+  extends BroadcastHashJoinExecTransformerBase(
     leftKeys,
     rightKeys,
     joinType,
@@ -193,7 +193,7 @@ case class GlutenBroadcastHashJoinExecTransformer(
 
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan,
-      newRight: SparkPlan): GlutenBroadcastHashJoinExecTransformer =
+      newRight: SparkPlan): BroadcastHashJoinExecTransformer =
     copy(left = newLeft, right = newRight)
 
   override protected def createBroadcastBuildSideRDD(): BroadcastBuildSideRDD = {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/FallbackSuite.scala
@@ -86,7 +86,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
         df =>
           val plan = df.queryExecution.executedPlan
           val bhj = find(plan) {
-            case _: BroadcastHashJoinExecTransformer => true
+            case _: BroadcastHashJoinExecTransformerBase => true
             case _ => false
           }
           assert(bhj.isDefined)

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -947,7 +947,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
             |select * from t1 cross join t2 on t1.c1 = t2.c1;
             |""".stripMargin
         ) {
-          checkOperatorMatch[GlutenBroadcastHashJoinExecTransformer]
+          checkOperatorMatch[BroadcastHashJoinExecTransformer]
         }
       }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -280,7 +280,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {
-        checkOperatorMatch[GlutenBroadcastHashJoinExecTransformer]
+        checkOperatorMatch[BroadcastHashJoinExecTransformer]
       }
     }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -279,7 +279,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {
-        checkOperatorMatch[GlutenBroadcastHashJoinExecTransformer]
+        checkOperatorMatch[BroadcastHashJoinExecTransformer]
       }
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -122,7 +122,7 @@ trait SparkPlanExecApi {
       condition: Option[Expression],
       left: SparkPlan,
       right: SparkPlan,
-      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExecTransformer
+      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExecTransformerBase
 
   /** Generate CartesianProductExecTransformer. */
   def genCartesianProductExecTransformer(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.{ExpandOutputPartitioningShim, SparkPlan, SQLExecution}
-import org.apache.spark.sql.execution.joins.{BaseJoinExec, HashJoin}
+import org.apache.spark.sql.execution.joins.{BaseJoinExec, HashedRelationBroadcastMode, HashJoin}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -93,10 +93,7 @@ trait ColumnarShuffledJoin extends BaseJoinExec {
 }
 
 /** Performs a hash join of two child relations by first shuffling the data using the join keys. */
-trait HashJoinLikeExecTransformer
-  extends BaseJoinExec
-  with TransformSupport
-  with ColumnarShuffledJoin {
+trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
 
   def joinBuildSide: BuildSide
   def hashJoinType: JoinType
@@ -252,7 +249,7 @@ trait HashJoinLikeExecTransformer
       joinParams.isWithCondition = true
     }
 
-    if (this.isInstanceOf[BroadcastHashJoinExecTransformer]) {
+    if (this.isInstanceOf[BroadcastHashJoinExecTransformerBase]) {
       joinParams.isBHJ = true
     }
 
@@ -355,7 +352,8 @@ abstract class ShuffledHashJoinExecTransformerBase(
     left: SparkPlan,
     right: SparkPlan,
     isSkewJoin: Boolean)
-  extends HashJoinLikeExecTransformer {
+  extends HashJoinLikeExecTransformer
+  with ColumnarShuffledJoin {
 
   override def joinBuildSide: BuildSide = buildSide
   override def hashJoinType: JoinType = joinType
@@ -365,7 +363,7 @@ abstract class ShuffledHashJoinExecTransformerBase(
   }
 }
 
-abstract class BroadcastHashJoinExecTransformer(
+abstract class BroadcastHashJoinExecTransformerBase(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
     joinType: JoinType,
@@ -376,9 +374,37 @@ abstract class BroadcastHashJoinExecTransformer(
     isNullAwareAntiJoin: Boolean)
   extends HashJoinLikeExecTransformer {
 
+  override def output: Seq[Attribute] = {
+    joinType match {
+      case _: InnerLike =>
+        left.output ++ right.output
+      case LeftOuter =>
+        left.output ++ right.output.map(_.withNullability(true))
+      case RightOuter =>
+        left.output.map(_.withNullability(true)) ++ right.output
+      case FullOuter =>
+        (left.output ++ right.output).map(_.withNullability(true))
+      case j: ExistenceJoin =>
+        left.output :+ j.exists
+      case LeftExistence(_) =>
+        left.output
+      case x =>
+        throw new IllegalArgumentException(s"${getClass.getSimpleName} not take $x as the JoinType")
+    }
+  }
+
+  override def requiredChildDistribution: Seq[Distribution] = {
+    val mode = HashedRelationBroadcastMode(buildKeyExprs, isNullAwareAntiJoin)
+    buildSide match {
+      case BuildLeft =>
+        BroadcastDistribution(mode) :: UnspecifiedDistribution :: Nil
+      case BuildRight =>
+        UnspecifiedDistribution :: BroadcastDistribution(mode) :: Nil
+    }
+  }
+
   override def joinBuildSide: BuildSide = buildSide
   override def hashJoinType: JoinType = joinType
-  override def isSkewJoin: Boolean = false
 
   // Unique ID for builded hash table
   lazy val buildHashTableId: String = "BuiltHashTable-" + buildPlan.id
@@ -400,5 +426,4 @@ abstract class BroadcastHashJoinExecTransformer(
   }
 
   protected def createBroadcastBuildSideRDD(): BroadcastBuildSideRDD
-
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -19,13 +19,11 @@ package io.glutenproject.execution
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
-import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.{JoinParams, SubstraitContext}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -40,10 +38,10 @@ case class SortMergeJoinExecTransformer(
     condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan,
-    isSkewJoin: Boolean = false,
-    projectList: Seq[NamedExpression] = null)
+    isSkewJoin: Boolean = false)
   extends BinaryExecNode
-  with TransformSupport {
+  with TransformSupport
+  with ColumnarShuffledJoin {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
@@ -62,10 +60,6 @@ case class SortMergeJoinExecTransformer(
     s"$nodeName $joinType ($opId)".trim
   }
 
-  override def nodeName: String = {
-    if (isSkewJoin) super.nodeName + "(skew=true)" else super.nodeName
-  }
-
   override def verboseStringWithOperatorId(): String = {
     val joinCondStr = if (condition.isDefined) {
       s"${condition.get}"
@@ -76,52 +70,6 @@ case class SortMergeJoinExecTransformer(
        |${ExplainUtils.generateFieldString("Right keys", rightKeys)}
        |${ExplainUtils.generateFieldString("Join condition", joinCondStr)}
     """.stripMargin
-  }
-
-  override def output: Seq[Attribute] = {
-    if (projectList != null && projectList.nonEmpty) {
-      return projectList.map(_.toAttribute)
-    }
-    joinType match {
-      case _: InnerLike =>
-        left.output ++ right.output
-      case LeftOuter =>
-        left.output ++ right.output.map(_.withNullability(true))
-      case RightOuter =>
-        left.output.map(_.withNullability(true)) ++ right.output
-      case FullOuter =>
-        (left.output ++ right.output).map(_.withNullability(true))
-      case j: ExistenceJoin =>
-        left.output :+ j.exists
-      case LeftExistence(_) =>
-        left.output
-      case x =>
-        throw new IllegalArgumentException(
-          s"${getClass.getSimpleName} should not take $x as the JoinType")
-    }
-  }
-
-  override def outputPartitioning: Partitioning = joinType match {
-    case _: InnerLike =>
-      PartitioningCollection(Seq(left.outputPartitioning, right.outputPartitioning))
-    // For left and right outer joins, the output is partitioned by the streamed input's join keys.
-    case LeftOuter => left.outputPartitioning
-    case RightOuter => right.outputPartitioning
-    case FullOuter => UnknownPartitioning(left.outputPartitioning.numPartitions)
-    case LeftExistence(_) => left.outputPartitioning
-    case x =>
-      throw new IllegalArgumentException(
-        s"${getClass.getSimpleName} should not take $x as the JoinType")
-  }
-
-  override def requiredChildDistribution: Seq[Distribution] = {
-    if (isSkewJoin) {
-      // We re-arrange the shuffle partitions to deal with skew join, and the new children
-      // partitioning doesn't satisfy `HashClusteredDistribution`.
-      UnspecifiedDistribution :: UnspecifiedDistribution :: Nil
-    } else {
-      SparkShimLoader.getSparkShims.getDistribution(leftKeys, rightKeys)
-    }
   }
 
   override def requiredChildOrdering: Seq[Seq[SortOrder]] =

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/ExpandFallbackPolicy.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/ExpandFallbackPolicy.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.extension.columnar
 
 import io.glutenproject.GlutenConfig
-import io.glutenproject.execution.BroadcastHashJoinExecTransformer
+import io.glutenproject.execution.BroadcastHashJoinExecTransformerBase
 import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.extension.columnar.MiscColumnarRules.TransformPostOverrides
 import io.glutenproject.utils.PlanUtil
@@ -186,7 +186,7 @@ case class ExpandFallbackPolicy(isAdaptiveContext: Boolean, originalPlan: SparkP
     }
 
     plan.find {
-      case j: BroadcastHashJoinExecTransformer
+      case j: BroadcastHashJoinExecTransformerBase
           if isColumnarBroadcastExchange(j.left) ||
             isColumnarBroadcastExchange(j.right) =>
         true

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.joins
 
 import io.glutenproject.GlutenConfig
-import io.glutenproject.execution.{BroadcastHashJoinExecTransformer, BroadcastNestedLoopJoinExecTransformer, ColumnarToRowExecBase, WholeStageTransformer}
+import io.glutenproject.execution.{BroadcastHashJoinExecTransformerBase, BroadcastNestedLoopJoinExecTransformer, ColumnarToRowExecBase, WholeStageTransformer}
 import io.glutenproject.utils.{BackendTestUtils, SystemParameters}
 
 import org.apache.spark.sql.{GlutenTestsCommonTrait, SparkSession}
@@ -226,7 +226,7 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
         df2.cache()
         val df3 = df1.join(broadcast(df2), Seq("key"), "inner")
         val numBroadCastHashJoin = collect(df3.queryExecution.executedPlan) {
-          case b: BroadcastHashJoinExecTransformer => b
+          case b: BroadcastHashJoinExecTransformerBase => b
         }.size
         assert(numBroadCastHashJoin === 1)
       } finally {
@@ -258,7 +258,7 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
         c2r.child match {
           case w: WholeStageTransformer =>
             w.child match {
-              case b: BroadcastHashJoinExecTransformer =>
+              case b: BroadcastHashJoinExecTransformerBase =>
                 assert(b.getClass.getSimpleName.endsWith(joinMethod))
                 assert(b.joinBuildSide == buildSide)
               case b: BroadcastNestedLoopJoinExecTransformer =>

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.adaptive.clickhouse
 
-import io.glutenproject.execution.{BroadcastHashJoinExecTransformer, ShuffledHashJoinExecTransformerBase, SortExecTransformer, SortMergeJoinExecTransformer}
+import io.glutenproject.execution.{BroadcastHashJoinExecTransformerBase, ShuffledHashJoinExecTransformerBase, SortExecTransformer, SortMergeJoinExecTransformer}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
@@ -89,8 +89,8 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
   }
 
   private def findTopLevelBroadcastHashJoinTransform(
-      plan: SparkPlan): Seq[BroadcastHashJoinExecTransformer] = {
-    collect(plan) { case j: BroadcastHashJoinExecTransformer => j }
+      plan: SparkPlan): Seq[BroadcastHashJoinExecTransformerBase] = {
+    collect(plan) { case j: BroadcastHashJoinExecTransformerBase => j }
   }
 
   private def findTopLevelBroadcastHashJoin(plan: SparkPlan): Seq[BroadcastHashJoinExec] = {
@@ -271,7 +271,7 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
           .count()
         checkAnswer(testDf, Seq())
         val plan = testDf.queryExecution.executedPlan
-        assert(find(plan)(_.isInstanceOf[BroadcastHashJoinExecTransformer]).isDefined)
+        assert(find(plan)(_.isInstanceOf[BroadcastHashJoinExecTransformerBase]).isDefined)
         val coalescedReads = collect(plan) { case r: AQEShuffleReadExec => r }
         assert(coalescedReads.length == 3, s"$plan")
         coalescedReads.foreach(r => assert(r.isLocalRead || r.partitionSpecs.length == 1))
@@ -757,7 +757,7 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
         val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
           "SELECT * FROM testData join testData2 ON key = a where value = '1'")
-        val join = collect(adaptivePlan) { case j: BroadcastHashJoinExecTransformer => j }.head
+        val join = collect(adaptivePlan) { case j: BroadcastHashJoinExecTransformerBase => j }.head
         assert(join.joinBuildSide == BuildLeft)
 
         val reads = collect(join.right) { case r: AQEShuffleReadExec => r }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.adaptive.clickhouse
 
-import io.glutenproject.execution.{BroadcastHashJoinExecTransformer, ShuffledHashJoinExecTransformerBase, SortExecTransformer, SortMergeJoinExecTransformer}
+import io.glutenproject.execution.{BroadcastHashJoinExecTransformerBase, ShuffledHashJoinExecTransformerBase, SortExecTransformer, SortMergeJoinExecTransformer}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
@@ -89,8 +89,8 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
   }
 
   private def findTopLevelBroadcastHashJoinTransform(
-      plan: SparkPlan): Seq[BroadcastHashJoinExecTransformer] = {
-    collect(plan) { case j: BroadcastHashJoinExecTransformer => j }
+      plan: SparkPlan): Seq[BroadcastHashJoinExecTransformerBase] = {
+    collect(plan) { case j: BroadcastHashJoinExecTransformerBase => j }
   }
 
   private def findTopLevelBroadcastHashJoin(plan: SparkPlan): Seq[BroadcastHashJoinExec] = {
@@ -271,7 +271,7 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
           .count()
         checkAnswer(testDf, Seq())
         val plan = testDf.queryExecution.executedPlan
-        assert(find(plan)(_.isInstanceOf[BroadcastHashJoinExecTransformer]).isDefined)
+        assert(find(plan)(_.isInstanceOf[BroadcastHashJoinExecTransformerBase]).isDefined)
         val coalescedReads = collect(plan) { case r: AQEShuffleReadExec => r }
         assert(coalescedReads.length == 3, s"$plan")
         coalescedReads.foreach(r => assert(r.isLocalRead || r.partitionSpecs.length == 1))
@@ -755,7 +755,7 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
         val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
           "SELECT * FROM testData join testData2 ON key = a where value = '1'")
-        val join = collect(adaptivePlan) { case j: BroadcastHashJoinExecTransformer => j }.head
+        val join = collect(adaptivePlan) { case j: BroadcastHashJoinExecTransformerBase => j }.head
         assert(join.joinBuildSide == BuildLeft)
 
         val reads = collect(join.right) { case r: AQEShuffleReadExec => r }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Relationship changes:

- `HashJoinLikeExecTransformer` should not inherit `ColumnarShuffledJoin` as it can be a broadcast join, so the current requiredChildDistribution of broadcast join is wrong
- `SortMergeJoinTransformer` should inherit `ColumnarShuffledJoin` to drop duplicate code

Name changes:

- `BroadcastHashJoinExecTransformer` -> `BroadcastHashJoinExecTransformerBase`
- `GlutenBroadcastHashJoinExecTransformer` -> `BroadcastHashJoinExecTransformer`

## How was this patch tested?

Pass CI
