### PR TITLE
[CH][Minor] Fix build due to Clickhouse Refactor

### DIFF
--- a/cpp-ch/local-engine/Common/DebugUtils.cpp
+++ b/cpp-ch/local-engine/Common/DebugUtils.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "DebugUtils.h"
+#include <iostream>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeDate.h>

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
@@ -26,6 +26,7 @@
 #include <Processors/Chunk.h>
 #include <base/types.h>
 #include <substrait/plan.pb.h>
+#include <Poco/JSON/Array.h>
 #include <Common/BlockIterator.h>
 #include <Common/PODArray.h>
 

--- a/cpp-ch/local-engine/Storages/Parquet/ColumnIndexFilter.cpp
+++ b/cpp-ch/local-engine/Storages/Parquet/ColumnIndexFilter.cpp
@@ -24,6 +24,7 @@
 #include <Storages/Parquet/ParquetConverter.h>
 #include <parquet/schema.h>
 #include <parquet/statistics.h>
+#include <Common/logger_useful.h>
 
 namespace local_engine
 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/ClickHouse/ClickHouse/pull/61604 reduce header dependencies and hence cause our build failed.
1. `DatabaseCatalog.h` remove `#include <Databases/IDatabase.h>`,  and `ColumnIndexFilter.cpp`  needs
 include `Common/logger_useful.h`
2. `IDataType.h` remove `#include <DataTypes/Serializations/SerializationInfo.h>` and `SelectorBuilder.h`  needs incldue `Poco/JSON/Array.h`
3. Also `DebugUtils.cpp` needs inculde `iostream`  becasue of 2

We can avoid upgrading clickhouse backend by this PR.

## How was this patch tested?
Using existed UT

