### PR TITLE
[GLUTEN-4933][VL] Update iceberg version to 1.4.3 for Spark 3.4 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
   <properties>
     <caffeine.version.java8>2.9.3</caffeine.version.java8>
     <delta.version>2.0.1</delta.version>
-    <iceberg.version>1.3.1</iceberg.version>
     <delta.binary.version>20</delta.binary.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scala.version>2.12.15</scala.version>
@@ -113,7 +112,8 @@
       <properties>
         <sparkbundle.version>3.2</sparkbundle.version>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
-        <spark.version>3.2.2</spark.version>
+	<spark.version>3.2.2</spark.version>
+	<iceberg.version>1.3.1</iceberg.version>
         <delta.version>2.0.1</delta.version>
         <delta.binary.version>20</delta.binary.version>
       </properties>
@@ -123,8 +123,10 @@
       <properties>
         <sparkbundle.version>3.3</sparkbundle.version>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark33</sparkshim.artifactId>
-        <spark.version>3.3.1</spark.version>
-        <delta.version>2.2.0</delta.version>
+	<spark.version>3.3.1</spark.version>
+	<!-- keep using iceberg v1.3.1 for parquet compatibilty. -->
+	<iceberg.version>1.3.1</iceberg.version>
+	<delta.version>2.2.0</delta.version>
         <delta.binary.version>22</delta.binary.version>
       </properties>
     </profile>
@@ -133,8 +135,9 @@
       <properties>
         <sparkbundle.version>3.4</sparkbundle.version>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark34</sparkshim.artifactId>
-        <spark.version>3.4.2</spark.version>
-        <delta.version>2.4.0</delta.version>
+	<spark.version>3.4.2</spark.version>
+	<iceberg.version>1.4.3</iceberg.version>
+	<delta.version>2.4.0</delta.version>
         <delta.binary.version>24</delta.binary.version>
       </properties>
     </profile>
@@ -143,7 +146,8 @@
       <properties>
         <sparkbundle.version>3.5</sparkbundle.version>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark35</sparkshim.artifactId>
-        <spark.version>3.5.1</spark.version>
+	<spark.version>3.5.1</spark.version>
+	<iceberg.version>1.4.3</iceberg.version>
         <delta.version>2.4.0</delta.version>
         <delta.binary.version>24</delta.binary.version>
       </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update iceberg version to 1.4.3 for Spark 3.3 and above, as v1.3.1 is not compatible with Spark 3.5.
Note that iceberg's latest version is 1.5.0 but as it's not available in mirror repo, we use 1.4.3 instead. So the version mapping is:

```
Spark 3.2 : v1.3.1
Spark 3.3 : v1.3.1
Spark 3.4 : v1.4.3
Spark 3.5 : v1.4.3  
```

## How was this patch tested?

Existing UTs
