### PR TITLE
[VL] Restore the test cases for corr in group-by.sql and udf-group-by.sql

### DIFF
--- a/gluten-ut/spark32/src/test/resources/sql-tests/inputs/group-by.sql
+++ b/gluten-ut/spark32/src/test/resources/sql-tests/inputs/group-by.sql
@@ -75,6 +75,10 @@ SELECT 1 from (
 ) b
 where b.z != b.z;
 
+-- SPARK-24369 multiple distinct aggregations having the same argument set
+SELECT corr(DISTINCT x, y), corr(DISTINCT y, x), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y);
+
 -- SPARK-25708 HAVING without GROUP BY means global aggregate
 SELECT 1 FROM range(10) HAVING true;
 

--- a/gluten-ut/spark32/src/test/resources/sql-tests/inputs/udf/udf-group-by.sql
+++ b/gluten-ut/spark32/src/test/resources/sql-tests/inputs/udf/udf-group-by.sql
@@ -71,6 +71,10 @@ SELECT 1 from (
 ) b
 where b.z != b.z;
 
+-- SPARK-24369 multiple distinct aggregations having the same argument set
+SELECT corr(DISTINCT x, y), udf(corr(DISTINCT y, x)), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y);
+
 -- SPARK-25708 HAVING without GROUP BY means global aggregate
 SELECT udf(1) FROM range(10) HAVING true;
 

--- a/gluten-ut/spark32/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/gluten-ut/spark32/src/test/resources/sql-tests/results/group-by.sql.out
@@ -244,6 +244,15 @@ struct<1:int>
 
 
 -- !query
+SELECT corr(DISTINCT x, y), corr(DISTINCT y, x), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y)
+-- !query schema
+struct<corr(DISTINCT x, y):double,corr(DISTINCT y, x):double,count(1):bigint>
+-- !query output
+0.9999999999999999	0.9999999999999999	3
+
+
+-- !query
 SELECT 1 FROM range(10) HAVING true
 -- !query schema
 struct<1:int>

--- a/gluten-ut/spark32/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/gluten-ut/spark32/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -244,6 +244,15 @@ struct<1:int>
 
 
 -- !query
+SELECT corr(DISTINCT x, y), udf(corr(DISTINCT y, x)), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y)
+-- !query schema
+struct<corr(DISTINCT x, y):double,udf(corr(DISTINCT y, x)):double,count(1):bigint>
+-- !query output
+0.9999999999999999	0.9999999999999999	3
+
+
+-- !query
 SELECT udf(1) FROM range(10) HAVING true
 -- !query schema
 struct<udf(1):int>

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -230,9 +230,9 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
 
   val OVERWRITE_SQL_QUERY_LIST: Set[String] = Set(
     // Velox corr has better computation logic but it fails Spark's precision check.
-    // Remove -- SPARK-24369 multiple distinct aggregations having the same argument set
+    // Overwrite below test cases.
+    // -- SPARK-24369 multiple distinct aggregations having the same argument set
     "group-by.sql",
-    // Remove -- SPARK-24369 multiple distinct aggregations having the same argument set
     "udf/udf-group-by.sql"
   )
 }

--- a/gluten-ut/spark33/src/test/resources/sql-tests/inputs/group-by.sql
+++ b/gluten-ut/spark33/src/test/resources/sql-tests/inputs/group-by.sql
@@ -84,6 +84,10 @@ SELECT 1 from (
 ) b
 where b.z != b.z;
 
+-- SPARK-24369 multiple distinct aggregations having the same argument set
+SELECT corr(DISTINCT x, y), corr(DISTINCT y, x), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y);
+
 -- SPARK-25708 HAVING without GROUP BY means global aggregate
 SELECT 1 FROM range(10) HAVING true;
 
