### PR TITLE
[CH]feat: Support external sort shuffle, reduce shuffle memory usage when the number of partitions is high

### DIFF
--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/CHShuffleSplitterJniWrapper.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/CHShuffleSplitterJniWrapper.java
@@ -34,7 +34,10 @@ public class CHShuffleSplitterJniWrapper {
       long spillThreshold,
       String hashAlgorithm,
       boolean throwIfMemoryExceed,
-      boolean flushBlockBufferBeforeEvict) {
+      boolean flushBlockBufferBeforeEvict,
+      long maxSortBufferSize,
+      boolean spillFirstlyBeforeStop,
+      boolean forceSort) {
     return nativeMake(
         part.getShortName(),
         part.getNumPartitions(),
@@ -51,7 +54,10 @@ public class CHShuffleSplitterJniWrapper {
         spillThreshold,
         hashAlgorithm,
         throwIfMemoryExceed,
-        flushBlockBufferBeforeEvict);
+        flushBlockBufferBeforeEvict,
+        maxSortBufferSize,
+        spillFirstlyBeforeStop,
+        forceSort);
   }
 
   public long makeForRSS(
@@ -97,7 +103,10 @@ public class CHShuffleSplitterJniWrapper {
       long spillThreshold,
       String hashAlgorithm,
       boolean throwIfMemoryExceed,
-      boolean flushBlockBufferBeforeEvict);
+      boolean flushBlockBufferBeforeEvict,
+      long maxSortBufferSize,
+      boolean spillFirstlyBeforeStop,
+      boolean forceSort);
 
   public native long nativeMakeForRSS(
       String shortName,

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -58,6 +58,9 @@ class CHColumnarShuffleWriter[K, V](
   private val throwIfMemoryExceed = GlutenConfig.getConf.chColumnarThrowIfMemoryExceed
   private val flushBlockBufferBeforeEvict =
     GlutenConfig.getConf.chColumnarFlushBlockBufferBeforeEvict
+  private val maxSortBufferSize = GlutenConfig.getConf.chColumnarMaxSortBufferSize
+  private val spillFirstlyBeforeStop = GlutenConfig.getConf.chColumnarSpillFirstlyBeforeStop
+  private val forceSortShuffle = GlutenConfig.getConf.chColumnarForceSortShuffle
   private val spillThreshold = GlutenConfig.getConf.chColumnarShuffleSpillThreshold
   private val jniWrapper = new CHShuffleSplitterJniWrapper
   // Are we in the process of stopping? Because map tasks can call stop() with success = true
@@ -108,7 +111,10 @@ class CHColumnarShuffleWriter[K, V](
         spillThreshold,
         CHBackendSettings.shuffleHashAlgorithm,
         throwIfMemoryExceed,
-        flushBlockBufferBeforeEvict
+        flushBlockBufferBeforeEvict,
+        maxSortBufferSize,
+        spillFirstlyBeforeStop,
+        forceSortShuffle
       )
       CHNativeMemoryAllocators.createSpillable(
         "ShuffleWriter",

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseColumnarSortShuffleAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseColumnarSortShuffleAQESuite.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.CoalescedPartitionSpec
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, AQEShuffleReadExec}
+
+class GlutenClickHouseColumnarSortShuffleAQESuite
+  extends GlutenClickHouseTPCHAbstractSuite
+  with AdaptiveSparkPlanHelper {
+
+  override protected val tablesPath: String = basePath + "/tpch-data-ch"
+  override protected val tpchQueries: String = rootPath + "queries/tpch-queries-ch"
+  override protected val queriesResults: String = rootPath + "mergetree-queries-output"
+
+  /** Run Gluten + ClickHouse Backend with ColumnarShuffleManager */
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.io.compression.codec", "LZ4")
+      .set("spark.sql.shuffle.partitions", "5")
+      .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
+      .set("spark.sql.adaptive.enabled", "true")
+      .set("spark.gluten.sql.columnar.backend.ch.forceSortShuffle", "true")
+  }
+
+  test("TPCH Q1") {
+    runTPCHQuery(1) {
+      df =>
+        assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
+
+        val colCustomShuffleReaderExecs = collect(df.queryExecution.executedPlan) {
+          case csr: AQEShuffleReadExec => csr
+        }
+        assert(colCustomShuffleReaderExecs.size == 2)
+        val coalescedPartitionSpec0 = colCustomShuffleReaderExecs(0)
+          .partitionSpecs(0)
+          .asInstanceOf[CoalescedPartitionSpec]
+        assert(coalescedPartitionSpec0.startReducerIndex == 0)
+        assert(coalescedPartitionSpec0.endReducerIndex == 5)
+        val coalescedPartitionSpec1 = colCustomShuffleReaderExecs(1)
+          .partitionSpecs(0)
+          .asInstanceOf[CoalescedPartitionSpec]
+        assert(coalescedPartitionSpec1.startReducerIndex == 0)
+        assert(coalescedPartitionSpec1.endReducerIndex == 5)
+    }
+  }
+
+  test("TPCH Q2") {
+    runTPCHQuery(2) { df => }
+  }
+
+  test("TPCH Q3") {
+    runTPCHQuery(3) { df => }
+  }
+
+  test("TPCH Q4") {
+    runTPCHQuery(4) { df => }
+  }
+
+  test("TPCH Q5") {
+    runTPCHQuery(5) { df => }
+  }
+
+  test("TPCH Q6") {
+    runTPCHQuery(6) { df => }
+  }
+
+  test("TPCH Q7") {
+    runTPCHQuery(7) { df => }
+  }
+
+  test("TPCH Q8") {
+    runTPCHQuery(8) { df => }
+  }
+
+  test("TPCH Q9") {
+    runTPCHQuery(9) { df => }
+  }
+
+  test("TPCH Q10") {
+    runTPCHQuery(10) { df => }
+  }
+
+  test("TPCH Q11") {
+    runTPCHQuery(11) {
+      df =>
+        assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
+        val adaptiveSparkPlanExec = collectWithSubqueries(df.queryExecution.executedPlan) {
+          case adaptive: AdaptiveSparkPlanExec => adaptive
+        }
+        assert(adaptiveSparkPlanExec.size == 2)
+    }
+  }
+
+  test("TPCH Q12") {
+    runTPCHQuery(12) { df => }
+  }
+
+  test("TPCH Q13") {
+    runTPCHQuery(13) { df => }
+  }
+
+  test("TPCH Q14") {
+    runTPCHQuery(14) { df => }
+  }
+
+  test("TPCH Q15") {
+    runTPCHQuery(15) {
+      df =>
+        assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
+        val adaptiveSparkPlanExec = collectWithSubqueries(df.queryExecution.executedPlan) {
+          case adaptive: AdaptiveSparkPlanExec => adaptive
+        }
+        assert(adaptiveSparkPlanExec.size == 2)
+    }
+  }
+
+  test("TPCH Q16") {
+    runTPCHQuery(16, noFallBack = false) { df => }
+  }
+
+  test("TPCH Q17") {
+    runTPCHQuery(17) { df => }
+  }
+
+  test("TPCH Q18") {
+    runTPCHQuery(18) {
+      df =>
+        val hashAggregates = collect(df.queryExecution.executedPlan) {
+          case hash: HashAggregateExecBaseTransformer => hash
+        }
+        assert(hashAggregates.size == 3)
+    }
+  }
+
+  test("TPCH Q19") {
+    runTPCHQuery(19) { df => }
+  }
+
+  test("TPCH Q20") {
+    runTPCHQuery(20) { df => }
+  }
+
+  test("TPCH Q21") {
+    runTPCHQuery(21, noFallBack = false) { df => }
+  }
+
+  test("TPCH Q22") {
+    runTPCHQuery(22) {
+      df =>
+        assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
+        val adaptiveSparkPlanExec = collectWithSubqueries(df.queryExecution.executedPlan) {
+          case adaptive: AdaptiveSparkPlanExec => adaptive
+        }
+        assert(adaptiveSparkPlanExec.size == 3)
+        assert(adaptiveSparkPlanExec(1) == adaptiveSparkPlanExec(2))
+    }
+  }
+}

--- a/cpp-ch/local-engine/Shuffle/CachedShuffleWriter.h
+++ b/cpp-ch/local-engine/Shuffle/CachedShuffleWriter.h
@@ -35,8 +35,9 @@ public:
     friend class PartitionWriter;
     friend class LocalPartitionWriter;
     friend class CelebornPartitionWriter;
+    friend class ExternalSortLocalPartitionWriter;
 
-    explicit CachedShuffleWriter(const String & short_name, const SplitOptions & options, jobject rss_pusher = nullptr);
+    explicit CachedShuffleWriter(const String & short_name, const SplitOptions & options,  jobject rss_pusher = nullptr);
     ~CachedShuffleWriter() override = default;
 
     void split(DB::Block & block) override;
@@ -53,6 +54,7 @@ private:
     std::unique_ptr<SelectorBuilder> partitioner;
     std::vector<size_t> output_columns_indicies;
     std::unique_ptr<PartitionWriter> partition_writer;
+    bool sort_shuffle = false;
 };
 }
 

