### PR TITLE
[GLUTEN-5083][CH] Invalid result with `mergeTwoPhasesHashBaseAggregateIfNeed` enable

### DIFF
--- a/cpp-ch/local-engine/Operator/GraceMergingAggregatedStep.cpp
+++ b/cpp-ch/local-engine/Operator/GraceMergingAggregatedStep.cpp
@@ -67,6 +67,10 @@ GraceMergingAggregatedStep::GraceMergingAggregatedStep(
 
 void GraceMergingAggregatedStep::transformPipeline(DB::QueryPipelineBuilder & pipeline, const DB::BuildQueryPipelineSettings &)
 {
+    if (params.max_bytes_before_external_group_by)
+    {
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "max_bytes_before_external_group_by is not supported in GraceMergingAggregatedStep");
+    }
     auto num_streams = pipeline.getNumStreams();
     auto transform_params = std::make_shared<DB::AggregatingTransformParams>(pipeline.getHeader(), params, true);
     pipeline.resize(1);

--- a/cpp-ch/local-engine/Operator/StreamingAggregatingStep.cpp
+++ b/cpp-ch/local-engine/Operator/StreamingAggregatingStep.cpp
@@ -286,6 +286,10 @@ StreamingAggregatingStep::StreamingAggregatingStep(
 
 void StreamingAggregatingStep::transformPipeline(DB::QueryPipelineBuilder & pipeline, const DB::BuildQueryPipelineSettings &)
 {
+    if (params.max_bytes_before_external_group_by)
+    {
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "max_bytes_before_external_group_by is not supported in StreamingAggregatingStep");
+    }
     pipeline.dropTotalsAndExtremes();
     auto transform_params = std::make_shared<DB::AggregatingTransformParams>(pipeline.getHeader(), params, false);
     pipeline.resize(1);

--- a/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
@@ -310,7 +310,7 @@ void AggregateRelParser::addCompleteModeAggregatedStep()
             settings.group_by_overflow_mode,
             settings.group_by_two_level_threshold,
             settings.group_by_two_level_threshold_bytes,
-            settings.max_bytes_before_external_group_by,
+            0, /*settings.max_bytes_before_external_group_by*/
             settings.empty_result_for_aggregation_by_empty_set,
             getContext()->getTempDataOnDisk(),
             settings.max_threads,


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #5083 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