@@ -243,6 +247,8 @@ SELECT k, count(*) FILTER (WHERE x IS NOT NULL), regr_count(y, x) FROM testRegre
 -- SPARK-37613: Support ANSI Aggregate Function: regr_r2
 SELECT regr_r2(y, x) FROM testRegression;
 SELECT regr_r2(y, x) FROM testRegression WHERE x IS NOT NULL;
+SELECT k, corr(y, x), regr_r2(y, x) FROM testRegression GROUP BY k;
+SELECT k, corr(y, x) FILTER (WHERE x IS NOT NULL), regr_r2(y, x) FROM testRegression GROUP BY k;
 
 -- SPARK-27974: Support ANSI Aggregate Function: array_agg
 SELECT

--- a/gluten-ut/spark33/src/test/resources/sql-tests/inputs/udf/udf-group-by.sql
+++ b/gluten-ut/spark33/src/test/resources/sql-tests/inputs/udf/udf-group-by.sql
@@ -71,6 +71,10 @@ SELECT 1 from (
 ) b
 where b.z != b.z;
 
+-- SPARK-24369 multiple distinct aggregations having the same argument set
+SELECT corr(DISTINCT x, y), udf(corr(DISTINCT y, x)), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y);
+
 -- SPARK-25708 HAVING without GROUP BY means global aggregate
 SELECT udf(1) FROM range(10) HAVING true;
 

--- a/gluten-ut/spark33/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/gluten-ut/spark33/src/test/resources/sql-tests/results/group-by.sql.out
@@ -273,6 +273,15 @@ struct<1:int>
 
 
 -- !query
+SELECT corr(DISTINCT x, y), corr(DISTINCT y, x), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y)
+-- !query schema
+struct<corr(DISTINCT x, y):double,corr(DISTINCT y, x):double,count(1):bigint>
+-- !query output
+0.9999999999999999	0.9999999999999999	3
+
+
+-- !query
 SELECT 1 FROM range(10) HAVING true
 -- !query schema
 struct<1:int>
@@ -882,6 +891,24 @@ SELECT regr_r2(y, x) FROM testRegression WHERE x IS NOT NULL
 struct<regr_r2(y, x):double>
 -- !query output
 0.997690531177829
+
+
+-- !query
+SELECT k, corr(y, x), regr_r2(y, x) FROM testRegression GROUP BY k
+-- !query schema
+struct<k:int,corr(y, x):double,regr_r2(y, x):double>
+-- !query output
+1	NULL	NULL
+2	0.9988445981121533	0.997690531177829
+
+
+-- !query
+SELECT k, corr(y, x) FILTER (WHERE x IS NOT NULL), regr_r2(y, x) FROM testRegression GROUP BY k
+-- !query schema
+struct<k:int,corr(y, x) FILTER (WHERE (x IS NOT NULL)):double,regr_r2(y, x):double>
+-- !query output
+1	NULL	NULL
+2	0.9988445981121533	0.997690531177829
 
 
 -- !query

--- a/gluten-ut/spark33/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/gluten-ut/spark33/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -244,6 +244,15 @@ struct<1:int>
 
 
 -- !query
+SELECT corr(DISTINCT x, y), udf(corr(DISTINCT y, x)), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y)
+-- !query schema
+struct<corr(DISTINCT x, y):double,udf(corr(DISTINCT y, x)):double,count(1):bigint>
+-- !query output
+0.9999999999999999	0.9999999999999999	3
+
+
+-- !query
 SELECT udf(1) FROM range(10) HAVING true
 -- !query schema
 struct<udf(1):int>

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -233,10 +233,9 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
 
   private val OVERWRITE_SQL_QUERY_LIST: Set[String] = Set(
     // Velox corr has better computation logic but it fails Spark's precision check.
-    // Remove -- SPARK-24369 multiple distinct aggregations having the same argument set,
-    //        -- SPARK-37613: Support ANSI Aggregate Function: regr_r2
+    // Overwrite below test cases.
+    // -- SPARK-24369 multiple distinct aggregations having the same argument set
     "group-by.sql",
-    // Remove -- SPARK-24369 multiple distinct aggregations having the same argument set
     "udf/udf-group-by.sql"
   )
 }

