### PR TITLE
[GLUTEN-5074][VL] fix: UDF load error in yarn-cluster mode

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/udf/UdfJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/udf/UdfJniWrapper.java
@@ -20,5 +20,5 @@ public class UdfJniWrapper {
 
   public UdfJniWrapper() {}
 
-  public native void nativeLoadUdfLibraries(String udfLibPaths);
+  public native void getFunctionSignatures();
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -649,7 +649,7 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
 
   override def genInjectedFunctions()
       : Seq[(FunctionIdentifier, ExpressionInfo, FunctionBuilder)] = {
-    UDFResolver.loadAndGetFunctionDescriptions
+    UDFResolver.getFunctionSignatures
   }
 
   override def rewriteSpillPath(path: String): String = {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -132,8 +132,9 @@ object UDFResolver extends Logging {
       case None =>
     }
 
-    logInfo(s"after resolve path " +
-      s"is:${sparkConf.getOption(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)}")
+    logInfo(
+      s"after resolve path " +
+        s"is:${sparkConf.getOption(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)}")
   }
 
   // Try to unpack archive. Throws exception if failed.

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -131,10 +131,6 @@ object UDFResolver extends Logging {
         conf.put(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS, getAllLibraries(paths, sparkConf))
       case None =>
     }
-
-    logInfo(
-      s"after resolve path " +
-        s"is:${conf.get(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)}")
   }
 
   // Try to unpack archive. Throws exception if failed.

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -134,7 +134,7 @@ object UDFResolver extends Logging {
 
     logInfo(
       s"after resolve path " +
-        s"is:${sparkConf.getOption(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)}")
+        s"is:${conf.get(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)}")
   }
 
   // Try to unpack archive. Throws exception if failed.

--- a/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
@@ -47,6 +47,9 @@ abstract class VeloxUdfSuite extends GlutenQueryTest with SQLHelper {
             "/path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so")
     }
 
+  protected lazy val udfLibRelativePath: String =
+    udfLibPath.split(",").map(p => Paths.get(p).getFileName.toString).mkString(",")
+
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     if (_spark == null) {
@@ -83,7 +86,7 @@ class VeloxUdfSuiteLocal extends VeloxUdfSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.files", udfLibPath)
-      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", "libmyudf.so")
+      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", udfLibRelativePath)
   }
 }
 

--- a/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
@@ -82,7 +82,8 @@ class VeloxUdfSuiteLocal extends VeloxUdfSuite {
   override val master: String = "local[2]"
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", udfLibPath)
+      .set("spark.files", udfLibPath)
+      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", "libmyudf.so")
   }
 }
 

--- a/cpp/velox/jni/JniUdf.cc
+++ b/cpp/velox/jni/JniUdf.cc
@@ -47,17 +47,14 @@ void gluten::finalizeVeloxJniUDF(JNIEnv* env) {
   env->DeleteGlobalRef(udfResolverClass);
 }
 
