### PR TITLE
[Gluten-5152][CH] fix bugs for optimizing tables on s3

### DIFF
--- a/cpp-ch/clickhouse.version
+++ b/cpp-ch/clickhouse.version
@@ -1,3 +1,3 @@
 CH_ORG=Kyligence
-CH_BRANCH=rebase_ch/20240409
-CH_COMMIT=9f58d706e23
+CH_BRANCH=debugging_5282
+CH_COMMIT=ea0186c3f1d

--- a/cpp-ch/clickhouse.version
+++ b/cpp-ch/clickhouse.version
@@ -1,3 +1,3 @@
 CH_ORG=Kyligence
-CH_BRANCH=debugging_5282
-CH_COMMIT=ea0186c3f1d
+CH_BRANCH=rebase_ch/20240409
+CH_COMMIT=9f58d706e23

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -97,6 +97,7 @@ CustomStorageMergeTreePtr MergeTreeRelParser::parseStorage(
                 buildMergeTreeSettings(merge_tree_table.table_configs));
             return custom_storage_merge_tree;
         });
+    restoreMetaData(storage, merge_tree_table, *local_engine::SerializedPlanParser::global_context);
     return storage;
 }
 
@@ -146,7 +147,7 @@ MergeTreeRelParser::parseReadRel(
             return custom_storage_merge_tree;
         });
 
-    restoreMetaData(storage, merge_tree_table, context);
+    restoreMetaData(storage, merge_tree_table, *context);
     for (const auto & [name, sizes] : storage->getColumnSizes())
         column_sizes[name] = sizes.data_compressed;
     query_context.storage_snapshot = std::make_shared<StorageSnapshot>(*storage, metadata);

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.cpp
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.cpp
@@ -97,9 +97,9 @@ CustomStorageMergeTree::CustomStorageMergeTree(
 
 std::atomic<int> CustomStorageMergeTree::part_num;
 
-DataPartsVector CustomStorageMergeTree::loadDataPartsWithNames(std::unordered_set<std::string> parts)
+MergeTreeData::MutableDataPartsVector CustomStorageMergeTree::loadDataPartsWithNames(std::unordered_set<std::string> parts)
 {
-    DataPartsVector data_parts;
+    MutableDataPartsVector data_parts;
     const auto disk = getStoragePolicy()->getDisks().at(0);
     for (const auto& name : parts)
     {

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
@@ -52,7 +52,7 @@ public:
     std::vector<MergeTreeMutationStatus> getMutationsStatus() const override;
     bool scheduleDataProcessingJob(BackgroundJobsAssignee & executor) override;
     std::map<std::string, MutationCommands> getUnfinishedMutationCommands() const override;
-    DataPartsVector loadDataPartsWithNames(std::unordered_set<std::string> parts);
+    MutableDataPartsVector loadDataPartsWithNames(std::unordered_set<std::string> parts);
 
 
     MergeTreeDataWriter writer;

--- a/cpp-ch/local-engine/Storages/Mergetree/MergeSparkMergeTreeTask.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/MergeSparkMergeTreeTask.cpp
@@ -150,6 +150,8 @@ void MergeSparkMergeTreeTask::prepare()
         cleanup,
         storage.merging_params,
         txn,
+        // need_prefix = false, so CH won't create a tmp_ folder while merging.
+        // the tmp_ folder is problematic when on S3 (particularlly when renaming)
         false);
 }
 
@@ -158,6 +160,7 @@ void MergeSparkMergeTreeTask::finish()
 {
     new_part = merge_task->getFuture().get();
 
+    // Since there is not tmp_ folder, we don't need renaming
     // MergeTreeData::Transaction transaction(storage, txn.get());
     // storage.merger_mutator.renameMergedTemporaryPart(new_part, future_part->parts, txn, transaction);
     // transaction.commit();

--- a/cpp-ch/local-engine/Storages/Mergetree/MergeSparkMergeTreeTask.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/MergeSparkMergeTreeTask.cpp
@@ -149,7 +149,8 @@ void MergeSparkMergeTreeTask::prepare()
         deduplicate_by_columns,
         cleanup,
         storage.merging_params,
-        txn);
+        txn,
+        false);
 }
 
 
@@ -157,9 +158,9 @@ void MergeSparkMergeTreeTask::finish()
 {
     new_part = merge_task->getFuture().get();
 
-    MergeTreeData::Transaction transaction(storage, txn.get());
-    storage.merger_mutator.renameMergedTemporaryPart(new_part, future_part->parts, txn, transaction);
-    transaction.commit();
+    // MergeTreeData::Transaction transaction(storage, txn.get());
+    // storage.merger_mutator.renameMergedTemporaryPart(new_part, future_part->parts, txn, transaction);
+    // transaction.commit();
 
     ThreadFuzzer::maybeInjectSleep();
     ThreadFuzzer::maybeInjectMemoryLimitException();

--- a/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.cpp
@@ -63,6 +63,8 @@ void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable &
 
     if (auto lock = storage->lockForAlter(context.getSettingsRef().lock_acquire_timeout))
     {
+        // put this return clause in lockForAlter
+        // so that it will not return until other thread finishes restoring
         if (not_exists_part.empty())
             return;
 

--- a/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.cpp
@@ -43,7 +43,7 @@ std::unordered_map<String, String> extractPartMetaData(ReadBuffer & in)
     return result;
 }
 
-void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable & mergeTreeTable, ContextPtr & context)
+void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable & mergeTreeTable, const Context & context)
 {
     auto data_disk = storage->getStoragePolicy()->getAnyDisk();
     if (!data_disk->isRemote())
@@ -63,7 +63,7 @@ void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable &
     if (not_exists_part.empty())
         return;
 
-    if (auto lock = storage->lockForAlter(context->getSettingsRef().lock_acquire_timeout))
+    if (auto lock = storage->lockForAlter(context.getSettingsRef().lock_acquire_timeout))
     {
         auto s3 = data_disk->getObjectStorage();
 

--- a/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.cpp
@@ -92,4 +92,28 @@ void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable &
     }
 }
 
