### PR TITLE
[VL] Refactor native validation exception handling

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -469,11 +469,16 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
     names.emplace_back(SubstraitParser::makeNodeName(inputPlanNodeId, colIdx));
   }
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
-
-  if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
-    LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
+  try {
+    if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
+      LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
+      return false;
+    }
+  } catch (const VeloxException& err) {
+    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;
   }
+  
   return true;
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -919,13 +919,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::CrossRel& crossR
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
 
   if (crossRel.has_expression()) {
-    try {
-      auto expression = exprConverter_->toVeloxExpr(crossRel.expression(), rowType);
-      exec::ExprSet exprSet({std::move(expression)}, execCtx_);
-    } catch (const VeloxException& err) {
-      logValidateMsg("Native validation failed due to: crossRel expression validation fails, " + err.message());
-      return false;
-    }
+    auto expression = exprConverter_->toVeloxExpr(crossRel.expression(), rowType);
+    exec::ExprSet exprSet({std::move(expression)}, execCtx_);
   }
 
   return true;

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -478,7 +478,6 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
     LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;
   }
-  
   return true;
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -95,12 +95,7 @@ bool SubstraitToVeloxPlanValidator::validateInputTypes(
   // Get the input types.
   const auto& sTypes = inputType.struct_().types();
   for (const auto& sType : sTypes) {
-    try {
-      types.emplace_back(SubstraitParser::parseType(sType));
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-      return false;
-    }
+    types.emplace_back(SubstraitParser::parseType(sType));
   }
   return true;
 }
@@ -469,13 +464,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
     names.emplace_back(SubstraitParser::makeNodeName(inputPlanNodeId, colIdx));
   }
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
-  try {
-    if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
-      LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
-      return false;
-    }
-  } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+  if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
+    LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
     return false;
   }
   return true;
@@ -519,31 +509,25 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expan
         return false;
       }
 
