### PR TITLE
[CORE] Add Complete case match in PullOutPreProject

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -607,7 +607,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       runQueryAndCompare(
         "select id, if(id % 2 = 0, sum(id), max(id)) as s1, " +
           "if(id %2 = 0, sum(id+1), sum(id+2)) as s2 from range(10) group by id") {
-        df => checkOperatorCount[ProjectExecTransformer](1)(df)
+        df => checkOperatorCount[ProjectExecTransformer](2)(df)
       }
 
       // CSE in sort

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension.columnar
 import io.glutenproject.utils.PullOutProjectHelper
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Partial}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ProjectExec, SortExec, SparkPlan, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, TypedAggregateExpression}
@@ -53,7 +53,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
             } else {
               expr.filter.exists(isNotAttribute) ||
               (expr.mode match {
-                case Partial =>
+                case Partial | Complete =>
                   expr.aggregateFunction.children.exists(isNotAttributeAndLiteral)
                 case _ => false
               })


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since ClickHouse has an optimizer rule `MergeTwoPhasesHashBaseAggregate` which will merge two aggregates and change the aggregate mode to `Complete`. `PullOutPreProject` rule should also match `Complete` mode.

## How was this patch tested?

Exists CI.

