### PR TITLE
[CORE][CH] Disable RAS for CH backend until workable

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -503,4 +503,6 @@ object BackendSettings extends BackendSettingsApi {
   }
 
   override def shouldRewriteCollect(): Boolean = true
+
+  override def supportRas(): Boolean = true
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -136,4 +136,6 @@ trait BackendSettingsApi {
   def shouldRewriteTypedImperativeAggregate(): Boolean = false
 
   def shouldRewriteCollect(): Boolean = false
+
+  def supportRas(): Boolean = false
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/ColumnarOverrides.scala
@@ -227,6 +227,11 @@ case class ColumnarOverrideRules(session: SparkSession)
 
     def maybeRas(outputsColumnar: Boolean): List[SparkSession => Rule[SparkPlan]] = {
       if (GlutenConfig.getConf.enableRas) {
+        if (!BackendsApiManager.getSettings.supportRas()) {
+          throw new UnsupportedOperationException(
+            s"RAS support is currently not added for backend: " +
+              s"${BackendsApiManager.getBackendName}")
+        }
         return List(
           (_: SparkSession) => TransformPreOverrides(List(ImplementFilter()), List.empty),
           (session: SparkSession) => EnumeratedTransform(session, outputsColumnar),


### PR DESCRIPTION
Will remove this restriction after we successfully integrated RAS with CH backend.

Perhaps the first millstone is to pass TPC-H which is currently being tested in PR https://github.com/apache/incubator-gluten/pull/5101