### PR TITLE
[CORE] Restore the function signature for eliminateProjectList

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
@@ -121,7 +121,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       // post-projection, the additional columns need to be removed, leaving only the original
       // output of the child.
       val preProject = ProjectExec(
-        eliminateProjectList(expressionMap.values.toSeq, sort.child.outputSet),
+        eliminateProjectList(sort.child.outputSet, expressionMap.values.toSeq),
         sort.child)
       val newSort = sort.copy(sortOrder = newSortOrder, child = preProject)
       // The pre-project and post-project of SortExec always appear together, so it's more
@@ -133,7 +133,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       val expressionMap = new mutable.HashMap[Expression, NamedExpression]()
       val newSortOrder = getNewSortOrder(topK.sortOrder, expressionMap)
       val preProject = ProjectExec(
-        eliminateProjectList(expressionMap.values.toSeq, topK.child.outputSet),
+        eliminateProjectList(topK.child.outputSet, expressionMap.values.toSeq),
         topK.child)
       topK.copy(sortOrder = newSortOrder, child = preProject)
 
@@ -152,7 +152,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
         newGroupingExpressions = newGroupingExpressions,
         newAggregateExpressions = newAggregateExpressions)
       val preProject = ProjectExec(
-        eliminateProjectList(expressionMap.values.toSeq, agg.child.outputSet),
+        eliminateProjectList(agg.child.outputSet, expressionMap.values.toSeq),
         agg.child)
       newAgg.withNewChildren(Seq(preProject))
 
@@ -175,7 +175,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
         partitionSpec = newPartitionSpec,
         windowExpression = newWindowExpressions.asInstanceOf[Seq[NamedExpression]],
         child = ProjectExec(
-          eliminateProjectList(expressionMap.values.toSeq, window.child.outputSet),
+          eliminateProjectList(window.child.outputSet, expressionMap.values.toSeq),
           window.child)
       )
 
@@ -188,7 +188,7 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       expand.copy(
         projections = newProjections,
         child = ProjectExec(
-          eliminateProjectList(expressionMap.values.toSeq, expand.child.outputSet),
+          eliminateProjectList(expand.child.outputSet, expressionMap.values.toSeq),
           expand.child))
 
     case generate: GenerateExec =>

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -70,10 +70,20 @@ trait PullOutProjectHelper {
           .toAttribute
     }
 
+  /**
+   * Append the pulled-out NamedExpressions after the child output and eliminate the duplicated
+   * parts in the append.
+   * @param childOutput
+   *   the outputSet of the child
+   * @param appendNamedExprs
+   *   the pulled-out NamedExpressions that need to be append after child output
+   * @return
+   *   the eliminated project list for the pre-project
+   */
   protected def eliminateProjectList(
-      projectAttributes: Seq[NamedExpression],
-      childOutput: AttributeSet): Seq[NamedExpression] = {
-    (childOutput -- projectAttributes).toIndexedSeq ++ projectAttributes
+      childOutput: AttributeSet,
+      appendNamedExprs: Seq[NamedExpression]): Seq[NamedExpression] = {
+    (childOutput -- appendNamedExprs).toIndexedSeq ++ appendNamedExprs
       .sortWith(_.exprId.id < _.exprId.id)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because we still need to append the pulled-out `NamedExpression`s after the child output, it would be more appropriate to revert back to the original function signature.

## How was this patch tested?

Exists CI tests.

