### PR TITLE
[VL] Remove glog level config in unit test

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
@@ -19,7 +19,6 @@ package io.glutenproject.benchmarks
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution.{VeloxWholeStageTransformerSuite, WholeStageTransformer}
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf
@@ -50,12 +49,6 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
     }
     FileUtils.forceMkdir(dir)
     createTPCHNotNullTables()
-  }
-
-  override protected def sparkConf: SparkConf = {
-    super.sparkConf
-      .set("spark.gluten.sql.debug", "true")
-      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
   }
 
   test("Test plan json non-empty - AQE off") {

--- a/backends-velox/src/test/scala/io/glutenproject/benchmarks/ShuffleWriterFuzzerTest.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/benchmarks/ShuffleWriterFuzzerTest.scala
@@ -59,8 +59,6 @@ class ShuffleWriterFuzzerTest extends VeloxWholeStageTransformerSuite {
       .set("spark.memory.offHeap.size", "512MB")
       .set("spark.driver.memory", "4g")
       .set("spark.driver.maxResultSize", "4g")
-      .set("spark.gluten.sql.debug", "true")
-      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
   }
 
   def getRootCause(e: Throwable): Throwable = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, in the Velox backend, the configuration of glog is reused at the process level. If the glog level is set in a test case, it will cause all subsequent test cases to run with glog=0, generating a large amount of redundant log information. The glog level should not be set in test cases unless necessary.

## How was this patch tested?

N/A