-      try {
-        for (const auto& projectExpr : projectExprs) {
-          const auto& typeCase = projectExpr.rex_type_case();
-          switch (typeCase) {
-            case ::substrait::Expression::RexTypeCase::kSelection:
-            case ::substrait::Expression::RexTypeCase::kLiteral:
-              break;
-            default:
-              LOG_VALIDATION_MSG("Only field or literal is supported in project of ExpandRel.");
-              return false;
-          }
-          if (rowType) {
-            expressions.emplace_back(exprConverter_->toVeloxExpr(projectExpr, rowType));
-          }
+      for (const auto& projectExpr : projectExprs) {
+        const auto& typeCase = projectExpr.rex_type_case();
+        switch (typeCase) {
+          case ::substrait::Expression::RexTypeCase::kSelection:
+          case ::substrait::Expression::RexTypeCase::kLiteral:
+            break;
+          default:
+            LOG_VALIDATION_MSG("Only field or literal is supported in project of ExpandRel.");
+            return false;
         }
-
         if (rowType) {
-          // Try to compile the expressions. If there is any unregistered
-          // function or mismatched type, exception will be thrown.
-          exec::ExprSet exprSet(std::move(expressions), execCtx_);
+          expressions.emplace_back(exprConverter_->toVeloxExpr(projectExpr, rowType));
         }
+      }
 
-      } catch (const VeloxException& err) {
-        LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-        return false;
+      if (rowType) {
+        // Try to compile the expressions. If there is any unregistered
+        // function or mismatched type, exception will be thrown.
+        exec::ExprSet exprSet(std::move(expressions), execCtx_);
       }
     } else {
       LOG_VALIDATION_MSG("Only SwitchingField is supported in ExpandRel.");
@@ -598,43 +582,38 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   std::vector<std::string> funcSpecs;
   funcSpecs.reserve(windowRel.measures().size());
   for (const auto& smea : windowRel.measures()) {
-    try {
-      const auto& windowFunction = smea.measure();
-      funcSpecs.emplace_back(planConverter_.findFuncSpec(windowFunction.function_reference()));
-      SubstraitParser::parseType(windowFunction.output_type());
-      for (const auto& arg : windowFunction.arguments()) {
-        auto typeCase = arg.value().rex_type_case();
-        switch (typeCase) {
-          case ::substrait::Expression::RexTypeCase::kSelection:
-          case ::substrait::Expression::RexTypeCase::kLiteral:
-            break;
-          default:
-            LOG_VALIDATION_MSG("Only field or constant is supported in window functions.");
-            return false;
-        }
-      }
-      // Validate BoundType and Frame Type
-      switch (windowFunction.window_type()) {
-        case ::substrait::WindowType::ROWS:
-        case ::substrait::WindowType::RANGE:
+    const auto& windowFunction = smea.measure();
+    funcSpecs.emplace_back(planConverter_.findFuncSpec(windowFunction.function_reference()));
+    SubstraitParser::parseType(windowFunction.output_type());
+    for (const auto& arg : windowFunction.arguments()) {
+      auto typeCase = arg.value().rex_type_case();
+      switch (typeCase) {
+        case ::substrait::Expression::RexTypeCase::kSelection:
+        case ::substrait::Expression::RexTypeCase::kLiteral:
           break;
         default:
-          LOG_VALIDATION_MSG(
-              "the window type only support ROWS and RANGE, and the input type is " +
-              std::to_string(windowFunction.window_type()));
+          LOG_VALIDATION_MSG("Only field or constant is supported in window functions.");
           return false;
       }
-
-      bool boundTypeSupported =
-          validateBoundType(windowFunction.upper_bound()) && validateBoundType(windowFunction.lower_bound());
-      if (!boundTypeSupported) {
+    }
+    // Validate BoundType and Frame Type
+    switch (windowFunction.window_type()) {
+      case ::substrait::WindowType::ROWS:
+      case ::substrait::WindowType::RANGE:
+        break;
+      default:
         LOG_VALIDATION_MSG(
-            "Found unsupported Bound Type: upper " + std::to_string(windowFunction.upper_bound().kind_case()) +
-            ", lower " + std::to_string(windowFunction.lower_bound().kind_case()));
+            "the window type only support ROWS and RANGE, and the input type is " +
+            std::to_string(windowFunction.window_type()));
         return false;
-      }
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+    }
+
+    bool boundTypeSupported =
+        validateBoundType(windowFunction.upper_bound()) && validateBoundType(windowFunction.lower_bound());
+    if (!boundTypeSupported) {
+      LOG_VALIDATION_MSG(
+          "Found unsupported Bound Type: upper " + std::to_string(windowFunction.upper_bound().kind_case()) +
+          ", lower " + std::to_string(windowFunction.lower_bound().kind_case()));
       return false;
     }
   }
@@ -653,24 +632,19 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   const auto& groupByExprs = windowRel.partition_expressions();
   std::vector<core::TypedExprPtr> expressions;
   expressions.reserve(groupByExprs.size());
-  try {
-    for (const auto& expr : groupByExprs) {
-      auto expression = exprConverter_->toVeloxExpr(expr, rowType);
-      auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-      if (exprField == nullptr) {
-        LOG_VALIDATION_MSG("Only field is supported for partition key in Window Operator!");
-        return false;
-      } else {
-        expressions.emplace_back(expression);
-      }
+  for (const auto& expr : groupByExprs) {
+    auto expression = exprConverter_->toVeloxExpr(expr, rowType);
+    auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+    if (exprField == nullptr) {
+      LOG_VALIDATION_MSG("Only field is supported for partition key in Window Operator!");
+      return false;
+    } else {
+      expressions.emplace_back(expression);
     }
-    // Try to compile the expressions. If there is any unregistred funciton or
-    // mismatched type, exception will be thrown.
-    exec::ExprSet exprSet(std::move(expressions), execCtx_);
-  } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-    return false;
   }
+  // Try to compile the expressions. If there is any unregistred funciton or
+  // mismatched type, exception will be thrown.
+  exec::ExprSet exprSet(std::move(expressions), execCtx_);
 
   // Validate Sort expression
   const auto& sorts = windowRel.sorts();
@@ -687,18 +661,13 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
     }
 
     if (sort.has_expr()) {
-      try {
-        auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
-        auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-        if (!exprField) {
-          LOG_VALIDATION_MSG("in windowRel, the sorting key in Sort Operator only support field.");
-          return false;
-        }
-        exec::ExprSet exprSet({std::move(expression)}, execCtx_);
-      } catch (const VeloxException& err) {
-        LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+      auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
+      auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+      if (!exprField) {
+        LOG_VALIDATION_MSG("in windowRel, the sorting key in Sort Operator only support field.");
         return false;
       }
+      exec::ExprSet exprSet({std::move(expression)}, execCtx_);
     }
   }
 
@@ -745,18 +714,13 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
     }
 
     if (sort.has_expr()) {
-      try {
-        auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
-        auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-        if (!exprField) {
-          LOG_VALIDATION_MSG("in SortRel, the sorting key in Sort Operator only support field.");
-          return false;
-        }
-        exec::ExprSet exprSet({std::move(expression)}, execCtx_);
-      } catch (const VeloxException& err) {
-        LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+      auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
+      auto exprField = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+      if (!exprField) {
+        LOG_VALIDATION_MSG("in SortRel, the sorting key in Sort Operator only support field.");
         return false;
       }
+      exec::ExprSet exprSet({std::move(expression)}, execCtx_);
     }
   }
 
@@ -794,20 +758,15 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ProjectRel& proj
   const auto& projectExprs = projectRel.expressions();
   std::vector<core::TypedExprPtr> expressions;
   expressions.reserve(projectExprs.size());
-  try {
-    for (const auto& expr : projectExprs) {
-      if (!validateExpression(expr, rowType)) {
-        return false;
-      }
-      expressions.emplace_back(exprConverter_->toVeloxExpr(expr, rowType));
+  for (const auto& expr : projectExprs) {
+    if (!validateExpression(expr, rowType)) {
+      return false;
     }
-    // Try to compile the expressions. If there is any unregistered function or
-    // mismatched type, exception will be thrown.
-    exec::ExprSet exprSet(std::move(expressions), execCtx_);
-  } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-    return false;
+    expressions.emplace_back(exprConverter_->toVeloxExpr(expr, rowType));
   }
+  // Try to compile the expressions. If there is any unregistered function or
+  // mismatched type, exception will be thrown.
+  exec::ExprSet exprSet(std::move(expressions), execCtx_);
   return true;
 }
 
@@ -839,18 +798,13 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filte
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
 
   std::vector<core::TypedExprPtr> expressions;
-  try {
-    if (!validateExpression(filterRel.condition(), rowType)) {
-      return false;
-    }
-    expressions.emplace_back(exprConverter_->toVeloxExpr(filterRel.condition(), rowType));
-    // Try to compile the expressions. If there is any unregistered function
-    // or mismatched type, exception will be thrown.
-    exec::ExprSet exprSet(std::move(expressions), execCtx_);
-  } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+  if (!validateExpression(filterRel.condition(), rowType)) {
     return false;
   }
+  expressions.emplace_back(exprConverter_->toVeloxExpr(filterRel.condition(), rowType));
+  // Try to compile the expressions. If there is any unregistered function
+  // or mismatched type, exception will be thrown.
+  exec::ExprSet exprSet(std::move(expressions), execCtx_);
   return true;
 }
 
@@ -913,22 +867,12 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
 
   if (joinRel.has_expression()) {
     std::vector<const ::substrait::Expression::FieldReference*> leftExprs, rightExprs;
-    try {
-      planConverter_.extractJoinKeys(joinRel.expression(), leftExprs, rightExprs);
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-      return false;
-    }
+    planConverter_.extractJoinKeys(joinRel.expression(), leftExprs, rightExprs);
   }
 
   if (joinRel.has_post_join_filter()) {
-    try {
-      auto expression = exprConverter_->toVeloxExpr(joinRel.post_join_filter(), rowType);
-      exec::ExprSet exprSet({std::move(expression)}, execCtx_);
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-      return false;
-    }
+    auto expression = exprConverter_->toVeloxExpr(joinRel.post_join_filter(), rowType);
+    exec::ExprSet exprSet({std::move(expression)}, execCtx_);
   }
   return true;
 }
