### PR TITLE
[GLUTEN-5060][CH] Remove unnecessary FilterExec execution when querying from MergeTree with the prewhere

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/extension/FallbackBroadcaseHashJoinRules.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/extension/FallbackBroadcaseHashJoinRules.scala
@@ -100,7 +100,8 @@ case class FallbackBroadcastHashJoinPrepQueryStage(session: SparkSession) extend
 case class FallbackBroadcastHashJoin(session: SparkSession) extends Rule[SparkPlan] {
 
   private val enableColumnarBroadcastJoin: Boolean =
-    GlutenConfig.getConf.enableColumnarBroadcastJoin && GlutenConfig.getConf.enableColumnarBroadcastExchange
+    GlutenConfig.getConf.enableColumnarBroadcastJoin &&
+      GlutenConfig.getConf.enableColumnarBroadcastExchange
 
   override def apply(plan: SparkPlan): SparkPlan = {
     plan.foreachUp {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When querying from MergeTree with the prewhere, all the filters will be pushdowned to the ScanExec, so it does not need to execute the FilterExec again.

Close #5060.

(Fixes: #5060)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

