### PR TITLE
[CORE] Introduce GlutenNotSupportException for expected fallback behavior

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -18,6 +18,7 @@ package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.{BackendsApiManager, SparkPlanExecApi}
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution._
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
@@ -321,7 +322,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       left: SparkPlan,
       right: SparkPlan,
       condition: Option[Expression]): CartesianProductExecTransformer =
-    throw new UnsupportedOperationException(
+    throw new GlutenNotSupportException(
       "CartesianProductExecTransformer is not supported in ch backend.")
 
   override def genBroadcastNestedLoopJoinExecTransformer(
@@ -330,7 +331,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       buildSide: BuildSide,
       joinType: JoinType,
       condition: Option[Expression]): BroadcastNestedLoopJoinExecTransformer =
-    throw new UnsupportedOperationException(
+    throw new GlutenNotSupportException(
       "BroadcastNestedLoopJoinExecTransformer is not supported in ch backend.")
 
   /** Generate an expression transformer to transform GetMapValue to Substrait. */
@@ -457,7 +458,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
           case union: ColumnarUnionExec =>
             wrapChild(union)
           case other =>
-            throw new UnsupportedOperationException(
+            throw new GlutenNotSupportException(
               s"Not supported operator ${other.nodeName} for BroadcastRelation")
         }
         (newChild, (child.output ++ appendedProjections).map(_.toAttribute), preProjectionBuildKeys)
@@ -587,7 +588,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       bucketSpec: Option[BucketSpec],
       options: Map[String, String],
       staticPartitions: TablePartitionSpec): WriteFilesExec = {
-    throw new UnsupportedOperationException("ColumnarWriteFilesExec is not support in ch backend.")
+    throw new GlutenNotSupportException("ColumnarWriteFilesExec is not support in ch backend.")
   }
 
   /**
@@ -633,7 +634,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
             val aggregateFunc = aggExpression.aggregateFunction
             val substraitAggFuncName = ExpressionMappings.expressionsMap.get(aggregateFunc.getClass)
             if (substraitAggFuncName.isEmpty) {
-              throw new UnsupportedOperationException(s"Not currently supported: $aggregateFunc.")
+              throw new GlutenNotSupportException(s"Not currently supported: $aggregateFunc.")
             }
 
             val childrenNodeList = new JArrayList[ExpressionNode]()
@@ -704,7 +705,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
             )
             windowExpressionNodes.add(windowFunctionNode)
           case _ =>
-            throw new UnsupportedOperationException(
+            throw new GlutenNotSupportException(
               "unsupported window function type: " +
                 wExpression.windowFunction)
         }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -17,8 +17,8 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.CHHashAggregateExecTransformer.getAggregateResultAttributes
 import io.glutenproject.exception.GlutenNotSupportException
+import io.glutenproject.execution.CHHashAggregateExecTransformer.getAggregateResultAttributes
 import io.glutenproject.expression._
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.{AggregationParams, SubstraitContext}

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -18,6 +18,7 @@ package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.CHHashAggregateExecTransformer.getAggregateResultAttributes
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression._
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
@@ -224,7 +225,7 @@ case class CHHashAggregateExecTransformer(
             // so far, it only happens in a three-stage count distinct case
             // e.g. select sum(a), count(distinct b) from f
             if (!child.isInstanceOf[BaseAggregateExec]) {
-              throw new UnsupportedOperationException(
+              throw new GlutenNotSupportException(
                 "PartialMerge's child not being HashAggregateExecBaseTransformer" +
                   " is unsupported yet")
             }
@@ -242,7 +243,7 @@ case class CHHashAggregateExecTransformer(
                 .replaceWithExpressionTransformer(aggExpr.resultAttribute, originalInputAttributes)
                 .doTransform(args))
           case other =>
-            throw new UnsupportedOperationException(s"$other not supported.")
+            throw new GlutenNotSupportException(s"$other not supported.")
         }
         for (node <- childrenNodes) {
           childrenNodeList.add(node)
@@ -457,7 +458,7 @@ case class CHHashAggregateExecPullOutHelper(
           resIndex += 1
           resIndex
         case other =>
-          throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
+          throw new GlutenNotSupportException(s"Unsupported aggregate mode: $other.")
       }
     }
   }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/expression/CHExpressionTransformer.scala
@@ -56,8 +56,7 @@ case class CHTruncTimestampTransformer(
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     // The format must be constant string in the function date_trunc of ch.
     if (!original.format.foldable) {
-      throw new GlutenNotSupportException(
-        s"The format ${original.format} must be constant string.")
+      throw new GlutenNotSupportException(s"The format ${original.format} must be constant string.")
     }
 
     val formatStr = original.format.eval().asInstanceOf[UTF8String]

--- a/backends-clickhouse/src/main/scala/io/glutenproject/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/expression/CHExpressionTransformer.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.clickhouse.CHBackendSettings
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression._
 
@@ -55,13 +56,13 @@ case class CHTruncTimestampTransformer(
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     // The format must be constant string in the function date_trunc of ch.
     if (!original.format.foldable) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         s"The format ${original.format} must be constant string.")
     }
 
     val formatStr = original.format.eval().asInstanceOf[UTF8String]
     if (formatStr == null) {
-      throw new UnsupportedOperationException("The format is null.")
+      throw new GlutenNotSupportException("The format is null.")
     }
 
     val (newFormatStr, timeZoneIgnore) = formatStr.toString.toLowerCase(Locale.ROOT) match {
@@ -76,7 +77,7 @@ case class CHTruncTimestampTransformer(
       // Can not support now.
       // case "microsecond" => "microsecond"
       // case "millisecond" => "millisecond"
-      case _ => throw new UnsupportedOperationException(s"The format $formatStr is invalidate.")
+      case _ => throw new GlutenNotSupportException(s"The format $formatStr is invalidate.")
     }
 
     // Currently, data_trunc function can not support to set the specified timezone,
@@ -88,7 +89,7 @@ case class CHTruncTimestampTransformer(
           s"${CHBackendSettings.getBackendConfigPrefix}.runtime_config.timezone")
       )
     ) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         s"It doesn't support trunc the format $newFormatStr with the specified timezone " +
           s"${timeZoneId.get}.")
     }
@@ -136,13 +137,13 @@ case class CHStringTranslateTransformer(
       !matchingNode.isInstanceOf[StringLiteralNode] ||
       !replaceNode.isInstanceOf[StringLiteralNode]
     ) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     val matchingLiteral = matchingNode.asInstanceOf[StringLiteralNode].getValue
     val replaceLiteral = replaceNode.asInstanceOf[StringLiteralNode].getValue
     if (matchingLiteral.length() != replaceLiteral.length()) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     GenericExpressionTransformer(
@@ -193,7 +194,7 @@ case class CHPosExplodeTransformer(
           Lists.newArrayList(childNode),
           ConverterUtils.getTypeNode(structType, false))
       case _ =>
-        throw new UnsupportedOperationException(s"posexplode($childType) not supported yet.")
+        throw new GlutenNotSupportException(s"posexplode($childType) not supported yet.")
     }
   }
 }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -297,7 +297,8 @@ object MergeTreePartsPartitionsUtil extends Logging {
     }
 
     if (optionalNumCoalescedBuckets.isDefined) {
-      throw new GlutenNotSupportException("Currently CH backend can't support coalesced buckets.")
+      throw new UnsupportedOperationException(
+        "Currently CH backend can't support coalesced buckets.")
     }
     Seq.tabulate(bucketSpec.numBuckets) {
       bucketId =>

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -297,8 +297,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
     }
 
     if (optionalNumCoalescedBuckets.isDefined) {
-      throw new GlutenNotSupportException(
-        "Currently CH backend can't support coalesced buckets.")
+      throw new GlutenNotSupportException("Currently CH backend can't support coalesced buckets.")
     }
     Seq.tabulate(bucketSpec.numBuckets) {
       bucketId =>

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -297,7 +297,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
     }
 
     if (optionalNumCoalescedBuckets.isDefined) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         "Currently CH backend can't support coalesced buckets.")
     }
     Seq.tabulate(bucketSpec.numBuckets) {

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -24,8 +24,7 @@ import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, IfThenNode}
-import io.glutenproject.vectorized.{ColumnarBatchSerializer, ColumnarBatchSerializeResult}
-
+import io.glutenproject.vectorized.{ColumnarBatchSerializeResult, ColumnarBatchSerializer}
 import org.apache.spark.{ShuffleDependency, SparkException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
@@ -53,15 +52,13 @@ import org.apache.spark.sql.expression.{UDFExpression, UDFResolver}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 import org.apache.commons.lang3.ClassUtils
 
 import javax.ws.rs.core.UriBuilder
-
 import java.lang.{Long => JLong}
 import java.util.{Map => JMap}
-
 import scala.collection.mutable.ListBuffer
 
 class SparkPlanExecApiImpl extends SparkPlanExecApi {
@@ -81,7 +78,7 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
       val decimalType = original.dataType.asInstanceOf[DecimalType]
       val precision = decimalType.precision
       if (precision > 18) {
-        throw new UnsupportedOperationException(
+        throw new GlutenNotSupportException(
           "GetArrayItem not support decimal precision more than 18")
       }
     }
@@ -482,7 +479,7 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
       SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
         != SQLConf.MapKeyDedupPolicy.EXCEPTION.toString
     ) {
-      throw new UnsupportedOperationException("Only EXCEPTION policy is supported!")
+      throw new GlutenNotSupportException("Only EXCEPTION policy is supported!")
     }
     GenericExpressionTransformer(substraitExprName, children, expr)
   }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -18,13 +18,15 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.SparkPlanExecApi
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution._
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, IfThenNode}
-import io.glutenproject.vectorized.{ColumnarBatchSerializeResult, ColumnarBatchSerializer}
+import io.glutenproject.vectorized.{ColumnarBatchSerializer, ColumnarBatchSerializeResult}
+
 import org.apache.spark.{ShuffleDependency, SparkException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
@@ -52,13 +54,15 @@ import org.apache.spark.sql.expression.{UDFExpression, UDFResolver}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 import org.apache.commons.lang3.ClassUtils
 
 import javax.ws.rs.core.UriBuilder
+
 import java.lang.{Long => JLong}
 import java.util.{Map => JMap}
+
 import scala.collection.mutable.ListBuffer
 
 class SparkPlanExecApiImpl extends SparkPlanExecApi {

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -25,6 +25,7 @@ import io.glutenproject.extension.ValidationResult
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
+
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Alias, CumeDist, DenseRank, Descending, Expression, Lag, Lead, Literal, NamedExpression, NthValue, NTile, PercentRank, Rand, RangeFrame, Rank, RowNumber, SortOrder, SpecialFrameBoundary, SpecifiedWindowFrame}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Count, Sum}
@@ -301,11 +302,9 @@ object BackendSettings extends BackendSettingsApi {
                       })
                   val rawValue = e.eval().toString.toLong
                   if (isUpperBound && rawValue < 0) {
-                    throw new GlutenNotSupportException(
-                      "Negative upper bound is not supported!")
+                    throw new GlutenNotSupportException("Negative upper bound is not supported!")
                   } else if (!isUpperBound && rawValue > 0) {
-                    throw new GlutenNotSupportException(
-                      "Positive lower bound is not supported!")
+                    throw new GlutenNotSupportException("Positive lower bound is not supported!")
                   }
                 case _ =>
               }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -18,13 +18,13 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.{GlutenConfig, GlutenPlugin, VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME}
 import io.glutenproject.backendsapi._
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution.WriteFilesExecTransformer
 import io.glutenproject.expression.WindowFunctionsBuilder
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
-
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Alias, CumeDist, DenseRank, Descending, Expression, Lag, Lead, Literal, NamedExpression, NthValue, NTile, PercentRank, Rand, RangeFrame, Rank, RowNumber, SortOrder, SpecialFrameBoundary, SpecifiedWindowFrame}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Count, Sum}
@@ -271,7 +271,7 @@ object BackendSettings extends BackendSettingsApi {
         func => {
           val windowExpression = func match {
             case alias: Alias => WindowFunctionsBuilder.extractWindowExpression(alias.child)
-            case _ => throw new UnsupportedOperationException(s"$func is not supported.")
+            case _ => throw new GlutenNotSupportException(s"$func is not supported.")
           }
 
           // Block the offloading by checking Velox's current limitations
@@ -285,7 +285,7 @@ object BackendSettings extends BackendSettingsApi {
                     order =>
                       order.direction match {
                         case Descending =>
-                          throw new UnsupportedOperationException(
+                          throw new GlutenNotSupportException(
                             "DESC order is not supported when" +
                               " literal bound type is used!")
                         case _ =>
@@ -295,16 +295,16 @@ object BackendSettings extends BackendSettingsApi {
                       order.dataType match {
                         case ByteType | ShortType | IntegerType | LongType | DateType =>
                         case _ =>
-                          throw new UnsupportedOperationException(
+                          throw new GlutenNotSupportException(
                             "Only integral type & date type are" +
                               " supported for sort key when literal bound type is used!")
                       })
                   val rawValue = e.eval().toString.toLong
                   if (isUpperBound && rawValue < 0) {
-                    throw new UnsupportedOperationException(
+                    throw new GlutenNotSupportException(
                       "Negative upper bound is not supported!")
                   } else if (!isUpperBound && rawValue > 0) {
-                    throw new UnsupportedOperationException(
+                    throw new GlutenNotSupportException(
                       "Positive lower bound is not supported!")
                   }
                 case _ =>

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.{GlutenException, GlutenNotSupportException}
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.extension.columnar.RewriteTypedImperativeAggregate
@@ -26,16 +27,18 @@ import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionB
 import io.glutenproject.substrait.extensions.{AdvancedExtensionNode, ExtensionBuilder}
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.VeloxIntermediateData
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+
 import com.google.protobuf.StringValue
-import io.glutenproject.exception.{GlutenException, GlutenNotSupportException}
 
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.exception.{GlutenException, GlutenNotSupportException}
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.extension.columnar.RewriteTypedImperativeAggregate
@@ -370,7 +370,7 @@ abstract class HashAggregateExecTransformer(
           exprNodes.addAll(childNodes)
 
         case _: HyperLogLogPlusPlus if aggFunc.aggBufferAttributes.size != 1 =>
-          throw new GlutenException("Only one input attribute is expected.")
+          throw new GlutenNotSupportException("Only one input attribute is expected.")
 
         case _ @VeloxIntermediateData.Type(veloxTypes: Seq[DataType]) =>
           val rewrittenInputAttributes =

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -18,12 +18,12 @@ package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exception.GlutenException
 import io.glutenproject.exec.Runtimes
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.{ArrowAbiUtil, Iterators}
 import io.glutenproject.vectorized._
-
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -36,7 +36,6 @@ import org.apache.spark.sql.utils.SparkArrowUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.TaskResources
-
 import org.apache.arrow.c.ArrowSchema
 import org.apache.arrow.memory.ArrowBuf
 
@@ -47,7 +46,7 @@ case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBas
   override def doExecuteColumnarInternal(): RDD[ColumnarBatch] = {
     BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema).foreach {
       reason =>
-        throw new UnsupportedOperationException(
+        throw new GlutenException(
           s"Input schema contains unsupported type when convert row to columnar for $schema " +
             s"due to $reason")
     }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -24,6 +24,7 @@ import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.{ArrowAbiUtil, Iterators}
 import io.glutenproject.vectorized._
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -36,6 +37,7 @@ import org.apache.spark.sql.utils.SparkArrowUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.TaskResources
+
 import org.apache.arrow.c.ArrowSchema
 import org.apache.arrow.memory.ArrowBuf
 

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxColumnarToRowExec.scala
@@ -22,6 +22,7 @@ import io.glutenproject.extension.ValidationResult
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.Iterators
 import io.glutenproject.vectorized.NativeColumnarToRowJniWrapper
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxColumnarToRowExec.scala
@@ -17,11 +17,11 @@
 package io.glutenproject.execution
 
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.Iterators
 import io.glutenproject.vectorized.NativeColumnarToRowJniWrapper
-
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -59,7 +59,7 @@ case class VeloxColumnarToRowExec(child: SparkPlan) extends ColumnarToRowExecBas
         case _: StructType =>
         case _: NullType =>
         case _ =>
-          throw new UnsupportedOperationException(
+          throw new GlutenNotSupportException(
             s"${field.dataType} is unsupported in " +
               s"VeloxColumnarToRowExec.")
       }

--- a/backends-velox/src/main/scala/io/glutenproject/expression/ExpressionTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/expression/ExpressionTransformer.scala
@@ -19,15 +19,13 @@ package io.glutenproject.expression
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.expression.ExpressionConverter.replaceWithExpressionTransformer
 import io.glutenproject.substrait.expression._
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{IntegerType, LongType}
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 import java.lang.{Integer => JInteger, Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
-
 import scala.language.existentials
 
 case class VeloxAliasTransformer(
@@ -76,7 +74,7 @@ case class VeloxGetStructFieldTransformer(
         // Append the nested index to selection node.
         node.addNestedChildIdx(JInteger.valueOf(ordinal))
       case other =>
-        throw new UnsupportedOperationException(s"$other is not supported.")
+        throw new GlutenNotSupportException(s"$other is not supported.")
     }
   }
 }
@@ -127,14 +125,14 @@ case class VeloxStringSplitTransformer(
       !regexExpr.isInstanceOf[LiteralTransformer] ||
       !limitExpr.isInstanceOf[LiteralTransformer]
     ) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         "Gluten only supports literal input as limit/regex for split function.")
     }
 
     val limit = limitExpr.doTransform(args).asInstanceOf[IntLiteralNode].getValue
     val regex = regexExpr.doTransform(args).asInstanceOf[StringLiteralNode].getValue
     if (limit > 0 || regex.length > 1) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         s"$original supported single-length regex and negative limit, but given $limit and $regex")
     }
 

--- a/backends-velox/src/main/scala/io/glutenproject/expression/ExpressionTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/expression/ExpressionTransformer.scala
@@ -16,16 +16,19 @@
  */
 package io.glutenproject.expression
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.expression.ExpressionConverter.replaceWithExpressionTransformer
 import io.glutenproject.substrait.expression._
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{IntegerType, LongType}
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 import java.lang.{Integer => JInteger, Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
+
 import scala.language.existentials
 
 case class VeloxAliasTransformer(

--- a/gluten-core/src/main/java/io/glutenproject/exception/GlutenNotSupportException.java
+++ b/gluten-core/src/main/java/io/glutenproject/exception/GlutenNotSupportException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.exception;
+
+/**
+ * Generally, this exception should be thrown if an operation is not supported
+ * by Gluten but supported by Spark. We expect a fallback behavior to handle
+ * such exception.
+ */
+public class GlutenNotSupportException extends GlutenException {
+}

--- a/gluten-core/src/main/java/io/glutenproject/exception/GlutenNotSupportException.java
+++ b/gluten-core/src/main/java/io/glutenproject/exception/GlutenNotSupportException.java
@@ -17,7 +17,23 @@
 package io.glutenproject.exception;
 
 /**
- * Generally, this exception should be thrown if an operation is not supported by Gluten but
- * supported by Spark. We expect a fallback behavior to handle such exception.
+ * Generally, this exception should be thrown if Gluten doesn't support an operation, but vanilla
+ * Spark supports it. We expect Gluten makes such operation or its relevant operations fall back to
+ * vanilla Spark when handling this exception.
  */
-public class GlutenNotSupportException extends GlutenException {}
+public class GlutenNotSupportException extends GlutenException {
+
+  public GlutenNotSupportException() {}
+
+  public GlutenNotSupportException(String message) {
+    super(message);
+  }
+
+  public GlutenNotSupportException(Throwable t) {
+    super(t);
+  }
+
+  public GlutenNotSupportException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/gluten-core/src/main/java/io/glutenproject/exception/GlutenNotSupportException.java
+++ b/gluten-core/src/main/java/io/glutenproject/exception/GlutenNotSupportException.java
@@ -17,9 +17,7 @@
 package io.glutenproject.exception;
 
 /**
- * Generally, this exception should be thrown if an operation is not supported
- * by Gluten but supported by Spark. We expect a fallback behavior to handle
- * such exception.
+ * Generally, this exception should be thrown if an operation is not supported by Gluten but
+ * supported by Spark. We expect a fallback behavior to handle such exception.
  */
-public class GlutenNotSupportException extends GlutenException {
-}
+public class GlutenNotSupportException extends GlutenException {}

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -20,11 +20,11 @@ import io.glutenproject.GlutenConfig.GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.events.GlutenBuildInfoEvent
+import io.glutenproject.exception.GlutenException
 import io.glutenproject.expression.ExpressionMappings
 import io.glutenproject.extension.{ColumnarOverrides, OthersExtensionOverrides, QueryStagePrepOverrides, StrategyOverrides}
 import io.glutenproject.test.TestStats
 import io.glutenproject.utils.TaskListener
-
 import org.apache.spark.{SparkConf, SparkContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.internal.Logging
@@ -39,7 +39,6 @@ import org.apache.spark.util.{SparkResourceUtil, TaskResources}
 
 import java.util
 import java.util.{Collections, Objects}
-
 import scala.collection.mutable
 import scala.language.implicitConversions
 
@@ -144,7 +143,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
 
     // off-heap bytes
     if (!conf.contains(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)) {
-      throw new UnsupportedOperationException(s"${GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY} is not set")
+      throw new GlutenException(s"${GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY} is not set")
     }
     // Session's local time zone must be set. If not explicitly set by user, its default
     // value (detected for the platform) is used, consistent with spark.

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -25,6 +25,7 @@ import io.glutenproject.expression.ExpressionMappings
 import io.glutenproject.extension.{ColumnarOverrides, OthersExtensionOverrides, QueryStagePrepOverrides, StrategyOverrides}
 import io.glutenproject.test.TestStats
 import io.glutenproject.utils.TaskListener
+
 import org.apache.spark.{SparkConf, SparkContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.internal.Logging
@@ -39,6 +40,7 @@ import org.apache.spark.util.{SparkResourceUtil, TaskResources}
 
 import java.util
 import java.util.{Collections, Objects}
+
 import scala.collection.mutable
 import scala.language.implicitConversions
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -20,6 +20,7 @@ import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution._
 import io.glutenproject.expression._
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
+
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
@@ -48,6 +49,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
+
 import scala.collection.JavaConverters._
 
 trait SparkPlanExecApi {
@@ -645,8 +647,7 @@ trait SparkPlanExecApi {
             extraFilters
         }
       case _ =>
-        throw new GlutenNotSupportException(
-          s"${sparkExecNode.getClass.toString} is not supported.")
+        throw new GlutenNotSupportException(s"${sparkExecNode.getClass.toString} is not supported.")
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -16,10 +16,10 @@
  */
 package io.glutenproject.backendsapi
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution._
 import io.glutenproject.expression._
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
-
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
@@ -48,7 +48,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
-
 import scala.collection.JavaConverters._
 
 trait SparkPlanExecApi {
@@ -196,7 +195,7 @@ trait SparkPlanExecApi {
       left: ExpressionTransformer,
       right: ExpressionTransformer,
       original: NaNvl): ExpressionTransformer = {
-    throw new UnsupportedOperationException("NaNvl is not supported")
+    throw new GlutenNotSupportException("NaNvl is not supported")
   }
 
   /** Transform map_entries to Substrait. */
@@ -204,7 +203,7 @@ trait SparkPlanExecApi {
       substraitExprName: String,
       child: ExpressionTransformer,
       expr: Expression): ExpressionTransformer = {
-    throw new UnsupportedOperationException("map_entries is not supported")
+    throw new GlutenNotSupportException("map_entries is not supported")
   }
 
   /** Transform inline to Substrait. */
@@ -212,7 +211,7 @@ trait SparkPlanExecApi {
       substraitExprName: String,
       child: ExpressionTransformer,
       expr: Expression): ExpressionTransformer = {
-    throw new UnsupportedOperationException("map_entries is not supported")
+    throw new GlutenNotSupportException("map_entries is not supported")
   }
 
   /**
@@ -488,7 +487,7 @@ trait SparkPlanExecApi {
             val aggregateFunc = aggExpression.aggregateFunction
             val substraitAggFuncName = ExpressionMappings.expressionsMap.get(aggregateFunc.getClass)
             if (substraitAggFuncName.isEmpty) {
-              throw new UnsupportedOperationException(s"Not currently supported: $aggregateFunc.")
+              throw new GlutenNotSupportException(s"Not currently supported: $aggregateFunc.")
             }
 
             val childrenNodeList = aggregateFunc.children
@@ -605,7 +604,7 @@ trait SparkPlanExecApi {
             )
             windowExpressionNodes.add(windowFunctionNode)
           case _ =>
-            throw new UnsupportedOperationException(
+            throw new GlutenNotSupportException(
               "unsupported window function type: " +
                 wExpression.windowFunction)
         }
@@ -646,7 +645,7 @@ trait SparkPlanExecApi {
             extraFilters
         }
       case _ =>
-        throw new UnsupportedOperationException(
+        throw new GlutenNotSupportException(
           s"${sparkExecNode.getClass.toString} is not supported.")
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -25,6 +25,7 @@ import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter, ExpressionTransformer}
 import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import io.glutenproject.metrics.MetricsUpdater
@@ -24,7 +25,6 @@ import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -373,7 +373,7 @@ object FilterHandler extends PredicateHelper {
           case scan: FileScan =>
             scan.dataFilters
           case _ =>
-            throw new UnsupportedOperationException(
+            throw new GlutenNotSupportException(
               s"${batchScan.scan.getClass.toString} is not supported")
         }
       case _ =>
@@ -415,6 +415,6 @@ object FilterHandler extends PredicateHelper {
           batchScan,
           allPushDownFilters = Some(pushDownFilters))
       case other =>
-        throw new UnsupportedOperationException(s"${other.getClass.toString} is not supported.")
+        throw new GlutenNotSupportException(s"${other.getClass.toString} is not supported.")
     }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -21,6 +21,7 @@ import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -17,10 +17,10 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -105,7 +105,7 @@ abstract class BatchScanExecTransformerBase(
     case fileScan: FileScan =>
       pushdownFilters.getOrElse(fileScan.dataFilters)
     case _ =>
-      throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
+      throw new GlutenNotSupportException(s"${scan.getClass.toString} is not supported")
   }
 
   override def getMetadataColumns(): Seq[AttributeReference] = Seq.empty

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -18,12 +18,12 @@ package io.glutenproject.execution
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression._
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.rel.RelNode
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.util.truncatedString
@@ -128,7 +128,7 @@ abstract class HashAggregateExecBaseTransformer(
     aggregateExpressions.foreach {
       expr =>
         if (!checkAggFuncModeSupport(expr.aggregateFunction, expr.mode)) {
-          throw new UnsupportedOperationException(
+          throw new GlutenNotSupportException(
             s"Unsupported aggregate mode: ${expr.mode} for ${expr.aggregateFunction.prettyName}")
         }
     }
@@ -159,7 +159,7 @@ abstract class HashAggregateExecBaseTransformer(
       case Complete => "COMPLETE"
       case Final => "FINAL"
       case other =>
-        throw new UnsupportedOperationException(s"not currently supported: $other.")
+        throw new GlutenNotSupportException(s"not currently supported: $other.")
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -24,6 +24,7 @@ import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.rel.RelNode
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.util.truncatedString

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
@@ -16,10 +16,10 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.sql.shims.SparkShimLoader
-
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -27,7 +27,6 @@ import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 
 import java.util.ServiceLoader
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.collection.JavaConverters._
 
 object ScanTransformerFactory {
@@ -88,7 +87,7 @@ object ScanTransformerFactory {
               table = SparkShimLoader.getSparkShims.getBatchScanExecTable(batchScanExec)
             )
           case _ =>
-            throw new UnsupportedOperationException(s"Unsupported scan $scan")
+            throw new GlutenNotSupportException(s"Unsupported scan $scan")
         }
     }
   }
@@ -122,7 +121,7 @@ object ScanTransformerFactory {
       }
     } else {
       if (validation) {
-        throw new UnsupportedOperationException(s"Unsupported scan ${batchScan.scan}")
+        throw new GlutenNotSupportException(s"Unsupported scan ${batchScan.scan}")
       }
       // If filter expressions aren't empty, we need to transform the inner operators,
       // and fallback the BatchScanExec itself.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
@@ -20,6 +20,7 @@ import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.sql.shims.SparkShimLoader
+
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -27,6 +28,7 @@ import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 
 import java.util.ServiceLoader
 import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.JavaConverters._
 
 object ScanTransformerFactory {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
@@ -20,6 +20,7 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.ExpressionBuilder
+
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.types.DataType
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
@@ -17,9 +17,9 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.ExpressionBuilder
-
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.types.DataType
 
@@ -44,7 +44,7 @@ object AggregateFunctionsBuilder {
             substraitAggFuncName.get,
             aggregateFunc)
         ) {
-          throw new UnsupportedOperationException(
+          throw new GlutenNotSupportException(
             s"Aggregate function not supported for $aggregateFunc.")
         }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
@@ -17,12 +17,14 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 import scala.collection.JavaConverters._
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
@@ -19,11 +19,10 @@ package io.glutenproject.expression
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 import scala.collection.JavaConverters._
 
@@ -39,7 +38,7 @@ case class CreateArrayTransformer(
     // transformation is only supported when useStringTypeWhenEmpty is false
     // because ClickHouse and Velox currently doesn't support this config.
     if (useStringTypeWhenEmpty && children.isEmpty) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     val childNodes = children.map(_.doTransform(args)).asJava

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -20,15 +20,18 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.substrait.`type`._
 import io.glutenproject.utils.SubstraitPlanPrinterUtil
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
+
 import io.substrait.proto.{NamedStruct, Type}
 
-import java.util.{Locale, ArrayList => JArrayList, List => JList}
+import java.util.{ArrayList => JArrayList, List => JList, Locale}
+
 import scala.collection.JavaConverters._
 
 object ConverterUtils extends Logging {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -17,20 +17,18 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.substrait.`type`._
 import io.glutenproject.utils.SubstraitPlanPrinterUtil
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
 import io.substrait.proto.{NamedStruct, Type}
 
-import java.util.{ArrayList => JArrayList, List => JList, Locale}
-
+import java.util.{Locale, ArrayList => JArrayList, List => JList}
 import scala.collection.JavaConverters._
 
 object ConverterUtils extends Logging {
@@ -208,7 +206,7 @@ object ConverterUtils extends Logging {
       case Type.KindCase.NOTHING =>
         (NullType, true)
       case unsupported =>
-        throw new UnsupportedOperationException(s"Type $unsupported not supported.")
+        throw new GlutenNotSupportException(s"Type $unsupported not supported.")
     }
   }
 
@@ -259,7 +257,7 @@ object ConverterUtils extends Logging {
       case _: NullType =>
         TypeBuilder.makeNothing()
       case unknown =>
-        throw new UnsupportedOperationException(s"Type $unknown not supported.")
+        throw new GlutenNotSupportException(s"Type $unknown not supported.")
     }
   }
 
@@ -385,7 +383,7 @@ object ConverterUtils extends Logging {
       case NullType =>
         "nothing"
       case other =>
-        throw new UnsupportedOperationException(s"Type $other not supported.")
+        throw new GlutenNotSupportException(s"Type $other not supported.")
     }
   }
 
@@ -405,7 +403,7 @@ object ConverterUtils extends Logging {
       case FunctionConfig.NON =>
         funcName.concat(":")
       case other =>
-        throw new UnsupportedOperationException(s"$other is not supported.")
+        throw new GlutenNotSupportException(s"$other is not supported.")
     }
 
     for (idx <- datatypes.indices) {
@@ -431,7 +429,7 @@ object ConverterUtils extends Logging {
       case LeftAnti =>
         "Anti"
       case other =>
-        throw new UnsupportedOperationException(s"Unsupported join type: $other")
+        throw new GlutenNotSupportException(s"Unsupported join type: $other")
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
@@ -19,15 +19,13 @@ package io.glutenproject.expression
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
-
 import scala.collection.JavaConverters._
 
 /** The extract trait for 'GetDateField' from Date */
@@ -49,7 +47,7 @@ case class ExtractDateTransformer(
     val dateFieldName =
       DateTimeExpressionsTransformer.EXTRACT_DATE_FIELD_MAPPING.get(original.getClass)
     if (dateFieldName.isEmpty) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
     val fieldNode = ExpressionBuilder.makeStringLiteral(dateFieldName.get)
     val expressNodes = Lists.newArrayList(fieldNode, childNode)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
@@ -17,15 +17,18 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
+
 import scala.collection.JavaConverters._
 
 /** The extract trait for 'GetDateField' from Date */

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DecimalRoundTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DecimalRoundTransformer.scala
@@ -16,12 +16,14 @@
  */
 package io.glutenproject.expression
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{DataType, DecimalType}
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 case class DecimalRoundTransformer(
     substraitExprName: String,

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DecimalRoundTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DecimalRoundTransformer.scala
@@ -18,11 +18,10 @@ package io.glutenproject.expression
 
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{DataType, DecimalType}
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 case class DecimalRoundTransformer(
     substraitExprName: String,
@@ -52,7 +51,7 @@ case class DecimalRoundTransformer(
         DecimalType(math.min(integralLeastNumDigits + newScale, 38), newScale)
       }
     case _ =>
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         s"Decimal type is expected but received ${original.child.dataType.typeName}.")
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -22,6 +22,7 @@ import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution.{ColumnarToRowExecBase, WholeStageTransformer}
 import io.glutenproject.test.TestStats
 import io.glutenproject.utils.{DecimalArithmeticUtil, PlanUtil}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.expressions._

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -18,13 +18,13 @@ package io.glutenproject.expression
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution.{ColumnarToRowExecBase, WholeStageTransformer}
 import io.glutenproject.test.TestStats
 import io.glutenproject.utils.{DecimalArithmeticUtil, PlanUtil}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
-import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, _}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.execution.{ScalarSubquery, _}
@@ -74,7 +74,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
             replaceWithExpressionTransformerInternal(_, attributeSeq, expressionsMap)),
           udf)
       case _ =>
-        throw new UnsupportedOperationException(s"Not supported python udf: $udf.")
+        throw new GlutenNotSupportException(s"Not supported python udf: $udf.")
     }
   }
 
@@ -91,7 +91,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
             replaceWithExpressionTransformerInternal(_, attributeSeq, expressionsMap)),
           udf)
       case _ =>
-        throw new UnsupportedOperationException(s"Not supported scala udf: $udf.")
+        throw new GlutenNotSupportException(s"Not supported scala udf: $udf.")
     }
   }
 
@@ -117,7 +117,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
     // Check whether Gluten supports this expression
     val substraitExprNameOpt = expressionsMap.get(expr.getClass)
     if (substraitExprNameOpt.isEmpty) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         s"Not supported to map spark function name" +
           s" to substrait function name: $expr, class name: ${expr.getClass.getSimpleName}.")
     }
