### PR TITLE
[VL] Remove the registry for Velox's prestosql scalar functions

### DIFF
--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -84,9 +84,6 @@ void registerFunctionOverwrite() {
 } // namespace
 
 void registerAllFunctions() {
-  // The registration order matters. Spark sql functions are registered after
-  // presto sql functions to overwrite the registration for same named
-  // functions.
   velox::functions::sparksql::registerFunctions("");
   velox::aggregate::prestosql::registerAllAggregateFunctions(
       "", true /*registerCompanionFunctions*/, false /*onlyPrestoSignatures*/, true /*overwrite*/);

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -34,6 +34,14 @@
 
 using namespace facebook;
 
+namespace facebook::velox::functions {
+void registerPrestoVectorFunctions() {
+  // Presto function. To be removed.
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, "arrays_overlap");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform_keys, "transform_keys");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform_values, "transform_values");
+}
+} // namespace facebook::velox::functions
 namespace gluten {
 namespace {
 void registerFunctionOverwrite() {
@@ -70,6 +78,8 @@ void registerFunctionOverwrite() {
   velox::functions::registerBinaryIntegral<velox::functions::CheckedMinusFunction>({"check_subtract"});
   velox::functions::registerBinaryIntegral<velox::functions::CheckedMultiplyFunction>({"check_multiply"});
   velox::functions::registerBinaryIntegral<velox::functions::CheckedDivideFunction>({"check_divide"});
+
+  velox::functions::registerPrestoVectorFunctions();
 }
 } // namespace
 

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -26,7 +26,6 @@
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
-#include "velox/functions/sparksql/Bitwise.h"
 #include "velox/functions/sparksql/Hash.h"
 #include "velox/functions/sparksql/Rand.h"
 #include "velox/functions/sparksql/Register.h"
@@ -67,7 +66,6 @@ void registerFunctionOverwrite() {
   velox::exec::registerFunctionCallToSpecialForm(
       kRowConstructorWithAllNull,
       std::make_unique<RowConstructorWithNullCallToSpecialForm>(kRowConstructorWithAllNull));
-  velox::functions::sparksql::registerBitwiseFunctions("spark_");
   velox::functions::registerBinaryIntegral<velox::functions::CheckedPlusFunction>({"check_add"});
   velox::functions::registerBinaryIntegral<velox::functions::CheckedMinusFunction>({"check_subtract"});
   velox::functions::registerBinaryIntegral<velox::functions::CheckedMultiplyFunction>({"check_multiply"});
@@ -79,7 +77,6 @@ void registerAllFunctions() {
   // The registration order matters. Spark sql functions are registered after
   // presto sql functions to overwrite the registration for same named
   // functions.
-  velox::functions::prestosql::registerAllScalarFunctions();
   velox::functions::sparksql::registerFunctions("");
   velox::aggregate::prestosql::registerAllAggregateFunctions(
       "", true /*registerCompanionFunctions*/, false /*onlyPrestoSignatures*/, true /*overwrite*/);

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -391,13 +391,6 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"named_struct", "row_constructor"},
     {"bit_or", "bitwise_or_agg"},
     {"bit_and", "bitwise_and_agg"},
-    {"bitwise_and", "spark_bitwise_and"},
-    {"bitwise_not", "spark_bitwise_not"},
-    {"bitwise_or", "spark_bitwise_or"},
-    {"bitwise_xor", "spark_bitwise_xor"},
-    // TODO: the below registry for rand functions can be removed
-    // after presto function registry is removed.
-    {"rand", "spark_rand"},
     {"murmur3hash", "hash_with_seed"},
     {"xxhash64", "xxhash64_with_seed"},
     {"modulus", "remainder"},

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -396,11 +396,8 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"modulus", "remainder"},
     {"date_format", "format_datetime"},
     {"collect_set", "set_agg"},
-    {"forall", "all_match"},
-    {"exists", "any_match"},
     {"negative", "unaryminus"},
-    {"get_array_item", "get"},
-    {"arrays_zip", "zip"}};
+    {"get_array_item", "get"}};
 
 const std::unordered_map<std::string, std::string> SubstraitParser::typeMap_ = {
     {"bool", "BOOLEAN"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Gluten registers Velox's prestosql scalar functions. Thus, some of them can be used for Spark SQL if there is no semantic difference. However, there are some conflict issues, which makes unexpected function calling. See below links. We plan to register used presto scalar functions (see below list) in sparksql registry.

https://github.com/apache/incubator-gluten/discussions/4759
https://github.com/apache/incubator-gluten/pull/5150

Function list:
url_decode/url_encode
array_distinct
array_except
array_position
map_entries
map_keys
map_values
reverse
crc32
regexp_extract_all
like
abs (for long/short decimal)
asin
atan
cos
degrees

## How was this patch tested?

Existing tests.

