### PR TITLE
[CH][Minor] Fix build due to Clickhouse Refactor

### DIFF
--- a/cpp-ch/local-engine/Common/GlutenSignalHandler.cpp
+++ b/cpp-ch/local-engine/Common/GlutenSignalHandler.cpp
@@ -25,14 +25,14 @@
 #include <base/phdr_cache.h>
 #include <base/sleep.h>
 #include <Poco/Exception.h>
+#include <Common/CurrentThread.h>
 #include <Common/GlutenSignalHandler.h>
 #include <Common/MemoryTracker.h>
 #include <Common/PipeFDs.h>
 #include <Common/ThreadStatus.h>
+#include <Common/config_version.h>
 #include <Common/getHashOfLoadedBinary.h>
 #include <Common/logger_useful.h>
-
-#include <Common/config_version.h>
 
 using namespace local_engine;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build due to https://github.com/ClickHouse/ClickHouse/pull/62170, which avoids public dependency on `CurrentThread.h`  and hence cause our build failed.

We can avoid https://github.com/apache/incubator-gluten/pull/5289 upgrading clickhouse backend by this PR.

## How was this patch tested?
Using existed UT