+
+void saveFileStatus(
+    const DB::MergeTreeData & storage,
+    const DB::ContextPtr& context,
+    IDataPartStorage & data_part_storage)
+{
+    const DiskPtr disk = storage.getStoragePolicy()->getAnyDisk();
+    if (!disk->isRemote())
+        return;
+    if (auto * const disk_metadata = dynamic_cast<MetadataStorageFromDisk *>(disk->getMetadataStorage().get()))
+    {
+        const auto out = data_part_storage.writeFile("metadata.gluten", DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+        for (const auto it = data_part_storage.iterate(); it->isValid(); it->next())
+        {
+            auto content = disk_metadata->readFileToString(it->path());
+            writeString(it->name(), *out);
+            writeChar('\t', *out);
+            writeIntText(content.length(), *out);
+            writeChar('\n', *out);
+            writeString(content, *out);
+        }
+        out->finalize();
+    }
+}
 }

--- a/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.h
+++ b/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.h
@@ -25,5 +25,10 @@ namespace local_engine
 
 void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable & mergeTreeTable, const Context & context);
 
+void saveFileStatus(
+    const DB::MergeTreeData & storage,
+    const DB::ContextPtr& context,
+    IDataPartStorage & data_part_storage);
+
 }
 

--- a/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.h
+++ b/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.h
@@ -23,7 +23,7 @@
 namespace local_engine
 {
 
-void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable & mergeTreeTable, ContextPtr & context);
+void restoreMetaData(CustomStorageMergeTreePtr & storage, const MergeTreeTable & mergeTreeTable, const Context & context);
 
 }
 

--- a/cpp-ch/local-engine/Storages/Mergetree/SparkMergeTreeWriter.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/SparkMergeTreeWriter.cpp
@@ -21,6 +21,7 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
 #include <rapidjson/prettywriter.h>
+#include <Storages/Mergetree/MetaDataHelper.h>
 
 using namespace DB;
 
@@ -77,30 +78,8 @@ SparkMergeTreeWriter::writeTempPartAndFinalize(
 {
     auto temp_part = writeTempPart(block_with_partition, metadata_snapshot);
     temp_part.finalize();
-    saveFileStatus(temp_part);
+    saveFileStatus(storage, context, temp_part.part->getDataPartStorage());
     return temp_part;
-}
-
-void SparkMergeTreeWriter::saveFileStatus(const DB::MergeTreeDataWriter::TemporaryPart & temp_part) const
-{
-    auto & data_part_storage = temp_part.part->getDataPartStorage();
-
-    const DiskPtr disk = storage.getStoragePolicy()->getAnyDisk();
-    if (!disk->isRemote()) return;
-    if (auto *const disk_metadata = dynamic_cast<MetadataStorageFromDisk *>(disk->getMetadataStorage().get()))
-    {
-        const auto out = data_part_storage.writeFile("metadata.gluten", DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
-        for (const auto it = data_part_storage.iterate(); it->isValid(); it->next())
-        {
-            auto content = disk_metadata->readFileToString(it->path());
-            writeString(it->name(), *out);
-            writeChar('\t', *out);
-            writeIntText(content.length(), *out);
-            writeChar('\n', *out);
-            writeString(content, *out);
-        }
-        out->finalize();
-    }
 }
 
 MergeTreeDataWriter::TemporaryPart SparkMergeTreeWriter::writeTempPart(

--- a/cpp-ch/local-engine/Storages/Mergetree/SparkMergeTreeWriter.h
+++ b/cpp-ch/local-engine/Storages/Mergetree/SparkMergeTreeWriter.h
@@ -85,7 +85,6 @@ private:
     writeTempPart(DB::BlockWithPartition & block_with_partition, const DB::StorageMetadataPtr & metadata_snapshot);
     DB::MergeTreeDataWriter::TemporaryPart
     writeTempPartAndFinalize(DB::BlockWithPartition & block_with_partition, const DB::StorageMetadataPtr & metadata_snapshot);
-    void saveFileStatus(const DB::MergeTreeDataWriter::TemporaryPart & temp_part) const;
 
     String uuid;
     String partition_dir;


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix multiple bugs for optimizing tables on s3, including:

1. take care of metadata.gluten
2. race condition bug when two tasks are performing restoreMetadata on same executor at same time.
3. avoid creating tmp folder because it's problematic to rename on S3

(Fixes: \#5152)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

