### PR TITLE
[VL][CI] Fix thrift download failure

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -500,6 +500,7 @@ jobs:
       - name: Build Gluten velox third party
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
+          export ARROW_THRIFT_URL=file:///opt/thrift-0.16.0.tar.gz && \
           source /env.sh && \
           sudo yum -y install patch && \
           cd /opt/gluten/ep/build-velox/src && \
@@ -550,6 +551,7 @@ jobs:
       - name: Build Gluten velox third party
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
+          export ARROW_THRIFT_URL=file:///opt/thrift-0.16.0.tar.gz && \
           yum -y install epel-release centos-release-scl patch sudo && \
           cd /opt/gluten/ep/build-velox/src && \
           source /opt/rh/devtoolset-9/enable && \
@@ -690,6 +692,7 @@ jobs:
       - name: Build Script Test
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
+          export ARROW_THRIFT_URL=file:///opt/thrift-0.16.0.tar.gz && \
           source /env.sh && \
           sudo yum -y install patch && \
           cd /opt/gluten/ && \

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -38,8 +38,8 @@ on:
       - 'dev/**'
 
 env:
-  HTTP_PROXY_HOST: child-prc.intel.com
-  HTTP_PROXY_PORT: 913
+  HTTP_PROXY_HOST: proxy-shz.intel.com
+  HTTP_PROXY_PORT: 911
   PATH_TO_GLUTEN_TE: ./tools/gluten-te
   DOCKER_PULL_REGISTRY: 10.1.0.25:5000
   MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.count=3
@@ -500,8 +500,6 @@ jobs:
       - name: Build Gluten velox third party
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
-          export http_proxy=http://child-prc.intel.com:913 && \
-          export https_proxy=http://child-prc.intel.com:913 && \
           source /env.sh && \
           sudo yum -y install patch && \
           cd /opt/gluten/ep/build-velox/src && \
@@ -552,8 +550,6 @@ jobs:
       - name: Build Gluten velox third party
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
-          export http_proxy=http://child-prc.intel.com:913 && \
-          export https_proxy=http://child-prc.intel.com:913 && \
           yum -y install epel-release centos-release-scl patch sudo && \
           cd /opt/gluten/ep/build-velox/src && \
           source /opt/rh/devtoolset-9/enable && \
@@ -694,8 +690,6 @@ jobs:
       - name: Build Script Test
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
-          export http_proxy=http://child-prc.intel.com:913 && \
-          export https_proxy=http://child-prc.intel.com:913 && \
           source /env.sh && \
           sudo yum -y install patch && \
           cd /opt/gluten/ && \

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -38,8 +38,8 @@ on:
       - 'dev/**'
 
 env:
-  HTTP_PROXY_HOST: proxy-shz.intel.com
-  HTTP_PROXY_PORT: 911
+  HTTP_PROXY_HOST: child-prc.intel.com
+  HTTP_PROXY_PORT: 913
   PATH_TO_GLUTEN_TE: ./tools/gluten-te
   DOCKER_PULL_REGISTRY: 10.1.0.25:5000
   MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.count=3
@@ -500,6 +500,8 @@ jobs:
       - name: Build Gluten velox third party
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
+          export http_proxy=http://child-prc.intel.com:913 && \
+          export https_proxy=http://child-prc.intel.com:913 && \
           source /env.sh && \
           sudo yum -y install patch && \
           cd /opt/gluten/ep/build-velox/src && \
@@ -550,6 +552,8 @@ jobs:
       - name: Build Gluten velox third party
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
+          export http_proxy=http://child-prc.intel.com:913 && \
+          export https_proxy=http://child-prc.intel.com:913 && \
           yum -y install epel-release centos-release-scl patch sudo && \
           cd /opt/gluten/ep/build-velox/src && \
           source /opt/rh/devtoolset-9/enable && \
@@ -690,6 +694,8 @@ jobs:
       - name: Build Script Test
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh '
+          export http_proxy=http://child-prc.intel.com:913 && \
+          export https_proxy=http://child-prc.intel.com:913 && \
           source /env.sh && \
           sudo yum -y install patch && \
           cd /opt/gluten/ && \

--- a/ep/build-velox/src/modify_arrow.patch
+++ b/ep/build-velox/src/modify_arrow.patch
@@ -1,16 +1,8 @@
 diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
-index a2627c190..0181dd633 100644
+index 94f926039..f7ebf9233 100644
 --- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
 +++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
-@@ -809,6 +809,7 @@ if(DEFINED ENV{ARROW_THRIFT_URL})
-   set(THRIFT_SOURCE_URL "$ENV{ARROW_THRIFT_URL}")
- else()
-   set_urls(THRIFT_SOURCE_URL
-+           "https://archive.apache.org/dist/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
-            "https://www.apache.org/dyn/closer.cgi?action=download&filename=/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
-            "https://downloads.apache.org/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
-            "https://apache.claz.org/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
-@@ -2557,13 +2558,9 @@ if(ARROW_WITH_ZSTD)
+@@ -2501,13 +2501,9 @@ if(ARROW_WITH_ZSTD)
    if(ZSTD_VENDORED)
      set(ARROW_ZSTD_LIBZSTD zstd::libzstd_static)
    else()

--- a/ep/build-velox/src/modify_arrow.patch
+++ b/ep/build-velox/src/modify_arrow.patch
@@ -1,8 +1,16 @@
 diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
-index 94f926039..f7ebf9233 100644
+index a2627c190..0181dd633 100644
 --- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
 +++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
-@@ -2501,13 +2501,9 @@ if(ARROW_WITH_ZSTD)
+@@ -809,6 +809,7 @@ if(DEFINED ENV{ARROW_THRIFT_URL})
+   set(THRIFT_SOURCE_URL "$ENV{ARROW_THRIFT_URL}")
+ else()
+   set_urls(THRIFT_SOURCE_URL
++           "https://archive.apache.org/dist/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+            "https://www.apache.org/dyn/closer.cgi?action=download&filename=/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+            "https://downloads.apache.org/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+            "https://apache.claz.org/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+@@ -2557,13 +2558,9 @@ if(ARROW_WITH_ZSTD)
    if(ZSTD_VENDORED)
      set(ARROW_ZSTD_LIBZSTD zstd::libzstd_static)
    else()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix CI failure on Centos-7/8.

~1. Use another proxy. 2. Add another download link for thrift.~
Pre-download thrift tar package into docker and let arrow find it from local path of docker container.