### PR TITLE
[GLUTEN-4999] Fix ColumnarUnionExec to get PartitionerAwareUnionRDD used if child RDDs share same partitioner

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -327,10 +327,7 @@ case class ColumnarUnionExec(children: Seq[SparkPlan]) extends SparkPlan with Gl
     if (children.isEmpty) {
       throw new IllegalArgumentException(s"Empty children")
     }
-    children
-      .map(c => Seq(c.executeColumnar()))
-      .reduce((a, b) => a ++ b)
-      .reduce((a, b) => a.union(b))
+    sparkContext.union(children.map(c => c.executeColumnar()))
   }
 
   override protected def doExecute()


### PR DESCRIPTION
…etter to be transformed to PartitionerAwareUnionRDD than UnionRDD when they has same partitioner. #4999

## What changes were proposed in this pull request?
For example:

select * from test a
union all
select * from test b
union all
select * from test c

They have the same partitioner.

In ColumnarUnionExec, they will be transformed to rdd1.union(rdd2).union(rdd3).

After this pr,

In ColumnarUnionExec, they will be transformed to PartitionerAwareUnionRDD(sc, Seq(rdd1, rdd2, rdd3)) if they have the same partitioner.



(Fixes: \#4999)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

