### PR TITLE
[VL] gluten-it: Shorten table creation and query runner logs

### DIFF
--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/TpcRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/TpcRunner.scala
@@ -63,7 +63,7 @@ object TpcRunner {
         }
       })
     } finally {
-      println("done.")
+      println("... Done.")
     }
   }
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/TpcRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/TpcRunner.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.gluten.integration.tpc
 
-import org.apache.spark.sql.{QueryRunner, RunResult, SparkSession}
-
+import org.apache.spark.sql.{AnalysisException, QueryRunner, RunResult, SparkSession}
 import com.google.common.base.Preconditions
 import org.apache.commons.io.FileUtils
 
@@ -59,7 +58,7 @@ object TpcRunner {
           try {
             spark.catalog.recoverPartitions(file.getName)
           } catch {
-            case _: Throwable =>
+            case _: AnalysisException =>
           }
         }
       })

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/TpcRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/TpcRunner.scala
@@ -47,13 +47,14 @@ class TpcRunner(val queryResourceFolder: String, val dataPath: String) {
 
 object TpcRunner {
   def createTables(spark: SparkSession, dataPath: String): Unit = {
-    val files = new File(dataPath).listFiles()
-    files.foreach(
-      file => {
+    print("Creating catalog tables: ")
+    try {
+      val files = new File(dataPath).listFiles()
+      files.foreach(file => {
         if (spark.catalog.tableExists(file.getName)) {
-          println("Table exists: " + file.getName)
+          print(s"${file.getName}(exists), ")
         } else {
-          println("Creating catalog table: " + file.getName)
+          print(s"${file.getName}, ")
           spark.catalog.createTable(file.getName, file.getAbsolutePath, "parquet")
           try {
             spark.catalog.recoverPartitions(file.getName)
@@ -62,6 +63,9 @@ object TpcRunner {
           }
         }
       })
+    } finally {
+      println("done.")
+    }
   }
 
   private def delete(path: String): Unit = {

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -18,7 +18,12 @@ package org.apache.spark.sql
 
 import org.apache.spark.{SparkContext, Success, TaskKilled}
 import org.apache.spark.executor.ExecutorMetrics
-import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorMetricsUpdate, SparkListenerTaskEnd, SparkListenerTaskStart}
+import org.apache.spark.scheduler.{
+  SparkListener,
+  SparkListenerExecutorMetricsUpdate,
+  SparkListenerTaskEnd,
+  SparkListenerTaskStart
+}
 import org.apache.spark.sql.KillTaskListener.INIT_WAIT_TIME_MS
 
 import com.google.common.base.Preconditions
@@ -45,8 +50,7 @@ object QueryRunner {
     "ProcessTreePythonVMemory",
     "ProcessTreePythonRSSMemory",
     "ProcessTreeOtherVMemory",
-    "ProcessTreeOtherRSSMemory"
-  )
+    "ProcessTreeOtherRSSMemory")
 
   def runTpcQuery(
       spark: SparkSession,
@@ -76,7 +80,7 @@ object QueryRunner {
     }
     killTaskListener.foreach(sc.addSparkListener(_))
 
-    println(s"Executing SQL query from resource path $queryPath...")
+    print(s"Executing SQL query from resource path $queryPath... ")
     try {
       val sql = resourceToString(queryPath)
       val prev = System.nanoTime()
@@ -90,13 +94,13 @@ object QueryRunner {
       RunResult(rows, millis, collectedMetrics)
     } finally {
       sc.removeSparkListener(metricsListener)
-      killTaskListener.foreach(
-        l => {
-          sc.removeSparkListener(l)
-          println(s"Successful kill rate ${"%.2f%%".format(
-              100 * l.successfulKillRate())} during execution of app: ${sc.applicationId}")
-        })
+      killTaskListener.foreach(l => {
+        sc.removeSparkListener(l)
+        println(s"Successful kill rate ${"%.2f%%"
+          .format(100 * l.successfulKillRate())} during execution of app: ${sc.applicationId}")
+      })
       sc.setJobDescription(null)
+      println("Done.")
     }
   }
 
@@ -156,8 +160,8 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
             sync.synchronized {
               val total = Math.min(
                 stageKillMaxWaitTimeLookup.computeIfAbsent(taskStart.stageId, _ => Long.MaxValue),
-                stageKillWaitTimeLookup.computeIfAbsent(taskStart.stageId, _ => INIT_WAIT_TIME_MS)
-              )
+                stageKillWaitTimeLookup
+                  .computeIfAbsent(taskStart.stageId, _ => INIT_WAIT_TIME_MS))
               val elapsed = System.currentTimeMillis() - startMs
               val remaining = total - elapsed
               if (remaining <= 0L) {

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
@@ -80,8 +80,9 @@ class SparkSessionSwitcher(val masterUrl: String, val logLevel: String) extends 
         .setAllWarningOnOverriding(sessionMap.get(desc.sessionToken).getAll)
       activateSession(conf, desc.appName)
       _activeSessionDesc = desc
+    } finally {
+      println("Done. ")
     }
-    println("Done. ")
   }
 
   def spark(): SparkSession = {

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
@@ -72,14 +72,16 @@ class SparkSessionSwitcher(val masterUrl: String, val logLevel: String) extends 
     if (!sessionMap.containsKey(desc.sessionToken)) {
       throw new IllegalArgumentException(s"Session doesn't exist: $desc")
     }
-    println(s"Switching to $desc session... ")
-    stopActiveSession()
-    val conf = new SparkConf(false)
-      .setAllWarningOnOverriding(testDefaults.getAll)
-      .setAllWarningOnOverriding(sessionMap.get(desc.sessionToken).getAll)
-    activateSession(conf, desc.appName)
-    _activeSessionDesc = desc
-    println(s"Successfully switched to $desc session. ")
+    print(s"Switching to $desc session... ")
+    try {
+      stopActiveSession()
+      val conf = new SparkConf(false)
+        .setAllWarningOnOverriding(testDefaults.getAll)
+        .setAllWarningOnOverriding(sessionMap.get(desc.sessionToken).getAll)
+      activateSession(conf, desc.appName)
+      _activeSessionDesc = desc
+    }
+    println("Done. ")
   }
 
   def spark(): SparkSession = {


### PR DESCRIPTION
Mainly to compact "Creating catalog table" logs into one line.

Before:
```
Running query: q65...
Switching to SessionDesc(SessionToken(baseline),Vanilla Spark TPC-DS q65) session... 
Successfully switched to SessionDesc(SessionToken(baseline),Vanilla Spark TPC-DS q65) session. 
Creating catalog table: customer
Creating catalog table: catalog_page
Creating catalog table: catalog_returns
Creating catalog table: item
Creating catalog table: web_page
Creating catalog table: web_sales
Creating catalog table: web_returns
Creating catalog table: warehouse
Creating catalog table: store_returns
Creating catalog table: customer_demographics
Creating catalog table: income_band
Creating catalog table: date_dim
Creating catalog table: web_site
Creating catalog table: promotion
Creating catalog table: catalog_sales
Creating catalog table: reason
Creating catalog table: customer_address
Creating catalog table: household_demographics
Creating catalog table: call_center
Creating catalog table: time_dim
Creating catalog table: store_sales
Creating catalog table: inventory
Creating catalog table: store
Creating catalog table: ship_mode
Executing SQL query from resource path /tpcds-queries/q65.sql...
```

After:

```
Running query: q65...
Switching to SessionDesc(SessionToken(baseline),Vanilla Spark TPC-DS q65) session... Done. 
Creating catalog tables: customer, catalog_page, catalog_returns, item, web_page, web_sales, web_returns, warehouse, store_returns, customer_demographics, income_band, date_dim, web_site, promotion, catalog_sales, reason, customer_address, household_demographics, call_center, time_dim, store_sales, inventory, store, ship_mode, ... Done.
Executing SQL query from resource path /tpcds-queries/q65.sql... Done.
```