### PR TITLE
[GLUTEN-5133]Modify the prompt information for TakeOrderedAndProjectE…

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -49,7 +49,7 @@ case class TakeOrderedAndProjectExecTransformer(
     val orderByString = truncatedString(sortOrder, "[", ",", "]", maxFields)
     val outputString = truncatedString(output, "[", ",", "]", maxFields)
 
-    s"TakeOrderedAndProjectExecTransform(limit=$limit, " +
+    s"TakeOrderedAndProjectExecTransformer (limit=$limit, " +
       s"orderBy=$orderByString, output=$outputString)"
   }
 


### PR DESCRIPTION
…xecTransformer #5133

## What changes were proposed in this pull request?

In TakeOrderedAndProjectExecTransformer, the prompt information is different from others.

For example:

spark-sql>explain select a from test.tablea order by a limit 5
plan
== Physical Plan ==
VeloxColumnarToRowExec
+- TakeOrderedAndProjectExecTransform(limit=5, orderBy=[a#13 ASC NULLS FIRST], output=[a#13])
+- ^(3) NativeScan hive test.tablea [a#13], HiveTableRelation [test.tablea, org.apache.hadoop.hive.ql.io.orc.OrcSerde, Data Cols: [a#13], Partition Cols: []]

"TakeOrderedAndProjectExecTransform" is changed to ""TakeOrderedAndProjectExecTransformer, which will be consistent with other enhanced information styles.

(Fixes: \#5133)


After this pr:

spark-sql>explain select a from test.tablea order by a limit 5
plan
== Physical Plan ==
VeloxColumnarToRowExec
+- TakeOrderedAndProjectExecTransformer (limit=5, orderBy=[a#13 ASC NULLS FIRST], output=[a#13])
+- ^(3) NativeScan hive test.tablea [a#13], HiveTableRelation [test.tablea, org.apache.hadoop.hive.ql.io.orc.OrcSerde, Data Cols: [a#13], Partition Cols: []]

## How was this patch tested?


