### PR TITLE
[GLUTEN-5027][VL] Fail fast for unsupported compilers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -103,7 +103,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   add_compile_options(-Wno-nullability-completeness)
   add_compile_options(-Wno-mismatched-tags)
 else()
-  message("Unsupported compiler ID: ${CMAKE_CXX_COMPILER_ID}")
+  message(FATAL_ERROR "Unsupported compiler ID: ${CMAKE_CXX_COMPILER_ID}")
 endif()
 
 # see https://issues.apache.org/jira/browse/ARROW-4665


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when unsupported compiler is detected, the build is not failed, just a message is logged, causing strange errors thrown later. By fail fast, it gives user a clear message what is going on.

Fixes: #5027

## How was this patch tested?

Manual tested on macOS.

