### PR TITLE
[GLUTEN-5020][VL] Add sudo for macOS related commands

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -168,7 +168,7 @@ function compile {
       if [ $OS == 'Linux' ]; then
         sudo cmake --install xsimd-build/
       elif [ $OS == 'Darwin' ]; then
-        cmake --install xsimd-build/
+        sudo cmake --install xsimd-build/
       fi
     fi
     if [ -d gtest-build ]; then
@@ -176,7 +176,7 @@ function compile {
       if [ $OS == 'Linux' ]; then
         sudo cmake --install gtest-build/
       elif [ $OS == 'Darwin' ]; then
-        cmake --install gtest-build/
+        sudo cmake --install gtest-build/
       fi
     fi
   fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add sudo for macOS related commands, without it installing xsimd and gtest will fail.

Fixes: #5020

## How was this patch tested?

Manual tested on macOS.

