### PR TITLE
[Gluten-5152][CH] fix core dump issues when running in parallel

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/ClickhouseSnapshot.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/ClickhouseSnapshot.scala
@@ -88,7 +88,7 @@ object ClickhouseSnapshot {
     .build()
 
   val addFileToAddMTPCache: LoadingCache[AddFileAsKey, AddMergeTreeParts] = CacheBuilder.newBuilder
-    .maximumSize(100000)
+    .maximumSize(1000000)
     .expireAfterAccess(3600L, TimeUnit.SECONDS)
     .recordStats
     .build[AddFileAsKey, AddMergeTreeParts](new CacheLoader[AddFileAsKey, AddMergeTreeParts]() {
@@ -99,7 +99,7 @@ object ClickhouseSnapshot {
     })
 
   val pathToAddMTPCache: Cache[String, AddMergeTreeParts] = CacheBuilder.newBuilder
-    .maximumSize(100000)
+    .maximumSize(1000000)
     .expireAfterAccess(3600L, TimeUnit.SECONDS)
     .recordStats()
     .build()

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -314,7 +314,8 @@ object ClickHouseTableV2 extends Logging {
     } else if (temporalThreadLocalCHTable.get() != null) {
       temporalThreadLocalCHTable.get()
     } else {
-      throw new IllegalStateException("Can not find ClickHouseTableV2")
+      throw new IllegalStateException(
+        s"Can not find ClickHouseTableV2 for deltalog ${deltaLog.dataPath}")
     }
   }
 

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -175,7 +175,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
                   "Can't find AddMergeTreeParts from cache pathToAddMTPCache for key: " +
                     path + ". This happens when too many new entries are added to " +
                     "pathToAddMTPCache during current query. " +
-                    "Try rerun current query. KeySample: " + keySample
+                    "Try rerun current query. Existing KeySample: " + keySample
                 )
               }
               ret
@@ -307,7 +307,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
                   "Can't find AddMergeTreeParts from cache pathToAddMTPCache for key: " +
                     path + ". This happens when too many new entries are added to " +
                     "pathToAddMTPCache during current query. " +
-                    "Try rerun current query. KeySample: " + keySample)
+                    "Try rerun current query. Existing KeySample: " + keySample)
               }
               ret
             }))

--- a/cpp-ch/local-engine/Operator/ExpandTransform.cpp
+++ b/cpp-ch/local-engine/Operator/ExpandTransform.cpp
@@ -16,7 +16,6 @@
  */
 #include <memory>
 
-#include "Columns/ColumnSparse.h"
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/IColumn.h>

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -66,7 +66,7 @@ static Int64 findMinPosition(const NameSet & condition_table_columns, const Name
 
 CustomStorageMergeTreePtr MergeTreeRelParser::parseStorage(
     const substrait::ReadRel::ExtensionTable & extension_table,
-    ContextMutablePtr context,  UUID uuid)
+    ContextMutablePtr context, UUID uuid)
 {
     google::protobuf::StringValue table;
     table.ParseFromString(extension_table.detail().value());

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.cpp
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.cpp
@@ -108,7 +108,15 @@ DataPartsVector CustomStorageMergeTree::loadDataPartsWithNames(std::unordered_se
         auto res = loadDataPart(part_info, name, disk, MergeTreeDataPartState::Active);
         data_parts.emplace_back(res.part);
     }
-    calculateColumnAndSecondaryIndexSizesImpl(); // without it "test mergetree optimize partitioned by one low card column" will log ERROR
+
+    if(getStorageID().hasUUID())
+    {
+        // the following lines will modify storage's member.
+        // So when current storage is shared (when UUID is default Nil value),
+        // we should avoid modify because we don't have locks here
+
+        calculateColumnAndSecondaryIndexSizesImpl(); // without it "test mergetree optimize partitioned by one low card column" will log ERROR
+    }
     return data_parts;
 }
 

--- a/cpp-ch/local-engine/Storages/StorageMergeTreeFactory.cpp
+++ b/cpp-ch/local-engine/Storages/StorageMergeTreeFactory.cpp
@@ -27,11 +27,36 @@ StorageMergeTreeFactory & StorageMergeTreeFactory::instance()
 void StorageMergeTreeFactory::freeStorage(StorageID id)
 {
     auto table_name = id.database_name + "." + id.table_name + "@" + toString(id.uuid);
-    std::lock_guard lock(storage_map_mutex);
-    if (storage_map.contains(table_name))
+
+
     {
-        storage_map.erase(table_name);
+        std::lock_guard lock(storage_map_mutex);
+        if (storage_map.contains(table_name))
+        {
+            storage_map.erase(table_name);
+        }
+        if (storage_columns_map.contains(table_name))
+        {
+            storage_columns_map.erase(table_name);
+        }
     }
+
+    {
+        std::lock_guard lock(datapart_mutex);
+        if (datapart_map.contains(table_name))
+        {
+            datapart_map.erase(table_name);
+        }
+    }
+
+    {
+        std::lock_guard lock(metadata_map_mutex);
+        if (metadata_map.contains(table_name))
+        {
+            metadata_map.erase(table_name);
+        }
+    }
+
 }
 
 CustomStorageMergeTreePtr


### PR DESCRIPTION
## What changes were proposed in this pull request?

When testing querying and optimizing with TPCH 100 data with 30 core,
we may encounter core dump issues, this PR fixes it.

Also fix some potential memory leak.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