--- a/cpp-ch/local-engine/Shuffle/PartitionWriter.cpp
+++ b/cpp-ch/local-engine/Shuffle/PartitionWriter.cpp
@@ -16,20 +16,25 @@
  */
 #include "PartitionWriter.h"
 #include <filesystem>
+#include <format>
 #include <memory>
 #include <ostream>
 #include <vector>
-#include <Storages/IO/CompressedWriteBuffer.h>
-#include <boost/algorithm/string/case_conv.hpp>
-#include <Shuffle/CachedShuffleWriter.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>
-#include <Common/Stopwatch.h>
-#include <Common/ThreadPool.h>
+#include <IO/WriteBufferFromString.h>
+#include <Processors/Merges/Algorithms/MergingSortedAlgorithm.h>
+#include <Shuffle/CachedShuffleWriter.h>
+#include <Shuffle/SortedPartitionDataMerger.h>
+#include <Storages/IO/AggregateSerializationUtils.h>
+#include <Storages/IO/CompressedWriteBuffer.h>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <Common/CHUtil.h>
 #include <Common/Exception.h>
-#include <IO/WriteBufferFromString.h>
-#include <format>
+#include <Common/Stopwatch.h>
+#include <Common/ThreadPool.h>
+
+#include <Processors/Transforms/SortingTransform.h>
 #include <Storages/IO/NativeWriter.h>
 
 
