### PR TITLE
[GLUTEN-5061][CH] Fix assert error when writing mergetree data with select * from table limit n

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
@@ -94,7 +94,7 @@ class ClickhouseOptimisticTransaction(
               aqe.isSubquery,
               supportsColumnar = true
             ))
-        case other => queryPlan.withNewChildren(Array(FakeRowAdaptor(other)))
+        case other => FakeRowAdaptor(other)
       }
 
       val statsTrackers: ListBuffer[WriteJobStatsTracker] = ListBuffer()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The below writing mergetree data sql will throw the assert error:
```
insert into table lineitem_mergetree
select * from lineitem **limit 10**
```

RC:
with limit n, there is a wrong wrapper logical with the FakeRowAdaptor for the query plan.

Close #5061.

(Fixes: #5061)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