-void gluten::jniLoadUdf(JNIEnv* env, const std::string& libPaths) {
+void gluten::jniGetFunctionSignatures(JNIEnv* env) {
   auto udfLoader = gluten::UdfLoader::getInstance();
-  udfLoader->loadUdfLibraries(libPaths);
-
   const auto& udfMap = udfLoader->getUdfMap();
   for (const auto& udf : udfMap) {
     auto udfString = udf.second;
     jbyteArray returnType = env->NewByteArray(udf.second.length());
     env->SetByteArrayRegion(returnType, 0, udfString.length(), reinterpret_cast<const jbyte*>(udfString.c_str()));
     jstring name = env->NewStringUTF(udf.first.c_str());
-
     jobject instance = env->GetStaticObjectField(
         udfResolverClass, env->GetStaticFieldID(udfResolverClass, "MODULE$", kUdfResolverClassPath.c_str()));
     env->CallVoidMethod(instance, registerUDFMethod, name, returnType);

--- a/cpp/velox/jni/JniUdf.h
+++ b/cpp/velox/jni/JniUdf.h
@@ -27,6 +27,6 @@ void initVeloxJniUDF(JNIEnv* env);
 
 void finalizeVeloxJniUDF(JNIEnv* env);
 
-void jniLoadUdf(JNIEnv* env, const std::string& libPaths);
+void jniGetFunctionSignatures(JNIEnv* env);
 
 } // namespace gluten

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -76,12 +76,11 @@ JNIEXPORT void JNICALL Java_io_glutenproject_init_NativeBackendInitializer_initi
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL Java_io_glutenproject_udf_UdfJniWrapper_nativeLoadUdfLibraries( // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_udf_UdfJniWrapper_getFunctionSignatures( // NOLINT
     JNIEnv* env,
-    jclass,
-    jstring libPaths) {
+    jclass) {
   JNI_METHOD_START
-  gluten::jniLoadUdf(env, jStringToCString(env, libPaths));
+  gluten::jniGetFunctionSignatures(env);
   JNI_METHOD_END()
 }
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -442,7 +442,7 @@ Note if running on Yarn client mode, the uploaded files are not reachable on dri
 --conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
 ```
 
-- Use the `--archives` option to upload a archive and configure its relative path
+- Use the `--archives` option to upload an archive and configure its relative path
 ```shell
 --archives /path/to/udf_archives.zip#udf_archives
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=udf_archives

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -434,15 +434,15 @@ Gluten loads the UDF libraries at runtime. You can upload UDF libraries via `--f
 
 Note if running on Yarn client mode, the uploaded files are not reachable on driver side. Users should copy those files to somewhere reachable for driver and set `spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths`. This configuration is also useful when the `udfLibraryPaths` is different between driver side and executor side.
 
-- Use `--files`
+- Use the `--files` option to upload a library and configure its relative path
 ```shell
 --files /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=libmyudf.so
 # Needed for Yarn client mode
---conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path/to/libmyudf.so
+--conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
 ```
 
-- Use `--archives`
+- Use the `--archives` option to upload a archive and configure its relative path
 ```shell
 --archives /path/to/udf_archives.zip#udf_archives
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=udf_archives
@@ -450,7 +450,7 @@ Note if running on Yarn client mode, the uploaded files are not reachable on dri
 --conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path/to/udf_archives.zip
 ```
 
-- Specify URI
+- Only configure URI
 
 You can also specify the local or HDFS URIs to the UDF libraries or archives. Local URIs should exist on driver and every worker nodes.
 ```shell
@@ -462,10 +462,17 @@ You can also specify the local or HDFS URIs to the UDF libraries or archives. Lo
 We provided an Velox UDF example file [MyUDF.cpp](../../cpp/velox/udf/examples/MyUDF.cpp). After building gluten cpp, you can find the example library at /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
 
 Start spark-shell or spark-sql with below configuration 
-```
+```shell
+# Use the `--files` option to upload a library and configure its relative path
 --files /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=libmyudf.so
 ```
+or
+```shell
+# Only configure URI
+--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=file:///path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
+```
+
 Run query. The functions `myudf1` and `myudf2` increment the input value by a constant of 5
 ```
 select myudf1(1), myudf2(100L)


### PR DESCRIPTION
## What changes were proposed in this pull request?
1.  Remove `driverUdfLibPath` and retain only `udfLibPath`, as there is no need to differentiate between the driver and executor. The method used to access the file is determined by whether --master=yarn is specified.
> For more details on the reason, refer to Issue link #5074 

3. The UDF is loaded by `VeloxBackend::initUdf` in both the driver and the executor. `UdfResolver` does not load the UDF repeatedly; it only retrieves the function signatures.

(Fixes: \#5074)

## How was this patch tested?
I tested with and without the --files/--archives arguments in local, yarn-client, and yarn-cluster modes.