@@ -37,7 +42,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+extern const int LOGICAL_ERROR;
 }
 }
 
@@ -52,7 +57,7 @@ void PartitionWriter::write(const PartitionInfo & partition_info, DB::Block & bl
         throw Exception(ErrorCodes::LOGICAL_ERROR, "PartitionWriter::write is invoked with evicting_or_writing being occupied");
 
     evicting_or_writing = true;
-    SCOPE_EXIT({evicting_or_writing = false;});
+    SCOPE_EXIT({ evicting_or_writing = false; });
 
     Stopwatch watch;
     size_t current_cached_bytes = bytes();
@@ -116,9 +121,7 @@ void PartitionWriter::write(const PartitionInfo & partition_info, DB::Block & bl
 
     /// Only works for local partition writer
     if (!supportsEvictSinglePartition() && options->spill_threshold && current_cached_bytes >= options->spill_threshold)
-    {
         unsafeEvictPartitions(false, options->flush_block_buffer_before_evict);
-    }
 
     shuffle_writer->split_result.total_split_time += watch.elapsedNanoseconds();
 }
@@ -191,7 +194,7 @@ size_t LocalPartitionWriter::unsafeEvictPartitions(bool for_memory_spill, bool f
     return res;
 }
 
-std::vector<UInt64> LocalPartitionWriter::mergeSpills(WriteBuffer& data_file)
+std::vector<UInt64> LocalPartitionWriter::mergeSpills(WriteBuffer & data_file)
 {
     auto codec = DB::CompressionCodecFactory::instance().get(boost::to_upper_copy(shuffle_writer->options.compress_method), {});
     CompressedWriteBuffer compressed_output(data_file, codec, shuffle_writer->options.io_buffer_size);
@@ -244,13 +247,12 @@ std::vector<UInt64> LocalPartitionWriter::mergeSpills(WriteBuffer& data_file)
     shuffle_writer->split_result.total_write_time += write_time_watch.elapsedNanoseconds();
     shuffle_writer->split_result.total_compress_time += compressed_output.getCompressTime();
     shuffle_writer->split_result.total_io_time += compressed_output.getWriteTime();
-    shuffle_writer->split_result.total_serialize_time = shuffle_writer->split_result.total_serialize_time - shuffle_writer->split_result.total_io_time - shuffle_writer->split_result.total_compress_time;
+    shuffle_writer->split_result.total_serialize_time = shuffle_writer->split_result.total_serialize_time
+        - shuffle_writer->split_result.total_io_time - shuffle_writer->split_result.total_compress_time;
     shuffle_writer->split_result.total_io_time += merge_io_time;
 
     for (const auto & spill : spill_infos)
-    {
         std::filesystem::remove(spill.spilled_file);
-    }
 
     return partition_length;
 }
@@ -300,7 +302,7 @@ size_t PartitionWriter::evictPartitions(bool for_memory_spill, bool flush_block_
         return 0;
 
     evicting_or_writing = true;
-    SCOPE_EXIT({evicting_or_writing = false;});
+    SCOPE_EXIT({ evicting_or_writing = false; });
     return unsafeEvictPartitions(for_memory_spill, flush_block_buffer);
 }
 
@@ -310,7 +312,7 @@ void PartitionWriter::stop()
         throw Exception(ErrorCodes::LOGICAL_ERROR, "PartitionWriter::stop is invoked with evicting_or_writing being occupied");
 
     evicting_or_writing = true;
-    SCOPE_EXIT({evicting_or_writing = false;});
+    SCOPE_EXIT({ evicting_or_writing = false; });
     return unsafeStop();
 }
 
@@ -327,6 +329,124 @@ size_t PartitionWriter::bytes() const
     return bytes;
 }
 
