### PR TITLE
[CORE][VL] ACBO: Add GlutenMetadataModel, move Gluten schema def from property model to metadata model

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -108,49 +108,6 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
     RowToCHNativeColumnarExec(child)
   }
 
-  override def genProjectExecTransformer(
-      projectList: Seq[NamedExpression],
-      child: SparkPlan): ProjectExecTransformer = {
-    def processProjectExecTransformer(projectList: Seq[NamedExpression]): Seq[NamedExpression] = {
-      // When there is a MergeScalarSubqueries which will create the named_struct with the same name,
-      // looks like {'bloomFilter', BF1, 'bloomFilter', BF2}
-      // or {'count(1)', count(1)#111L, 'avg(a)', avg(a)#222L, 'count(1)', count(1)#333L},
-      // it will cause problem for ClickHouse backend,
-      // which cannot tolerate duplicate type names in struct type,
-      // so we need to rename 'nameExpr' in the named_struct to make them unique
-      // after executing the MergeScalarSubqueries.
-      var needToReplace = false
-      val newProjectList = projectList.map {
-        case alias @ Alias(cns @ CreateNamedStruct(children: Seq[Expression]), "mergedValue") =>
-          // check whether there are some duplicate names
-          if (cns.nameExprs.distinct.size == cns.nameExprs.size) {
-            alias
-          } else {
-            val newChildren = children
-              .grouped(2)
-              .flatMap {
-                case Seq(name: Literal, value: NamedExpression) =>
-                  val newLiteral = Literal(name.toString() + "#" + value.exprId.id)
-                  Seq(newLiteral, value)
-                case Seq(name, value) => Seq(name, value)
-              }
-              .toSeq
-            needToReplace = true
-            Alias.apply(CreateNamedStruct(newChildren), "mergedValue")(alias.exprId)
-          }
-        case other: NamedExpression => other
-      }
-
-      if (!needToReplace) {
-        projectList
-      } else {
-        newProjectList
-      }
-    }
-
-    ProjectExecTransformer.createUnsafe(processProjectExecTransformer(projectList), child)
-  }
-
   /**
    * Generate FilterExecTransformer.
    *

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -108,6 +108,49 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
     RowToCHNativeColumnarExec(child)
   }
 
+  override def genProjectExecTransformer(
+      projectList: Seq[NamedExpression],
+      child: SparkPlan): ProjectExecTransformer = {
+    def processProjectExecTransformer(projectList: Seq[NamedExpression]): Seq[NamedExpression] = {
+      // When there is a MergeScalarSubqueries which will create the named_struct with the same name,
+      // looks like {'bloomFilter', BF1, 'bloomFilter', BF2}
+      // or {'count(1)', count(1)#111L, 'avg(a)', avg(a)#222L, 'count(1)', count(1)#333L},
+      // it will cause problem for ClickHouse backend,
+      // which cannot tolerate duplicate type names in struct type,
+      // so we need to rename 'nameExpr' in the named_struct to make them unique
+      // after executing the MergeScalarSubqueries.
+      var needToReplace = false
+      val newProjectList = projectList.map {
+        case alias @ Alias(cns @ CreateNamedStruct(children: Seq[Expression]), "mergedValue") =>
+          // check whether there are some duplicate names
+          if (cns.nameExprs.distinct.size == cns.nameExprs.size) {
+            alias
+          } else {
+            val newChildren = children
+              .grouped(2)
+              .flatMap {
+                case Seq(name: Literal, value: NamedExpression) =>
+                  val newLiteral = Literal(name.toString() + "#" + value.exprId.id)
+                  Seq(newLiteral, value)
+                case Seq(name, value) => Seq(name, value)
+              }
+              .toSeq
+            needToReplace = true
+            Alias.apply(CreateNamedStruct(newChildren), "mergedValue")(alias.exprId)
+          }
+        case other: NamedExpression => other
+      }
+
+      if (!needToReplace) {
+        projectList
+      } else {
+        newProjectList
+      }
+    }
+
+    ProjectExecTransformer.createUnsafe(processProjectExecTransformer(projectList), child)
+  }
+
   /**
    * Generate FilterExecTransformer.
    *

--- a/backends-velox/src/test/scala/io/glutenproject/planner/VeloxCboSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/planner/VeloxCboSuite.scala
@@ -16,11 +16,12 @@
  */
 package io.glutenproject.planner
 
-import io.glutenproject.cbo.{Cbo, CboSuiteBase}
+import io.glutenproject.cbo.Cbo
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.path.CboPath
 import io.glutenproject.cbo.property.PropertySet
 import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
