### PR TITLE
[VL] Fix load and link libglog.so.1 in SharedLibraryLoaderCentos8

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoaderCentos8.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoaderCentos8.scala
@@ -35,7 +35,7 @@ class SharedLibraryLoaderCentos8 extends SharedLibraryLoader {
       .loadAndCreateLink("libdouble-conversion.so.3", "libdouble-conversion.so", false)
       .loadAndCreateLink("libevent-2.1.so.6", "libevent-2.1.so", false)
       .loadAndCreateLink("libgflags.so.2.2", "libgflags.so", false)
-      .loadAndCreateLink("libglog.so.0", "libglog.so", false)
+      .loadAndCreateLink("libglog.so.1", "libglog.so", false)
       .loadAndCreateLink("libdwarf.so.1", "libdwarf.so", false)
       .loadAndCreateLink("libidn.so.11", "libidn.so", false)
       .loadAndCreateLink("libntlm.so.0", "libntlm.so", false)


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/incubator-gluten/pull/5265 fixed the `libglog.so.0` to `libglog.so.1`, but forgot to modify the load and link in `SharedLibraryLoaderCentos8`. This will cause the gluten to fail to start.

## How was this patch tested?

N/A