+void ExternalSortLocalPartitionWriter::write(const PartitionInfo & info, DB::Block & block)
+{
+    Stopwatch write_time_watch;
+    if (output_header.columns() == 0)
+        output_header = block.cloneEmpty();
+    static const String partition_column_name = "partition";
+    auto partition_column = ColumnUInt64::create();
+    partition_column->reserve(block.rows());
+    partition_column->getData().insert_assume_reserved(info.src_partition_num.begin(), info.src_partition_num.end());
+    block.insert({std::move(partition_column), std::make_shared<DataTypeUInt64>(), partition_column_name});
+    if (sort_header.columns() == 0)
+    {
+        sort_header = block.cloneEmpty();
+        sort_description.emplace_back(SortColumnDescription(partition_column_name));
+    }
+    // partial sort
+    sortBlock(block, sort_description);
+    Chunk chunk;
+    chunk.setColumns(block.getColumns(), block.rows());
+    accumulated_blocks.emplace_back(std::move(chunk));
+    current_accumulated_bytes += accumulated_blocks.back().allocatedBytes();
+    if (current_accumulated_bytes >= max_sort_buffer_size)
+        unsafeEvictPartitions(false, false);
+    shuffle_writer->split_result.total_write_time += write_time_watch.elapsedNanoseconds();
+}
+
+size_t ExternalSortLocalPartitionWriter::unsafeEvictPartitions(bool, bool)
+{
+    // escape memory track
+    IgnoreMemoryTracker ignore(128 * 1024 * 1024);
+    if (accumulated_blocks.empty())
+        return 0;
+    Stopwatch watch;
+    MergeSorter sorter(sort_header, std::move(accumulated_blocks), sort_description, max_merge_block_size, 0);
+    streams.emplace_back(&tmp_data->createStream(sort_header));
+    while (auto data = sorter.read())
+    {
+        Block serialized_block = sort_header.cloneWithColumns(data.detachColumns());
+        streams.back()->write(serialized_block);
+    }
+    streams.back()->finishWriting();
+    auto result = current_accumulated_bytes;
+    current_accumulated_bytes = 0;
+    shuffle_writer->split_result.total_spill_time += watch.elapsedNanoseconds();
+    return result;
+}
+
+std::queue<Block> ExternalSortLocalPartitionWriter::mergeDataInMemory()
+{
+    if (accumulated_blocks.empty())
+        return {};
+    std::queue<Block> result;
+    MergeSorter sorter(sort_header, std::move(accumulated_blocks), sort_description, max_merge_block_size, 0);
+    while (auto data = sorter.read())
+    {
+        Block serialized_block = sort_header.cloneWithColumns(data.detachColumns());
+        result.push(serialized_block);
+    }
+    return result;
+}
+
+void ExternalSortLocalPartitionWriter::unsafeStop()
+{
+    // escape memory track
+    IgnoreMemoryTracker ignore(512 * 1024 * 1024);
+    Stopwatch write_time_watch;
+    // no data to write
+    if (streams.empty() && accumulated_blocks.empty())
+        return;
+    if (options->spill_firstly_before_stop)
+        unsafeEvictPartitions(false, false);
+    auto num_input = accumulated_blocks.empty() ? streams.size() : streams.size() + 1;
+    std::unique_ptr<MergingSortedAlgorithm> algorithm = std::make_unique<MergingSortedAlgorithm>(
+        sort_header, num_input, sort_description, max_merge_block_size, 0, SortingQueueStrategy::Batch);
+
+    WriteBufferFromFile output(options->data_file, options->io_buffer_size);
+    auto codec = DB::CompressionCodecFactory::instance().get(boost::to_upper_copy(shuffle_writer->options.compress_method), {});
+    CompressedWriteBuffer compressed_output(output, codec, shuffle_writer->options.io_buffer_size);
+    local_engine::NativeWriter native_writer(compressed_output, output_header);
+
+    auto sorted_memory_data = mergeDataInMemory();
+    SortedPartitionDataMerger merger(std::move(algorithm), streams, sorted_memory_data, output_header);
+    std::vector<UInt64> partition_length(shuffle_writer->options.partition_num, 0);
+    size_t current_file_size = 0;
+    size_t current_partition_raw_size = 0;
+    size_t current_partition_id = 0;
+    auto finish_partition_if_needed = [&]()
+    {
+        if (!partition_length[current_partition_id])
+        {
+            compressed_output.sync();
+            shuffle_writer->split_result.raw_partition_lengths[current_partition_id] = current_partition_raw_size;
+            partition_length[current_partition_id] = output.count() - current_file_size;
+            current_file_size = output.count();
+            current_partition_id++;
+            current_partition_raw_size = 0;
+        }
+    };
+    while (!merger.isFinished())
+    {
+        auto result = merger.next();
+        if (result.empty)
+            break;
+        for (auto & item : result.blocks)
+        {
+            while (item.second - current_partition_id > 1)
+                finish_partition_if_needed();
+            current_partition_raw_size += native_writer.write(item.first);
+        }
+    }
+    while (shuffle_writer->options.partition_num - current_partition_id > 0)
+        finish_partition_if_needed();
+    shuffle_writer->split_result.partition_lengths = partition_length;
+    shuffle_writer->split_result.total_write_time += write_time_watch.elapsedNanoseconds();
+    shuffle_writer->split_result.total_compress_time += compressed_output.getCompressTime();
+    shuffle_writer->split_result.total_io_time += compressed_output.getWriteTime();
+}
+
 CelebornPartitionWriter::CelebornPartitionWriter(CachedShuffleWriter * shuffleWriter, std::unique_ptr<CelebornClient> celeborn_client_)
     : PartitionWriter(shuffleWriter), celeborn_client(std::move(celeborn_client_))
 {
@@ -336,9 +456,7 @@ size_t CelebornPartitionWriter::unsafeEvictPartitions(bool for_memory_spill, boo
 {
     size_t res = 0;
     for (size_t partition_id = 0; partition_id < options->partition_num; ++partition_id)
-    {
         res += unsafeEvictSinglePartition(for_memory_spill, flush_block_buffer, partition_id);
-    }
     return res;
 }
 
@@ -413,9 +531,7 @@ void CelebornPartitionWriter::unsafeStop()
     unsafeEvictPartitions(false, true);
 
     for (const auto & length : shuffle_writer->split_result.partition_lengths)
-    {
         shuffle_writer->split_result.total_bytes_written += length;
-    }
 }
 
 void Partition::addBlock(DB::Block block)
@@ -445,4 +561,3 @@ size_t Partition::spill(NativeWriter & writer)
 }
 
 }