@@ -998,16 +942,11 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
     auto funcSpec = planConverter_.findFuncSpec(aggFunction.function_reference());
     std::vector<TypePtr> types;
     bool isDecimal = false;
-    try {
-      types = SubstraitParser::sigToTypes(funcSpec);
-      for (const auto& type : types) {
-        if (!isDecimal && type->isDecimal()) {
-          isDecimal = true;
-        }
+    types = SubstraitParser::sigToTypes(funcSpec);
+    for (const auto& type : types) {
+      if (!isDecimal && type->isDecimal()) {
+        isDecimal = true;
       }
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-      return false;
     }
     auto baseFuncName =
         SubstraitParser::mapToVeloxFunction(SubstraitParser::getNameBeforeDelimiter(funcSpec), isDecimal);
@@ -1076,47 +1015,42 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
   std::vector<std::string> funcSpecs;
   funcSpecs.reserve(aggRel.measures().size());
   for (const auto& smea : aggRel.measures()) {
-    try {
-      // Validate the filter expression
-      if (smea.has_filter()) {
-        ::substrait::Expression aggRelMask = smea.filter();
-        if (aggRelMask.ByteSizeLong() > 0) {
-          auto typeCase = aggRelMask.rex_type_case();
-          switch (typeCase) {
-            case ::substrait::Expression::RexTypeCase::kSelection:
-              break;
-            default:
-              LOG_VALIDATION_MSG("Only field is supported in aggregate filter expression.");
-              return false;
-          }
-        }
-      }
-
-      const auto& aggFunction = smea.measure();
-      const auto& functionSpec = planConverter_.findFuncSpec(aggFunction.function_reference());
-      funcSpecs.emplace_back(functionSpec);
-      SubstraitParser::parseType(aggFunction.output_type());
-      // Validate the size of arguments.
-      if (SubstraitParser::getNameBeforeDelimiter(functionSpec) == "count" && aggFunction.arguments().size() > 1) {
-        LOG_VALIDATION_MSG("Count should have only one argument.");
-        // Count accepts only one argument.
-        return false;
-      }
-
-      for (const auto& arg : aggFunction.arguments()) {
-        auto typeCase = arg.value().rex_type_case();
+    // Validate the filter expression
+    if (smea.has_filter()) {
+      ::substrait::Expression aggRelMask = smea.filter();
+      if (aggRelMask.ByteSizeLong() > 0) {
+        auto typeCase = aggRelMask.rex_type_case();
         switch (typeCase) {
           case ::substrait::Expression::RexTypeCase::kSelection:
-          case ::substrait::Expression::RexTypeCase::kLiteral:
             break;
           default:
-            LOG_VALIDATION_MSG("Only field is supported in aggregate functions.");
+            LOG_VALIDATION_MSG("Only field is supported in aggregate filter expression.");
             return false;
         }
       }
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+    }
+
+    const auto& aggFunction = smea.measure();
+    const auto& functionSpec = planConverter_.findFuncSpec(aggFunction.function_reference());
+    funcSpecs.emplace_back(functionSpec);
+    SubstraitParser::parseType(aggFunction.output_type());
+    // Validate the size of arguments.
+    if (SubstraitParser::getNameBeforeDelimiter(functionSpec) == "count" && aggFunction.arguments().size() > 1) {
+      LOG_VALIDATION_MSG("Count should have only one argument.");
+      // Count accepts only one argument.
       return false;
+    }
+
+    for (const auto& arg : aggFunction.arguments()) {
+      auto typeCase = arg.value().rex_type_case();
+      switch (typeCase) {
+        case ::substrait::Expression::RexTypeCase::kSelection:
+        case ::substrait::Expression::RexTypeCase::kLiteral:
+          break;
+        default:
+          LOG_VALIDATION_MSG("Only field is supported in aggregate functions.");
+          return false;
+      }
     }
   }
 
@@ -1182,12 +1116,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
 }
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ReadRel& readRel) {
-  try {
-    planConverter_.toVeloxPlan(readRel);
-  } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
-    return false;
-  }
+  planConverter_.toVeloxPlan(readRel);
 
   // Validate filter in ReadRel.
   if (readRel.has_filter()) {
@@ -1206,18 +1135,13 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ReadRel& readRel
 
     auto rowType = std::make_shared<RowType>(std::move(names), std::move(veloxTypeList));
     std::vector<core::TypedExprPtr> expressions;
-    try {
-      if (!validateExpression(readRel.filter(), rowType)) {
-        return false;
-      }
-      expressions.emplace_back(exprConverter_->toVeloxExpr(readRel.filter(), rowType));
-      // Try to compile the expressions. If there is any unregistered function
-      // or mismatched type, exception will be thrown.
-      exec::ExprSet exprSet(std::move(expressions), execCtx_);
-    } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+    if (!validateExpression(readRel.filter(), rowType)) {
       return false;
     }
+    expressions.emplace_back(exprConverter_->toVeloxExpr(readRel.filter(), rowType));
+    // Try to compile the expressions. If there is any unregistered function
+    // or mismatched type, exception will be thrown.
+    exec::ExprSet exprSet(std::move(expressions), execCtx_);
   }
 
   return true;
@@ -1262,19 +1186,24 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::RelRoot& relRoot
 }
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::Plan& plan) {
-  // Create plan converter and expression converter to help the validation.
-  planConverter_.constructFunctionMap(plan);
-  exprConverter_ = planConverter_.getExprConverter();
+  try {
+    // Create plan converter and expression converter to help the validation.
+    planConverter_.constructFunctionMap(plan);
+    exprConverter_ = planConverter_.getExprConverter();
 
-  for (const auto& rel : plan.relations()) {
-    if (rel.has_root()) {
-      return validate(rel.root());
-    } else if (rel.has_rel()) {
-      return validate(rel.rel());
+    for (const auto& rel : plan.relations()) {
+      if (rel.has_root()) {
+        return validate(rel.root());
+      } else if (rel.has_rel()) {
+        return validate(rel.rel());
+      }
     }
-  }
 
-  return false;
+    return false;
+  } catch (const VeloxException& err) {
+    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
+    return false;
+  }
 }
 
 } // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -29,6 +29,14 @@ class SubstraitToVeloxPlanValidator {
   SubstraitToVeloxPlanValidator(memory::MemoryPool* pool, core::ExecCtx* execCtx)
       : pool_(pool), execCtx_(execCtx), planConverter_(pool_, confMap_, std::nullopt, true) {}
 
