### PR TITLE
[VL] RAS: Group reduction support

### DIFF
--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -24,6 +24,7 @@ on:
       - 'gluten-celeborn/common'
       - 'gluten-celeborn/package'
       - 'gluten-celeborn/velox'
+      - 'gluten-ras/**'
       - 'gluten-core/**'
       - 'gluten-data/**'
       - 'gluten-delta/**'


### PR DESCRIPTION
Support adding RAS rule to reduce from plan tree to group. This could be useful when a rule just removes a unary node from the input plan.