### PR TITLE
[Core] Rename checkOperatorMatch and checkFallbackOperatorMatch

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseHiveTableSuite.scala
@@ -1055,7 +1055,7 @@ class GlutenClickHouseHiveTableSuite
       s"CREATE FUNCTION my_add as " +
         s"'org.apache.hadoop.hive.contrib.udf.example.UDFExampleAdd2' USING JAR '$jarUrl'")
     runQueryAndCompare("select MY_ADD(id, id+1) from range(10)")(
-      checkOperatorMatch[ProjectExecTransformer])
+      checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("GLUTEN-4333: fix CSE in aggregate operator") {
@@ -1147,7 +1147,7 @@ class GlutenClickHouseHiveTableSuite
     Seq("true", "false").foreach {
       enabled =>
         withSQLConf(SQLConf.JSON_EXPRESSION_OPTIMIZATION.key -> enabled) {
-          runQueryAndCompare(selectSql)(checkOperatorMatch[ProjectExecTransformer])
+          runQueryAndCompare(selectSql)(checkGlutenOperatorMatch[ProjectExecTransformer])
         }
     }
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -318,14 +318,14 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         |lateral view explode(set) as b
         |order by a, b
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[CHHashAggregateExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[CHHashAggregateExecTransformer])
   }
 
   test("test 'aggregate function collect_list'") {
     val df = runQueryAndCompare(
       "select l_orderkey,from_unixtime(l_orderkey, 'yyyy-MM-dd HH:mm:ss') " +
         "from lineitem order by l_orderkey desc limit 10"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 10)
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -362,20 +362,20 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
   test("test 'function pmod'") {
     val df = runQueryAndCompare(
       "select pmod(-10, id+10) from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 10)
   }
 
   test("test 'function ascii'") {
     val df = runQueryAndCompare(
       "select ascii(cast(id as String)) from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 10)
   }
 
   test("test 'function rand'") {
     runSql("select rand(), rand(1), rand(null) from range(10)")(
-      checkOperatorMatch[ProjectExecTransformer])
+      checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'function date_add/date_sub/datediff'") {
@@ -385,20 +385,20 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         "date_sub(l_shipdate, 1), date_sub(l_shipdate, -1), " +
         "datediff(l_shipdate, l_commitdate), datediff(l_commitdate, l_shipdate) " +
         "from lineitem order by l_shipdate, l_commitdate limit 1"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'function remainder'") {
     runQueryAndCompare(
       "select l_orderkey, l_partkey, l_orderkey % l_partkey, l_partkey % l_orderkey " +
         "from lineitem order by l_orderkey desc, l_partkey desc limit 1"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test positive/negative") {
     runQueryAndCompare(
       "select +n_nationkey, positive(n_nationkey), -n_nationkey, negative(n_nationkey) from nation"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   // TODO: enable when supports interval type
@@ -408,7 +408,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       runQueryAndCompare(
         "select +interval 1 day, positive(interval 1 day), -interval 1 day, negative(interval 1 day)",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -418,24 +418,24 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       runQueryAndCompare(
         "select a from (select array_intersect(split(n_comment, ' '), split(n_comment, ' ')) as arr " +
           "from nation) lateral view explode(arr) as a order by a"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select a from (select array_intersect(array(null,1,2,3,null), array(3,5,1,null,null)) as arr) " +
           "lateral view explode(arr) as a order by a",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select array_intersect(array(null,1,2,3,null), cast(null as array<int>))",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select a from (select array_intersect(array(array(1,2),array(3,4)), array(array(1,2),array(3,4))) as arr) " +
           "lateral view explode(arr) as a order by a",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -444,14 +444,14 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select array_position(split(n_comment, ' '), 'final') from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select array_position(array(1,2,3,null), 1), array_position(array(1,2,3,null), null)," +
           "array_position(array(1,2,3,null), 5), array_position(array(1,2,3), 5), " +
           "array_position(array(1,2,3), 2), array_position(cast(null as array<int>), 1)",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -460,14 +460,14 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select array_contains(split(n_comment, ' '), 'final') from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select array_contains(array(1,2,3,null), 1), array_contains(array(1,2,3,null), " +
           "cast(null as int)), array_contains(array(1,2,3,null), 5), array_contains(array(1,2,3), 5)," +
           "array_contains(array(1,2,3), 2), array_contains(cast(null as array<int>), 1)",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -476,40 +476,40 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select sort_array(split(n_comment, ' ')) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select sort_array(split(n_comment, ' '), false) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select sort_array(array(1,3,2,null)), sort_array(array(1,2,3,null),false)",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
   test("test coalesce") {
     var df = runQueryAndCompare(
       "select l_orderkey, coalesce(l_comment, 'default_val') " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 5)
     df = runQueryAndCompare(
       "select l_orderkey, coalesce(cast(null as string), l_comment, 'default_val') " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 5)
     df = runQueryAndCompare(
       "select l_orderkey, coalesce(cast(null as string), cast(null as string), l_comment) " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 5)
     df = runQueryAndCompare(
       "select l_orderkey, coalesce(cast(null as string), cast(null as string), 1, 2) " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 5)
     df = runQueryAndCompare(
       "select l_orderkey, " +
         "coalesce(cast(null as string), cast(null as string), cast(null as string)) "
-        + "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        + "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 5)
   }
 
@@ -518,7 +518,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       "select l_orderkey, from_unixtime(l_orderkey, 'yyyy-MM-dd HH:mm:ss'), " +
         "from_unixtime(l_orderkey, 'yyyy-MM-dd') " +
         "from lineitem order by l_orderkey desc limit 10"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 10)
   }
 
@@ -526,7 +526,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     val df = runQueryAndCompare(
       "select l_orderkey,from_unixtime(l_orderkey, 'yyyy-MM-dd HH:mm:ss') " +
         "from lineitem order by l_orderkey desc limit 10"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df, 10)
   }
 
@@ -537,47 +537,47 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         "select find_in_set(null, 'a'), find_in_set('a', null), " +
           "find_in_set('a', 'a,b'), find_in_set('a', 'ab,ab')",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
   test("test 'function regexp_replace'") {
     runQueryAndCompare(
       "select l_orderkey, regexp_replace(l_comment, '([a-z])', '1') " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       "select l_orderkey, regexp_replace(l_comment, '([a-z])', '1', 1) " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("regexp_extract") {
     runQueryAndCompare(
       s"select l_orderkey, regexp_extract(l_comment, '([a-z])', 1) " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_extract(l_comment, '([a-z])') " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_extract(l_comment, '([a-z])', 0) " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("lpad") {
     runQueryAndCompare(
       s"select l_orderkey, lpad(l_comment, 80) " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lpad(l_comment, 80, '??') " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("rpad") {
     runQueryAndCompare(
       s"select l_orderkey, rpad(l_comment, 80) " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rpad(l_comment, 80, '??') " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test elt") {
@@ -585,11 +585,11 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select elt(2, n_comment, n_regionkey) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
       runQueryAndCompare(
         "select elt(null, 'a', 'b'), elt(0, 'a', 'b'), elt(1, 'a', 'b'), elt(3, 'a', 'b')",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -598,12 +598,12 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select array_max(split(n_comment, ' ')) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
       runQueryAndCompare(
         "select array_max(null), array_max(array(null)), array_max(array(1, 2, 3, null)), " +
           "array_max(array(1.0, 2.0, 3.0, null)), array_max(array('z', 't', 'abc'))",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -612,12 +612,12 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select array_min(split(n_comment, ' ')) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
       runQueryAndCompare(
         "select array_min(null), array_min(array(null)), array_min(array(1, 2, 3, null)), " +
           "array_min(array(1.0, 2.0, 3.0, null)), array_min(array('z', 't', 'abc'))",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -630,7 +630,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |""".stripMargin
     withSQLConf(
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
-      runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+      runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -660,13 +660,13 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select array_distinct(split(n_comment, ' ')) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select array_distinct(array(1,2,1,2,3)), array_distinct(array(null,1,null,1,2,null,3)), " +
           "array_distinct(array(array(1,null,2), array(1,null,2))), array_distinct(null), array_distinct(array(null))",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -675,7 +675,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select array_union(split(n_comment, ' '), reverse(split(n_comment, ' '))) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select array_union(array(1,2,1,2,3), array(2,4,2,3,5)), " +
@@ -684,23 +684,25 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
           "array_union(array(null), array(null)), " +
           "array_union(cast(null as array<int>), cast(null as array<int>))",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
   test("test 'function regexp_extract_all'") {
     runQueryAndCompare(
       "select l_orderkey, regexp_extract_all(l_comment, '([a-z])', 1) " +
-        "from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'function to_unix_timestamp/unix_timestamp'") {
     runQueryAndCompare(
       "select to_unix_timestamp(concat(cast(l_shipdate as String), ' 00:00:00')) " +
-        "from lineitem order by l_shipdate limit 10;")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem order by l_shipdate limit 10;")(
+      checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       "select unix_timestamp(concat(cast(l_shipdate as String), ' 00:00:00')) " +
-        "from lineitem order by l_shipdate limit 10;")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem order by l_shipdate limit 10;")(
+      checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test literals") {
@@ -725,7 +727,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         ARRAY(1, NULL, 3) as array_with_null_literal,
         MAP(1, 2, CAST(3 as SHORT), null) as map_with_null_literal
       from range(10)"""
-    runQueryAndCompare(query)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(query)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   // see issue https://github.com/Kyligence/ClickHouse/issues/93
@@ -778,7 +780,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |from nation
         |order by n_regionkey
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[WindowExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[WindowExecTransformer])
   }
 
   test("window max") {
@@ -1050,7 +1052,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |grouping sets((a, n_regionkey, n_nationkey),(a, n_regionkey), (a))
         |order by a, n_regionkey, n_nationkey
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ExpandExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ExpandExecTransformer])
   }
 
   test("expand col result") {
@@ -1060,7 +1062,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |group by n_regionkey, n_nationkey with rollup
         |order by n_regionkey, n_nationkey, cnt
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ExpandExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ExpandExecTransformer])
   }
 
   test("expand with not nullable") {
@@ -1070,7 +1072,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |(select nvl(n_nationkey, 0) as c, nvl(n_name, '') as b, nvl(n_nationkey, 0) as a from nation)
         |group by a,b with rollup
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ExpandExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ExpandExecTransformer])
   }
 
   test("expand with function expr") {
@@ -1084,7 +1086,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |group by n_name
         |order by n_name, col1, col2
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ExpandExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ExpandExecTransformer])
   }
 
   test("test 'position/locate'") {
@@ -1108,7 +1110,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |position(null, null, null)
         |from lineitem
         |""".stripMargin
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test stddev_samp 1") {
@@ -1147,7 +1149,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
   test("test 'sequence'") {
     runQueryAndCompare(
       "select sequence(id, id+10), sequence(id+10, id), sequence(id, id+10, 3), " +
-        "sequence(id+10, id, -3) from range(1)")(checkOperatorMatch[ProjectExecTransformer])
+        "sequence(id+10, id, -3) from range(1)")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("GLUTEN-2491: sequence with null value as argument") {
@@ -1157,12 +1159,12 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         "select sequence(null, 1), sequence(1, null), sequence(1, 3, null), sequence(1, 5)," +
           "sequence(5, 1), sequence(1, 5, 2), sequence(5, 1, -2)",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select sequence(n_nationkey, n_nationkey+10), sequence(n_nationkey, n_nationkey+10, 2) " +
           "from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -1183,13 +1185,13 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |lateral view explode(set) as b
         |order by a, b
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[CHHashAggregateExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[CHHashAggregateExecTransformer])
   }
 
   test("collect_set should return empty set") {
     runQueryAndCompare(
       "select collect_set(if(n_regionkey != -1, null, n_regionkey)) from nation"
-    )(checkOperatorMatch[CHHashAggregateExecTransformer])
+    )(checkGlutenOperatorMatch[CHHashAggregateExecTransformer])
   }
 
   test("Test 'spark.gluten.enabled' false") {
@@ -1210,7 +1212,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       "cast(x as date), cast(x as timestamp), cast(x as decimal(10, 2)) from " +
       "(select cast(null as string) as x from range(10) union all " +
       "select cast(id as string) as x from range(2))"
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'max(NULL)/min(NULL) from table'") {
@@ -1227,47 +1229,47 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
   test("test 'dayofweek/weekday'") {
     val sql = "select l_orderkey, l_shipdate, weekday(l_shipdate), dayofweek(l_shipdate) " +
       "from lineitem limit 10"
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'to_date/to_timestamp'") {
     val sql = "select to_date(concat('2022-01-0', cast(id+1 as String)), 'yyyy-MM-dd')," +
       "to_timestamp(concat('2022-01-01 10:30:0', cast(id+1 as String)), 'yyyy-MM-dd HH:mm:ss') " +
       "from range(9)"
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'btrim/ltrim/rtrim/trim'") {
     runQueryAndCompare(
       "select l_comment, btrim(l_comment), btrim(l_comment, 'abcd') " +
-        "from lineitem limit 10")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 10")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       "select l_comment, ltrim(l_comment), ltrim('abcd', l_comment) " +
-        "from lineitem limit 10")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 10")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       "select l_comment, rtrim(l_comment), rtrim('abcd', l_comment) " +
-        "from lineitem limit 10")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 10")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       "select l_comment, trim(l_comment), trim('abcd' from l_comment), " +
         "trim(BOTH 'abcd' from l_comment), trim(LEADING 'abcd' from l_comment), " +
         "trim(TRAILING 'abcd' from l_comment) from lineitem limit 10"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("bit_and/bit_or/bit_xor") {
     runQueryAndCompare(
       "select bit_and(n_regionkey), bit_or(n_regionkey), bit_xor(n_regionkey) from nation") {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select bit_and(l_partkey), bit_or(l_suppkey), bit_xor(l_orderkey) from lineitem") {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
   }
 
   test("test 'EqualNullSafe'") {
     runQueryAndCompare("select l_linenumber <=> l_orderkey, l_linenumber <=> null from lineitem") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -1278,14 +1280,14 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     val sql = """
                 | select id from test_1767 lateral view
                 | posexplode(split(data['k'], ',')) tx as a, b""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[CHGenerateExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[CHGenerateExecTransformer])
 
     spark.sql("drop table test_1767")
   }
 
   test("test posexplode issue: https://github.com/oap-project/gluten/issues/2492") {
     val sql = "select posexplode(split(n_comment, ' ')) from nation where n_comment is null"
-    runQueryAndCompare(sql)(checkOperatorMatch[CHGenerateExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[CHGenerateExecTransformer])
   }
 
   test("test posexplode issue: https://github.com/oap-project/gluten/issues/2454") {
@@ -1297,7 +1299,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     )
 
     for (sql <- sqls) {
-      runQueryAndCompare(sql)(checkOperatorMatch[CHGenerateExecTransformer])
+      runQueryAndCompare(sql)(checkGlutenOperatorMatch[CHGenerateExecTransformer])
     }
   }
 
@@ -1306,7 +1308,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     spark.sql("insert into test_3124  values (31, null, 'm'), (32, 'a,b,c', 'f')")
 
     val sql = "select id, flag from test_3124 lateral view explode(split(name, ',')) as flag"
-    runQueryAndCompare(sql)(checkOperatorMatch[CHGenerateExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[CHGenerateExecTransformer])
 
     spark.sql("drop table test_3124")
   }
@@ -1314,7 +1316,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
   test("test 'scala udf'") {
     spark.udf.register("my_add", (x: Long, y: Long) => x + y)
     runQueryAndCompare("select my_add(id, id+1) from range(10)")(
-      checkOperatorMatch[ProjectExecTransformer])
+      checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   override protected def runTPCHQuery(
@@ -1350,7 +1352,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ConstantFolding.ruleName) {
       runQueryAndCompare(
         "select size(null), size(split(l_shipinstruct, ' ')) from lineitem"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -1362,7 +1364,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |concat(split(n_comment, ' '), split(n_name, ' '))
         |from nation
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("GLUTEN-1620: fix 'attribute binding failed.' when executing hash agg without aqe") {
@@ -1566,7 +1568,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ConstantFolding.ruleName) {
       runQueryAndCompare(
         "select struct(1.0f), array(2.0f), map('a', 3.0f) from range(1)"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -1783,20 +1785,20 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
   test("GLUTEN-2095: test cast(string as binary)") {
     runQueryAndCompare(
       "select cast(n_nationkey as binary), cast(n_comment as binary) from nation"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("var_samp") {
     runQueryAndCompare("""
                          |select var_samp(l_quantity) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
     runQueryAndCompare("""
                          |select l_orderkey % 5, var_samp(l_quantity) from lineitem
                          |group by l_orderkey % 5;
                          |""".stripMargin) {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
   }
 
@@ -1804,13 +1806,13 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     runQueryAndCompare("""
                          |select var_pop(l_quantity) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
     runQueryAndCompare("""
                          |select l_orderkey % 5, var_pop(l_quantity) from lineitem
                          |group by l_orderkey % 5;
                          |""".stripMargin) {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
   }
 
@@ -1818,7 +1820,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     runQueryAndCompare("""
                          |select corr(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[CHHashAggregateExecTransformer]
+      checkGlutenOperatorMatch[CHHashAggregateExecTransformer]
     }
 
     runQueryAndCompare(
@@ -1842,12 +1844,12 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
           "concat_ws(null, 'a'), concat_ws('-', 'a'), concat_ws('-', 'a', null), " +
           "concat_ws('-', 'a', null, 'b', 'c', null, array(null), array('d', null), array('f', 'g'))",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select concat_ws('-', n_comment, " +
           "array(if(n_regionkey=0, null, cast(n_regionkey as string)))) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -1857,7 +1859,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         |select a from values (1.0), (2.1), (null), (cast('NaN' as double)), (cast('inf' as double)),
         | (cast('-inf' as double)) as data(a) order by a asc nulls last
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[SortExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[SortExecTransformer])
   }
 
   test("GLUTEN-2639: log1p") {
@@ -1865,7 +1867,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
       runQueryAndCompare(
         "select log1p(n_regionkey), log1p(-1.0), log1p(-2.0) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -1989,7 +1991,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
     // cast('nan' as double) output 'NaN' in Spark, 'nan' in CH
     // cast('inf' as double) output 'Infinity' in Spark, 'inf' in CH
     // ignore them temporarily
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("GLUTEN-3501: test json output format with struct contains null value") {
@@ -1997,7 +1999,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       """
         |select to_json(struct(cast(id as string), null, id, 1.1, 1.1f, 1.1d)) from range(3)
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("GLUTEN-3216: invalid read rel schema in aggregation") {
@@ -2080,11 +2082,11 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       runQueryAndCompare(
         "select 1/0f, 1/0.0d",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select n_nationkey / n_regionkey from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -2303,12 +2305,12 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       runQueryAndCompare(
         "select trunc('2023-12-06', 'MM'), trunc('2023-12-06', 'YEAR'), trunc('2023-12-06', 'WEEK'), trunc('2023-12-06', 'QUARTER')",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       runQueryAndCompare(
         "select trunc(l_shipdate, 'MM'), trunc(l_shipdate, 'YEAR'), trunc(l_shipdate, 'WEEK'), " +
           "trunc(l_shipdate, 'QUARTER') from lineitem"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -2319,7 +2321,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
         "select log10(n_regionkey), log10(-1.0), log10(0), log10(n_regionkey - 100000), " +
           "log2(n_regionkey), log2(-1.0), log2(0), log2(n_regionkey - 100000), " +
           "ln(n_regionkey), ln(-1.0), ln(0), ln(n_regionkey - 100000) from nation"
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -213,37 +213,37 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
 
   test("Test get_json_object 1") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$.a') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test get_json_object 2") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$.1a') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test get_json_object 3") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$.a_2') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   ignore("Test get_json_object 4") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$[a]') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test get_json_object 5") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$[\\\'a\\\']') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test get_json_object 6") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$[\\\'a 2\\\']') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -268,7 +268,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
   test("Test nested get_json_object") {
     runQueryAndCompare(
       "SELECT get_json_object(get_json_object(string_field1, '$.a'), '$.x') from json_test") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -304,7 +304,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         "xxhash64(cast(from_unixtime(id) as timestamp)), xxhash64(cast(id as decimal(5, 2))), " +
         "xxhash64(cast(id as decimal(10, 2))), xxhash64(cast(id as decimal(30, 2))) " +
         "from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df1, 10)
 
     val df2 = runQueryAndCompare(
@@ -317,7 +317,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         "xxhash64(cast(id as decimal(5, 2)), 'spark'), " +
         "xxhash64(cast(id as decimal(10, 2)), 'spark'), " +
         "xxhash64(cast(id as decimal(30, 2)), 'spark') from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df2, 10)
   }
 
@@ -334,7 +334,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         |  xxhash64(struct(id, cast(id as string), 100, 'spark', null))
         |from range(10);
       """.stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test 'function murmur3hash'") {
@@ -345,7 +345,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         "hash(cast(from_unixtime(id) as date)), " +
         "hash(cast(from_unixtime(id) as timestamp)), hash(cast(id as decimal(5, 2))), " +
         "hash(cast(id as decimal(10, 2))), hash(cast(id as decimal(30, 2))) from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df1, 10)
 
     val df2 = runQueryAndCompare(
@@ -357,7 +357,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         "hash(cast(from_unixtime(id) as timestamp), 'spark'), " +
         "hash(cast(id as decimal(5, 2)), 'spark'), hash(cast(id as decimal(10, 2)), 'spark'), " +
         "hash(cast(id as decimal(30, 2)), 'spark') from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
     checkLengthAndPlan(df2, 10)
   }
 
@@ -374,7 +374,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         |  hash(struct(id, cast(id as string), 100, 'spark', null))
         |from range(10);
       """.stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test next_day const") {
@@ -395,7 +395,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       """
         |select array(null, array(id,2)) from range(10)
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test issue: https://github.com/oap-project/gluten/issues/2947") {
@@ -403,7 +403,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       """
         |select if(id % 2 = 0, null, array(id, 2, null)) from range(10)
         |""".stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test str2map") {
@@ -411,7 +411,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       """
         |select str, str_to_map(str, ',', ':') from str2map_table
         |""".stripMargin
-    runQueryAndCompare(sql1)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql1)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test parse_url") {
@@ -419,49 +419,49 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       """
         | select url, parse_url(url, "HOST") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql1)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql1)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql2 =
       """
         | select url, parse_url(url, "QUERY") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql2)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql2)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql3 =
       """
         | select url, parse_url(url, "QUERY", "x") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql3)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql3)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql5 =
       """
         | select url, parse_url(url, "FILE") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql5)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql5)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql6 =
       """
         | select url, parse_url(url, "REF") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql6)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql6)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql7 =
       """
         | select url, parse_url(url, "USERINFO") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql7)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql7)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql8 =
       """
         | select url, parse_url(url, "AUTHORITY") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql8)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql8)(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     val sql9 =
       """
         | select url, parse_url(url, "PROTOCOL") from url_table order by url
       """.stripMargin
-    runQueryAndCompare(sql9)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql9)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test decode and encode") {
@@ -472,20 +472,20 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       runQueryAndCompare(
         "SELECT decode(encode('Spark SQL', 'US-ASCII'), 'US-ASCII')",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       // Test codec with 'UTF-16'
       runQueryAndCompare(
         "SELECT decode(encode('Spark SQL', 'UTF-16'), 'UTF-16')",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
   test("test cast float string to int") {
     runQueryAndCompare(
       "select cast(concat(cast(id as string), '.1') as int) from range(10)"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test cast string to float") {
@@ -495,18 +495,18 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       runQueryAndCompare(
         "select cast('7.921901' as float), cast('7.921901' as double)",
         noFallBack = false
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
   test("test round issue: https://github.com/oap-project/gluten/issues/3462") {
     runQueryAndCompare(
       "select round(0.41875d * id , 4) from range(10);"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       "select round(0.41875f * id , 4) from range(10);"
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test date comparision expression override") {
@@ -543,7 +543,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         "SELECT array(array(1,2,3), array(4,5,6))[1], " +
           "array(array(id,id+1,id+2), array(id+3,id+4,id+5)) from range(100)",
         noFallBack = true
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       // input type is array<array<string>>
       runQueryAndCompare(
@@ -551,14 +551,14 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
           "array(array('1','2',cast(id as string)), array('4','5',cast(id as string)))[1] " +
           "from range(100)",
         noFallBack = true
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
       // input type is array<map<string, int>>
       runQueryAndCompare(
         "SELECT array(map(cast(id as string), id), map(cast(id+1 as string), id+1))[1] " +
           "from range(100)",
         noFallBack = true
-      )(checkOperatorMatch[ProjectExecTransformer])
+      )(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
 
@@ -631,13 +631,13 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
         |  FROM range(10)
         |) t
       """.stripMargin
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("test parse string with blank to integer") {
     // issue https://github.com/apache/incubator-gluten/issues/4956
     val sql = "select  cast(concat(' ', cast(id as string)) as bigint) from range(10)"
-    runQueryAndCompare(sql)(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("avg(bigint) overflow") {
@@ -653,9 +653,9 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
               |(9223372036854775807)
               |""".stripMargin)
         val q = "select avg(id) from big_int"
-        runQueryAndCompare(q)(checkOperatorMatch[CHHashAggregateExecTransformer])
+        runQueryAndCompare(q)(checkGlutenOperatorMatch[CHHashAggregateExecTransformer])
         val disinctSQL = "select count(distinct id), avg(distinct id), avg(id) from big_int"
-        runQueryAndCompare(disinctSQL)(checkOperatorMatch[CHHashAggregateExecTransformer])
+        runQueryAndCompare(disinctSQL)(checkGlutenOperatorMatch[CHHashAggregateExecTransformer])
       }
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -26,60 +26,60 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
 
   // Test "SELECT ..." without a from clause.
   test("isnull function") {
-    runQueryAndCompare("SELECT isnull(1)")(checkOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare("SELECT isnull(1)")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("Test bit_count function") {
     runQueryAndCompare("SELECT bit_count(l_partkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test bit_get function") {
     runQueryAndCompare("SELECT bit_get(l_partkey, 0) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test chr function") {
     runQueryAndCompare("SELECT chr(l_orderkey + 64) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test abs function") {
     runQueryAndCompare("SELECT abs(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test ceil function") {
     runQueryAndCompare("SELECT ceil(cast(l_orderkey as long)) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test floor function") {
     runQueryAndCompare("SELECT floor(cast(l_orderkey as long)) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test Exp function") {
     runQueryAndCompare("SELECT exp(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test Power function") {
     runQueryAndCompare("SELECT power(l_orderkey, 2) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test Pmod function") {
     runQueryAndCompare("SELECT pmod(cast(l_orderkey as int), 3) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -87,13 +87,13 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "SELECT round(cast(l_orderkey as int), 2)" +
         "from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
 
     runQueryAndCompare("""
                          |select round(l_quantity, 2) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -108,7 +108,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     val df = runQueryAndCompare(
       "SELECT bin(l_orderkey) " +
         "from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
@@ -156,20 +156,20 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
   test("greatest function") {
     val df = runQueryAndCompare(
       "SELECT greatest(l_orderkey, l_orderkey)" +
-        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 1")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("least function") {
     val df = runQueryAndCompare(
       "SELECT least(l_orderkey, l_orderkey)" +
-        "from lineitem limit 1")(checkOperatorMatch[ProjectExecTransformer])
+        "from lineitem limit 1")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("Test greatest function") {
     runQueryAndCompare(
       "SELECT greatest(l_orderkey, l_orderkey)" +
         "from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -177,13 +177,13 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "SELECT least(l_orderkey, l_orderkey)" +
         "from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test hash function") {
     runQueryAndCompare("SELECT hash(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -191,7 +191,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "SELECT get_json_object(string_field1, '$.a') " +
         "from datatab limit 1;") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -199,85 +199,85 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "SELECT l_orderkey, get_json_object('{\"a\":\"b\"}', '$.a') " +
         "from lineitem limit 1;") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   ignore("json_array_length") {
     runQueryAndCompare(
       s"select *, json_array_length(string_field1) " +
-        s"from datatab limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from datatab limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, json_array_length('[1,2,3,4]') " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, json_array_length(null) " +
-        s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from lineitem limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("Test acos function") {
     runQueryAndCompare("SELECT acos(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test asin function") {
     runQueryAndCompare("SELECT asin(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test atan function") {
     runQueryAndCompare("SELECT atan(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   ignore("Test atan2 function datatab") {
     runQueryAndCompare("SELECT atan2(double_field1, 0) from datatab limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test ceiling function") {
     runQueryAndCompare("SELECT ceiling(cast(l_orderkey as long)) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test cos function") {
     runQueryAndCompare("SELECT cos(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test cosh function") {
     runQueryAndCompare("SELECT cosh(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test degrees function") {
     runQueryAndCompare("SELECT degrees(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test log10 function") {
     runQueryAndCompare("SELECT log10(l_orderkey) from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test shiftleft function") {
     val df = runQueryAndCompare("SELECT shiftleft(int_field1, 1) from datatab limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test shiftright function") {
     val df = runQueryAndCompare("SELECT shiftright(int_field1, 1) from datatab limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -299,7 +299,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("view")
 
         runQueryAndCompare("SELECT date_add(a, b) from view") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -322,7 +322,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("view")
 
         runQueryAndCompare("SELECT datediff(a, b) from view") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -340,10 +340,10 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("view")
 
         runQueryAndCompare("SELECT to_utc_timestamp(a, \"America/Los_Angeles\") from view") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
         runQueryAndCompare("SELECT to_utc_timestamp(a, b) from view") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -366,7 +366,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         runQueryAndCompare(
           "select aggregate(i, 0, (acc, x) -> acc + x," +
             " acc -> acc * 3) as v from array_tbl;") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
     withTempPath {
@@ -382,7 +382,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("array_tbl")
 
         runQueryAndCompare("select aggregate(ys, 0, (y, a) -> y + a + x) as v from array_tbl;") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -411,7 +411,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("map_tbl")
 
         runQueryAndCompare("select i[\"1\"] from map_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -431,7 +431,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("map_tbl")
 
         runQueryAndCompare("select map_entries(i) from map_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -451,7 +451,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("map_tbl")
 
         runQueryAndCompare("select map_keys(i) from map_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -471,7 +471,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("map_tbl")
 
         runQueryAndCompare("select map_values(i) from map_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -480,7 +480,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "SELECT isnan(l_orderkey), isnan(cast('NaN' as double)), isnan(0.0F/0.0F)" +
         " from lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -491,21 +491,21 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
                          | nanvl(l_orderkey, l_orderkey / 0.0d),
                          | nanvl(cast('nan' as float), l_orderkey)
                          | from lineitem limit 1""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test monotonically_increasing_id function") {
     runQueryAndCompare("""SELECT monotonically_increasing_id(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test spark_partition_id function") {
     runQueryAndCompare("""SELECT spark_partition_id(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -519,7 +519,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.sparkContext.setLogLevel("info")
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("url_tbl")
         runQueryAndCompare("select url_decode(a) from url_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -534,20 +534,20 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.sparkContext.setLogLevel("info")
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("url_tbl")
         runQueryAndCompare("select url_encode(a) from url_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
 
   test("Test hex function") {
     runQueryAndCompare("SELECT hex(l_partkey), hex(l_shipmode) FROM lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("Test unhex function") {
     runQueryAndCompare("SELECT unhex(hex(l_shipmode)) FROM lineitem limit 1") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -568,7 +568,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
 
         runQueryAndCompare(
           "select make_timestamp(year, month, day, hour, min, sec) from make_timestamp_tbl1") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
     withTempPath {
@@ -589,22 +589,22 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
                              |select make_timestamp(year, month, day, hour, min, sec, timezone)
                              |from make_timestamp_tbl2
                              |""".stripMargin) {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
 
   test("Test make_ym_interval function") {
     runQueryAndCompare("select make_ym_interval(1, 1)") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
 
     runQueryAndCompare("select make_ym_interval(1)") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
 
     runQueryAndCompare("select make_ym_interval()") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
 
     withTempPath {
@@ -617,29 +617,29 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("make_ym_interval_tbl")
 
         runQueryAndCompare("select make_ym_interval(year, month) from make_ym_interval_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
 
         runQueryAndCompare("select make_ym_interval(year) from make_ym_interval_tbl") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
 
   test("Test uuid function") {
     runQueryAndCompare("""SELECT uuid() from lineitem limit 100""".stripMargin, false) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
   test("regexp_replace") {
     runQueryAndCompare(
       "SELECT regexp_replace(c_comment, '\\w', 'something') FROM customer limit 50") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     runQueryAndCompare(
       "SELECT regexp_replace(c_comment, '\\w', 'something', 3) FROM customer limit 50") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -647,7 +647,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "select bit_length(c_comment), bit_length(cast(c_comment as binary))" +
         " from customer limit 50") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -656,7 +656,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
       "select cast(l_orderkey as tinyint) & cast(l_partkey as tinyint)," +
         " cast(l_orderkey as int) & cast(l_partkey as int), l_orderkey & l_partkey" +
         " from lineitem") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -664,7 +664,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "select ~(cast(l_orderkey as tinyint)), ~(cast(l_orderkey as int)), ~l_orderkey" +
         " from lineitem") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -673,7 +673,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
       "select cast(l_orderkey as tinyint) | cast(l_partkey as tinyint)," +
         " cast(l_orderkey as int) | cast(l_partkey as int), l_orderkey | l_partkey" +
         " from lineitem") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -682,7 +682,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
       "select cast(l_orderkey as tinyint) ^ cast(l_partkey as tinyint)," +
         " cast(l_orderkey as int) ^ cast(l_partkey as int), l_orderkey ^ l_partkey" +
         " from lineitem") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -202,19 +202,19 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(
             "select ntile(4) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select row_number() over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select rank() over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
@@ -232,63 +232,63 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(
             "select l_suppkey, l_orderkey, nth_value(l_orderkey, 2) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select l_suppkey, l_orderkey, nth_value(l_orderkey, 2) IGNORE NULLS over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select sum(l_partkey + 1) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select max(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select min(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select avg(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select lag(l_orderkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           runQueryAndCompare(
             "select lead(l_orderkey) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           // Test same partition/ordering keys.
           runQueryAndCompare(
             "select avg(l_partkey) over" +
               " (partition by l_suppkey order by l_suppkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
 
           // Test overlapping partition/ordering keys.
           runQueryAndCompare(
             "select avg(l_partkey) over" +
               " (partition by l_suppkey order by l_suppkey, l_orderkey) from lineitem ") {
-            checkOperatorMatch[WindowExecTransformer]
+            checkGlutenOperatorMatch[WindowExecTransformer]
           }
         }
     }
@@ -352,7 +352,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                          | select * from lineitem limit 10
                          |) where l_suppkey != 0 limit 100;
                          |""".stripMargin) {
-      checkOperatorMatch[LimitTransformer]
+      checkGlutenOperatorMatch[LimitTransformer]
     }
   }
 
@@ -365,7 +365,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           .parquet(path.getCanonicalPath)
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("view")
         runQueryAndCompare("SELECT a from view") {
-          checkOperatorMatch[FileSourceScanExecTransformer]
+          checkGlutenOperatorMatch[FileSourceScanExecTransformer]
         }
     }
   }
@@ -377,7 +377,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                          |abs(cast (l_quantity as decimal(12, 2))),
                          |abs(cast (l_quantity as decimal(12, 2))) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     withTempPath {
       path =>
@@ -387,7 +387,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           .parquet(path.getCanonicalPath)
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("view")
         runQueryAndCompare("SELECT abs(cast (a as decimal(19, 6))) from view") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }
@@ -407,7 +407,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                          |ORDER BY
                          |  l_orderkey
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
   }
 
@@ -422,7 +422,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     // https://github.com/facebookincubator/velox/pull/6051#issuecomment-1731028215.
     // assert(result.collect()(0).get(0).toString.equals("0.0345678900000000000000000000000000000"))
     assert((result.collect()(0).get(0).toString.toDouble - d).abs < 0.00000000001)
-    checkOperatorMatch[HashAggregateExecTransformer](result)
+    checkGlutenOperatorMatch[HashAggregateExecTransformer](result)
   }
 
   test("orc scan") {
@@ -455,7 +455,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     runQueryAndCompare("""
                          |select l_quantity <=> 1000 from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -463,7 +463,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     runQueryAndCompare("""
                          |select overlay(l_shipdate placing '_' from 0) from lineitem limit 1;
                          |""".stripMargin) {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
@@ -487,7 +487,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
             |join t2 on t1.c1 = t2.c1 and t1.c1 > conv(t2.c1, 2, 10);
             |""".stripMargin
         ) {
-          checkOperatorMatch[HashAggregateExecTransformer]
+          checkGlutenOperatorMatch[HashAggregateExecTransformer]
         }
       }
     }
@@ -503,11 +503,11 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         .saveAsTable("t")
 
       runQueryAndCompare("SELECT c1, explode(array(c2)) FROM t") {
-        checkOperatorMatch[GenerateExecTransformer]
+        checkGlutenOperatorMatch[GenerateExecTransformer]
       }
 
       runQueryAndCompare("SELECT c1, explode(c3) FROM (SELECT c1, array(c2) as c3 FROM t)") {
-        checkOperatorMatch[GenerateExecTransformer]
+        checkGlutenOperatorMatch[GenerateExecTransformer]
       }
     }
   }
@@ -604,7 +604,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       if (!SparkShimLoader.getSparkVersion.startsWith("3.2")) {
         sql("create table t using parquet as select sum(l_partkey) from lineitem")
         runQueryAndCompare("select * from t") {
-          checkOperatorMatch[FileSourceScanExecTransformer]
+          checkGlutenOperatorMatch[FileSourceScanExecTransformer]
         }
       } else {
         val msg = intercept[AnalysisException] {
@@ -622,23 +622,23 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         runQueryAndCompare(s"""
                               |SELECT $func(array(1, 2, 3));
                               |""".stripMargin) {
-          checkOperatorMatch[GenerateExecTransformer]
+          checkGlutenOperatorMatch[GenerateExecTransformer]
         }
         runQueryAndCompare(s"""
                               |SELECT $func(map(1, 'a', 2, 'b'));
                               |""".stripMargin) {
-          checkOperatorMatch[GenerateExecTransformer]
+          checkGlutenOperatorMatch[GenerateExecTransformer]
         }
         runQueryAndCompare(
           s"""
              |SELECT $func(array(map(1, 'a', 2, 'b'), map(3, 'c', 4, 'd'), map(5, 'e', 6, 'f')));
              |""".stripMargin) {
-          checkOperatorMatch[GenerateExecTransformer]
+          checkGlutenOperatorMatch[GenerateExecTransformer]
         }
         runQueryAndCompare(s"""
                               |SELECT $func(map(1, array(1, 2), 2, array(3, 4)));
                               |""".stripMargin) {
-          checkOperatorMatch[GenerateExecTransformer]
+          checkGlutenOperatorMatch[GenerateExecTransformer]
         }
 
         // CreateArray/CreateMap: func(array(col)), func(map(k, v))
@@ -649,7 +649,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(s"""
                                 |SELECT $func(array(a)) from t1;
                                 |""".stripMargin) {
-            checkOperatorMatch[GenerateExecTransformer]
+            checkGlutenOperatorMatch[GenerateExecTransformer]
           }
           sql("""select * from values (1, 'a'), (2, 'b'), (3, null), (4, null)
                 |as tbl(a, b)
@@ -657,7 +657,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(s"""
                                 |SELECT $func(map(a, b)) from t1;
                                 |""".stripMargin) {
-            checkOperatorMatch[GenerateExecTransformer]
+            checkGlutenOperatorMatch[GenerateExecTransformer]
           }
         }
 
@@ -671,7 +671,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(s"""
                                 |SELECT $func(a) from t2;
                                 |""".stripMargin) {
-            checkOperatorMatch[GenerateExecTransformer]
+            checkGlutenOperatorMatch[GenerateExecTransformer]
           }
           sql("""select * from values
                 |  map(1, 'a', 2, 'b', 3, null),
@@ -681,7 +681,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           runQueryAndCompare(s"""
                                 |SELECT $func(a) from t2;
                                 |""".stripMargin) {
-            checkOperatorMatch[GenerateExecTransformer]
+            checkGlutenOperatorMatch[GenerateExecTransformer]
           }
         }
     }
@@ -694,7 +694,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                           |  named_struct('c1', 0, 'c2', 1),
                           |  named_struct('c1', 2, 'c2', null)));
                           |""".stripMargin) {
-      checkOperatorMatch[GenerateExecTransformer]
+      checkGlutenOperatorMatch[GenerateExecTransformer]
     }
 
     // CreateArray: func(array(col))
@@ -708,7 +708,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare(s"""
                             |SELECT inline(array(a)) from t1;
                             |""".stripMargin) {
-        checkOperatorMatch[GenerateExecTransformer]
+        checkGlutenOperatorMatch[GenerateExecTransformer]
       }
     }
 
@@ -729,7 +729,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("""
                            |SELECT inline(a) from t2;
                            |""".stripMargin) {
-        checkOperatorMatch[GenerateExecTransformer]
+        checkGlutenOperatorMatch[GenerateExecTransformer]
       }
     }
 
@@ -749,22 +749,22 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("""
                            |SELECT array_except(c1, c2) FROM t;
                            |""".stripMargin) {
-        checkOperatorMatch[ProjectExecTransformer]
+        checkGlutenOperatorMatch[ProjectExecTransformer]
       }
       runQueryAndCompare("""
                            |SELECT array_distinct(c1), array_distinct(c2) FROM t;
                            |""".stripMargin) {
-        checkOperatorMatch[ProjectExecTransformer]
+        checkGlutenOperatorMatch[ProjectExecTransformer]
       }
       runQueryAndCompare("""
                            |SELECT array_position(c1, 3), array_position(c2, 2) FROM t;
                            |""".stripMargin) {
-        checkOperatorMatch[ProjectExecTransformer]
+        checkGlutenOperatorMatch[ProjectExecTransformer]
       }
       runQueryAndCompare("""
                            |SELECT array_repeat(c3, 5) FROM t;
                            |""".stripMargin) {
-        checkOperatorMatch[ProjectExecTransformer]
+        checkGlutenOperatorMatch[ProjectExecTransformer]
       }
     }
   }
@@ -774,13 +774,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       sql("create table t (id int, b boolean) using parquet")
       sql("insert into t values (1, true), (2, false), (3, null)")
       runQueryAndCompare("select * from t where b = true") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
       runQueryAndCompare("select * from t where b = false") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
       runQueryAndCompare("select * from t where b is NULL") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
     }
   }
@@ -792,19 +792,19 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         s"insert into short_table values " +
           s"(1, 1), (null, 2), (${Short.MinValue}, 3), (${Short.MaxValue}, 4)")
       runQueryAndCompare("select * from short_table where a = 1") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       runQueryAndCompare("select * from short_table where a is NULL") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       runQueryAndCompare(s"select * from short_table where a != ${Short.MinValue}") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       runQueryAndCompare(s"select * from short_table where a != ${Short.MaxValue}") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
     }
   }
@@ -816,19 +816,19 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         s"insert into int_table values " +
           s"(1, 1), (null, 2), (${Int.MinValue}, 3), (${Int.MaxValue}, 4)")
       runQueryAndCompare("select * from int_table where a = 1") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       runQueryAndCompare("select * from int_table where a is NULL") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       runQueryAndCompare(s"select * from int_table where a != ${Int.MinValue}") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       runQueryAndCompare(s"select * from int_table where a != ${Int.MaxValue}") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
     }
   }
@@ -841,7 +841,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       sql("insert into ts values (3, timestamp'1965-01-01 10:11:12.123456')")
 
       runQueryAndCompare("select c1, c2 from ts where c1 = 1") {
-        checkOperatorMatch[FileSourceScanExecTransformer]
+        checkGlutenOperatorMatch[FileSourceScanExecTransformer]
       }
 
       // Fallback should only happen when there is a filter on timestamp column
@@ -871,7 +871,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           |select * from t1 cross join t2 on t1.c1 = t2.c1;
           |""".stripMargin
       ) {
-        checkOperatorMatch[ShuffledHashJoinExecTransformer]
+        checkGlutenOperatorMatch[ShuffledHashJoinExecTransformer]
       }
 
       withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "1MB") {
@@ -880,7 +880,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
             |select * from t1 cross join t2 on t1.c1 = t2.c1;
             |""".stripMargin
         ) {
-          checkOperatorMatch[BroadcastHashJoinExecTransformer]
+          checkGlutenOperatorMatch[BroadcastHashJoinExecTransformer]
         }
       }
 
@@ -890,7 +890,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
             |select * from t1 cross join t2 on t1.c1 = t2.c1;
             |""".stripMargin
         ) {
-          checkOperatorMatch[SortMergeJoinExecTransformer]
+          checkGlutenOperatorMatch[SortMergeJoinExecTransformer]
         }
       }
 
@@ -899,7 +899,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           |select * from t1 cross join t2;
           |""".stripMargin
       ) {
-        checkOperatorMatch[CartesianProductExecTransformer]
+        checkGlutenOperatorMatch[CartesianProductExecTransformer]
       }
 
       runQueryAndCompare(
@@ -907,7 +907,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           |select * from t1 cross join t2 on t1.c1 > t2.c1;
           |""".stripMargin
       ) {
-        checkOperatorMatch[CartesianProductExecTransformer]
+        checkGlutenOperatorMatch[CartesianProductExecTransformer]
       }
 
       withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "1MB") {
@@ -916,7 +916,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
             |select * from t1 cross join t2 on 2*t1.c1 > 3*t2.c1;
             |""".stripMargin
         ) {
-          checkOperatorMatch[BroadcastNestedLoopJoinExecTransformer]
+          checkGlutenOperatorMatch[BroadcastNestedLoopJoinExecTransformer]
         }
       }
     }
@@ -939,7 +939,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
 
     spark.read.format("parquet").load(path).createOrReplaceTempView("test")
     runQueryAndCompare("select * from test") {
-      checkOperatorMatch[FileSourceScanExecTransformer]
+      checkGlutenOperatorMatch[FileSourceScanExecTransformer]
     }
   }
 
@@ -1052,14 +1052,14 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         |select (l_partkey % 10 + 5)
         |from lineitem
         |""".stripMargin
-    )(checkOperatorMatch[ProjectExecTransformer])
+    )(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       """
         |select l_partkey
         |from lineitem where (l_partkey % 10 + 5) > 6
         |""".stripMargin
-    )(checkOperatorMatch[FilterExecTransformer])
+    )(checkGlutenOperatorMatch[FilterExecTransformer])
 
     withSQLConf(GlutenConfig.COLUMNAR_FALLBACK_EXPRESSIONS_THRESHOLD.key -> "2") {
       runQueryAndCompare(
@@ -1067,14 +1067,14 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           |select (l_partkey % 10 + 5)
           |from lineitem
           |""".stripMargin
-      )(checkFallbackOperatorMatch[ProjectExec])
+      )(checkSparkOperatorMatch[ProjectExec])
 
       runQueryAndCompare(
         """
           |select l_partkey
           |from lineitem where (l_partkey % 10 + 5) > 6
           |""".stripMargin
-      )(checkFallbackOperatorMatch[FilterExec])
+      )(checkSparkOperatorMatch[FilterExec])
     }
   }
 
@@ -1155,7 +1155,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                          |   'id_str', cast(id as string)) as s from range(100)
                          |) group by s
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
   }
 
@@ -1169,7 +1169,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
             +- ^(2) ProjectExecTransformer [hash(l_orderkey#16L, l_partkey#17L) AS hash_partition_key#302, l_orderkey#16L, l_partkey#17L]
                 +- ^(2) BatchScanExecTransformer[l_orderkey#16L, l_partkey#17L] ParquetScan DataFilters: [], Format: parquet, Location: InMemoryFileIndex(1 paths)[..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<l_orderkey:bigint,l_partkey:bigint>, PushedFilters: [] RuntimeFilters: []
        */
-      checkOperatorMatch[SortExecTransformer]
+      checkGlutenOperatorMatch[SortExecTransformer]
     }
     // scalastyle:on
 
@@ -1193,7 +1193,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("""
                            |SELECT c1, collect_list(map_c2) FROM t1 group by c1;
                            |""".stripMargin) {
-        checkOperatorMatch[HashAggregateExecTransformer]
+        checkGlutenOperatorMatch[HashAggregateExecTransformer]
       }
     }
     // test map<str,map<str,str>>
@@ -1206,7 +1206,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("""
                            |SELECT c1, collect_list(map_c2) FROM t2 group by c1;
                            |""".stripMargin) {
-        checkOperatorMatch[HashAggregateExecTransformer]
+        checkGlutenOperatorMatch[HashAggregateExecTransformer]
       }
     }
     // test map<map<str,str>,map<str,str>>
@@ -1219,7 +1219,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("""
                            |SELECT collect_list(map_c2) FROM t3 group by c1;
                            |""".stripMargin) {
-        checkOperatorMatch[HashAggregateExecTransformer]
+        checkGlutenOperatorMatch[HashAggregateExecTransformer]
       }
     }
     // test map<str,list<str>>
@@ -1232,7 +1232,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("""
                            |SELECT collect_list(map_c2) FROM t4 group by c1;
                            |""".stripMargin) {
-        checkOperatorMatch[HashAggregateExecTransformer]
+        checkGlutenOperatorMatch[HashAggregateExecTransformer]
       }
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -46,7 +46,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
   test("count") {
     val df =
       runQueryAndCompare("select count(*) from lineitem where l_partkey in (1552, 674, 1062)") {
-        checkOperatorMatch[HashAggregateExecTransformer]
+        checkGlutenOperatorMatch[HashAggregateExecTransformer]
       }
     runQueryAndCompare("select count(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -62,7 +62,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
 
   test("avg") {
     val df = runQueryAndCompare("select avg(l_partkey) from lineitem where l_partkey < 1000") {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select avg(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -115,7 +115,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
 
   test("sum") {
     runQueryAndCompare("select sum(l_partkey) from lineitem where l_partkey < 2000") {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select sum(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -128,7 +128,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
         }
     }
     runQueryAndCompare("select sum(cast (l_quantity as DECIMAL(22, 2))) from lineitem") {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select sum(cast (l_quantity as DECIMAL(12, 2))), " +
@@ -173,7 +173,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
   test("min and max") {
     runQueryAndCompare(
       "select min(l_partkey), max(l_partkey) from lineitem where l_partkey < 2000") {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select min(l_partkey), max(l_partkey), count(distinct l_partkey) from lineitem") {
@@ -206,13 +206,13 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select stddev_samp(l_quantity) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("""
                          |select l_orderkey, stddev_samp(l_quantity) from lineitem
                          |group by l_orderkey;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select stddev_samp(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -230,13 +230,13 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select stddev_pop(l_quantity) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("""
                          |select l_orderkey, stddev_pop(l_quantity) from lineitem
                          |group by l_orderkey;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select stddev_pop(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -254,13 +254,13 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select var_samp(l_quantity) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("""
                          |select l_orderkey, var_samp(l_quantity) from lineitem
                          |group by l_orderkey;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select var_samp(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -278,13 +278,13 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select var_pop(l_quantity) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("""
                          |select l_orderkey, var_pop(l_quantity) from lineitem
                          |group by l_orderkey;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select var_pop(l_quantity), count(distinct l_partkey) from lineitem") {
       df =>
@@ -305,7 +305,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
                             |select $func(l_linenumber) from lineitem
                             |group by l_orderkey;
                             |""".stripMargin) {
-        checkOperatorMatch[HashAggregateExecTransformer]
+        checkGlutenOperatorMatch[HashAggregateExecTransformer]
       }
       runQueryAndCompare(s"select $func(l_linenumber), count(distinct l_partkey) from lineitem") {
         df =>
@@ -324,7 +324,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select corr(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select corr(l_partkey, l_suppkey), count(distinct l_orderkey) from lineitem") {
@@ -340,7 +340,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select covar_pop(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select covar_pop(l_partkey, l_suppkey), count(distinct l_orderkey) from lineitem") {
@@ -356,7 +356,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select covar_samp(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select covar_samp(l_partkey, l_suppkey), count(distinct l_orderkey) from lineitem") {
@@ -375,7 +375,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select regr_r2(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select regr_r2(l_partkey, l_suppkey), count(distinct l_orderkey) from lineitem") {
@@ -394,14 +394,14 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare(s"""
                           |select first(l_linenumber), first(l_linenumber, true) from lineitem;
                           |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       s"""
          |select first_value(l_linenumber), first_value(l_linenumber, true) from lineitem
          |group by l_orderkey;
          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       s"""
@@ -423,14 +423,14 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare(s"""
                           |select last(l_linenumber), last(l_linenumber, true) from lineitem;
                           |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(s"""
                           |select last_value(l_linenumber), last_value(l_linenumber, true)
                           |from lineitem
                           |group by l_orderkey;
                           |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       s"""
@@ -452,7 +452,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select approx_count_distinct(l_shipmode) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(
       "select approx_count_distinct(l_partkey), count(distinct l_orderkey) from lineitem") {
@@ -471,7 +471,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare(s"""
                           |select max_by(l_linenumber, l_comment) from lineitem;
                           |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(s"""
                           |select max_by(distinct l_linenumber, l_comment)
@@ -492,7 +492,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare(s"""
                           |select min_by(l_linenumber, l_comment) from lineitem;
                           |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare(s"""
                           |select min_by(distinct l_linenumber, l_comment)
@@ -907,7 +907,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select skewness(l_partkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select skewness(l_partkey), count(distinct l_orderkey) from lineitem") {
       df =>
@@ -925,7 +925,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     runQueryAndCompare("""
                          |select kurtosis(l_partkey) from lineitem;
                          |""".stripMargin) {
-      checkOperatorMatch[HashAggregateExecTransformer]
+      checkGlutenOperatorMatch[HashAggregateExecTransformer]
     }
     runQueryAndCompare("select kurtosis(l_partkey), count(distinct l_orderkey) from lineitem") {
       df =>

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -197,7 +197,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
       "select type1.short, int from type1" +
         " where type1.short = 1",
       false) {
-      checkOperatorMatch[BatchScanExecTransformer]
+      checkGlutenOperatorMatch[BatchScanExecTransformer]
     }
 
     // Validation: BatchScan Project Aggregate Expand Sort Limit
@@ -265,13 +265,13 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
                          | select date, int from type1 limit 100
                          |) where int != 0 limit 10;
                          |""".stripMargin) {
-      checkOperatorMatch[LimitTransformer]
+      checkGlutenOperatorMatch[LimitTransformer]
     }
 
     // Validation: Window.
     runQueryAndCompare(
       "select row_number() over (partition by date order by int) from type1 order by int, date") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     // Validation: BroadHashJoin.
@@ -279,7 +279,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {
-        checkOperatorMatch[BroadcastHashJoinExecTransformer]
+        checkGlutenOperatorMatch[BroadcastHashJoinExecTransformer]
       }
     }
 
@@ -288,7 +288,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {
-        checkOperatorMatch[ShuffledHashJoinExecTransformer]
+        checkGlutenOperatorMatch[ShuffledHashJoinExecTransformer]
       }
     }
 
@@ -298,7 +298,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
         runQueryAndCompare(
           "select type1.date from type1," +
             " type2 where type1.date = type2.date") {
-          checkOperatorMatch[SortMergeJoinExecTransformer]
+          checkGlutenOperatorMatch[SortMergeJoinExecTransformer]
         }
       }
     }
@@ -327,7 +327,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
     withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
       // Validation: BatchScan.
       runQueryAndCompare("select array from type1") {
-        checkOperatorMatch[BatchScanExecTransformer]
+        checkGlutenOperatorMatch[BatchScanExecTransformer]
       }
 
       // Validation: BatchScan Project Aggregate Expand Sort Limit

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -196,7 +196,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
       "select type1.short, int from type1" +
         " where type1.short = 1",
       false) {
-      checkOperatorMatch[BatchScanExecTransformer]
+      checkGlutenOperatorMatch[BatchScanExecTransformer]
     }
 
     // Validation: BatchScan Project Aggregate Expand Sort Limit
@@ -264,13 +264,13 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
                          | select date, int from type1 limit 100
                          |) where int != 0 limit 10;
                          |""".stripMargin) {
-      checkOperatorMatch[LimitTransformer]
+      checkGlutenOperatorMatch[LimitTransformer]
     }
 
     // Validation: Window.
     runQueryAndCompare(
       "select row_number() over (partition by date order by int) from type1 order by int, date") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     // Validation: BroadHashJoin.
@@ -278,7 +278,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {
-        checkOperatorMatch[BroadcastHashJoinExecTransformer]
+        checkGlutenOperatorMatch[BroadcastHashJoinExecTransformer]
       }
     }
 
@@ -287,7 +287,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {
-        checkOperatorMatch[ShuffledHashJoinExecTransformer]
+        checkGlutenOperatorMatch[ShuffledHashJoinExecTransformer]
       }
     }
 
@@ -297,7 +297,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
         runQueryAndCompare(
           "select type1.date from type1," +
             " type2 where type1.date = type2.date") {
-          checkOperatorMatch[SortMergeJoinExecTransformer]
+          checkGlutenOperatorMatch[SortMergeJoinExecTransformer]
         }
       }
     }
@@ -326,7 +326,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
       // Validation: BatchScan.
       runQueryAndCompare("select array from type1") {
-        checkOperatorMatch[BatchScanExecTransformer]
+        checkGlutenOperatorMatch[BatchScanExecTransformer]
       }
 
       // Validation: BatchScan Project Aggregate Expand Sort Limit

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
@@ -60,152 +60,152 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("ascii") {
     runQueryAndCompare(
       s"select l_orderkey, ascii(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       s"select l_orderkey, ascii($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("concat") {
     runQueryAndCompare(
       s"select l_orderkey, concat(l_comment, 'hello') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, concat(l_comment, 'hello', 'world') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("extract") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, " +
         s"extract(doy FROM DATE'2019-08-12') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("day") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, day(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, day($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("dayofmonth") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, dayofmonth(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, dayofmonth($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("day_of_year") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, dayofyear(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, dayofyear($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("dayofweek") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, dayofweek(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, dayofweek($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   ignore("weekday") { // todo: result mismatched
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, weekday(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, weekday($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("month") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, month(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, month($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("quarter") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, quarter(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, quarter($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("year") {
     runQueryAndCompare(
       s"select l_orderkey, l_shipdate, year(l_shipdate) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, year($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("instr") {
     runQueryAndCompare(
       s"select l_orderkey, instr(l_comment, 'h') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, instr(l_comment, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, instr($NULL_STR_COL, 'h') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("length") {
     runQueryAndCompare(
       s"select l_orderkey, length(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, length($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       s"select l_orderkey, CHAR_LENGTH(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, CHAR_LENGTH($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       s"select l_orderkey, CHARACTER_LENGTH(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, CHARACTER_LENGTH($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("md5") {
     runQueryAndCompare(
       s"select l_orderkey, md5(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, md5($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("sha1") {
     runQueryAndCompare(
       s"select l_orderkey, sha1(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, sha1($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("sha2") {
@@ -213,168 +213,168 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
       bitLength =>
         runQueryAndCompare(
           s"select l_orderkey, sha2(l_comment, $bitLength) " +
-            s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+            s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
     runQueryAndCompare(
       s"select l_orderkey, sha2($NULL_STR_COL, 256) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, sha2(l_comment, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("crc32") {
     runQueryAndCompare(
       s"select l_orderkey, crc32(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, crc32($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("lower") {
     runQueryAndCompare(
       s"select l_orderkey, lower(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lower($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("upper") {
     runQueryAndCompare(
       s"select l_orderkey, upper(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, upper($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("lcase") {
     runQueryAndCompare(
       s"select l_orderkey, lcase(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lcase($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("ucase") {
     runQueryAndCompare(
       s"select l_orderkey, ucase(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, ucase($NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   ignore("locate") {
     runQueryAndCompare(
       s"select l_orderkey, locate(l_comment, 'a', 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, locate($NULL_STR_COL, 'a', 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("trim") {
     runQueryAndCompare(
       s"select l_orderkey, trim(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, trim('. abcdefg', l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, trim($NULL_STR_COL), " +
         s"trim($NULL_STR_COL, l_comment), trim('. abcdefg', $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("ltrim") {
     runQueryAndCompare(
       s"select l_orderkey, ltrim(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, ltrim('. abcdefg', l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, ltrim($NULL_STR_COL), " +
         s"ltrim($NULL_STR_COL, l_comment), ltrim('. abcdefg', $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("rtrim") {
     runQueryAndCompare(
       s"select l_orderkey, rtrim(l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rtrim('. abcdefg', l_comment) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rtrim($NULL_STR_COL), " +
         s"rtrim($NULL_STR_COL, l_comment), rtrim('. abcdefg', $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("lpad") {
     runQueryAndCompare(
       s"select l_orderkey, lpad($NULL_STR_COL, 80) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lpad(l_comment, 80) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lpad(l_comment, 80, '??') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lpad(l_comment, $NULL_STR_COL, '??') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, lpad(l_comment, 80, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("rpad") {
     runQueryAndCompare(
       s"select l_orderkey, rpad($NULL_STR_COL, 80) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rpad(l_comment, 80) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rpad(l_comment, 80, '??') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rpad(l_comment, $NULL_STR_COL, '??') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rpad(l_comment, 80, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("like") {
     runQueryAndCompare(
       """select l_orderkey, like(l_comment, '%\%') """ +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, like(l_comment, 'a_%b') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, like(l_comment, 'a\\__b') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, like(l_comment, 'abc_') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, like(l_comment, ' ') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, like($NULL_STR_COL, '%a%') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, like(l_comment, '%a%') " +
         s"from $LINEITEM_TABLE where l_comment like '%a%' limit $LENGTH") {
-      checkOperatorMatch[ProjectExecTransformer]
+      checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     runQueryAndCompare(
       s"select l_orderkey, like(l_comment, ' ') " +
@@ -387,13 +387,13 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("rlike") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, rlike(l_comment, 'a*') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rlike(l_comment, ' ') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, rlike($NULL_STR_COL, '%a%') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, l_comment " +
         s"from $LINEITEM_TABLE where l_comment rlike '%a%' limit $LENGTH") { _ => }
@@ -408,13 +408,13 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("regexp") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, regexp(l_comment, 'a*') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp(l_comment, ' ') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp($NULL_STR_COL, '%a%') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, l_comment " +
         s"from $LINEITEM_TABLE where l_comment regexp '%a%' limit $LENGTH") { _ => }
@@ -429,28 +429,28 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("regexp_like") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, regexp_like(l_comment, 'a*') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_like(l_comment, ' ') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_like($NULL_STR_COL, '%a%') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("regexp_extract") {
     runQueryAndCompare(
       s"select l_orderkey, regexp_extract(l_comment, '([a-z])', 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_extract($NULL_STR_COL, '([a-z])', 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("regexp_extract_all") {
     runQueryAndCompare(
       s"select l_orderkey, regexp_extract_all(l_comment, '([a-z])', 1) " +
-        s"from $LINEITEM_TABLE limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     // fall back because of unsupported cast(array)
     runQueryAndCompare(
       s"select l_orderkey, l_comment, " +
@@ -461,13 +461,13 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("regexp_replace") {
     runQueryAndCompare(
       s"select l_orderkey, regexp_replace(l_comment, '([a-z])', '1') " +
-        s"from $LINEITEM_TABLE limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_replace(l_comment, '([a-z])', '1', 1) " +
-        s"from $LINEITEM_TABLE limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, regexp_replace(l_comment, '([a-z])', '1', 10) " +
-        s"from $LINEITEM_TABLE limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("regex invalid") {
@@ -496,22 +496,22 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("replace") {
     runQueryAndCompare(
       s"select l_orderkey, replace(l_comment, ' ', 'hello') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, replace(l_comment, 'ha') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, replace(l_comment, ' ', $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, replace(l_comment, $NULL_STR_COL, 'hello') " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("reverse") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, reverse(l_comment) " +
-        s"from $LINEITEM_TABLE limit 5")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit 5")(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     // fall back because of unsupported cast(array)
     runQueryAndCompare(
@@ -541,56 +541,56 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
   test("substr") {
     runQueryAndCompare(
       s"select l_orderkey, substr(l_comment, 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substr(l_comment, 1, 3) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substr($NULL_STR_COL, 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substr($NULL_STR_COL, 1, 3) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substr(l_comment, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substr(l_comment, $NULL_STR_COL, 3) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("substring") {
     runQueryAndCompare(
       s"select l_orderkey, substring(l_comment, 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substring(l_comment, 1, 3) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substring($NULL_STR_COL, 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substring($NULL_STR_COL, 1, 3) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substring(l_comment, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, substring(l_comment, $NULL_STR_COL, 3) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
   test("left") {
     runQueryAndCompare(
       s"select l_orderkey, left(l_comment, 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       s"select l_orderkey, left($NULL_STR_COL, 1) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
 
     runQueryAndCompare(
       s"select l_orderkey, left(l_comment, $NULL_STR_COL) " +
-        s"from $LINEITEM_TABLE limit $LENGTH")(checkOperatorMatch[ProjectExecTransformer])
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxWindowExpressionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxWindowExpressionSuite.scala
@@ -45,28 +45,28 @@ class VeloxWindowExpressionSuite extends WholeStageTransformerSuite {
       "select max(l_suppkey) over" +
         " (partition by l_suppkey order by l_orderkey " +
         "rows between 2 preceding and 1 preceding) from lineitem ") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     runQueryAndCompare(
       "select max(l_suppkey) over" +
         " (partition by l_suppkey order by l_orderkey " +
         "rows between 2 following and 3 following) from lineitem ") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     runQueryAndCompare(
       "select max(l_suppkey) over" +
         " (partition by l_suppkey order by l_orderkey " +
         "rows between -3 following and -2 following) from lineitem ") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     runQueryAndCompare(
       "select max(l_suppkey) over" +
         " (partition by l_suppkey order by l_orderkey " +
         "rows between unbounded preceding and 3 following) from lineitem ") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/WindowFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/WindowFunctionsValidateSuite.scala
@@ -22,13 +22,13 @@ class WindowFunctionsValidateSuite extends FunctionsValidateTest {
     runQueryAndCompare(
       "select lag(l_orderkey, -2) over" +
         " (partition by l_suppkey order by l_orderkey) from lineitem") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     runQueryAndCompare(
       "select lead(l_orderkey, -2) over" +
         " (partition by l_suppkey order by l_orderkey) from lineitem") {
-      checkOperatorMatch[WindowExecTransformer]
+      checkGlutenOperatorMatch[WindowExecTransformer]
     }
   }
 

--- a/gluten-core/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.utils.{Arm, FallbackUtil}
 
 import org.apache.spark.SparkConf
@@ -235,7 +236,7 @@ abstract class WholeStageTransformerSuite
    * @tparam T:
    *   type of the expected plan.
    */
-  def checkOperatorMatch[T <: TransformSupport](df: DataFrame)(implicit tag: ClassTag[T]): Unit = {
+  def checkGlutenOperatorMatch[T <: GlutenPlan](df: DataFrame)(implicit tag: ClassTag[T]): Unit = {
     val executedPlan = getExecutedPlan(df)
     assert(
       executedPlan.exists(plan => tag.runtimeClass.isInstance(plan)),
@@ -244,7 +245,7 @@ abstract class WholeStageTransformerSuite
     )
   }
 
-  def checkFallbackOperatorMatch[T <: SparkPlan](df: DataFrame)(implicit tag: ClassTag[T]): Unit = {
+  def checkSparkOperatorMatch[T <: SparkPlan](df: DataFrame)(implicit tag: ClassTag[T]): Unit = {
     val executedPlan = getExecutedPlan(df)
     assert(executedPlan.exists(plan => tag.runtimeClass.isInstance(plan)))
   }

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -68,7 +68,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
       runQueryAndCompare("""
                            |select * from iceberg_tb;
                            |""".stripMargin) {
-        checkOperatorMatch[IcebergScanTransformer]
+        checkGlutenOperatorMatch[IcebergScanTransformer]
       }
     }
   }
@@ -401,7 +401,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
       runQueryAndCompare("""
                            |select * from iceberg_mor_tb;
                            |""".stripMargin) {
-        checkOperatorMatch[IcebergScanTransformer]
+        checkGlutenOperatorMatch[IcebergScanTransformer]
       }
     }
   }
@@ -471,7 +471,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
       runQueryAndCompare("""
                            |select * from iceberg_mor_tb;
                            |""".stripMargin) {
-        checkOperatorMatch[IcebergScanTransformer]
+        checkGlutenOperatorMatch[IcebergScanTransformer]
       }
     }
   }


### PR DESCRIPTION
rename `checkOperatorMatch` -> `checkGlutenOperatorMatch`
rename `checkFallbackOperatorMatch` -> `checkSparkOperatorMatch`
change the upper type bound `checkOperatorMatch[T <: TransformSupport]` to `checkGlutenOperatorMatch[T <: GlutenPlan]`