### PR TITLE
[VL][CI] Add a nightly build job

### DIFF
--- a/.github/workflows/velox_nightly.yml
+++ b/.github/workflows/velox_nightly.yml
@@ -43,14 +43,12 @@ jobs:
           sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
       - name: build
         run: |
-          yum install -y epel-release sudo dnf && \
-          yum install -y dnf-plugins-core && \
-          yum config-manager --set-enabled powertools && \
-          dnf --enablerepo=powertools install -y ninja-build && \
-          dnf --enablerepo=powertools install -y libdwarf-devel && \
-          dnf install -y --setopt=install_weak_deps=False ccache gcc-toolset-9 git wget which libevent-devel openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel curl-devel cmake libicu-devel && \
-          source /opt/rh/gcc-toolset-9/enable || exit 1 && \
-          yum install -y java-1.8.0-openjdk-devel patch && \
+          yum install -y epel-release sudo dnf
+          if [ "${{ matrix.os }}" = "centos:8" ]; then
+            dnf install -y --setopt=install_weak_deps=False gcc-toolset-9
+            source /opt/rh/gcc-toolset-9/enable || exit 1
+          fi
+          yum install -y java-1.8.0-openjdk-devel patch wget git && \
           export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk && \
           export PATH=$JAVA_HOME/bin:$PATH && \
           wget https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \

--- a/.github/workflows/velox_nightly.yml
+++ b/.github/workflows/velox_nightly.yml
@@ -43,10 +43,15 @@ jobs:
           sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
       - name: build
         run: |
+          yum update -y
           yum install -y epel-release sudo dnf
           if [ "${{ matrix.os }}" = "centos:8" ]; then
             dnf install -y --setopt=install_weak_deps=False gcc-toolset-9
             source /opt/rh/gcc-toolset-9/enable || exit 1
+          else
+            yum install -y centos-release-scl
+            yum install -y devtoolset-9
+            source /opt/rh/devtoolset-9/enable || exit 1
           fi
           yum install -y java-1.8.0-openjdk-devel patch wget git && \
           export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk && \

--- a/.github/workflows/velox_nightly.yml
+++ b/.github/workflows/velox_nightly.yml
@@ -51,7 +51,7 @@ jobs:
           yum install -y java-1.8.0-openjdk-devel patch wget git && \
           export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk && \
           export PATH=$JAVA_HOME/bin:$PATH && \
-          wget https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
+          wget --no-check-certificate https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
           tar -xvf apache-maven-3.8.8-bin.tar.gz && \
           mv apache-maven-3.8.8 /usr/lib/maven && \
           export MAVEN_HOME=/usr/lib/maven && \

--- a/.github/workflows/velox_nightly.yml
+++ b/.github/workflows/velox_nightly.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nightly-build-on-centos:
+  build-on-centos:
     strategy:
       fail-fast: false
       matrix:
@@ -63,3 +63,20 @@ jobs:
           export PATH=${PATH}:${MAVEN_HOME}/bin && \
           cd $GITHUB_WORKSPACE/ && \
           ./dev/package.sh
+
+  build-on-ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu:20.04", "ubuntu:22.04" ]
+    runs-on: ubuntu-20.04
+    container: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: |
+          # To avoid the prompt for region selection during installing tzdata.
+          export DEBIAN_FRONTEND="noninteractive"
+          apt-get update && apt-get install -y sudo openjdk-8-jdk maven wget git
+          export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+          cd $GITHUB_WORKSPACE/ && ./dev/package.sh

--- a/.github/workflows/velox_nightly.yml
+++ b/.github/workflows/velox_nightly.yml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Velox backend nightly job
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/velox_nightly.yml'
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  nightly-build-on-centos:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "centos:7", "centos:8" ]
+    runs-on: ubuntu-20.04
+    container: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update mirror list
+        if: matrix.os == 'centos:8'
+        run: |
+          sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* || true
+          sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
+      - name: build
+        run: |
+          yum install -y epel-release sudo dnf && \
+          yum install -y dnf-plugins-core && \
+          yum config-manager --set-enabled powertools && \
+          dnf --enablerepo=powertools install -y ninja-build && \
+          dnf --enablerepo=powertools install -y libdwarf-devel && \
+          dnf install -y --setopt=install_weak_deps=False ccache gcc-toolset-9 git wget which libevent-devel openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel curl-devel cmake libicu-devel && \
+          source /opt/rh/gcc-toolset-9/enable || exit 1 && \
+          yum install -y java-1.8.0-openjdk-devel patch && \
+          export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk && \
+          export PATH=$JAVA_HOME/bin:$PATH && \
+          wget https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
+          tar -xvf apache-maven-3.8.8-bin.tar.gz && \
+          mv apache-maven-3.8.8 /usr/lib/maven && \
+          export MAVEN_HOME=/usr/lib/maven && \
+          export PATH=${PATH}:${MAVEN_HOME}/bin && \
+          cd $GITHUB_WORKSPACE/ && \
+          ./dev/package.sh

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -169,9 +169,6 @@ function process_setup_centos7 {
 
   # No need to re-install git.
   sed -i 's/dnf_install ccache git/dnf_install ccache/' scripts/setup-centos7.sh
-  # cmake 3 and ninja should be installed
-  sed -i '/^run_and_time install_cmake/d' scripts/setup-centos7.sh
-  sed -i '/^run_and_time install_ninja/d' scripts/setup-centos7.sh
 
   # install gtest
   sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_gtest' scripts/setup-centos7.sh

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -93,7 +93,6 @@ function process_setup_ubuntu {
   sed -i '/ccache/a\  libuuid1 \\' scripts/setup-ubuntu.sh
   sed -i '/ccache/a\  uuid-dev \\' scripts/setup-ubuntu.sh
   sed -i '/ccache/a\  curl \\' scripts/setup-ubuntu.sh
-  sed -i '/libre2-dev/d' scripts/setup-ubuntu.sh
   sed -i '/libgmock-dev/d' scripts/setup-ubuntu.sh # resolved by ep/build-velox/build/velox_ep/CMake/resolve_dependency_modules/gtest.cmake
   sed -i 's/github_checkout boostorg\/boost \"\${BOOST_VERSION}\" --recursive/wget_and_untar https:\/\/github.com\/boostorg\/boost\/releases\/download\/boost-1.84.0\/boost-1.84.0.tar.gz boost \&\& cd boost/g' scripts/setup-ubuntu.sh
   if [ $ENABLE_HDFS == "ON" ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes a nightly job to verify gluten build script from a clean environment.

1. Gluten's existing CI jobs are using docker images with pre-installed dependencies to accelerate validation process, but it is possible the code doesn't work in a clean environment.
E.g., Gluten changes velox's setup script by using "sed" command to match some code, then modifying it. The expected change sometimes doesn't happen due to upstream's code changes.
2. dev/package.sh is still necessary to some users, even though static build is recommended. It lacks CI verification. 

To avoid slowing down PR verification process, this job will be triggered only if the added yml file is changed or scheduled nightly test time comes.


## How was this patch tested?

N/A

