### PR TITLE
[Core] minor change for eliminateProjectList

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
@@ -121,7 +121,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       // post-projection, the additional columns need to be removed, leaving only the original
       // output of the child.
       val preProject = ProjectExec(
-        eliminateProjectList(sort.child.outputSet, expressionMap.values.toSeq),
+        eliminateProjectList(expressionMap.values.toSeq, sort.child.outputSet),
         sort.child)
       val newSort = sort.copy(sortOrder = newSortOrder, child = preProject)
       // The pre-project and post-project of SortExec always appear together, so it's more
@@ -133,7 +133,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       val expressionMap = new mutable.HashMap[Expression, NamedExpression]()
       val newSortOrder = getNewSortOrder(topK.sortOrder, expressionMap)
       val preProject = ProjectExec(
-        eliminateProjectList(topK.child.outputSet, expressionMap.values.toSeq),
+        eliminateProjectList(expressionMap.values.toSeq, topK.child.outputSet),
         topK.child)
       topK.copy(sortOrder = newSortOrder, child = preProject)
 
@@ -152,7 +152,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
         newGroupingExpressions = newGroupingExpressions,
         newAggregateExpressions = newAggregateExpressions)
       val preProject = ProjectExec(
-        eliminateProjectList(agg.child.outputSet, expressionMap.values.toSeq),
+        eliminateProjectList(expressionMap.values.toSeq, agg.child.outputSet),
         agg.child)
       newAgg.withNewChildren(Seq(preProject))
 
@@ -175,7 +175,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
         partitionSpec = newPartitionSpec,
         windowExpression = newWindowExpressions.asInstanceOf[Seq[NamedExpression]],
         child = ProjectExec(
-          eliminateProjectList(window.child.outputSet, expressionMap.values.toSeq),
+          eliminateProjectList(expressionMap.values.toSeq, window.child.outputSet),
           window.child)
       )
 
@@ -188,7 +188,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       expand.copy(
         projections = newProjections,
         child = ProjectExec(
-          eliminateProjectList(expand.child.outputSet, expressionMap.values.toSeq),
+          eliminateProjectList(expressionMap.values.toSeq, expand.child.outputSet),
           expand.child))
 
     case generate: GenerateExec =>

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -73,7 +73,7 @@ trait PullOutProjectHelper {
   protected def eliminateProjectList(
       projectAttributes: Seq[NamedExpression],
       childOutput: AttributeSet): Seq[NamedExpression] = {
-    (projectAttributes ++ (childOutput -- projectAttributes).toIndexedSeq)
+    (childOutput -- projectAttributes).toIndexedSeq ++ projectAttributes
       .sortWith(_.exprId.id < _.exprId.id)
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -71,11 +71,9 @@ trait PullOutProjectHelper {
     }
 
   protected def eliminateProjectList(
-      childOutput: AttributeSet,
-      appendAttributes: Seq[NamedExpression]): Seq[NamedExpression] = {
-    childOutput.toIndexedSeq.filter {
-      attr => !appendAttributes.exists(_.exprId == attr.exprId)
-    } ++ appendAttributes
+      projectAttributes: Seq[NamedExpression],
+      childOutput: AttributeSet): Seq[NamedExpression] = {
+    (projectAttributes ++ (childOutput -- projectAttributes).toIndexedSeq)
       .sortWith(_.exprId.id < _.exprId.id)
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -73,8 +73,9 @@ trait PullOutProjectHelper {
   protected def eliminateProjectList(
       childOutput: AttributeSet,
       appendAttributes: Seq[NamedExpression]): Seq[NamedExpression] = {
-    childOutput.toIndexedSeq ++ appendAttributes
-      .filter(attr => !childOutput.contains(attr))
+    childOutput.toIndexedSeq.filter {
+      attr => !appendAttributes.exists(_.exprId == attr.exprId)
+    } ++ appendAttributes
       .sortWith(_.exprId.id < _.exprId.id)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`eliminateProjectList` removed the project function, like below:


`HashAggregate(keys=[knownfloatingpointnormalized(normalizenanandzero(f#38)) AS f#38], functions=[partial_count(1)], output=[f#38, count#46L])`
-->
```
+- ^(5) FlushableHashAggregateTransformer(keys=[f#38], functions=[partial_count(1)], output=[f#38, count#46L])
                                  +- ^(5) ProjectExecTransformer [f#38]
```
`knownfloatingpointnormalized(normalizenanandzero` are removed after the transfer. This is found when doing the change https://github.com/facebookincubator/velox/pull/9272, it can be reproduced by the query:
`Seq(0.0f, -0.0f, 0.0f/0.0f, Float.NaN).toDF("f").groupBy("f").count().collect`