-import io.glutenproject.planner.property.GlutenProperties.{Conventions, Schemas}
+import io.glutenproject.planner.property.GlutenProperties.Conventions
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -41,7 +42,7 @@ class VeloxCboSuite extends SharedSparkSession {
   test("C2R, R2C - explicitly requires any properties") {
     val in = RowUnary(RowLeaf())
     val planner =
-      newCbo().newPlanner(in, PropertySet(List(Conventions.ANY, Schemas.ANY)))
+      newCbo().newPlanner(in, PropertySet(List(Conventions.ANY)))
     val out = planner.plan()
     assert(out == RowUnary(RowLeaf()))
   }
@@ -49,7 +50,7 @@ class VeloxCboSuite extends SharedSparkSession {
   test("C2R, R2C - requires columnar output") {
     val in = RowUnary(RowLeaf())
     val planner =
-      newCbo().newPlanner(in, PropertySet(List(Conventions.VANILLA_COLUMNAR, Schemas.ANY)))
+      newCbo().newPlanner(in, PropertySet(List(Conventions.VANILLA_COLUMNAR)))
     val out = planner.plan()
     assert(out == RowToColumnarExec(RowUnary(RowLeaf())))
   }
@@ -58,7 +59,7 @@ class VeloxCboSuite extends SharedSparkSession {
     val in =
       ColumnarUnary(RowUnary(RowUnary(ColumnarUnary(RowUnary(RowUnary(ColumnarUnary(RowLeaf())))))))
     val planner =
-      newCbo().newPlanner(in, PropertySet(List(Conventions.ROW_BASED, Schemas.ANY)))
+      newCbo().newPlanner(in, PropertySet(List(Conventions.ROW_BASED)))
     val out = planner.plan()
     assert(out == ColumnarToRowExec(ColumnarUnary(
       RowToColumnarExec(RowUnary(RowUnary(ColumnarToRowExec(ColumnarUnary(RowToColumnarExec(
@@ -82,7 +83,7 @@ class VeloxCboSuite extends SharedSparkSession {
       ColumnarUnary(RowUnary(RowUnary(ColumnarUnary(RowUnary(RowUnary(ColumnarUnary(RowLeaf())))))))
     val planner =
       newCbo(List(ConvertRowUnaryToColumnar))
-        .newPlanner(in, PropertySet(List(Conventions.ROW_BASED, Schemas.ANY)))
+        .newPlanner(in, PropertySet(List(Conventions.ROW_BASED)))
     val out = planner.plan()
     assert(out == ColumnarToRowExec(ColumnarUnary(ColumnarUnary(ColumnarUnary(
       ColumnarUnary(ColumnarUnary(ColumnarUnary(ColumnarUnary(RowToColumnarExec(RowLeaf()))))))))))
@@ -92,7 +93,7 @@ class VeloxCboSuite extends SharedSparkSession {
   }
 }
 
-object VeloxCboSuite extends CboSuiteBase {
+object VeloxCboSuite {
   def newCbo(): Cbo[SparkPlan] = {
     GlutenOptimization().asInstanceOf[Cbo[SparkPlan]]
   }

--- a/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/CboCluster.scala
+++ b/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/CboCluster.scala
@@ -21,7 +21,9 @@ import io.glutenproject.cbo.property.PropertySet
 
 import scala.collection.mutable
 
-trait CboClusterKey
+trait CboClusterKey {
+  def metadata: Metadata
+}
 
 object CboClusterKey {
   implicit class CboClusterKeyImplicits[T <: AnyRef](key: CboClusterKey) {
@@ -44,11 +46,11 @@ object CboCluster {
   }
 
   object MutableCboCluster {
-    def apply[T <: AnyRef](cbo: Cbo[T]): MutableCboCluster[T] = {
-      new RegularMutableCboCluster(cbo)
+    def apply[T <: AnyRef](cbo: Cbo[T], metadata: Metadata): MutableCboCluster[T] = {
+      new RegularMutableCboCluster(cbo, metadata)
     }
 
-    private class RegularMutableCboCluster[T <: AnyRef](val cbo: Cbo[T])
+    private class RegularMutableCboCluster[T <: AnyRef](val cbo: Cbo[T], metadata: Metadata)
       extends MutableCboCluster[T] {
       private val buffer: mutable.Set[CanonicalNode[T]] =
         mutable.Set()
@@ -58,6 +60,7 @@ object CboCluster {
       }
 
       override def add(t: CanonicalNode[T]): Unit = {
+        cbo.metadataModel.verify(metadata, cbo.metadataModel.metadataOf(t.self()))
         assert(!buffer.contains(t))
         buffer += t
       }

--- a/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/CboGroup.scala
+++ b/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/CboGroup.scala
@@ -42,7 +42,7 @@ object CboGroup {
       override val id: Int,
       override val propSet: PropertySet[T])
     extends CboGroup[T] {
-    private val groupLeaf: T = cbo.planModel.newGroupLeaf(id, propSet)
+    private val groupLeaf: T = cbo.planModel.newGroupLeaf(id, clusterKey.metadata, propSet)
 
     override def clusterKey(): CboClusterKey = clusterKey
     override def self(): T = groupLeaf

--- a/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/MetadataModel.scala
+++ b/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/MetadataModel.scala
@@ -16,17 +16,13 @@
  */
 package io.glutenproject.cbo
 
-import io.glutenproject.cbo.property.PropertySet
-
-trait PlanModel[T <: AnyRef] {
-  // Trivial tree operations.
-  def childrenOf(node: T): Seq[T]
-  def withNewChildren(node: T, children: Seq[T]): T
-  def hashCode(node: T): Int
-  def equals(one: T, other: T): Boolean
-
-  // Group operations.
-  def newGroupLeaf(groupId: Int, meta: Metadata, propSet: PropertySet[T]): T
-  def isGroupLeaf(node: T): Boolean
-  def getGroupId(node: T): Int
+/**
+ * Metadata defines the common traits among nodes in one single cluster. E.g. Schema, statistics.
+ */
+trait MetadataModel[T <: AnyRef] {
+  def metadataOf(node: T): Metadata
+  def dummy(): Metadata
+  def verify(one: Metadata, other: Metadata): Unit
 }
+
+trait Metadata {}

--- a/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/memo/Memo.scala
+++ b/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/memo/Memo.scala
@@ -53,8 +53,8 @@ object Memo {
     private val memoTable: MemoTable.Writable[T] = MemoTable.create(cbo)
     private val cache: NodeToClusterMap[T] = new NodeToClusterMap(cbo)
 
-    private def newCluster(): CboClusterKey = {
-      memoTable.newCluster()
+    private def newCluster(metadata: Metadata): CboClusterKey = {
+      memoTable.newCluster(metadata)
     }
 
     private def addToCluster(clusterKey: CboClusterKey, can: CanonicalNode[T]): Unit = {
@@ -107,7 +107,8 @@ object Memo {
         cache.get(node)
       } else {
         // Node not yet added to cluster.
-        val clusterKey = newCluster()
+        val meta = cbo.metadataModel.metadataOf(node.self())
+        val clusterKey = newCluster(meta)
         addToCluster(clusterKey, node)
         clusterKey
       }

--- a/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/memo/MemoTable.scala
+++ b/gluten-cbo/common/src/main/scala/io/glutenproject/cbo/memo/MemoTable.scala
@@ -42,7 +42,7 @@ object MemoTable {
   def create[T <: AnyRef](cbo: Cbo[T]): Writable[T] = ForwardMemoTable(cbo)
 
   trait Writable[T <: AnyRef] extends MemoTable[T] {
-    def newCluster(): CboClusterKey
+    def newCluster(metadata: Metadata): CboClusterKey
     def groupOf(key: CboClusterKey, propertySet: PropertySet[T]): CboGroup[T]
 
     def addToCluster(key: CboClusterKey, node: CanonicalNode[T]): Unit

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboMetadataSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboMetadataSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.cbo
+
+import io.glutenproject.cbo.CboConfig.PlannerType
+import io.glutenproject.cbo.CboSuiteBase._
+import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExhaustiveCboMetadataSuite extends CboMetadataSuite {
+  override protected def conf: CboConfig = CboConfig(plannerType = PlannerType.Exhaustive)
+}
+
+class DpCboMetadataSuite extends CboMetadataSuite {
+  override protected def conf: CboConfig = CboConfig(plannerType = PlannerType.Dp)
+}
+
+abstract class CboMetadataSuite extends AnyFunSuite {
+  import CboMetadataSuite._
+  protected def conf: CboConfig
+
+  test("Dry run") {
+    val cbo =
+      Cbo[TestNode](
+        PlanModelImpl,
+        CostModelImpl,
+        RowCountMetadataModel,
+        PropertyModelImpl,
+        ExplainImpl,
+        CboRule.Factory.none())
+        .withNewConfig(_ => conf)
+
+    val planner = cbo.newPlanner(KnownRowCountUnary(0.5, KnownRowCountLeaf(2000)))
+    val out = planner.plan()
+    assert(out == KnownRowCountUnary(0.5, KnownRowCountLeaf(2000)))
+  }
+
+  test("Trivial planning") {
+    object CombineUnaryNodes extends CboRule[TestNode] {
+      override def shift(node: TestNode): Iterable[TestNode] = node match {
+        case KnownRowCountUnary(0.25d, KnownRowCountUnary(2.0d, child)) =>
+          assert(child.isInstanceOf[Group])
+          assert(child.asInstanceOf[Group].meta.isInstanceOf[IntRowCount])
+          assert(child.asInstanceOf[Group].meta.asInstanceOf[IntRowCount].value == 2000)
+          List(KnownRowCountUnary(0.5d, child))
+        case other => List.empty
+      }
+
+      override def shape(): Shape[TestNode] = Shapes.fixedHeight(2)
+    }
+
+    val cbo =
+      Cbo[TestNode](
+        PlanModelImpl,
+        CostModelImpl,
+        RowCountMetadataModel,
+        PropertyModelImpl,
+        ExplainImpl,
+        CboRule.Factory.reuse(List(CombineUnaryNodes)))
+        .withNewConfig(_ => conf)
+
+    val planner =
+      cbo.newPlanner(KnownRowCountUnary(0.25d, KnownRowCountUnary(2.0d, KnownRowCountLeaf(2000))))
+    val out = planner.plan()
+    assert(out == KnownRowCountUnary(0.5d, KnownRowCountLeaf(2000)))
+  }
+
+  test("Cluster merge") {
+    object CombineUnaryNodes extends CboRule[TestNode] {
+      override def shift(node: TestNode): Iterable[TestNode] = node match {
+        case KnownRowCountUnary(0.25d, KnownRowCountUnary(2.0d, child)) =>
+          assert(child.isInstanceOf[Group])
+          assert(child.asInstanceOf[Group].meta.isInstanceOf[IntRowCount])
+          assert(child.asInstanceOf[Group].meta.asInstanceOf[IntRowCount].value == 2000)
+          List(KnownRowCountUnary(0.5d, child))
+        case other => List.empty
+      }
+
+      override def shape(): Shape[TestNode] = Shapes.fixedHeight(2)
+    }
+
+    val cbo =
+      Cbo[TestNode](
+        PlanModelImpl,
+        CostModelImpl,
+        RowCountMetadataModel,
+        PropertyModelImpl,
+        ExplainImpl,
+        CboRule.Factory.reuse(List(CombineUnaryNodes)))
+        .withNewConfig(_ => conf)
+
+    val in = KnownRowCountBinary(
+      KnownRowCountUnary(0.5d, KnownRowCountLeaf(2000)),
+      KnownRowCountUnary(0.25d, KnownRowCountUnary(2.0d, KnownRowCountLeaf(2000))))
+    val planner = cbo.newPlanner(in)
+    val out = planner.plan()
+    assert(
+      out == KnownRowCountBinary(
+        KnownRowCountUnary(0.5, KnownRowCountLeaf(2000)),
+        KnownRowCountUnary(0.5, KnownRowCountLeaf(2000))))
+  }
+}
+
+object CboMetadataSuite {
+  private object RowCountMetadataModel extends MetadataModel[TestNode] {
+    override def metadataOf(node: TestNode): Metadata = node match {
+      case n: KnownRowCountNode =>
+        IntRowCount(n.rowCount())
+      case other =>
+        throw new UnsupportedOperationException()
+    }
+
+    override def dummy(): Metadata = IntRowCount(0)
+    override def verify(one: Metadata, other: Metadata): Unit = (one, other) match {
+      case (IntRowCount(a), IntRowCount(b)) =>
+        assert(a == b)
+      case other =>
+        throw new UnsupportedOperationException()
+    }
+  }
+
+  trait RowCount extends Metadata
+
+  case class IntRowCount(value: Int) extends RowCount
+
+  trait KnownRowCountNode extends TestNode {
+    def rowCount(): Int
+  }
+
+  case class KnownRowCountUnary(selectivity: Double, override val child: TestNode)
+    extends UnaryLike
+    with KnownRowCountNode {
+    private val childRowCount = child match {
+      case n: KnownRowCountNode => n.rowCount()
+      case g: Group => g.meta.asInstanceOf[IntRowCount].value
+      case other => throw new UnsupportedOperationException()
+    }
+
+    override def withNewChildren(child: TestNode): UnaryLike = copy(selectivity, child)
+    override def rowCount(): Int = (childRowCount * selectivity).toInt
+    override def selfCost(): Long = childRowCount
+  }
+
+  case class KnownRowCountLeaf(rowCount: Int) extends LeafLike with KnownRowCountNode {
+    override def makeCopy(): LeafLike = this
+    override def selfCost(): Long = rowCount
+  }
+
+  case class KnownRowCountBinary(override val left: TestNode, override val right: TestNode)
+    extends BinaryLike
+    with KnownRowCountNode {
+    private val leftRowCount = left match {
+      case n: KnownRowCountNode => n.rowCount()
+      case g: Group => g.meta.asInstanceOf[IntRowCount].value
+      case other => throw new UnsupportedOperationException()
+    }
+
+    private val rightRowCount = right match {
+      case n: KnownRowCountNode => n.rowCount()
+      case g: Group => g.meta.asInstanceOf[IntRowCount].value
+      case other => throw new UnsupportedOperationException()
+    }
+
+    override def withNewChildren(left: TestNode, right: TestNode): BinaryLike = copy(left, right)
+    override def rowCount(): Int = leftRowCount * rightRowCount
+    override def selfCost(): Long = leftRowCount + rightRowCount
+  }
+}

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboOperationSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboOperationSuite.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.cbo
 
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.path.CboPath
 import io.glutenproject.cbo.property.PropertySet
 import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
@@ -47,8 +48,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(l2l2, u2u2, Unary2Unary2ToUnary3)))
@@ -68,8 +70,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(l2l2, u2u2, u2u22u3)))
@@ -94,8 +97,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
+        PlanModelImpl,
         CostModelImpl,
-        planModel,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(l2l2, u2u2)))
@@ -123,8 +127,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
+        PlanModelImpl,
         CostModelImpl,
-        planModel,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(l2l2, u2u2, u2u22u3)))
@@ -158,8 +163,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
+        PlanModelImpl,
         CostModelImpl,
-        planModel,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(new UnaryToUnary2(), new LeafToLeaf2(), rule)))
@@ -198,8 +204,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        costModel,
         PlanModelImpl,
+        costModel,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(new UnaryToUnary2, new Unary2ToUnary3)))
@@ -259,8 +266,9 @@ class CboOperationSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        costModel,
         PlanModelImpl,
+        costModel,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(new UnaryToUnary2, new Unary2ToUnary3)))
@@ -288,7 +296,7 @@ class CboOperationSuite extends AnyFunSuite {
   }
 }
 
-object CboOperationSuite extends CboSuiteBase {
+object CboOperationSuite {
 
   case class Unary(override val selfCost: Long, override val child: TestNode) extends UnaryLike {
     override def withNewChildren(child: TestNode): UnaryLike = copy(child = child)
@@ -403,9 +411,9 @@ object CboOperationSuite extends CboSuiteBase {
       equalsCount += 1
       delegated.equals(one, other)
     }
-    override def newGroupLeaf(groupId: Int, propSet: PropertySet[T]): T = {
+    override def newGroupLeaf(groupId: Int, metadata: Metadata, propSet: PropertySet[T]): T = {
       newGroupLeafCount += 1
-      delegated.newGroupLeaf(groupId, propSet)
+      delegated.newGroupLeaf(groupId, metadata, propSet)
     }
     override def isGroupLeaf(node: T): Boolean = {
       isGroupLeafCount += 1

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboPropertySuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboPropertySuite.scala
@@ -18,6 +18,7 @@ package io.glutenproject.cbo
 
 import io.glutenproject.cbo.Best.BestNotFoundException
 import io.glutenproject.cbo.CboConfig.PlannerType
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.property.PropertySet
 import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
 
@@ -57,8 +58,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
   test(s"Cannot enforce property") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModelWithOutEnforcerRules,
         ExplainImpl,
         CboRule.Factory.none())
@@ -73,8 +75,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
   test(s"Property enforcement - A to B") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -90,8 +93,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
   test(s"Property convert - (A, B)") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
         CboRule.Factory.reuse(List(ReplaceByTypeARule, ReplaceByTypeBRule)))
@@ -145,8 +149,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModelWithOutEnforcerRules,
         ExplainImpl,
         CboRule.Factory.reuse(List(ReplaceLeafAByLeafBRule, HitCacheOp, FinalOp))
@@ -190,8 +195,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModelWithOutEnforcerRules,
         ExplainImpl,
         CboRule.Factory.reuse(List(ReplaceLeafAByLeafBRule, ReplaceUnaryBByUnaryARule))
@@ -218,8 +224,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
         CboRule.Factory.reuse(List(ConvertEnforcerAndTypeAToTypeB)))
@@ -255,11 +262,13 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
-        CboRule.Factory.reuse(List(ReplaceByTypeARule, ReplaceNonUnaryByTypeBRule)))
+        CboRule.Factory.reuse(List(ReplaceByTypeARule, ReplaceNonUnaryByTypeBRule))
+      )
         .withNewConfig(_ => conf)
     val plan =
       TypedBinary(TypeA, 5, TypedUnary(TypeA, 10, TypedLeaf(TypeA, 10)), TypedLeaf(TypeA, 10))
@@ -305,8 +314,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
         CboRule.Factory.reuse(List(ReduceTypeBCost, ConvertUnaryTypeBToTypeC)))
@@ -356,8 +366,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
         CboRule.Factory.reuse(List(LeftOp, RightOp))
@@ -402,8 +413,9 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
         CboRule.Factory.reuse(List(ConvertTypeBEnforcerAndLeafToTypeC, ConvertTypeATypeCToTypeC))
@@ -454,11 +466,13 @@ abstract class CboPropertySuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         NodeTypePropertyModel,
         ExplainImpl,
-        CboRule.Factory.reuse(List(ReplaceNonUnaryByTypeBRule, ReduceTypeBCost)))
+        CboRule.Factory.reuse(List(ReplaceNonUnaryByTypeBRule, ReduceTypeBCost))
+      )
         .withNewConfig(_ => conf)
     val plan =
       TypedBinary(TypeA, 5, TypedUnary(TypeA, 10, TypedLeaf(TypeA, 10)), TypedLeaf(TypeA, 10))
@@ -473,7 +487,7 @@ abstract class CboPropertySuite extends AnyFunSuite {
   }
 }
 
-object CboPropertySuite extends CboSuiteBase {
+object CboPropertySuite {
 
   case class NoopEnforcerRule[T <: AnyRef]() extends CboRule[T] {
     override def shift(node: T): Iterable[T] = List.empty
@@ -519,7 +533,7 @@ object CboPropertySuite extends CboSuiteBase {
   object DummyPropertyDef extends PropertyDef[TestNode, DummyProperty] {
     override def getProperty(plan: TestNode): DummyProperty = {
       plan match {
-        case Group(_, _) => throw new IllegalStateException()
+        case Group(_, _, _) => throw new IllegalStateException()
         case PUnary(_, prop, _) => prop
         case PLeaf(_, prop) => prop
         case PBinary(_, prop, _, _) => prop

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/CboSuite.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.cbo
 
 import io.glutenproject.cbo.CboConfig.PlannerType
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.memo.Memo
 import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
 
@@ -38,8 +39,9 @@ abstract class CboSuite extends AnyFunSuite {
   test("Group memo - re-memorize") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -53,8 +55,9 @@ abstract class CboSuite extends AnyFunSuite {
   test("Group memo - define equivalence") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -71,8 +74,9 @@ abstract class CboSuite extends AnyFunSuite {
   test("Group memo - define equivalence: binary with similar children, 1") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -91,8 +95,9 @@ abstract class CboSuite extends AnyFunSuite {
   test("Group memo - define equivalence: binary with similar children, 2") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -111,8 +116,9 @@ abstract class CboSuite extends AnyFunSuite {
   test("Group memo - partial canonical") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -155,8 +161,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(DivideUnaryCost, DecreaseUnaryCost)))
@@ -181,8 +188,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(InsertUnary2)))
@@ -213,8 +221,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(DivideBinaryCost)))
@@ -240,8 +249,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(SymmetricRule)))
@@ -270,8 +280,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(BinarySwap)))
@@ -297,8 +308,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(BinarySwap)))
@@ -324,8 +336,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(Unary2Unary3)))
@@ -345,8 +358,9 @@ abstract class CboSuite extends AnyFunSuite {
     val u2u2 = new UnaryToUnary2()
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(l2l2, u2u2)))
@@ -381,8 +395,9 @@ abstract class CboSuite extends AnyFunSuite {
 
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(l2l2, u2u2, Unary2Unary2ToUnary3)))
@@ -398,7 +413,7 @@ abstract class CboSuite extends AnyFunSuite {
   }
 }
 
-object CboSuite extends CboSuiteBase {
+object CboSuite {
 
   case class Binary(
       override val selfCost: Long,

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/mock/MockMemoState.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/mock/MockMemoState.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.cbo.mock
 
 import io.glutenproject.cbo._
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.memo.{MemoState, MemoStore}
 import io.glutenproject.cbo.property.PropertySet
 import io.glutenproject.cbo.vis.GraphvizVisualizer
@@ -64,7 +65,7 @@ object MockMemoState {
     def newCluster(): MockMutableCluster[T] = {
       val id = clusterBuffer.size
       val key = MockMutableCluster.DummyIntClusterKey(id)
-      val cluster = MockMutableCluster[T](cbo, key, propSet, groupFactory)
+      val cluster = MockMutableCluster[T](cbo, key, groupFactory)
       clusterBuffer += (key -> cluster)
       cluster
     }
@@ -103,12 +104,13 @@ object MockMemoState {
     def apply[T <: AnyRef](
         cbo: Cbo[T],
         key: CboClusterKey,
-        propSet: PropertySet[T],
         groupFactory: MockMutableGroup.Factory[T]): MockMutableCluster[T] = {
       new MockMutableCluster[T](cbo, key, groupFactory)
     }
 
-    case class DummyIntClusterKey(id: Int) extends CboClusterKey
+    case class DummyIntClusterKey(id: Int) extends CboClusterKey {
+      override def metadata: Metadata = MetadataModelImpl.DummyMetadata
+    }
   }
 
   class MockMutableGroup[T <: AnyRef] private (
@@ -137,7 +139,11 @@ object MockMemoState {
       def newGroup(clusterKey: CboClusterKey): MockMutableGroup[T] = {
         val id = groupBuffer.size
         val group =
-          new MockMutableGroup[T](id, clusterKey, propSet, cbo.planModel.newGroupLeaf(id, propSet))
+          new MockMutableGroup[T](
+            id,
+            clusterKey,
+            propSet,
+            cbo.planModel.newGroupLeaf(id, clusterKey.metadata, propSet))
         groupBuffer += group
         group
       }

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/CboPathSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/CboPathSuite.scala
@@ -16,7 +16,8 @@
  */
 package io.glutenproject.cbo.path
 
-import io.glutenproject.cbo.{Cbo, CboSuiteBase}
+import io.glutenproject.cbo.Cbo
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.mock.MockCboPath
 import io.glutenproject.cbo.rule.CboRule
 
@@ -28,8 +29,9 @@ class CboPathSuite extends AnyFunSuite {
   test("Path aggregate - empty") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List.empty))
@@ -39,8 +41,9 @@ class CboPathSuite extends AnyFunSuite {
   test("Path aggregate") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List.empty))
@@ -91,7 +94,7 @@ class CboPathSuite extends AnyFunSuite {
   }
 }
 
-object CboPathSuite extends CboSuiteBase {
+object CboPathSuite {
   case class Leaf(name: String, override val selfCost: Long) extends LeafLike {
     override def makeCopy(): LeafLike = this
   }

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/PathFinderSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/PathFinderSuite.scala
@@ -16,7 +16,8 @@
  */
 package io.glutenproject.cbo.path
 
-import io.glutenproject.cbo.{CanonicalNode, Cbo, CboSuiteBase}
+import io.glutenproject.cbo.{CanonicalNode, Cbo}
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.mock.MockMemoState
 import io.glutenproject.cbo.rule.CboRule
 
@@ -28,8 +29,9 @@ class PathFinderSuite extends AnyFunSuite {
   test("Base") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -82,8 +84,9 @@ class PathFinderSuite extends AnyFunSuite {
   test("Find - multiple depths") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -161,8 +164,9 @@ class PathFinderSuite extends AnyFunSuite {
   test("Dive - basic") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -219,8 +223,9 @@ class PathFinderSuite extends AnyFunSuite {
   test("Find/Dive - binary with different children heights") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -286,7 +291,7 @@ class PathFinderSuite extends AnyFunSuite {
   }
 }
 
-object PathFinderSuite extends CboSuiteBase {
+object PathFinderSuite {
   case class Leaf(name: String, override val selfCost: Long) extends LeafLike {
     override def makeCopy(): LeafLike = this
   }

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/PathMaskSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/PathMaskSuite.scala
@@ -16,8 +16,6 @@
  */
 package io.glutenproject.cbo.path
 
-import io.glutenproject.cbo.CboSuiteBase
-
 import org.scalatest.funsuite.AnyFunSuite
 
 class PathMaskSuite extends AnyFunSuite {
@@ -110,4 +108,4 @@ class PathMaskSuite extends AnyFunSuite {
   }
 }
 
-object PathMaskSuite extends CboSuiteBase {}
+object PathMaskSuite {}

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/WizardSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/path/WizardSuite.scala
@@ -16,7 +16,8 @@
  */
 package io.glutenproject.cbo.path
 
-import io.glutenproject.cbo.{Cbo, CboSuiteBase}
+import io.glutenproject.cbo.Cbo
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.mock.MockMemoState
 import io.glutenproject.cbo.rule.CboRule
 
@@ -28,8 +29,9 @@ class WizardSuite extends AnyFunSuite {
   test("None") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -52,8 +54,9 @@ class WizardSuite extends AnyFunSuite {
   test("Prune by maximum depth") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -128,8 +131,9 @@ class WizardSuite extends AnyFunSuite {
   test("Prune by pattern") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -218,8 +222,9 @@ class WizardSuite extends AnyFunSuite {
   test("Prune by mask") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -286,7 +291,7 @@ class WizardSuite extends AnyFunSuite {
   }
 }
 
-object WizardSuite extends CboSuiteBase {
+object WizardSuite {
   case class Leaf(name: String, override val selfCost: Long) extends LeafLike {
     override def makeCopy(): LeafLike = this
   }

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/rule/PatternSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/rule/PatternSuite.scala
@@ -16,7 +16,8 @@
  */
 package io.glutenproject.cbo.rule
 
-import io.glutenproject.cbo.{rule, Cbo, CboSuiteBase}
+import io.glutenproject.cbo.Cbo
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.mock.MockCboPath
 import io.glutenproject.cbo.path.{CboPath, Pattern}
 
@@ -27,8 +28,9 @@ class PatternSuite extends AnyFunSuite {
   test("Match any") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -43,8 +45,9 @@ class PatternSuite extends AnyFunSuite {
   test("Match ignore") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -59,8 +62,9 @@ class PatternSuite extends AnyFunSuite {
   test("Match unary") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -81,8 +85,9 @@ class PatternSuite extends AnyFunSuite {
   test("Match binary") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -113,8 +118,9 @@ class PatternSuite extends AnyFunSuite {
   test("Matches above a certain depth") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -169,7 +175,7 @@ class PatternSuite extends AnyFunSuite {
   }
 }
 
-object PatternSuite extends CboSuiteBase {
+object PatternSuite {
   case class Leaf(name: String, override val selfCost: Long) extends LeafLike {
     override def makeCopy(): LeafLike = this
   }
@@ -188,7 +194,7 @@ object PatternSuite extends CboSuiteBase {
   }
 
   case class DummyGroup() extends LeafLike {
-    override def makeCopy(): rule.PatternSuite.LeafLike = throw new UnsupportedOperationException()
+    override def makeCopy(): LeafLike = throw new UnsupportedOperationException()
     override def selfCost(): Long = throw new UnsupportedOperationException()
   }
 

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/specific/CyclicSearchSpaceSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/specific/CyclicSearchSpaceSuite.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.cbo.specific
 
 import io.glutenproject.cbo._
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.best.BestFinder
 import io.glutenproject.cbo.memo.MemoState
 import io.glutenproject.cbo.mock.MockMemoState
@@ -39,8 +40,9 @@ abstract class CyclicSearchSpaceSuite extends AnyFunSuite {
   test("Cyclic - find paths, simple self cycle") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -73,8 +75,9 @@ abstract class CyclicSearchSpaceSuite extends AnyFunSuite {
   test("Cyclic - find best, simple self cycle") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -101,8 +104,9 @@ abstract class CyclicSearchSpaceSuite extends AnyFunSuite {
   test("Cyclic - find best, case 1") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -164,8 +168,9 @@ abstract class CyclicSearchSpaceSuite extends AnyFunSuite {
   test("Cyclic - find best, case 2") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -208,7 +213,7 @@ abstract class CyclicSearchSpaceSuite extends AnyFunSuite {
   }
 }
 
-object CyclicSearchSpaceSuite extends CboSuiteBase {
+object CyclicSearchSpaceSuite {
   case class Leaf(name: String, override val selfCost: Long) extends LeafLike {
     override def makeCopy(): LeafLike = this
   }

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/specific/DistributedSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/specific/DistributedSuite.scala
@@ -18,6 +18,7 @@ package io.glutenproject.cbo.specific
 
 import io.glutenproject.cbo._
 import io.glutenproject.cbo.CboConfig.PlannerType
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.property.PropertySet
 import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
 
@@ -39,8 +40,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Project - dry run") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -55,8 +57,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Project - required distribution") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -72,8 +75,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Aggregate - none-distribution constraint") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -92,8 +96,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Project - required ordering") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -109,8 +114,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Project - required distribution and ordering") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -128,8 +134,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Aggregate - avoid re-exchange") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -147,8 +154,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   test("Aggregate - avoid re-exchange, required ordering") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.none())
@@ -167,8 +175,9 @@ abstract class DistributedSuite extends AnyFunSuite {
   ignore("Aggregate - avoid re-exchange, partial") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         DistributedPropertyModel,
         ExplainImpl,
         CboRule.Factory.reuse(List(PartialAggregateRule)))
@@ -191,7 +200,7 @@ abstract class DistributedSuite extends AnyFunSuite {
   }
 }
 
-object DistributedSuite extends CboSuiteBase {
+object DistributedSuite {
 
   object PartialAggregateRule extends CboRule[TestNode] {
 

--- a/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/specific/JoinReorderSuite.scala
+++ b/gluten-cbo/common/src/test/scala/io/glutenproject/cbo/specific/JoinReorderSuite.scala
@@ -16,8 +16,9 @@
  */
 package io.glutenproject.cbo.specific
 
-import io.glutenproject.cbo.{Cbo, CboConfig, CboSuiteBase}
+import io.glutenproject.cbo.{Cbo, CboConfig}
 import io.glutenproject.cbo.CboConfig.PlannerType
+import io.glutenproject.cbo.CboSuiteBase._
 import io.glutenproject.cbo.rule.{CboRule, Shape, Shapes}
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -38,8 +39,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("3 way join - dry run") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.none())
@@ -53,8 +55,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("3 way join - reorder") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(JoinAssociateRule, JoinCommuteRule)))
@@ -68,8 +71,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("5 way join - reorder") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(JoinAssociateRule, JoinCommuteRule)))
@@ -88,8 +92,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   ignore("7 way join - reorder") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(JoinAssociateRule, JoinCommuteRule)))
@@ -108,8 +113,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   ignore("9 way join - reorder") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(JoinAssociateRule, JoinCommuteRule)))
@@ -129,8 +135,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   ignore("12 way join - reorder") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(List(JoinAssociateRule, JoinCommuteRule)))
@@ -152,8 +159,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("2 way join - reorder, left deep only") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(leftDeepJoinRules(2)))
@@ -167,8 +175,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("3 way join - reorder, left deep only") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(leftDeepJoinRules(3)))
@@ -182,8 +191,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("5 way join - reorder, left deep only") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(leftDeepJoinRules(5)))
@@ -201,8 +211,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("7 way join - reorder, left deep only") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(leftDeepJoinRules(7)))
@@ -227,8 +238,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   test("9 way join - reorder, left deep only") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(leftDeepJoinRules(9)))
@@ -263,8 +275,9 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   ignore("12 way join - reorder, left deep only") {
     val cbo =
       Cbo[TestNode](
-        CostModelImpl,
         PlanModelImpl,
+        CostModelImpl,
+        MetadataModelImpl,
         PropertyModelImpl,
         ExplainImpl,
         CboRule.Factory.reuse(leftDeepJoinRules(12)))
@@ -284,7 +297,7 @@ abstract class JoinReorderSuite extends AnyFunSuite {
   }
 }
 
-object JoinReorderSuite extends CboSuiteBase {
+object JoinReorderSuite {
 
   object JoinAssociateRule extends CboRule[TestNode] {
     override def shift(node: TestNode): Iterable[TestNode] = node match {

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -85,6 +85,11 @@ trait SparkPlanExecApi {
   def genHiveTableScanExecTransformer(plan: SparkPlan): HiveTableScanExecTransformer =
     HiveTableScanExecTransformer(plan)
 
+  def genProjectExecTransformer(
+      projectList: Seq[NamedExpression],
+      child: SparkPlan): ProjectExecTransformer =
+    ProjectExecTransformer.createUnsafe(projectList, child)
+
   /** Generate HashAggregateExecTransformer. */
   def genHashAggregateExecTransformer(
       requiredChildDistributionExpressions: Option[Seq[Expression]],

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -85,11 +85,6 @@ trait SparkPlanExecApi {
   def genHiveTableScanExecTransformer(plan: SparkPlan): HiveTableScanExecTransformer =
     HiveTableScanExecTransformer(plan)
 
-  def genProjectExecTransformer(
-      projectList: Seq[NamedExpression],
-      child: SparkPlan): ProjectExecTransformer =
-    ProjectExecTransformer.createUnsafe(projectList, child)
-
   /** Generate HashAggregateExecTransformer. */
   def genHashAggregateExecTransformer(
       requiredChildDistributionExpressions: Option[Seq[Expression]],

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -248,14 +248,47 @@ case class ProjectExecTransformer private (projectList: Seq[NamedExpression], ch
     copy(child = newChild)
 }
 object ProjectExecTransformer {
-  def apply(projectList: Seq[NamedExpression], child: SparkPlan): ProjectExecTransformer = {
-    BackendsApiManager.getSparkPlanExecApiInstance.genProjectExecTransformer(projectList, child)
+  private def processProjectExecTransformer(
+      projectList: Seq[NamedExpression]): Seq[NamedExpression] = {
+
+    // When there is a MergeScalarSubqueries which will create the named_struct with the same name,
+    // looks like {'bloomFilter', BF1, 'bloomFilter', BF2}
+    // or {'count(1)', count(1)#111L, 'avg(a)', avg(a)#222L, 'count(1)', count(1)#333L},
+    // it will cause problem for some backends, e.g. ClickHouse,
+    // which cannot tolerate duplicate type names in struct type,
+    // so we need to rename 'nameExpr' in the named_struct to make them unique
+    // after executing the MergeScalarSubqueries.
+    var needToReplace = false
+    val newProjectList = projectList.map {
+      case alias @ Alias(cns @ CreateNamedStruct(children: Seq[Expression]), "mergedValue") =>
+        // check whether there are some duplicate names
+        if (cns.nameExprs.distinct.size == cns.nameExprs.size) {
+          alias
+        } else {
+          val newChildren = children
+            .grouped(2)
+            .flatMap {
+              case Seq(name: Literal, value: NamedExpression) =>
+                val newLiteral = Literal(name.toString() + "#" + value.exprId.id)
+                Seq(newLiteral, value)
+              case Seq(name, value) => Seq(name, value)
+            }
+            .toSeq
+          needToReplace = true
+          Alias.apply(CreateNamedStruct(newChildren), "mergedValue")(alias.exprId)
+        }
+      case other: NamedExpression => other
+    }
+
+    if (!needToReplace) {
+      projectList
+    } else {
+      newProjectList
+    }
   }
 
-  // Directly creating a project transformer may not be considered safe since some backends, E.g.,
-  // Clickhouse may require to intercept the instantiation procedure.
-  def createUnsafe(projectList: Seq[NamedExpression], child: SparkPlan): ProjectExecTransformer =
-    new ProjectExecTransformer(projectList, child)
+  def apply(projectList: Seq[NamedExpression], child: SparkPlan): ProjectExecTransformer =
+    new ProjectExecTransformer(processProjectExecTransformer(projectList), child)
 }
 
 // An alternatives for UnionExec.

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/EnumeratedTransform.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/EnumeratedTransform.scala
@@ -45,9 +45,9 @@ case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
     Seq(GlutenProperties.Conventions.GLUTEN_COLUMNAR, GlutenProperties.Conventions.ROW_BASED)
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    val constraintSet = PropertySet(List(GlutenProperties.Schemas.ANY, reqConvention))
+    val constraintSet = PropertySet(List(reqConvention))
     val altConstraintSets =
-      altConventions.map(altConv => PropertySet(List(GlutenProperties.Schemas.ANY, altConv)))
+      altConventions.map(altConv => PropertySet(List(altConv)))
     val planner = optimization.newPlanner(plan, constraintSet, altConstraintSets)
     val out = planner.plan()
     out

--- a/gluten-core/src/main/scala/io/glutenproject/planner/GlutenOptimization.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/planner/GlutenOptimization.scala
@@ -19,6 +19,7 @@ package io.glutenproject.planner
 import io.glutenproject.cbo.{CboExplain, Optimization}
 import io.glutenproject.cbo.rule.CboRule
 import io.glutenproject.planner.cost.GlutenCostModel
+import io.glutenproject.planner.metadata.GlutenMetadataModel
 import io.glutenproject.planner.plan.GlutenPlanModel
 import io.glutenproject.planner.property.GlutenPropertyModel
 import io.glutenproject.planner.rule.GlutenRules
@@ -32,8 +33,9 @@ object GlutenOptimization {
 
   def apply(): Optimization[SparkPlan] = {
     Optimization[SparkPlan](
-      GlutenCostModel(),
       GlutenPlanModel(),
+      GlutenCostModel(),
+      GlutenMetadataModel(),
       GlutenPropertyModel(),
       GlutenExplain,
       CboRule.Factory.reuse(GlutenRules()))
@@ -41,8 +43,9 @@ object GlutenOptimization {
 
   def apply(rules: Seq[CboRule[SparkPlan]]): Optimization[SparkPlan] = {
     Optimization[SparkPlan](
-      GlutenCostModel(),
       GlutenPlanModel(),
+      GlutenCostModel(),
+      GlutenMetadataModel(),
       GlutenPropertyModel(),
       GlutenExplain,
       CboRule.Factory.reuse(rules))

--- a/gluten-core/src/main/scala/io/glutenproject/planner/metadata/GlutenMetadata.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/planner/metadata/GlutenMetadata.scala
@@ -14,19 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.cbo
+package io.glutenproject.planner.metadata
 
-import io.glutenproject.cbo.property.PropertySet
+import io.glutenproject.cbo.Metadata
 
-trait PlanModel[T <: AnyRef] {
-  // Trivial tree operations.
-  def childrenOf(node: T): Seq[T]
-  def withNewChildren(node: T, children: Seq[T]): T
-  def hashCode(node: T): Int
-  def equals(one: T, other: T): Boolean
+import org.apache.spark.sql.catalyst.expressions.Attribute
 
-  // Group operations.
-  def newGroupLeaf(groupId: Int, meta: Metadata, propSet: PropertySet[T]): T
-  def isGroupLeaf(node: T): Boolean
-  def getGroupId(node: T): Int
+sealed trait GlutenMetadata extends Metadata {
+  import GlutenMetadata._
+  def schema(): Schema
+}
+
+object GlutenMetadata {
+  def apply(schema: Schema): Metadata = {
+    Impl(schema)
+  }
+
+  private case class Impl(schema: Schema) extends GlutenMetadata
+  case class Schema(output: Seq[Attribute])
 }

--- a/gluten-core/src/main/scala/io/glutenproject/planner/metadata/GlutenMetadataModel.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/planner/metadata/GlutenMetadataModel.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.planner.metadata
+
+import io.glutenproject.cbo.{Metadata, MetadataModel}
+import io.glutenproject.planner.metadata.GlutenMetadata.Schema
+import io.glutenproject.planner.plan.GlutenPlanModel.GroupLeafExec
+
+import org.apache.spark.sql.execution.SparkPlan
+
+object GlutenMetadataModel {
+
+  def apply(): MetadataModel[SparkPlan] = {
+    MetadataModelImpl
+  }
+
+  private object MetadataModelImpl extends MetadataModel[SparkPlan] {
+    override def metadataOf(node: SparkPlan): Metadata = node match {
+      case g: GroupLeafExec => throw new UnsupportedOperationException()
+      case other => GlutenMetadata(Schema(other.output))
+    }
+
+    override def dummy(): Metadata = GlutenMetadata(Schema(List()))
+    override def verify(one: Metadata, other: Metadata): Unit = {
+      assert(one == other)
+    }
+  }
+}


### PR DESCRIPTION
Metadata model would be used to retrieve nodes' logical properties, specifically the collected statistics from Spark in future. With this it would become possible to write heuristics in rule for more directed cost-based optimization.