-

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
@@ -58,6 +58,7 @@ PartitionInfo PartitionInfo::fromSelector(DB::IColumn::Selector selector, size_t
     return PartitionInfo{
         .partition_selector = std::move(partition_selector),
         .partition_start_points = partition_row_idx_start_points,
+        .src_partition_num = std::move(selector),
         .partition_num = partition_num};
 }
 

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
@@ -40,26 +40,36 @@ extern const int LOGICAL_ERROR;
 }
 namespace local_engine
 {
-PartitionInfo PartitionInfo::fromSelector(DB::IColumn::Selector selector, size_t partition_num)
+PartitionInfo PartitionInfo::fromSelector(DB::IColumn::Selector selector, size_t partition_num, bool use_external_sort_shuffle)
 {
-    auto rows = selector.size();
-    std::vector<size_t> partition_row_idx_start_points(partition_num + 1, 0);
-    IColumn::Selector partition_selector(rows, 0);
-    for (size_t i = 0; i < rows; ++i)
-        partition_row_idx_start_points[selector[i]]++;
-
-    for (size_t i = 1; i <= partition_num; ++i)
-        partition_row_idx_start_points[i] += partition_row_idx_start_points[i - 1];
-    for (size_t i = rows; i-- > 0;)
+    if (use_external_sort_shuffle)
     {
-        partition_selector[partition_row_idx_start_points[selector[i]] - 1] = i;
-        partition_row_idx_start_points[selector[i]]--;
+        return PartitionInfo{
+            .src_partition_num = std::move(selector),
+            .partition_num = partition_num};
     }
-    return PartitionInfo{
-        .partition_selector = std::move(partition_selector),
-        .partition_start_points = partition_row_idx_start_points,
-        .src_partition_num = std::move(selector),
-        .partition_num = partition_num};
+    else
+    {
+        auto rows = selector.size();
+        std::vector<size_t> partition_row_idx_start_points(partition_num + 1, 0);
+        IColumn::Selector partition_selector(rows, 0);
+        for (size_t i = 0; i < rows; ++i)
+            partition_row_idx_start_points[selector[i]]++;
+
+        for (size_t i = 1; i <= partition_num; ++i)
+            partition_row_idx_start_points[i] += partition_row_idx_start_points[i - 1];
+        for (size_t i = rows; i-- > 0;)
+        {
+            partition_selector[partition_row_idx_start_points[selector[i]] - 1] = i;
+            partition_row_idx_start_points[selector[i]]--;
+        }
+        return PartitionInfo{
+            .partition_selector = std::move(partition_selector),
+            .partition_start_points = partition_row_idx_start_points,
+            .src_partition_num = std::move(selector),
+            .partition_num = partition_num};
+    }
+
 }
 
 PartitionInfo RoundRobinSelectorBuilder::build(DB::Block & block)
@@ -71,12 +81,12 @@ PartitionInfo RoundRobinSelectorBuilder::build(DB::Block & block)
         pid = pid_selection;
         pid_selection = (pid_selection + 1) % parts_num;
     }
-    return PartitionInfo::fromSelector(std::move(result), parts_num);
+    return PartitionInfo::fromSelector(std::move(result), parts_num, use_external_sort_shuffle);
 }
 
 HashSelectorBuilder::HashSelectorBuilder(
-    UInt32 parts_num_, const std::vector<size_t> & exprs_index_, const std::string & hash_function_name_)
-    : parts_num(parts_num_), exprs_index(exprs_index_), hash_function_name(hash_function_name_)
+    UInt32 parts_num_, const std::vector<size_t> & exprs_index_, const std::string & hash_function_name_, bool use_external_sort_shuffle)
+    : SelectorBuilder(use_external_sort_shuffle), parts_num(parts_num_), exprs_index(exprs_index_), hash_function_name(hash_function_name_)
 {
 }
 
@@ -146,13 +156,14 @@ PartitionInfo HashSelectorBuilder::build(DB::Block & block)
             }
         }
     }
-    return PartitionInfo::fromSelector(std::move(partition_ids), parts_num);
+    return PartitionInfo::fromSelector(std::move(partition_ids), parts_num, use_external_sort_shuffle);
 }
 
 
 static std::map<int, std::pair<int, int>> direction_map = {{1, {1, -1}}, {2, {1, 1}}, {3, {-1, 1}}, {4, {-1, -1}}};
 
