### PR TITLE
[CH] Move project transformer rewriting code to CH backend

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -108,6 +108,49 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
     RowToCHNativeColumnarExec(child)
   }
 
+  override def genProjectExecTransformer(
+      projectList: Seq[NamedExpression],
+      child: SparkPlan): ProjectExecTransformer = {
+    def processProjectExecTransformer(projectList: Seq[NamedExpression]): Seq[NamedExpression] = {
+      // When there is a MergeScalarSubqueries which will create the named_struct with the same name,
+      // looks like {'bloomFilter', BF1, 'bloomFilter', BF2}
+      // or {'count(1)', count(1)#111L, 'avg(a)', avg(a)#222L, 'count(1)', count(1)#333L},
+      // it will cause problem for ClickHouse backend,
+      // which cannot tolerate duplicate type names in struct type,
+      // so we need to rename 'nameExpr' in the named_struct to make them unique
+      // after executing the MergeScalarSubqueries.
+      var needToReplace = false
+      val newProjectList = projectList.map {
+        case alias @ Alias(cns @ CreateNamedStruct(children: Seq[Expression]), "mergedValue") =>
+          // check whether there are some duplicate names
+          if (cns.nameExprs.distinct.size == cns.nameExprs.size) {
+            alias
+          } else {
+            val newChildren = children
+              .grouped(2)
+              .flatMap {
+                case Seq(name: Literal, value: NamedExpression) =>
+                  val newLiteral = Literal(name.toString() + "#" + value.exprId.id)
+                  Seq(newLiteral, value)
+                case Seq(name, value) => Seq(name, value)
+              }
+              .toSeq
+            needToReplace = true
+            Alias.apply(CreateNamedStruct(newChildren), "mergedValue")(alias.exprId)
+          }
+        case other: NamedExpression => other
+      }
+
+      if (!needToReplace) {
+        projectList
+      } else {
+        newProjectList
+      }
+    }
+
+    ProjectExecTransformer.createUnsafe(processProjectExecTransformer(projectList), child)
+  }
+
   /**
    * Generate FilterExecTransformer.
    *

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -112,8 +112,8 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       projectList: Seq[NamedExpression],
       child: SparkPlan): ProjectExecTransformer = {
     def processProjectExecTransformer(projectList: Seq[NamedExpression]): Seq[NamedExpression] = {
-      // When there is a MergeScalarSubqueries which will create the named_struct with the same name,
-      // looks like {'bloomFilter', BF1, 'bloomFilter', BF2}
+      // When there is a MergeScalarSubqueries which will create the named_struct with the
+      // same name, looks like {'bloomFilter', BF1, 'bloomFilter', BF2}
       // or {'count(1)', count(1)#111L, 'avg(a)', avg(a)#222L, 'count(1)', count(1)#333L},
       // it will cause problem for ClickHouse backend,
       // which cannot tolerate duplicate type names in struct type,

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -85,6 +85,11 @@ trait SparkPlanExecApi {
   def genHiveTableScanExecTransformer(plan: SparkPlan): HiveTableScanExecTransformer =
     HiveTableScanExecTransformer(plan)
 
+  def genProjectExecTransformer(
+      projectList: Seq[NamedExpression],
+      child: SparkPlan): ProjectExecTransformer =
+    ProjectExecTransformer.createUnsafe(projectList, child)
+
   /** Generate HashAggregateExecTransformer. */
   def genHashAggregateExecTransformer(
       requiredChildDistributionExpressions: Option[Seq[Expression]],


### PR DESCRIPTION
Since the rewrite logic is currently specialized to CH backend. ACBO would require for this fix to make sure a node's metadata doesn't get changed after applying rule (although it's not a MUST for ACBO, it's better to keep metadata not changed after applying rules).