--- a/gluten-ut/spark34/src/test/resources/sql-tests/inputs/group-by.sql
+++ b/gluten-ut/spark34/src/test/resources/sql-tests/inputs/group-by.sql
@@ -81,6 +81,10 @@ SELECT 1 from (
 ) b
 where b.z != b.z;
 
+-- SPARK-24369 multiple distinct aggregations having the same argument set
+SELECT corr(DISTINCT x, y), corr(DISTINCT y, x), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y);
+
 -- SPARK-25708 HAVING without GROUP BY means global aggregate
 SELECT 1 FROM range(10) HAVING true;
 

--- a/gluten-ut/spark34/src/test/resources/sql-tests/inputs/udf/udf-group-by.sql
+++ b/gluten-ut/spark34/src/test/resources/sql-tests/inputs/udf/udf-group-by.sql
@@ -71,6 +71,10 @@ SELECT 1 from (
 ) b
 where b.z != b.z;
 
+-- SPARK-24369 multiple distinct aggregations having the same argument set
+SELECT corr(DISTINCT x, y), udf(corr(DISTINCT y, x)), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y);
+
 -- SPARK-25708 HAVING without GROUP BY means global aggregate
 SELECT udf(1) FROM range(10) HAVING true;
 

--- a/gluten-ut/spark34/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/gluten-ut/spark34/src/test/resources/sql-tests/results/group-by.sql.out
@@ -331,6 +331,16 @@ struct<1:int>
 -- !query output
 
 
+
+-- !query
+SELECT corr(DISTINCT x, y), corr(DISTINCT y, x), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y)
+-- !query schema
+struct<corr(DISTINCT x, y):double,corr(DISTINCT y, x):double,count(1):bigint>
+-- !query output
+0.9999999999999999	0.9999999999999999	3
+
+
 -- !query
 SELECT 1 FROM range(10) HAVING true
 -- !query schema

--- a/gluten-ut/spark34/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/gluten-ut/spark34/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -297,6 +297,16 @@ struct<1:int>
 -- !query output
 
 
+
+-- !query
+SELECT corr(DISTINCT x, y), udf(corr(DISTINCT y, x)), count(*)
+  FROM (VALUES (1, 1), (2, 2), (2, 2)) t(x, y)
+-- !query schema
+struct<corr(DISTINCT x, y):double,udf(corr(DISTINCT y, x)):double,count(1):bigint>
+-- !query output
+0.9999999999999999	0.9999999999999999	3
+
+
 -- !query
 SELECT udf(1) FROM range(10) HAVING true
 -- !query schema

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -234,7 +234,8 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
 
   val OVERWRITE_SQL_QUERY_LIST: Set[String] = Set(
     // Velox corr has better computation logic but it fails Spark's precision check.
-    // Remove -- SPARK-24369 multiple distinct aggregations having the same argument set
+    // Overwrite below test cases.
+    // -- SPARK-24369 multiple distinct aggregations having the same argument set
     "group-by.sql",
     "udf/udf-group-by.sql",
     // Exception string doesn't match for


### PR DESCRIPTION
## What changes were proposed in this pull request?

The calculation formula of `corr` in Velox is slightly different from that in Spark, which causes some differences in the accuracy of the final calculation results, but these differences are within the allowed precision range. Previously, the inconsistent test cases were deleted, but now it has been found that other statistics-related agg functions such as `skewness`, `stddev`, and `variance` also have differences in calculation accuracy. We cannot delete all of these test cases that have differences. A better approach is to modify the content in the result file.

In this PR, we restore the `corr` test cases in group-by.sql and udf-group-by.sql, and modify the correct results in .out file.

## How was this patch tested?

Exists CI.

