### PR TITLE
[VL] Copy the libsodium.so with version number in dynamic packaging

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/utils/SharedLibraryLoaderCentos8.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/SharedLibraryLoaderCentos8.scala
@@ -43,7 +43,7 @@ class SharedLibraryLoaderCentos8 extends SharedLibraryLoader {
       .loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so", false)
       .loadAndCreateLink("libhdfs3.so.1", "libhdfs3.so", false)
       .loadAndCreateLink("libre2.so.0", "libre2.so", false)
-      .loadAndCreateLink("libsodium.so", "libsodium.so", false)
+      .loadAndCreateLink("libsodium.so.23", "libsodium.so", false)
       .commit()
   }
 }

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -28,7 +28,7 @@ function process_setup_ubuntu_2204 {
 }
 
 function process_setup_centos_8 {
-  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libgflags.so.2.2,libglog.so.0,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0,libsodium.so} $THIRDPARTY_LIB/
+  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libgflags.so.2.2,libglog.so.0,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0,libsodium.so.23} $THIRDPARTY_LIB/
   cp /usr/local/lib/{libhdfs3.so.1,libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_regex.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_atomic.so.1.84.0,libprotobuf.so.32} $THIRDPARTY_LIB/
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
#4870 Add libsodium.so in `SharedLibraryLoaderCentos8`. However, it should not link `libsodium.so` to `libsodium.so`, as this would cause the shared object to fail to load at runtime. I discovered the following warning while using GDB to debug:
```
warning: Could not load shared library symbols for /tmp/gluten-81e940a2-74ff-4c8d-8098-112e930af733/jni/5d511fe8-1801-4338-86dc-8b7e31613bac/gluten-9058260266840333844/libsodium.so.
```

We should load and create link for `libsodium.so.23` to `libsodium.so` or `libsodium.so.23.3.0` to `libsodium.so`.

## How was this patch tested?

N/A

