### PR TITLE
[CH][Build][Minor] Fix Build Due to Clickhouse refactor

### DIFF
--- a/cpp-ch/local-engine/Common/AggregateUtil.cpp
+++ b/cpp-ch/local-engine/Common/AggregateUtil.cpp
@@ -27,6 +27,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_AGGREGATED_DATA_VARIANT;
 }
 
 template <typename Method>

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -70,6 +70,8 @@ namespace ErrorCodes
 }
 }
 
+namespace fs = std::filesystem;
+
 namespace local_engine
 {
 template <class key_type, class value_type>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. https://github.com/ClickHouse/ClickHouse/pull/61211 remove following declaration from `Aggregator.h`, let's declare it our unit

```c++
namespace ErrorCodes
{
    extern const int UNKNOWN_AGGREGATED_DATA_VARIANT;
}
```

2. https://github.com/ClickHouse/ClickHouse/pull/61003 remove `namespace fs = std::filesystem;` in [src/Interpreters/DatabaseCatalog.h](https://github.com/ClickHouse/ClickHouse/pull/61003/files#diff-ffc50ad8fde8d1f6f16044bd86c640f2f6097b9ab1d9d1a4b1f4c6653c0f0b7d), let's fix it


## How was this patch tested?

Using existed UT

