### PR TITLE
[GLUTEN-5301] Remove unnecessary test util method 'isSparkVersionAtleast'

### DIFF
--- a/gluten-core/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
@@ -100,21 +100,6 @@ abstract class WholeStageTransformerSuite
       .set("spark.gluten.ui.enabled", "false")
   }
 
-  protected def isSparkVersionAtleast(version: String): Boolean = {
-    val currentVersion = spark.version
-    val currentVersionSplit = currentVersion.split("\\.")
-    val versionSplit = version.split("\\.")
-    currentVersionSplit.zip(versionSplit).foreach {
-      case (current, required) =>
-        if (current.toInt > required.toInt) {
-          return true
-        } else if (current.toInt < required.toInt) {
-          return false
-        }
-    }
-    true
-  }
-
   protected def checkFallbackOperators(df: DataFrame, num: Int): Unit = {
     // Decrease one VeloxColumnarToRowExec for the top level node
     assert(

--- a/gluten-delta/src/test/scala/org/apache/gluten/execution/VeloxDeltaSuite.scala
+++ b/gluten-delta/src/test/scala/org/apache/gluten/execution/VeloxDeltaSuite.scala
@@ -81,8 +81,7 @@ class VeloxDeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  test("delta: time travel") {
-    assume(isSparkVersionAtleast("3.3"))
+  testWithSpecifiedSparkVersion("delta: time travel", Some("3.3.1")) {
     withTable("delta_tm") {
       spark.sql(s"""
                    |create table delta_tm (id int, name string) using delta

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -58,8 +58,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  test("iceberg bucketed join") {
-    assume(isSparkVersionAtleast("3.4"))
+  testWithSpecifiedSparkVersion("iceberg bucketed join", Some("3.4")) {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -139,8 +138,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  test("iceberg bucketed join with partition") {
-    assume(isSparkVersionAtleast("3.4"))
+  testWithSpecifiedSparkVersion("iceberg bucketed join with partition", Some("3.4")) {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -220,8 +218,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  test("iceberg bucketed join with partition filter") {
-    assume(isSparkVersionAtleast("3.4"))
+  testWithSpecifiedSparkVersion("iceberg bucketed join with partition filter", Some("3.4")) {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`isSparkVersionAtleast` is duplicated with testWithSpecifiedSparkVersion, should remove it.

## How was this patch tested?

CI/CD

