### PR TITLE
[VL] Velox patch to avoid installing libunwind-dev no longer works

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -86,7 +86,7 @@ function process_setup_ubuntu {
   # need set BUILD_SHARED_LIBS flag for thrift
   sed -i  "/facebook\/fbthrift/{n;s/cmake_install -DBUILD_TESTS=OFF/cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF/;}" scripts/setup-ubuntu.sh
   # Do not install libunwind which can cause interruption when catching native exception.
-  sed -i 's/sudo --preserve-env apt install -y libunwind-dev && //' scripts/setup-ubuntu.sh
+  sed -i 's/${SUDO} apt install -y libunwind-dev//' scripts/setup-ubuntu.sh
   sed -i '/ccache/a\  *thrift* \\' scripts/setup-ubuntu.sh
   sed -i '/ccache/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
   sed -i '/ccache/a\  libxml2-dev \\' scripts/setup-ubuntu.sh


### PR DESCRIPTION
For the background of this, please refer to https://github.com/apache/incubator-gluten/blob/main/docs/velox-backend-troubleshooting.md#fatal-error-after-native-exception-is-thrown

In future we may need to improve the patching code by at least by throwing some errors when failing to find a match.