### PR TITLE
[VL] Fix bug where session config is lost when benchmark is enabled

### DIFF
--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -220,11 +220,11 @@ std::unique_ptr<ColumnarBatchSerializer> VeloxRuntime::createColumnarBatchSerial
 void VeloxRuntime::dumpConf(const std::string& path) {
   auto backendConf = VeloxBackend::get()->getBackendConf();
   auto allConf = backendConf;
-  
+
   for (const auto& pair : confMap_) {
     allConf.insert_or_assign(pair.first, pair.second);
   }
-  
+
   // Open file "velox.conf" for writing, automatically creating it if it doesn't exist,
   // or overwriting it if it does.
   std::ofstream outFile(path);

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -220,8 +220,11 @@ std::unique_ptr<ColumnarBatchSerializer> VeloxRuntime::createColumnarBatchSerial
 void VeloxRuntime::dumpConf(const std::string& path) {
   auto backendConf = VeloxBackend::get()->getBackendConf();
   auto allConf = backendConf;
-  allConf.merge(confMap_);
-
+  
+  for (const auto& pair : confMap_) {
+    allConf.insert_or_assign(pair.first, pair.second);
+  }
+  
   // Open file "velox.conf" for writing, automatically creating it if it doesn't exist,
   // or overwriting it if it does.
   std::ofstream outFile(path);


### PR DESCRIPTION
It's a quick bug fix.

unordered_map::merge removes the duplicated items from source.

https://en.cppreference.com/w/cpp/container/unordered_map/merge