### PR TITLE
[VL] Add velox decimal avg sum large precision test case

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
@@ -99,6 +99,19 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
               }) == 4)
         }
     }
+    // Test the situation that precision + 4 of input decimal value exceeds 38.
+    runQueryAndCompare(
+      "select avg(cast (l_quantity as DECIMAL(36, 2))), " +
+        "count(distinct l_partkey) from lineitem") {
+      df =>
+        {
+          assert(
+            getExecutedPlan(df).count(
+              plan => {
+                plan.isInstanceOf[HashAggregateExecTransformer]
+              }) == 4)
+        }
+    }
   }
 
   test("sum") {
@@ -132,6 +145,20 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
     runQueryAndCompare(
       "select sum(cast (l_quantity as DECIMAL(22, 2))), " +
+        "count(distinct l_partkey) from lineitem") {
+      df =>
+        {
+          assert(
+            getExecutedPlan(df).count(
+              plan => {
+                plan.isInstanceOf[HashAggregateExecTransformer]
+              }) == 4)
+        }
+    }
+
+    // Test the situation that precision + 4 of input decimal value exceeds 38.
+    runQueryAndCompare(
+      "select sum(cast (l_quantity as DECIMAL(36, 2))), " +
         "count(distinct l_partkey) from lineitem") {
       df =>
         {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the input decimal precision is very large, the precision of sum and avg may exceed 38, and we should not infer the intermediate type based on the result type in decimal sum/avg functions, we should always infer the intermediate type and result type based on the raw input type.

For example, in average aggregate function:
input = decimal(p, s)
intermediate = row(decimal(min(38, p + 10), s), bigint)
result = decimal(min(38, p + 4), min(38, s + 4))

We should not infer intermediate type by using result precision + 6, it is not correct when p > 34.

Add some test cases with large precision to prevent future modifications to decimal avg sum from introducing errors.

## How was this patch tested?

Add large precision test cases in avg and sum `VeloxAggregateFunctionsSuite`.

