### PR TITLE
[VL][MINOR] Refactor operator/function tests

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseWholeStageTransformerSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseWholeStageTransformerSuite.scala
@@ -70,7 +70,6 @@ class GlutenClickHouseWholeStageTransformerSuite extends WholeStageTransformerSu
   protected val metaStorePathAbsolute = basePath + "/meta"
   protected val hiveMetaStoreDB = metaStorePathAbsolute + "/metastore_db"
 
-  override protected val backend: String = "ch"
   final override protected val resourcePath: String = "" // ch not need this
   override protected val fileFormat: String = "parquet"
 }

--- a/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
@@ -35,7 +35,6 @@ import scala.collection.JavaConverters._
 object GenerateExample extends Tag("io.glutenproject.tags.GenerateExample")
 
 class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
   val generatedPlanDir = getClass.getResource("/").getPath + "../../../generated-native-benchmark/"

--- a/backends-velox/src/test/scala/io/glutenproject/benchmarks/ShuffleWriterFuzzerTest.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/benchmarks/ShuffleWriterFuzzerTest.scala
@@ -37,7 +37,6 @@ object ShuffleWriterFuzzerTest {
 @FuzzerTest
 @SkipTestTags
 class ShuffleWriterFuzzerTest extends VeloxWholeStageTransformerSuite {
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/FallbackSuite.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEShuf
 
 class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/FunctionsValidateTest.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/FunctionsValidateTest.scala
@@ -28,7 +28,6 @@ import scala.collection.JavaConverters._
 class FunctionsValidateTest extends WholeStageTransformerSuite {
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
-
   private var parquetPath: String = _
 
   override protected def sparkConf: SparkConf = {
@@ -66,7 +65,7 @@ class FunctionsValidateTest extends WholeStageTransformerSuite {
       Row(1.045, 3, null)
     )
 
-    var dfParquet = spark.createDataFrame(rowData.asJava, schema)
+    val dfParquet = spark.createDataFrame(rowData.asJava, schema)
     dfParquet
       .coalesce(1)
       .write

--- a/backends-velox/src/test/scala/io/glutenproject/execution/FunctionsValidateTest.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/FunctionsValidateTest.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.execution
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, NullPropagation}
+import org.apache.spark.sql.types._
+
+import java.nio.file.Files
+
+import scala.collection.JavaConverters._
+
+class FunctionsValidateTest extends WholeStageTransformerSuite {
+  override protected val resourcePath: String = "/tpch-data-parquet-velox"
+  override protected val fileFormat: String = "parquet"
+
+  private var parquetPath: String = _
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.sql.files.maxPartitionBytes", "1g")
+      .set("spark.sql.shuffle.partitions", "1")
+      .set("spark.memory.offHeap.size", "2g")
+      .set("spark.unsafe.exceptionOnMemoryLeak", "true")
+      .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      .set("spark.sql.sources.useV1SourceList", "avro")
+      .set(
+        "spark.sql.optimizer.excludedRules",
+        ConstantFolding.ruleName + "," +
+          NullPropagation.ruleName)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createTPCHNotNullTables()
+
+    val lfile = Files.createTempFile("", ".parquet").toFile
+    lfile.deleteOnExit()
+    parquetPath = lfile.getAbsolutePath
+
+    val schema = StructType(
+      Array(
+        StructField("double_field1", DoubleType, true),
+        StructField("int_field1", IntegerType, true),
+        StructField("string_field1", StringType, true)
+      ))
+    val rowData = Seq(
+      Row(1.025, 1, "{\"a\":\"b\"}"),
+      Row(1.035, 2, null),
+      Row(1.045, 3, null)
+    )
+
+    var dfParquet = spark.createDataFrame(rowData.asJava, schema)
+    dfParquet
+      .coalesce(1)
+      .write
+      .format("parquet")
+      .mode("overwrite")
+      .parquet(parquetPath)
+
+    spark.catalog.createTable("datatab", parquetPath, fileFormat)
+  }
+}

--- a/backends-velox/src/test/scala/io/glutenproject/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/ScalarFunctionsValidateSuite.scala
@@ -19,12 +19,12 @@ package io.glutenproject.execution
 import org.apache.spark.sql.types._
 
 class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
-
+  disableFallbackCheck
   import testImplicits._
 
   // Test "SELECT ..." without a from clause.
   test("isnull function") {
-    runQueryAndCompare("SELECT isnull(1)") { _ => }
+    runQueryAndCompare("SELECT isnull(1)")(checkOperatorMatch[ProjectExecTransformer])
   }
 
   test("Test bit_count function") {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/ScalarFunctionsValidateSuite.scala
@@ -16,68 +16,15 @@
  */
 package io.glutenproject.execution
 
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, NullPropagation}
 import org.apache.spark.sql.types._
 
-import java.nio.file.Files
-
-import scala.collection.JavaConverters._
-
-class VeloxFunctionsValidateSuite extends VeloxWholeStageTransformerSuite {
-
-  override protected val resourcePath: String = "/tpch-data-parquet-velox"
-  override protected val fileFormat: String = "parquet"
-
-  private var parquetPath: String = _
+class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
 
   import testImplicits._
 
-  override protected def sparkConf: SparkConf = {
-    super.sparkConf
-      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
-      .set("spark.sql.files.maxPartitionBytes", "1g")
-      .set("spark.sql.shuffle.partitions", "1")
-      .set("spark.memory.offHeap.size", "2g")
-      .set("spark.unsafe.exceptionOnMemoryLeak", "true")
-      .set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      .set("spark.sql.sources.useV1SourceList", "avro")
-      .set(
-        "spark.sql.optimizer.excludedRules",
-        ConstantFolding.ruleName + "," +
-          NullPropagation.ruleName)
-  }
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    createTPCHNotNullTables()
-
-    val lfile = Files.createTempFile("", ".parquet").toFile
-    lfile.deleteOnExit()
-    parquetPath = lfile.getAbsolutePath
-
-    val schema = StructType(
-      Array(
-        StructField("double_field1", DoubleType, true),
-        StructField("int_field1", IntegerType, true),
-        StructField("string_field1", StringType, true)
-      ))
-    val rowData = Seq(
-      Row(1.025, 1, "{\"a\":\"b\"}"),
-      Row(1.035, 2, null),
-      Row(1.045, 3, null)
-    )
-
-    var dfParquet = spark.createDataFrame(rowData.asJava, schema)
-    dfParquet
-      .coalesce(1)
-      .write
-      .format("parquet")
-      .mode("overwrite")
-      .parquet(parquetPath)
-
-    spark.catalog.createTable("datatab", parquetPath, fileFormat)
+  // Test "SELECT ..." without a from clause.
+  test("isnull function") {
+    runQueryAndCompare("SELECT isnull(1)") { _ => }
   }
 
   test("Test bit_count function") {
@@ -134,12 +81,86 @@ class VeloxFunctionsValidateSuite extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  ignore("Test round function") {
+  test("Test round function") {
     runQueryAndCompare(
       "SELECT round(cast(l_orderkey as int), 2)" +
         "from lineitem limit 1") {
       checkOperatorMatch[ProjectExecTransformer]
     }
+
+    runQueryAndCompare("""
+                         |select round(l_quantity, 2) from lineitem;
+                         |""".stripMargin) {
+      checkOperatorMatch[ProjectExecTransformer]
+    }
+  }
+
+  test("chr function") {
+    val df = runQueryAndCompare(
+      "SELECT chr(l_orderkey + 64) " +
+        "from lineitem limit 1") { _ => }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("bin function") {
+    val df = runQueryAndCompare(
+      "SELECT bin(l_orderkey) " +
+        "from lineitem limit 1") {
+      checkOperatorMatch[ProjectExecTransformer]
+    }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("abs function") {
+    val df = runQueryAndCompare(
+      "SELECT abs(l_orderkey) " +
+        "from lineitem limit 1") { _ => }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("ceil function") {
+    val df = runQueryAndCompare(
+      "SELECT ceil(cast(l_orderkey as long)) " +
+        "from lineitem limit 1") { _ => }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("floor function") {
+    val df = runQueryAndCompare(
+      "SELECT floor(cast(l_orderkey as long)) " +
+        "from lineitem limit 1") { _ => }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("exp function") {
+    val df = spark.sql("SELECT exp(l_orderkey) from lineitem limit 1")
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("power function") {
+    val df = runQueryAndCompare(
+      "SELECT power(l_orderkey, 2.0) " +
+        "from lineitem limit 1") { _ => }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("pmod function") {
+    val df = runQueryAndCompare(
+      "SELECT pmod(cast(l_orderkey as int), 3) " +
+        "from lineitem limit 1") { _ => }
+    checkLengthAndPlan(df, 1)
+  }
+
+  test("greatest function") {
+    val df = runQueryAndCompare(
+      "SELECT greatest(l_orderkey, l_orderkey)" +
+        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
+  }
+
+  test("least function") {
+    val df = runQueryAndCompare(
+      "SELECT least(l_orderkey, l_orderkey)" +
+        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
   }
 
   test("Test greatest function") {
@@ -343,6 +364,14 @@ class VeloxFunctionsValidateSuite extends VeloxWholeStageTransformerSuite {
     }
   }
 
+  test("Support HOUR function") {
+    withTable("t1") {
+      sql("create table t1 (c1 int, c2 timestamp) USING PARQUET")
+      sql("INSERT INTO t1 VALUES(1, NOW())")
+      runQueryAndCompare("SELECT c1, HOUR(c2) FROM t1 LIMIT 1")(df => checkFallbackOperators(df, 0))
+    }
+  }
+
   test("map extract - getmapvalue") {
     withTempPath {
       path =>
@@ -541,20 +570,6 @@ class VeloxFunctionsValidateSuite extends VeloxWholeStageTransformerSuite {
     runQueryAndCompare(
       "SELECT regexp_replace(c_comment, '\\w', 'something', 3) FROM customer limit 50") {
       checkOperatorMatch[ProjectExecTransformer]
-    }
-  }
-
-  test("lag/lead window function with negative input offset") {
-    runQueryAndCompare(
-      "select lag(l_orderkey, -2) over" +
-        " (partition by l_suppkey order by l_orderkey) from lineitem") {
-      checkOperatorMatch[WindowExecTransformer]
-    }
-
-    runQueryAndCompare(
-      "select lead(l_orderkey, -2) over" +
-        " (partition by l_suppkey order by l_orderkey) from lineitem") {
-      checkOperatorMatch[WindowExecTransformer]
     }
   }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -20,7 +20,7 @@ import io.glutenproject.GlutenConfig
 import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.execution.{FilterExec, GenerateExec, ProjectExec, RDDScanExec}
 import org.apache.spark.sql.functions.{avg, col, lit, udf}
 import org.apache.spark.sql.internal.SQLConf
@@ -294,85 +294,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  test("chr function") {
-    val df = runQueryAndCompare(
-      "SELECT chr(l_orderkey + 64) " +
-        "from lineitem limit 1") { _ => }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("bin function") {
-    val df = runQueryAndCompare(
-      "SELECT bin(l_orderkey) " +
-        "from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
-    }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("abs function") {
-    val df = runQueryAndCompare(
-      "SELECT abs(l_orderkey) " +
-        "from lineitem limit 1") { _ => }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("ceil function") {
-    val df = runQueryAndCompare(
-      "SELECT ceil(cast(l_orderkey as long)) " +
-        "from lineitem limit 1") { _ => }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("floor function") {
-    val df = runQueryAndCompare(
-      "SELECT floor(cast(l_orderkey as long)) " +
-        "from lineitem limit 1") { _ => }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("exp function") {
-    val df = spark.sql("SELECT exp(l_orderkey) from lineitem limit 1")
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("power function") {
-    val df = runQueryAndCompare(
-      "SELECT power(l_orderkey, 2.0) " +
-        "from lineitem limit 1") { _ => }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("pmod function") {
-    val df = runQueryAndCompare(
-      "SELECT pmod(cast(l_orderkey as int), 3) " +
-        "from lineitem limit 1") { _ => }
-    checkLengthAndPlan(df, 1)
-  }
-
-  test("round function") {
-    val df = runQueryAndCompare(
-      "SELECT round(cast(l_orderkey as int), 2)" +
-        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
-  }
-
-  test("greatest function") {
-    val df = runQueryAndCompare(
-      "SELECT greatest(l_orderkey, l_orderkey)" +
-        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
-  }
-
-  test("least function") {
-    val df = runQueryAndCompare(
-      "SELECT least(l_orderkey, l_orderkey)" +
-        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
-  }
-
-  // Test "SELECT ..." without a from clause.
-  test("isnull function") {
-    runQueryAndCompare("SELECT isnull(1)") { _ => }
-  }
-
   test("df.count()") {
     val df = runQueryAndCompare("select * from lineitem limit 1") { _ => }
     checkLengthAndPlan(df, 1)
@@ -432,14 +353,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                          |) where l_suppkey != 0 limit 100;
                          |""".stripMargin) {
       checkOperatorMatch[LimitTransformer]
-    }
-  }
-
-  test("round") {
-    runQueryAndCompare("""
-                         |select round(l_quantity, 2) from lineitem;
-                         |""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -1118,14 +1031,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       spark.sql("INSERT INTO TABLE remainder VALUES(0, null)")
 
       runQueryAndCompare("SELECT c1 % c2 FROM remainder")(df => checkFallbackOperators(df, 0))
-    }
-  }
-
-  test("Support HOUR function") {
-    withTable("t1") {
-      sql("create table t1 (c1 int, c2 timestamp) USING PARQUET")
-      sql("INSERT INTO t1 VALUES(1, NOW())")
-      runQueryAndCompare("SELECT c1, HOUR(c2) FROM t1 LIMIT 1")(df => checkFallbackOperators(df, 0))
     }
   }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -197,36 +197,25 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
   }
 
   test("window expression") {
-    def assertWindowOffloaded: DataFrame => Unit = {
-      df =>
-        {
-          assert(
-            getExecutedPlan(df).count(
-              plan => {
-                plan.isInstanceOf[WindowExecTransformer]
-              }) > 0)
-        }
-    }
-
     Seq("sort", "streaming").foreach {
       windowType =>
         withSQLConf("spark.gluten.sql.columnar.backend.velox.window.type" -> windowType) {
           runQueryAndCompare(
             "select ntile(4) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select row_number() over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select rank() over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
@@ -244,63 +233,63 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(
             "select l_suppkey, l_orderkey, nth_value(l_orderkey, 2) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select l_suppkey, l_orderkey, nth_value(l_orderkey, 2) IGNORE NULLS over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select sum(l_partkey + 1) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select max(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select min(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select avg(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select lag(l_orderkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select lead(l_orderkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           // Test same partition/ordering keys.
           runQueryAndCompare(
             "select avg(l_partkey) over" +
               " (partition by l_suppkey order by l_suppkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
 
           // Test overlapping partition/ordering keys.
           runQueryAndCompare(
             "select avg(l_partkey) over" +
               " (partition by l_suppkey order by l_suppkey, l_orderkey) from lineitem ") {
-            assertWindowOffloaded
+            checkOperatorMatch[WindowExecTransformer]
           }
         }
     }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -31,7 +31,6 @@ import scala.collection.JavaConverters
 class TestOperator extends VeloxWholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.internal.SQLConf
 abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxColumnarCacheSuite.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.storage.StorageLevel
 
 class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxFunctionsValidateSuite.scala
@@ -29,7 +29,6 @@ class VeloxFunctionsValidateSuite extends VeloxWholeStageTransformerSuite {
 
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
-  override protected val backend: String = "velox"
 
   private var parquetPath: String = _
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxHashJoinSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxHashJoinSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.InputIteratorTransformer
 
 class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.execution.ProjectExec
 class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
   override protected val resourcePath: String = "placeholder"
   override protected val fileFormat: String = "parquet"
-  override protected val backend: String = "velox"
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxMetricsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxMetricsSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 
 class VeloxMetricsSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -22,7 +22,6 @@ import java.io.File
 
 class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/data-type-validation-data"
   override protected val fileFormat: String = "orc"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -22,7 +22,6 @@ import java.io.File
 
 class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/data-type-validation-data"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxScanSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxScanSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.execution.ScalarSubquery
 
 class VeloxScanSuite extends VeloxWholeStageTransformerSuite {
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxStringFunctionsSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.types.StringType
 class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCDSSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCDSSuite.scala
@@ -30,7 +30,6 @@ import scala.io.Source
 // Then set the `ignore` to `test`
 class VeloxTPCDSSuite extends VeloxWholeStageTransformerSuite {
 
-  override protected val backend: String = "velox"
   override protected val resourcePath: String =
     sys.env.getOrElse("SPARK_TPCDS_DATA", "/tmp/tpcds-generated")
   override protected val fileFormat: String = "parquet"

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
@@ -27,7 +27,6 @@ import java.nio.charset.StandardCharsets
 
 abstract class VeloxTPCHTableSupport extends VeloxWholeStageTransformerSuite {
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxWindowExpressionSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxWindowExpressionSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.SparkConf
 class VeloxWindowExpressionSuite extends WholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/WindowFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/WindowFunctionsValidateSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.execution
+
+class WindowFunctionsValidateSuite extends FunctionsValidateTest {
+
+  test("lag/lead window function with negative input offset") {
+    runQueryAndCompare(
+      "select lag(l_orderkey, -2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkOperatorMatch[WindowExecTransformer]
+    }
+
+    runQueryAndCompare(
+      "select lead(l_orderkey, -2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkOperatorMatch[WindowExecTransformer]
+    }
+  }
+
+}

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -25,7 +25,6 @@ import org.apache.spark.SparkConf
 import org.junit.Assert
 
 class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -39,7 +39,6 @@ abstract class WholeStageTransformerSuite
   with SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
-  protected val backend: String
   protected val resourcePath: String
   protected val fileFormat: String
   protected val logLevel: String = "WARN"

--- a/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxDeltaSuite.scala
+++ b/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxDeltaSuite.scala
@@ -25,7 +25,6 @@ import scala.collection.JavaConverters._
 class VeloxDeltaSuite extends WholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/gluten-iceberg/src/test/scala/io/glutenproject/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/io/glutenproject/execution/VeloxIcebergSuite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.SparkConf
 class VeloxIcebergSuite extends WholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
-  override protected val backend: String = "velox"
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove the below useless method from some test classes.
    `protected val backend: String`
2. Rename `VeloxFunctionSValidateSuite` to `ScalarFunctionsValidateSuite`, and create `WindowFunctionsValidateSuite` to let them respectively hold scalar function tests & window function tests.
3. Move some scalar function tests in `TestOperator.scala` to `ScalarFunctionsValidateSuite.scala`.

## How was this patch tested?

Existing tests.