+  /// Used to validate whether the computing of this Plan is supported.
+  bool validate(const ::substrait::Plan& plan);
+
+  const std::vector<std::string>& getValidateLog() const {
+    return validateLog_;
+  }
+
+ private:
   /// Used to validate whether the computing of this Write is supported.
   bool validate(const ::substrait::WriteRel& writeRel);
 
@@ -71,14 +79,6 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this RelRoot is supported.
   bool validate(const ::substrait::RelRoot& relRoot);
 
-  /// Used to validate whether the computing of this Plan is supported.
-  bool validate(const ::substrait::Plan& plan);
-
-  const std::vector<std::string>& getValidateLog() const {
-    return validateLog_;
-  }
-
- private:
   /// A memory pool used for function validation.
   memory::MemoryPool* pool_;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Exception handling logic for GenerateExec is missed, so error is not properly caught. We may move the exception handling to common place to avoid such case.

Issue query:
`spark.sql("SELECT explode(array(struct(1, 'a'), null))").collect`

Query sould fallback but fail with below error:
```
java.lang.RuntimeException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: NOT_IMPLEMENTED
Reason: NULL for struct type is not supported.
Retriable: False
Function: literalsToRowVector
File: /var/git/gluten/cpp/velox/substrait/SubstraitToVeloxExpr.cc
Line: 494
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, char const*>(facebook::velox::detail::VeloxCheckFailArgs const&, char const*)
# 2  gluten::SubstraitVeloxExprConverter::literalsToRowVector(substrait::Expression_Literal const&)
# 3  gluten::SubstraitVeloxExprConverter::literalsToVector(substrait::Expression_Literal const&, int, std::function<substrait::Expression_Literal (int)>)
# 4  gluten::SubstraitVeloxExprConverter::literalsToArrayVector(substrait::Expression_Literal const&)
# 5  gluten::SubstraitVeloxExprConverter::toVeloxExpr(substrait::Expression_Literal const&)
# 6  gluten::SubstraitVeloxExprConverter::toVeloxExpr(substrait::Expression const&, std::shared_ptr<facebook::velox::RowType const> const&)
# 7  gluten::SubstraitToVeloxPlanValidator::validateScalarFunction(substrait::Expression_ScalarFunction const&, std::shared_ptr<facebook::velox::RowType const> const&)
# 8  gluten::SubstraitToVeloxPlanValidator::validate(substrait::GenerateRel const&)
# 9  Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeValidateWithFailureReason
# 10 0x00007f7389018426
# 11 0x00007f7389007d7f
# 12 0x00007f7389007d7f
# 13 0x00007f7389007d7f
# 14 0x00007f7389007e53
# 15 0x00007f7389007d7f
# 16 0x00007f7389007e53
# 17 0x00007f7389007d7f
# 18 0x00007f7389007d7f
# 19 0x00007f7389007d7f
# 20 0x00007f7389007e53
# 21 0x00007f7389007d7f
# 22 0x00007f7389007d7f
# 23 0x00007f7389007d7f
# 24 0x00007f7389007ffc
# 25 0x00007f7389007d7f
# 26 0x00007f7389007d7f
# 27 0x00007f7389007d7f
# 28 0x00007f73899a2533

  at io.glutenproject.vectorized.PlanEvaluatorJniWrapper.nativeValidateWithFailureReason(Native Method)
  at io.glutenproject.vectorized.NativePlanEvaluator.doNativeValidateWithFailureReason(NativePlanEvaluator.java:54)
  at io.glutenproject.backendsapi.velox.ValidatorApiImpl.$anonfun$doNativeValidateWithFailureReason$1(ValidatorApiImpl.scala:39)
  at org.apache.spark.util.TaskResources$.runUnsafe(TaskResources.scala:81)
  at io.glutenproject.backendsapi.velox.ValidatorApiImpl.doNativeValidateWithFailureReason(ValidatorApiImpl.scala:37)
  at io.glutenproject.extension.GlutenPlan.doNativeValidation(GlutenPlan.scala:94)
  at io.glutenproject.extension.GlutenPlan.doNativeValidation$(GlutenPlan.scala:90)
  at io.glutenproject.execution.GenerateExecTransformerBase.doNativeValidation(GenerateExecTransformerBase.scala:35)
  at io.glutenproject.execution.GenerateExecTransformerBase.doValidateInternal(GenerateExecTransformerBase.scala:76)
  at io.glutenproject.extension.GlutenPlan.doValidate(GlutenPlan.scala:67)
  at io.glutenproject.extension.GlutenPlan.doValidate$(GlutenPlan.scala:64)
  at io.glutenproject.execution.GenerateExecTransformerBase.doValidate(GenerateExecTransformerBase.scala:35)
  at io.glutenproject.extension.columnar.AddTransformHintRule.addTransformableTag(TransformHintRule.scala:714)
  at io.glutenproject.extension.columnar.AddTransformHintRule.addTransformableTags(TransformHintRule.scala:391)
  at io.glutenproject.extension.columnar.AddTransformHintRule.apply(TransformHintRule.scala:384)
  at io.glutenproject.extension.columnar.RewriteSparkPlanRulesManager$$anonfun$apply$1.applyOrElse(RewriteSparkPlanRulesManager.scala:108)
  at io.glutenproject.extension.columnar.RewriteSparkPlanRulesManager$$anonfun$apply$1.applyOrElse(RewriteSparkPlanRulesManager.scala:91)
  at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformUpWithPruning$2(TreeNode.scala:566)
  at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:104)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformUpWithPruning(TreeNode.scala:566)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformUp(TreeNode.scala:539)
  at io.glutenproject.extension.columnar.RewriteSparkPlanRulesManager.apply(RewriteSparkPlanRulesManager.scala:91)
  at io.glutenproject.extension.columnar.RewriteSparkPlanRulesManager.apply(RewriteSparkPlanRulesManager.scala:44)
  at io.glutenproject.extension.ColumnarOverrideRules.$anonfun$transformPlan$3(ColumnarOverrides.scala:363)
  at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
  at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
  at scala.collection.immutable.List.foldLeft(List.scala:91)
  at io.glutenproject.extension.ColumnarOverrideRules.$anonfun$transformPlan$1(ColumnarOverrides.scala:361)
  at io.glutenproject.metrics.GlutenTimeMetric$.withNanoTime(GlutenTimeMetric.scala:41)
  at io.glutenproject.metrics.GlutenTimeMetric$.withMillisTime(GlutenTimeMetric.scala:46)
  at io.glutenproject.extension.ColumnarOverrideRules.transformPlan(ColumnarOverrides.scala:371)
  at io.glutenproject.extension.ColumnarOverrideRules.$anonfun$withTransformRules$3(ColumnarOverrides.scala:339)
  at io.glutenproject.extension.ColumnarOverrideRules.prepareFallback(ColumnarOverrides.scala:308)
  at io.glutenproject.extension.ColumnarOverrideRules.$anonfun$withTransformRules$2(ColumnarOverrides.scala:338)
  at io.glutenproject.utils.QueryPlanSelector.maybe(QueryPlanSelector.scala:74)
  at io.glutenproject.extension.ColumnarOverrideRules.io$glutenproject$extension$ColumnarOverrideRules$$$anonfun$withTransformRules$1(ColumnarOverrides.scala:336)
  at io.glutenproject.extension.ColumnarOverrideRules$$anonfun$withTransformRules$4.apply(ColumnarOverrides.scala:335)
  at io.glutenproject.extension.ColumnarOverrideRules$$anonfun$withTransformRules$4.apply(ColumnarOverrides.scala:335)
  at io.glutenproject.extension.ColumnarOverrideRules.io$glutenproject$extension$ColumnarOverrideRules$$$anonfun$postColumnarTransitions$1(ColumnarOverrides.scala:330)
  at io.glutenproject.extension.ColumnarOverrideRules$$anonfun$postColumnarTransitions$2.apply(ColumnarOverrides.scala:326)
  at io.glutenproject.extension.ColumnarOverrideRules$$anonfun$postColumnarTransitions$2.apply(ColumnarOverrides.scala:326)
```

