### PR TITLE
[VL] Update clang-format version to v4.11.0 for Velox backend

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -36,9 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run clang-format style check for C/C++ programs.
-        uses: jidicula/clang-format-action@v3.5.1
+        uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '12'
+          clang-format-version: '15'
           check-path: ${{ matrix.path['check'] }}
           fallback-style: 'Google' # optional
 

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -420,7 +420,8 @@ VectorPtr SubstraitVeloxExprConverter::literalsToVector(
     case ::substrait::Expression_Literal::LiteralTypeCase::kNull: {
       auto veloxType = SubstraitParser::parseType(childLiteral.null());
       auto kind = veloxType->kind();
-      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(constructFlatVector, kind, elementAtFunc, childSize, veloxType, pool_);
+      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+          constructFlatVector, kind, elementAtFunc, childSize, veloxType, pool_);
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kIntervalDayToSecond:
       return constructFlatVector<TypeKind::BIGINT>(elementAtFunc, childSize, INTERVAL_DAY_TIME(), pool_);


### PR DESCRIPTION
## What changes were proposed in this pull request?

jidicula/clang-format-action@v3.5.1 doesn't meet Apache criteria and will cause following error. So we upgrade to v4.11.0 which is also used by CH backend.
<img width="790" alt="image" src="https://github.com/apache/incubator-gluten/assets/11849056/f7a7dffd-ed9a-498f-8930-2eb4446e7d83">


## How was this patch tested?

CI

