### PR TITLE
[CORE] Move BackendBuildInfo case class from GlutenPlugin to Backend class file

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.backendsapi.clickhouse
 
-import io.glutenproject.{CH_BRANCH, CH_COMMIT, GlutenConfig, GlutenPlugin}
+import io.glutenproject.{CH_BRANCH, CH_COMMIT, GlutenConfig}
 import io.glutenproject.backendsapi._
 import io.glutenproject.expression.WindowFunctionsBuilder
 import io.glutenproject.extension.ValidationResult
@@ -41,8 +41,8 @@ import scala.util.control.Breaks.{break, breakable}
 
 class CHBackend extends Backend {
   override def name(): String = CHBackend.BACKEND_NAME
-  override def buildInfo(): GlutenPlugin.BackendBuildInfo =
-    GlutenPlugin.BackendBuildInfo("ClickHouse", CH_BRANCH, CH_COMMIT, "UNKNOWN")
+  override def buildInfo(): BackendBuildInfo =
+    BackendBuildInfo("ClickHouse", CH_BRANCH, CH_COMMIT, "UNKNOWN")
   override def iteratorApi(): IteratorApi = new CHIteratorApi
   override def sparkPlanExecApi(): SparkPlanExecApi = new CHSparkPlanExecApi
   override def transformerApi(): TransformerApi = new CHTransformerApi

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.backendsapi.velox
 
-import io.glutenproject.{GlutenConfig, GlutenPlugin, VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME}
+import io.glutenproject.{GlutenConfig, VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME}
 import io.glutenproject.backendsapi._
 import io.glutenproject.exception.GlutenNotSupportException
 import io.glutenproject.execution.WriteFilesExecTransformer
@@ -44,8 +44,8 @@ import scala.util.control.Breaks.breakable
 
 class VeloxBackend extends Backend {
   override def name(): String = VeloxBackend.BACKEND_NAME
-  override def buildInfo(): GlutenPlugin.BackendBuildInfo =
-    GlutenPlugin.BackendBuildInfo("Velox", VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME)
+  override def buildInfo(): BackendBuildInfo =
+    BackendBuildInfo("Velox", VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME)
   override def iteratorApi(): IteratorApi = new IteratorApiImpl
   override def sparkPlanExecApi(): SparkPlanExecApi = new SparkPlanExecApiImpl
   override def transformerApi(): TransformerApi = new TransformerApiImpl

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -278,10 +278,4 @@ private[glutenproject] object GlutenPlugin {
   implicit def sparkConfImplicit(conf: SparkConf): SparkConfImplicits = {
     new SparkConfImplicits(conf)
   }
-
-  case class BackendBuildInfo(
-      backend: String,
-      backendBranch: String,
-      backendRevision: String,
-      backendRevisionTime: String)
 }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/Backend.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/Backend.scala
@@ -16,12 +16,10 @@
  */
 package io.glutenproject.backendsapi
 
-import io.glutenproject.GlutenPlugin
-
 trait Backend {
   def name(): String
 
-  def buildInfo(): GlutenPlugin.BackendBuildInfo
+  def buildInfo(): BackendBuildInfo
 
   def iteratorApi(): IteratorApi
 
@@ -39,3 +37,9 @@ trait Backend {
 
   def settings(): BackendSettingsApi
 }
+
+case class BackendBuildInfo(
+    backend: String,
+    backendBranch: String,
+    backendRevision: String,
+    backendRevisionTime: String)

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
@@ -16,8 +16,6 @@
  */
 package io.glutenproject.backendsapi
 
-import io.glutenproject.GlutenPlugin
-
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters
@@ -57,7 +55,7 @@ object BackendsApiManager {
     backend.name()
   }
 
-  def getBuildInfo: GlutenPlugin.BackendBuildInfo = {
+  def getBuildInfo: BackendBuildInfo = {
     backend.buildInfo()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `BackendBuildInfo` case class seemed more appropriate in `Backend` class file, so I moved it.

## How was this patch tested?