@@ -125,7 +125,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
 
     // Check whether each backend supports this expression
     if (!BackendsApiManager.getValidatorApiInstance.doExprValidate(substraitExprName, expr)) {
-      throw new UnsupportedOperationException(s"Not supported: $expr.")
+      throw new GlutenNotSupportException(s"Not supported: $expr.")
     }
     expr match {
       case extendedExpr
@@ -281,7 +281,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         )
       case i: In =>
         if (i.list.exists(!_.foldable)) {
-          throw new UnsupportedOperationException(
+          throw new GlutenNotSupportException(
             s"In list option does not support non-foldable expression, ${i.list.map(_.sql)}")
         }
         InTransformer(
@@ -484,7 +484,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         // PrecisionLoss=false: velox not support / ch support
         // TODO ch support PrecisionLoss=true
         if (!BackendsApiManager.getSettings.allowDecimalArithmetic) {
-          throw new UnsupportedOperationException(
+          throw new GlutenNotSupportException(
             s"Not support ${SQLConf.DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key} " +
               s"${conf.decimalOperationsAllowPrecisionLoss} mode")
         }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/LambdaFunctionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/LambdaFunctionTransformer.scala
@@ -18,6 +18,7 @@ package io.glutenproject.expression
 
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
 import org.apache.spark.sql.catalyst.expressions.LambdaFunction
 
 case class LambdaFunctionTransformer(

--- a/gluten-core/src/main/scala/io/glutenproject/expression/LambdaFunctionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/LambdaFunctionTransformer.scala
@@ -16,8 +16,8 @@
  */
 package io.glutenproject.expression
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.sql.catalyst.expressions.LambdaFunction
 
 case class LambdaFunctionTransformer(
@@ -31,7 +31,7 @@ case class LambdaFunctionTransformer(
   override def doTransform(args: Object): ExpressionNode = {
     // Need to fallback when hidden be true as it's not supported in Velox
     if (hidden) {
-      throw new UnsupportedOperationException(s"Unsupported LambdaFunction with hidden be true.")
+      throw new GlutenNotSupportException(s"Unsupported LambdaFunction with hidden be true.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(

--- a/gluten-core/src/main/scala/io/glutenproject/expression/MapExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/MapExpressionTransformer.scala
@@ -19,10 +19,9 @@ package io.glutenproject.expression
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.sql.catalyst.expressions._
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 case class CreateMapTransformer(
     substraitExprName: String,
@@ -36,7 +35,7 @@ case class CreateMapTransformer(
     // transformation is only supported when useStringTypeWhenEmpty is false
     // because ClickHouse and Velox currently doesn't support this config.
     if (children.isEmpty && useStringTypeWhenEmpty) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     val childNodes = new java.util.ArrayList[ExpressionNode]()
@@ -67,11 +66,11 @@ case class GetMapValueTransformer(
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     if (BackendsApiManager.getSettings.alwaysFailOnMapExpression()) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     if (failOnError) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     val childNode = child.doTransform(args)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/MapExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/MapExpressionTransformer.scala
@@ -17,11 +17,13 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
 import org.apache.spark.sql.catalyst.expressions._
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 case class CreateMapTransformer(
     substraitExprName: String,

--- a/gluten-core/src/main/scala/io/glutenproject/expression/StringExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/StringExpressionTransformer.scala
@@ -16,11 +16,13 @@
  */
 package io.glutenproject.expression
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression._
+
 import org.apache.spark.sql.catalyst.expressions._
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 case class String2TrimExpressionTransformer(
     substraitExprName: String,

--- a/gluten-core/src/main/scala/io/glutenproject/expression/StringExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/StringExpressionTransformer.scala
@@ -18,10 +18,9 @@ package io.glutenproject.expression
 
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression._
-
 import org.apache.spark.sql.catalyst.expressions._
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 case class String2TrimExpressionTransformer(
     substraitExprName: String,
@@ -65,7 +64,7 @@ case class RegExpReplaceTransformer(
       !posNode.isInstanceOf[IntLiteralNode] ||
       posNode.asInstanceOf[IntLiteralNode].getValue != 1
     ) {
-      throw new UnsupportedOperationException(s"$original not supported yet.")
+      throw new GlutenNotSupportException(s"$original not supported yet.")
     }
 
     GenericExpressionTransformer(substraitExprName, Seq(subject, regexp, rep), original)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
@@ -21,11 +21,10 @@ import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.`type`.ListNode
 import io.glutenproject.substrait.`type`.MapNode
 import io.glutenproject.substrait.expression.{BooleanLiteralNode, ExpressionBuilder, ExpressionNode, IntLiteralNode}
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
-
 import com.google.common.collect.Lists
+import io.glutenproject.exception.GlutenNotSupportException
 
 case class ChildTransformer(child: ExpressionTransformer) extends ExpressionTransformer {
   override def doTransform(args: java.lang.Object): ExpressionNode = {
@@ -68,7 +67,7 @@ case class ExplodeTransformer(
       case m: MapNode =>
         ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, m.getNestedType)
       case _ =>
-        throw new UnsupportedOperationException(s"explode($childTypeNode) not supported yet.")
+        throw new GlutenNotSupportException(s"explode($childTypeNode) not supported yet.")
     }
   }
 }
@@ -105,7 +104,7 @@ case class PosExplodeTransformer(
     val (valType, valContainsNull) = original.child.dataType match {
       case a: ArrayType => (a.elementType, a.containsNull)
       case _ =>
-        throw new UnsupportedOperationException(
+        throw new GlutenNotSupportException(
           s"posexplode(${original.child.dataType}) not supported yet.")
     }
     val outputType = MapType(keyType, valType, valContainsNull)
@@ -143,7 +142,7 @@ case class PosExplodeTransformer(
           Lists.newArrayList(mapFromArraysExprNode),
           ConverterUtils.getTypeNode(structType, false))
       case _ =>
-        throw new UnsupportedOperationException(s"posexplode($childType) not supported yet.")
+        throw new GlutenNotSupportException(s"posexplode($childType) not supported yet.")
     }
   }
 }
@@ -204,7 +203,7 @@ case class RandTransformer(
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     if (!original.hideSeed) {
       // TODO: for user-specified seed, we need to pass partition index to native engine.
-      throw new UnsupportedOperationException("User-specified seed is not supported.")
+      throw new GlutenNotSupportException("User-specified seed is not supported.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(

--- a/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
@@ -17,14 +17,16 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.`type`.ListNode
 import io.glutenproject.substrait.`type`.MapNode
 import io.glutenproject.substrait.expression.{BooleanLiteralNode, ExpressionBuilder, ExpressionNode, IntLiteralNode}
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
+
 import com.google.common.collect.Lists
-import io.glutenproject.exception.GlutenNotSupportException
 
 case class ChildTransformer(child: ExpressionTransformer) extends ExpressionTransformer {
   override def doTransform(args: java.lang.Object): ExpressionNode = {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/WindowFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/WindowFunctionsBuilder.scala
@@ -19,6 +19,7 @@ package io.glutenproject.expression
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.ExpressionBuilder
+
 import org.apache.spark.sql.catalyst.expressions.{Expression, WindowExpression, WindowFunction}
 
 import scala.util.control.Breaks.{break, breakable}

--- a/gluten-core/src/main/scala/io/glutenproject/expression/WindowFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/WindowFunctionsBuilder.scala
@@ -16,9 +16,9 @@
  */
 package io.glutenproject.expression
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.ExpressionBuilder
-
 import org.apache.spark.sql.catalyst.expressions.{Expression, WindowExpression, WindowFunction}
 
 import scala.util.control.Breaks.{break, breakable}
@@ -28,7 +28,7 @@ object WindowFunctionsBuilder {
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val substraitFunc = ExpressionMappings.expressionsMap.get(windowFunc.getClass)
     if (substraitFunc.isEmpty) {
-      throw new UnsupportedOperationException(
+      throw new GlutenNotSupportException(
         s"not currently supported: ${windowFunc.getClass.getName}.")
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -16,8 +16,8 @@
  */
 package io.glutenproject.extension
 
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.{ExpressionTransformer, Sig}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, AggregateMode}
@@ -57,7 +57,7 @@ trait ExpressionExtensionTrait {
   /** Get the custom agg function substrait name and the input types of the child */
   def buildCustomAggregateFunction(
       aggregateFunc: AggregateFunction): (Option[String], Seq[DataType]) = {
-    throw new UnsupportedOperationException(
+    throw new GlutenNotSupportException(
       s"Aggregate function ${aggregateFunc.getClass} is not supported.")
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -18,6 +18,7 @@ package io.glutenproject.extension
 
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.{ExpressionTransformer, Sig}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, AggregateMode}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/MiscColumnarRules.scala
@@ -18,12 +18,12 @@ package io.glutenproject.extension.columnar
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.{ColumnarToRowLike, GlutenPlan}
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.utils.{LogLevelUtil, PlanUtil}
-
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
@@ -479,7 +479,7 @@ object MiscColumnarRules {
           TransformHints.tagNotTransformable(newSource, validateResult.reason.get)
           newSource
         case other =>
-          throw new UnsupportedOperationException(s"${other.getClass.toString} is not supported.")
+          throw new GlutenNotSupportException(s"${other.getClass.toString} is not supported.")
       }
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/MiscColumnarRules.scala
@@ -24,6 +24,7 @@ import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.{ColumnarToRowLike, GlutenPlan}
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.utils.{LogLevelUtil, PlanUtil}
+
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -738,7 +738,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         // Currently we assume a plan to be transformable by default.
       }
     } catch {
-      case e: GlutenNotSupportException | UnsupportedOperationException =>
+      case e @ (_: GlutenNotSupportException | _: UnsupportedOperationException) =>
         TransformHints.tagNotTransformable(
           plan,
           s"${e.getMessage}, original Spark plan is " +

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -24,6 +24,7 @@ import io.glutenproject.expression.ExpressionUtils.getExpressionTreeDepth
 import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import io.glutenproject.extension.columnar.TransformHints.EncodeTransformableTagImplicits
 import io.glutenproject.sql.shims.SparkShimLoader
+
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -42,6 +43,7 @@ import org.apache.spark.sql.execution.python.EvalPythonExec
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 import org.apache.spark.sql.types.StringType
+
 import org.apache.commons.lang3.exception.ExceptionUtils
 
 sealed trait TransformHint {
@@ -742,7 +744,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           s"${e.getMessage}, original Spark plan is " +
             s"${plan.getClass}(${plan.children.toList.map(_.getClass)})")
         if (!e.isInstanceOf[GlutenNotSupportException]) {
-          logDebug("This exception may need to be fixed: " +  e.getMessage)
+          logDebug("This exception may need to be fixed: " + e.getMessage)
         }
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/TypeConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/TypeConverter.scala
@@ -16,9 +16,11 @@
  */
 package io.glutenproject.substrait
 
-import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
-import com.google.protobuf.CodedInputStream
 import io.glutenproject.exception.GlutenNotSupportException
+
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
+
+import com.google.protobuf.CodedInputStream
 import io.substrait.proto.Type.KindCase._
 
 case class ExpressionType(dataType: DataType, nullable: Boolean) {}

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/TypeConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/TypeConverter.scala
@@ -17,8 +17,8 @@
 package io.glutenproject.substrait
 
 import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
-
 import com.google.protobuf.CodedInputStream
+import io.glutenproject.exception.GlutenNotSupportException
 import io.substrait.proto.Type.KindCase._
 
 case class ExpressionType(dataType: DataType, nullable: Boolean) {}
@@ -50,7 +50,7 @@ object TypeConverter {
       case BINARY => ExpressionType(BinaryType, isNullable(t.getBinary.getNullability))
       case TIMESTAMP => ExpressionType(TimestampType, isNullable(t.getTimestamp.getNullability))
       case t =>
-        throw new UnsupportedOperationException(s"Conversion from substrait type not supported: $t")
+        throw new GlutenNotSupportException(s"Conversion from substrait type not supported: $t")
     }
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/utils/DecimalArithmeticUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/DecimalArithmeticUtil.scala
@@ -17,8 +17,8 @@
 package io.glutenproject.utils
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.{CheckOverflowTransformer, ChildTransformer, DecimalArithmeticExpressionTransformer, ExpressionTransformer}
-
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.expressions.{Add, BinaryArithmetic, Cast, Divide, Expression, Literal, Multiply, Pmod, PromotePrecision, Remainder, Subtract}
 import org.apache.spark.sql.types.{ByteType, Decimal, DecimalType, IntegerType, LongType, ShortType}
@@ -60,7 +60,7 @@ object DecimalArithmeticUtil {
         resultPrecision =
           Math.min(type1.precision - type1.scale, type2.precision - type2.scale + resultScale)
       case other =>
-        throw new UnsupportedOperationException(s"$other is not supported.")
+        throw new GlutenNotSupportException(s"$other is not supported.")
     }
     adjustScaleIfNeeded(resultPrecision, resultScale)
   }
@@ -101,7 +101,7 @@ object DecimalArithmeticUtil {
       case _: Multiply => OperationType.MULTIPLY
       case _: Divide => OperationType.DIVIDE
       case other =>
-        throw new UnsupportedOperationException(s"$other is not supported.")
+        throw new GlutenNotSupportException(s"$other is not supported.")
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/utils/DecimalArithmeticUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/DecimalArithmeticUtil.scala
@@ -19,6 +19,7 @@ package io.glutenproject.utils
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.{CheckOverflowTransformer, ChildTransformer, DecimalArithmeticExpressionTransformer, ExpressionTransformer}
+
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.expressions.{Add, BinaryArithmetic, Cast, Divide, Expression, Literal, Multiply, Pmod, PromotePrecision, Remainder, Subtract}
 import org.apache.spark.sql.types.{ByteType, Decimal, DecimalType, IntegerType, LongType, ShortType}

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -16,12 +16,12 @@
  */
 package io.glutenproject.utils
 
+import io.glutenproject.exception.GlutenNotSupportException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction}
 import org.apache.spark.sql.execution.aggregate._
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.mutable
 
 trait PullOutProjectHelper {
@@ -108,7 +108,7 @@ trait PullOutProjectHelper {
         resultExpressions = newResultExpressions
       )
     case _ =>
-      throw new UnsupportedOperationException(s"Unsupported agg $agg")
+      throw new GlutenNotSupportException(s"Unsupported agg $agg")
   }
 
   protected def rewriteAggregateExpression(

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -17,11 +17,13 @@
 package io.glutenproject.utils
 
 import io.glutenproject.exception.GlutenNotSupportException
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction}
 import org.apache.spark.sql.execution.aggregate._
 
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.mutable
 
 trait PullOutProjectHelper {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `java.lang.UnsupportedOperationException` will be thrown in Gluten when an operation is not supported. And Gluten will then collectively handle such exception and make fallback behavior happen. As a JDK class commonly used, such exception can be thrown by any code (including third-party code) in Gluten's validation/transform path, then will cause a fallback at last. But for some situation, we need developers to dig the reason and fix the exception. With a dedicated Gluten exception introduced, it may be helpful to debug by distinguishing the situations where developer expects fallback happens and other situations where developer doesn't expect.

## How was this patch tested?

Existing tests.

