### PR TITLE
[VL] Correct preProjection to rowConstruction for hash aggregate metrics

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/MetricsApiImpl.scala
@@ -222,7 +222,7 @@ class MetricsApiImpl extends MetricsApi with Logging {
         "rowConstruction cpu wall time count"),
       "rowConstructionWallNanos" -> SQLMetrics.createNanoTimingMetric(
         sparkContext,
-        "totaltime of preProjection"),
+        "totaltime of rowConstruction"),
       "extractionCpuCount" -> SQLMetrics.createMetric(
         sparkContext,
         "extraction cpu wall time count"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `preProjection` to `rowConstruction` in `HashAggregateTransformerMetrics`.

## How was this patch tested?

N/A

