### PR TITLE
[VL] Remove useless agg mode check in applyExtractStruct

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -140,11 +140,6 @@ abstract class HashAggregateExecTransformer(
     }
 
     for (expr <- aggregateExpressions) {
-      expr.mode match {
-        case Partial | PartialMerge =>
-        case _ =>
-          throw new GlutenNotSupportException(s"${expr.mode} not supported.")
-      }
       val aggFunc = expr.aggregateFunction
       aggFunc match {
         case _ @VeloxIntermediateData.Type(veloxTypes: Seq[DataType]) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is already ensured in the `extractStructNeeded` method that only `Partial` and `PartialMerge` will enter `applyExtractStruct`. There is no need to check again.

## How was this patch tested?

N/A

