### PR TITLE
[VL] Daily Update Velox Version (2024_03_26)

### DIFF
--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -56,7 +56,8 @@ void registerFunctionOverwrite() {
   velox::exec::registerVectorFunction(
       "row_constructor_with_null",
       std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{},
-      std::make_unique<RowFunctionWithNull>());
+      std::make_unique<RowFunctionWithNull>(),
+      RowFunctionWithNull::metadata());
   velox::exec::registerFunctionCallToSpecialForm(
       RowConstructorWithNullCallToSpecialForm::kRowConstructorWithNull,
       std::make_unique<RowConstructorWithNullCallToSpecialForm>());

--- a/cpp/velox/operators/functions/RowFunctionWithNull.h
+++ b/cpp/velox/operators/functions/RowFunctionWithNull.h
@@ -26,6 +26,7 @@ namespace gluten {
  * A customized RowFunction to set struct as null when one of its argument is null.
  */
 class RowFunctionWithNull final : public facebook::velox::exec::VectorFunction {
+ public:
   void apply(
       const facebook::velox::SelectivityVector& rows,
       std::vector<facebook::velox::VectorPtr>& args,
@@ -58,8 +59,8 @@ class RowFunctionWithNull final : public facebook::velox::exec::VectorFunction {
     context.moveOrCopyResult(localResult, rows, result);
   }
 
-  bool isDefaultNullBehavior() const override {
-    return false;
+  static facebook::velox::exec::VectorFunctionMetadata metadata() {
+    return facebook::velox::exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build();
   }
 };
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_03_25
+VELOX_BRANCH=2024_03_26
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
3aa020dff (upstream/main) Fix fbthrift build in setup-*.sh (#9204)
c4f322526 Replace test methods with lambdas in sparksql/tests/StringTest.cpp (#9066)
5c67de403 Fix multiple files spilled for the distinct hash table (#9230)
f5dbf1ea5 Record pause time and off thread time per driver (#9199)
835b88e04 Fix build error in ArrowBridgeArrayTest (#9243)
b842c14fe Move scalar function metadata to the registry (#9209)
049cf2021 Add nightly runs of Aggregation fuzzer using Presto as source of truth. (#9087)
05cede5ea Fix allocation calls where requested size is covered by the collateral (#9145)
700ce6d41 Ensure memory reservation before shrinking cache and allocating (#9136)
e955b4be2 Fix incorrect std::move in ExprCompiler.cpp (#9237)
fe49b3733 Rewrite GenericInPredicate as simple function (#9236)
c3a7bfc84 Fix formatting and typos in CompareFlags.h (#9232)
ce0161088 Add bitwise_xor and bitwise_not Spark functions (#9146)
7a2996c4a Fix segfault in HiveDataSource::next() when preloading an empty split (#8850)
```