-RangeSelectorBuilder::RangeSelectorBuilder(const std::string & option, const size_t partition_num_)
+RangeSelectorBuilder::RangeSelectorBuilder(const std::string & option, const size_t partition_num_, bool use_external_sort_shuffle)
+    : SelectorBuilder(use_external_sort_shuffle)
 {
     Poco::JSON::Parser parser;
     auto info = parser.parse(option).extract<Poco::JSON::Object::Ptr>();
@@ -166,7 +177,7 @@ PartitionInfo RangeSelectorBuilder::build(DB::Block & block)
 {
     DB::IColumn::Selector result;
     computePartitionIdByBinarySearch(block, result);
-    return PartitionInfo::fromSelector(std::move(result), partition_num);
+    return PartitionInfo::fromSelector(std::move(result), partition_num, use_external_sort_shuffle);
 }
 
 void RangeSelectorBuilder::initSortInformation(Poco::JSON::Array::Ptr orderings)

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
@@ -40,20 +40,23 @@ struct PartitionInfo
     DB::IColumn::Selector src_partition_num;
     size_t partition_num;
 
-    static PartitionInfo fromSelector(DB::IColumn::Selector selector, size_t partition_num);
+    static PartitionInfo fromSelector(DB::IColumn::Selector selector, size_t partition_num, bool use_external_sort_shuffle);
 };
 
 class SelectorBuilder
 {
 public:
+    explicit SelectorBuilder(bool use_external_sort_shuffle) : use_external_sort_shuffle(use_external_sort_shuffle) { }
     virtual ~SelectorBuilder() = default;
     virtual PartitionInfo build(DB::Block & block) = 0;
+protected:
+    bool use_external_sort_shuffle = false;
 };
 
 class RoundRobinSelectorBuilder : public SelectorBuilder
 {
 public:
-    explicit RoundRobinSelectorBuilder(size_t parts_num_) : parts_num(parts_num_) { }
+    explicit RoundRobinSelectorBuilder(size_t parts_num_, bool use_external_sort_shuffle = false) : SelectorBuilder(use_external_sort_shuffle), parts_num(parts_num_) { }
     ~RoundRobinSelectorBuilder() override = default;
     PartitionInfo build(DB::Block & block) override;
 
@@ -65,7 +68,7 @@ private:
 class HashSelectorBuilder : public SelectorBuilder
 {
 public:
-    explicit HashSelectorBuilder(UInt32 parts_num_, const std::vector<size_t> & exprs_index_, const std::string & hash_function_name_);
+    explicit HashSelectorBuilder(UInt32 parts_num_, const std::vector<size_t> & exprs_index_, const std::string & hash_function_name_, bool use_external_sort_shuffle = false);
     ~HashSelectorBuilder() override = default;
     PartitionInfo build(DB::Block & block) override;
 
@@ -79,7 +82,7 @@ private:
 class RangeSelectorBuilder : public SelectorBuilder
 {
 public:
-    explicit RangeSelectorBuilder(const std::string & options_, const size_t partition_num_);
+    explicit RangeSelectorBuilder(const std::string & options_, const size_t partition_num_, bool use_external_sort_shuffle = false);
     ~RangeSelectorBuilder() override = default;
     PartitionInfo build(DB::Block & block) override;
 

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
@@ -36,6 +36,8 @@ struct PartitionInfo
 {
     DB::IColumn::Selector partition_selector;
     std::vector<size_t> partition_start_points;
+    // for sort partition
+    DB::IColumn::Selector src_partition_num;
     size_t partition_num;
 
     static PartitionInfo fromSelector(DB::IColumn::Selector selector, size_t partition_num);

--- a/cpp-ch/local-engine/Shuffle/ShuffleSplitter.h
+++ b/cpp-ch/local-engine/Shuffle/ShuffleSplitter.h
@@ -50,6 +50,10 @@ struct SplitOptions
     bool throw_if_memory_exceed = true;
     /// Whether to flush partition_block_buffer in PartitionWriter before evict.
     bool flush_block_buffer_before_evict = false;
+    size_t max_sort_buffer_size = 1_GiB;
+    // Whether to spill firstly before stop external sort shuffle.
+    bool spill_firstly_before_stop = true;
+    bool force_sort = true;
 };
 
 class ColumnsBuffer

--- a/cpp-ch/local-engine/Shuffle/SortedPartitionDataMerger.cpp
+++ b/cpp-ch/local-engine/Shuffle/SortedPartitionDataMerger.cpp
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SortedPartitionDataMerger.h"
+using namespace DB;
+namespace local_engine
+{
+SortedPartitionDataMerger::SortedPartitionDataMerger(
+    std::unique_ptr<MergingSortedAlgorithm> algorithm,
+    const std::vector<TemporaryFileStream *> & streams,
+    std::queue<DB::Block> & extra_blocks_in_memory_,
+    const Block & output_header_)
+{
+    merging_algorithm = std::move(algorithm);
+    IMergingAlgorithm::Inputs initial_inputs;
+    bool use_in_memory_data = !extra_blocks_in_memory_.empty();
+    for (auto * stream : streams)
+    {
+        Block data = stream->read();
+        IMergingAlgorithm::Input input;
+        input.set({data.getColumns(), data.rows()});
+        initial_inputs.emplace_back(std::move(input));
+    }
+    if (use_in_memory_data)
+    {
+        IMergingAlgorithm::Input input;
+        const auto & data = extra_blocks_in_memory_.front();
+        input.set({data.getColumns(), data.rows()});
+        initial_inputs.emplace_back(std::move(input));
+        extra_blocks_in_memory_.pop();
+    }
+    for (int i = 0; i < streams.size(); ++i)
+        sources.emplace_back(std::make_shared<SortedData>(streams[i], i));
+    if (use_in_memory_data)
+        sources.emplace_back(std::make_shared<SortedData>(extra_blocks_in_memory_, sources.size()));
+    output_header = output_header_;
+    merging_algorithm->initialize(std::move(initial_inputs));
+}
+
+int64_t searchLastPartitionIdIndex(ColumnPtr column, size_t start, size_t partition_id)
+{
+    const auto * int64_column = checkAndGetColumn<ColumnUInt64>(*column);
+    int64_t low = start, high = int64_column->size() - 1;
+    while (low <= high)
+    {
+        int64_t mid = low + (high - low) / 2;
+        if (int64_column->get64(mid) > partition_id)
+            high = mid - 1;
+        else
+            low = mid + 1;
+        if (int64_column->get64(high) == partition_id)
+            return high;
+    }
+    return -1;
+}
+
+SortedPartitionDataMerger::Result SortedPartitionDataMerger::next()
+{
+    if (finished)
+        return Result{.empty = true};
+    Chunk chunk;
+    while (true)
+    {
+        auto result = merging_algorithm->merge();
+
+        if (result.required_source >= 0)
+        {
+            auto stream = sources[result.required_source];
+            auto block = stream->next();
+            if (block)
+            {
+                IMergingAlgorithm::Input input;
+                input.set({block.getColumns(), block.rows()});
+                merging_algorithm->consume(input, stream->getPartitionId());
+            }
+        }
+        if (result.chunk.getNumRows() > 0)
+        {
+            chunk = std::move(result.chunk);
+            break;
+        }
+        if (result.is_finished)
+        {
+            finished = true;
+            if (chunk.getNumRows() == 0)
+                return Result{.empty = true};
+            break;
+        }
+    }
+    Result partitions;
+    size_t row_idx = 0;
+    Columns result_columns;
+    result_columns.reserve(chunk.getColumns().size() - 1);
+    for (size_t i = 0; i < chunk.getColumns().size() - 1; ++i)
+        result_columns.push_back(chunk.getColumns()[i]);
+    while (row_idx < chunk.getNumRows())
+    {
+        auto idx = searchLastPartitionIdIndex(chunk.getColumns().back(), row_idx, current_partition_id);
+        if (idx >= 0)
+        {
+            if (row_idx == 0 && idx == chunk.getNumRows() - 1)
+            {
+                partitions.blocks.emplace_back(output_header.cloneWithColumns(result_columns), current_partition_id);
+                break;
+            }
+            else
+            {
+                Columns cut_columns;
+                cut_columns.reserve(result_columns.size());
+                for (auto & result_column : result_columns)
+                    cut_columns.push_back(result_column->cut(row_idx, idx - row_idx + 1));
+                partitions.blocks.emplace_back(output_header.cloneWithColumns(cut_columns), current_partition_id);
+                row_idx = idx + 1;
+                if (idx != chunk.getNumRows() - 1)
+                    current_partition_id++;
+            }
+        }
+        else
+        {
+            current_partition_id++;
+        }
+    }
+    return partitions;
+}
+}

--- a/cpp-ch/local-engine/Shuffle/SortedPartitionDataMerger.h
+++ b/cpp-ch/local-engine/Shuffle/SortedPartitionDataMerger.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <queue>
+#include <Interpreters/TemporaryDataOnDisk.h>
+#include <Processors/Merges/Algorithms/MergingSortedAlgorithm.h>
+
+
+namespace local_engine
+{
+class SortedPartitionDataMerger;
+using SortedPartitionDataMergerPtr = std::unique_ptr<SortedPartitionDataMerger>;
+class SortedPartitionDataMerger
+{
+public:
+    struct Result
+    {
+        bool empty = false;
+        std::vector<std::pair<DB::Block, size_t>> blocks;
+    };
+
+    class SortedData
+    {
+    public:
+        SortedData(DB::TemporaryFileStream * stream, size_t partitionId) : stream(stream), partition_id(partitionId) { }
+        SortedData(const std::queue<DB::Block> & blocksInMemory, size_t partitionId)
+            : blocks_in_memory(blocksInMemory), partition_id(partitionId)
+        {
+        }
+        DB::Block next()
+        {
+            if (stream)
+            {
+                auto data = stream->read();
+                end = !data;
+                return data;
+            }
+            if (!blocks_in_memory.empty())
+            {
+                auto block = blocks_in_memory.front();
+                blocks_in_memory.pop();
+                return block;
+            }
+            return {};
+        }
+        bool isEnd() const
+        {
+            if (stream)
+                return stream->isEof();
+            return blocks_in_memory.empty() || end;
+        }
+        size_t getPartitionId() const { return partition_id; }
+
+    private:
+        DB::TemporaryFileStream * stream = nullptr;
+        std::queue<DB::Block> blocks_in_memory;
+        size_t partition_id;
+        bool end = false;
+    };
+
+    SortedPartitionDataMerger(
+        std::unique_ptr<DB::MergingSortedAlgorithm> algorithm,
+        const std::vector<DB::TemporaryFileStream *> & streams,
+        std::queue<DB::Block> & extra_blocks_in_memory,
+        const DB::Block & output_header);
+    Result next();
+    bool isFinished() const { return finished; }
+
+private:
+    std::unique_ptr<DB::MergingSortedAlgorithm> merging_algorithm;
+    std::vector<std::shared_ptr<SortedData>> sources;
+    DB::Block output_header;
+    bool finished = false;
+    size_t current_partition_id = 0;
+};
+
+}

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -664,7 +664,10 @@ JNIEXPORT jlong Java_org_apache_gluten_vectorized_CHShuffleSplitterJniWrapper_na
     jlong spill_threshold,
     jstring hash_algorithm,
     jboolean throw_if_memory_exceed,
-    jboolean flush_block_buffer_before_evict)
+    jboolean flush_block_buffer_before_evict,
+    jlong max_sort_buffer_size,
+    jboolean spill_firstly_before_stop,
+    jboolean force_sort)
 {
     LOCAL_ENGINE_JNI_METHOD_START
     std::string hash_exprs;
@@ -708,7 +711,11 @@ JNIEXPORT jlong Java_org_apache_gluten_vectorized_CHShuffleSplitterJniWrapper_na
         .spill_threshold = static_cast<size_t>(spill_threshold),
         .hash_algorithm = jstring2string(env, hash_algorithm),
         .throw_if_memory_exceed = static_cast<bool>(throw_if_memory_exceed),
-        .flush_block_buffer_before_evict = static_cast<bool>(flush_block_buffer_before_evict)};
+        .flush_block_buffer_before_evict = static_cast<bool>(flush_block_buffer_before_evict),
+        .max_sort_buffer_size = static_cast<size_t>(max_sort_buffer_size),
+        .spill_firstly_before_stop = static_cast<bool>(spill_firstly_before_stop),
+        .force_sort = static_cast<bool>(force_sort)
+    };
     auto name = jstring2string(env, short_name);
     local_engine::SplitterHolder * splitter;
     if (prefer_spill)

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -287,6 +287,13 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def chColumnarFlushBlockBufferBeforeEvict: Boolean =
     conf.getConf(COLUMNAR_CH_FLUSH_BLOCK_BUFFER_BEFORE_EVICT)
 
