### PR TITLE
[VL] Use collect_list aggregate function in velox

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -401,8 +401,7 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"murmur3hash", "hash_with_seed"},
     {"modulus", "remainder"},
     {"date_format", "format_datetime"},
-    {"collect_set", "set_agg"},
-    {"collect_list", "array_agg"}};
+    {"collect_set", "set_agg"}};
 
 const std::unordered_map<std::string, std::string> SubstraitParser::typeMap_ = {
     {"bool", "BOOLEAN"},

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteCollect.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteCollect.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.utils.PullOutProjectHelper
 
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, If, IsNotNull, IsNull, Literal, NamedExpression}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, CollectList, CollectSet, Complete, Final, Partial}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, CollectSet, Complete, Final, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
@@ -53,7 +53,7 @@ object RewriteCollect extends Rule[SparkPlan] with PullOutProjectHelper {
 
   private def shouldReplaceNullToEmptyArray(ae: AggregateExpression): Boolean = {
     ae.aggregateFunction match {
-      case _: CollectSet | _: CollectList =>
+      case _: CollectSet =>
         ae.mode match {
           case Final | Complete => true
           case _ => false


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/facebookincubator/velox/pull/9231 implemented a new `collect_list` aggregate function based on the semantics of Spark. Gluten can switch to use this new aggregate function without the need to rewrite the `collect_list` function in Spark.

## How was this patch tested?

Exists CI tests.

