### PR TITLE
[GLUTEN-5264][VL] Correct libglog.so.0 & libglog.so.1 path when building third-lib package on centos-8

### DIFF
--- a/dev/package.sh
+++ b/dev/package.sh
@@ -28,8 +28,9 @@ function process_setup_ubuntu_2204 {
 }
 
 function process_setup_centos_8 {
-  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libgflags.so.2.2,libglog.so.0,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0,libsodium.so.23} $THIRDPARTY_LIB/
+  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0,libsodium.so.23} $THIRDPARTY_LIB/
   cp /usr/local/lib/{libhdfs3.so.1,libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_regex.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_atomic.so.1.84.0,libprotobuf.so.32} $THIRDPARTY_LIB/
+  cp /usr/local/lib64/{libgflags.so.2.2,libglog.so.1} $THIRDPARTY_LIB/
 }
 
 function process_setup_centos_7 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to correct `.so` file path:
* /usr/lib64/libglog.so.0 -> /usr/local/lib64/libglog.so.1
* /usr/lib64/libgflags.so.2.2 -> /usr/local/lib64/libgflags.so.2.2

(Fixes: \#5264)

## How was this patch tested?

Build test in github action https://github.com/dcoliversun/gluten/actions/runs/8521763988