+  def chColumnarMaxSortBufferSize: Long = conf.getConf(COLUMNAR_CH_MAX_SORT_BUFFER_SIZE)
+
+  def chColumnarSpillFirstlyBeforeStop: Boolean =
+    conf.getConf(COLUMNAR_CH_SPILL_FIRSTLY_BEFORE_STOP)
+
+  def chColumnarForceSortShuffle: Boolean = conf.getConf(COLUMNAR_CH_FORCE_SORT_SHUFFLE)
+
   def cartesianProductTransformerEnabled: Boolean =
     conf.getConf(CARTESIAN_PRODUCT_TRANSFORMER_ENABLED)
 
@@ -1336,6 +1343,28 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.columnar.backend.ch.flushBlockBufferBeforeEvict")
       .internal()
       .doc("Whether to flush partition_block_buffer before execute evict in CH PartitionWriter.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_CH_MAX_SORT_BUFFER_SIZE =
+    buildConf("spark.gluten.sql.columnar.backend.ch.maxSortBufferSize")
+      .internal()
+      .doc("The maximum size of sort shuffle buffer in CH backend.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1GB")
+
+  val COLUMNAR_CH_SPILL_FIRSTLY_BEFORE_STOP =
+    buildConf("spark.gluten.sql.columnar.backend.ch.spillFirstlyBeforeStop")
+      .internal()
+      .doc("Whether to spill the sort buffers before stopping the shuffle writer.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COLUMNAR_CH_FORCE_SORT_SHUFFLE =
+    buildConf("spark.gluten.sql.columnar.backend.ch.forceSortShuffle")
+      .internal()
+      .doc("Whether to force to use sort shuffle in CH backend. " +
+        "Sort shuffle will enable When partition num greater than 300.")
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

add external sort shuffle writer

## How was this patch tested?

unit tests


Three new configurations are introduced
```
spark.gluten.sql.columnar.backend.ch.maxSortBufferSize
```
The maximum size of sort shuffle buffer in CH backend.
```
spark.gluten.sql.columnar.backend.ch.spillFirstlyBeforeStop
```
Whether to spill the sort buffers before stopping the shuffle writer.
```
spark.gluten.sql.columnar.backend.ch.forceSortShuffle
```
Whether to force to use sort shuffle in CH backend. Sort shuffle disabled by default


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

