### PR TITLE
[VL] Daily Update Velox Version (2024_03_20)

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -555,7 +555,7 @@ std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig()
   configs[velox::connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession] =
       !veloxCfg_->get<bool>(kCaseSensitive, false) ? "true" : "false";
   configs[velox::connector::hive::HiveConfig::kPartitionPathAsLowerCaseSession] = "false";
-  configs[velox::connector::hive::HiveConfig::kArrowBridgeTimestampUnit] = "6";
+  configs[velox::connector::hive::HiveConfig::kParquetWriteTimestampUnit] = "6";
   configs[velox::connector::hive::HiveConfig::kMaxPartitionsPerWritersSession] =
       std::to_string(veloxCfg_->get<int32_t>(kMaxPartitions, 10000));
   configs[velox::connector::hive::HiveConfig::kIgnoreMissingFilesSession] =

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -96,6 +96,7 @@ void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::str
     maxRowGroupRows_ = static_cast<int64_t>(stoi(sparkConfs.find(kParquetBlockRows)->second));
   }
   velox::parquet::WriterOptions writeOption;
+  writeOption.parquetWriteTimestampUnit = 6 /*micro*/;
   auto compressionCodec = CompressionKind::CompressionKind_SNAPPY;
   if (sparkConfs.find(kParquetCompressionCodec) != sparkConfs.end()) {
     auto compressionCodecStr = sparkConfs.find(kParquetCompressionCodec)->second;

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_03_19
+VELOX_BRANCH=2024_03_20
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
Velox Upstream New Commits:
```
0b4b6e84a by wypb, Add more test cases for cast(string as float) (#9148)
9c7eb6c17 by Masha Basmanova, Add support for DECIMAL types to Simple Function API (#9096)
a942ac836 by rui-mo, Support different timestamp units in arrow bridge (#7625)
0ad627ab6 by Ubuntu, Wave Table Scan Infrastructure (#9131)
c571bcd69 by Masha Basmanova, Speedup PrefixSortTest::fuzzMulti (#9151)
ff346f2ac by joey.ljy, Allow setting variables for intermediateType in AggregateFunctionSignature (#9106)
813c4b4e5 by xiaoxmeng, Fix flaky MultiFragmentTest.partitionedOutputWithLargeInput (#9147)
3e13ff56b by Jacob Wujciak-Jens, Disable sanitizer check in cpr build (#9139)
3055f4a2b by Masha Basmanova, Decouple UDFHolder from SimpleFunctionMetadata (#9143)
0e94ab554 by InitialZJ, Update Presto coverage map (#9128)
ca0f4a986 by Masha Basmanova, Pass input types to simple function's 'initialize' method (#9124)
```