### PR TITLE
[CORE] Catch more specific exceptions in Gluten plan validation

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -83,6 +83,9 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       udf: ScalaUDF,
       attributeSeq: Seq[Attribute],
       expressionsMap: Map[Class[_], String]): ExpressionTransformer = {
+    if (!udf.udfName.isDefined) {
+      throw new GlutenNotSupportException("UDF name is not found!")
+    }
     val substraitExprName = UDFMappings.scalaUDFMap.get(udf.udfName.get)
     substraitExprName match {
       case Some(name) =>

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -18,6 +18,7 @@ package io.glutenproject.extension
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.expression.TransformerState
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.PlanBuilder
@@ -69,7 +70,10 @@ trait GlutenPlan extends SparkPlan with LogLevelUtil {
       }
       res
     } catch {
-      case e: Exception =>
+      case e @ (_: GlutenNotSupportException | _: UnsupportedOperationException) =>
+        if (!e.isInstanceOf[GlutenNotSupportException]) {
+          logDebug(s"This exception may need to be fixed: ${e.getMessage}")
+        }
         // FIXME: Use a validation-specific method to catch validation failures
         TestStats.addFallBackClassName(this.getClass.toString)
         logValidationMessage(s"Validation failed with exception for plan: $nodeName, due to:", e)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up to use the newly introduced GlutenNotSupportException in plan validation. The `Exception` caught in GlutenPlan validation is too general, which makes some exceptions that require us to handle hidden in fall back behavior.

## How was this patch tested?

Existing tests.

