### PR TITLE
[GLUTEN-5225][CH] Add mergetree index filter on driver

### DIFF
--- a/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/CHDatasourceJniWrapper.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/CHDatasourceJniWrapper.java
@@ -37,6 +37,8 @@ public class CHDatasourceJniWrapper {
       String partition_dir,
       String bucket_dir);
 
+  public static native String filterRangesOnDriver(byte[] plan, byte[] read);
+
   public native void write(long instanceId, long blockAddress);
 
   public native void writeToMergeTree(long instanceId, long blockAddress);

--- a/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/clickhouse/MergeTreePartFilterReturnedRange.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/clickhouse/MergeTreePartFilterReturnedRange.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.clickhouse;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MergeTreePartFilterReturnedRange {
+  @JsonProperty("part_name")
+  protected String partName;
+
+  @JsonProperty("begin")
+  protected long begin;
+
+  @JsonProperty("end")
+  protected long end;
+
+  public String getPartName() {
+    return partName;
+  }
+
+  public void setPartName(String partName) {
+    this.partName = partName;
+  }
+
+  public long getBegin() {
+    return begin;
+  }
+
+  public void setBegin(long begin) {
+    this.begin = begin;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
+  public void setEnd(long end) {
+    this.end = end;
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
@@ -23,7 +23,7 @@ import org.apache.gluten.substrait.expression.{BooleanLiteralNode, ExpressionBui
 import org.apache.gluten.utils.{CHInputPartitionsUtil, ExpressionDocUtil}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.delta.catalog.ClickHouseTableV2
 import org.apache.spark.sql.delta.files.TahoeFileIndex
@@ -49,7 +49,8 @@ class CHTransformerApi extends TransformerApi with Logging {
       bucketedScan: Boolean,
       optionalBucketSet: Option[BitSet],
       optionalNumCoalescedBuckets: Option[Int],
-      disableBucketedScan: Boolean): Seq[InputPartition] = {
+      disableBucketedScan: Boolean,
+      filterExprs: Seq[Expression]): Seq[InputPartition] = {
     relation.location match {
       case index: TahoeFileIndex
           if relation.fileFormat
@@ -64,7 +65,8 @@ class CHTransformerApi extends TransformerApi with Logging {
             bucketedScan,
             optionalBucketSet,
             optionalNumCoalescedBuckets,
-            disableBucketedScan
+            disableBucketedScan,
+            filterExprs
           )
       case _: TahoeFileIndex =>
         throw new UnsupportedOperationException("Does not support delta-parquet")

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/GlutenMergeTreePartition.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/GlutenMergeTreePartition.scala
@@ -22,6 +22,7 @@ case class MergeTreePartRange(
     name: String,
     dirName: String,
     targetNode: String,
+    bucketNum: String,
     start: Long,
     marks: Long,
     size: Long) {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/GlutenMergeTreePartition.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/GlutenMergeTreePartition.scala
@@ -18,6 +18,18 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.substrait.plan.PlanBuilder
 
+case class MergeTreePartRange(
+    name: String,
+    dirName: String,
+    targetNode: String,
+    start: Long,
+    marks: Long,
+    size: Long) {
+  override def toString: String = {
+    s"part name: $name, range: $start-${start + marks}"
+  }
+}
+
 case class MergeTreePartSplit(
     name: String,
     dirName: String,

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -297,7 +297,7 @@ class ClickHouseTableV2(
     case None => ""
   }
 
-  def orderByKey(): String = primaryKeyOption match {
+  def orderByKey(): String = orderByKeyOption match {
     case Some(keys) => keys.mkString(",")
     case None => "tuple()"
   }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -291,6 +291,36 @@ class ClickHouseTableV2(
   }
 
   cacheThis()
+
+  def primaryKey(): String = primaryKeyOption match {
+    case Some(keys) => keys.mkString(",")
+    case None => ""
+  }
+
+  def orderByKey(): String = primaryKeyOption match {
+    case Some(keys) => keys.mkString(",")
+    case None => "tuple()"
+  }
+
+  def lowCardKey(): String = lowCardKeyOption match {
+    case Some(keys) => keys.mkString(",")
+    case None => ""
+  }
+
+  def minmaxIndexKey(): String = minmaxIndexKeyOption match {
+    case Some(keys) => keys.mkString(",")
+    case None => ""
+  }
+
+  def bfIndexKey(): String = bfIndexKeyOption match {
+    case Some(keys) => keys.mkString(",")
+    case None => ""
+  }
+
+  def setIndexKey(): String = setIndexKeyOption match {
+    case Some(keys) => keys.mkString(",")
+    case None => ""
+  }
 }
 
 class TempClickHouseTableV2(
@@ -333,7 +363,8 @@ object ClickHouseTableV2 extends Logging {
       bucketedScan: Boolean,
       optionalBucketSet: Option[BitSet],
       optionalNumCoalescedBuckets: Option[Int],
-      disableBucketedScan: Boolean): Seq[InputPartition] = {
+      disableBucketedScan: Boolean,
+      filterExprs: Seq[Expression]): Seq[InputPartition] = {
     val tableV2 = ClickHouseTableV2.getTable(deltaLog)
 
     MergeTreePartsPartitionsUtil.getMergeTreePartsPartitions(
@@ -345,7 +376,8 @@ object ClickHouseTableV2 extends Logging {
       tableV2,
       optionalBucketSet,
       optionalNumCoalescedBuckets,
-      disableBucketedScan)
+      disableBucketedScan,
+      filterExprs)
 
   }
 }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -16,22 +16,38 @@
  */
 package org.apache.spark.sql.execution.datasources.utils
 
-import org.apache.gluten.execution.{GlutenMergeTreePartition, MergeTreePartSplit}
-import org.apache.gluten.expression.ConverterUtils
+import org.apache.gluten.GlutenConfig
+import org.apache.gluten.execution.{GlutenMergeTreePartition, MergeTreePartRange, MergeTreePartSplit}
+import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter}
+import org.apache.gluten.substrait.`type`.ColumnTypeNode
+import org.apache.gluten.substrait.SubstraitContext
+import org.apache.gluten.substrait.extensions.ExtensionBuilder
+import org.apache.gluten.substrait.rel.{ExtensionTableBuilder, RelBuilder}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.delta.ClickhouseSnapshot
 import org.apache.spark.sql.delta.catalog.ClickHouseTableV2
 import org.apache.spark.sql.delta.files.TahoeFileIndex
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{CHDatasourceJniWrapper, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.clickhouse.MergeTreePartFilterReturnedRange
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.AddMergeTreeParts
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.source.DeltaMergeTreeFileFormat
+import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.util.collection.BitSet
 
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.protobuf.{Any, StringValue}
+import io.substrait.proto.Plan
+
+import java.lang.{Long => JLong}
+import java.util.{ArrayList => JArrayList}
+
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 // scalastyle:off argcount
@@ -46,7 +62,8 @@ object MergeTreePartsPartitionsUtil extends Logging {
       table: ClickHouseTableV2,
       optionalBucketSet: Option[BitSet],
       optionalNumCoalescedBuckets: Option[Int],
-      disableBucketedScan: Boolean): Seq[InputPartition] = {
+      disableBucketedScan: Boolean,
+      filterExprs: Seq[Expression]): Seq[InputPartition] = {
     if (
       !relation.location.isInstanceOf[TahoeFileIndex] || !relation.fileFormat
         .isInstanceOf[DeltaMergeTreeFileFormat]
@@ -68,30 +85,6 @@ object MergeTreePartsPartitionsUtil extends Logging {
     val engine = "MergeTree"
     val relativeTablePath = fileIndex.deltaLog.dataPath.toUri.getPath.substring(1)
     val absoluteTablePath = fileIndex.deltaLog.dataPath.toUri.toString
-
-    val (orderByKey, primaryKey) =
-      MergeTreeDeltaUtil.genOrderByAndPrimaryKeyStr(table.orderByKeyOption, table.primaryKeyOption)
-
-    val lowCardKey = table.lowCardKeyOption match {
-      case Some(keys) => keys.mkString(",")
-      case None => ""
-    }
-
-    val minmaxIndexKey = table.minmaxIndexKeyOption match {
-      case Some(keys) => keys.mkString(",")
-      case None => ""
-    }
-
-    val bfIndexKey = table.bfIndexKeyOption match {
-      case Some(keys) => keys.mkString(",")
-      case None => ""
-    }
-
-    val setIndexKey = table.setIndexKeyOption match {
-      case Some(keys) => keys.mkString(",")
-      case None => ""
-    }
-
     val tableSchemaJson = ConverterUtils.convertNamedStructJson(table.schema())
 
     // bucket table
@@ -109,13 +102,9 @@ object MergeTreePartsPartitionsUtil extends Logging {
         selectedPartitions,
         tableSchemaJson,
         partitions,
-        orderByKey,
-        lowCardKey,
-        minmaxIndexKey,
-        bfIndexKey,
-        setIndexKey,
-        primaryKey,
+        table,
         table.clickhouseTableConfigs,
+        filterExprs,
         sparkSession
       )
     } else {
@@ -130,13 +119,10 @@ object MergeTreePartsPartitionsUtil extends Logging {
         selectedPartitions,
         tableSchemaJson,
         partitions,
-        orderByKey,
-        lowCardKey,
-        minmaxIndexKey,
-        bfIndexKey,
-        setIndexKey,
-        primaryKey,
+        table,
         table.clickhouseTableConfigs,
+        output,
+        filterExprs,
         sparkSession
       )
     }
@@ -154,14 +140,22 @@ object MergeTreePartsPartitionsUtil extends Logging {
       selectedPartitions: Array[PartitionDirectory],
       tableSchemaJson: String,
       partitions: ArrayBuffer[InputPartition],
-      orderByKey: String,
-      lowCardKey: String,
-      minmaxIndexKey: String,
-      bfIndexKey: String,
-      setIndexKey: String,
-      primaryKey: String,
+      table: ClickHouseTableV2,
       clickhouseTableConfigs: Map[String, String],
+      output: Seq[Attribute],
+      filterExprs: Seq[Expression],
       sparkSession: SparkSession): Unit = {
+
+    val bucketingEnabled = sparkSession.sessionState.conf.bucketingEnabled
+    val shouldProcess: String => Boolean = optionalBucketSet match {
+      case Some(bucketSet) if bucketingEnabled =>
+        name =>
+          // find bucket it in name pattern of:
+          // "partition_col=1/00001/373c9386-92a4-44ef-baaf-a67e1530b602_0_006"
+          name.split("/").dropRight(1).filterNot(_.contains("=")).map(_.toInt).forall(bucketSet.get)
+      case _ =>
+        _ => true
+    }
 
     val selectPartsFiles = selectedPartitions
       .flatMap(
@@ -186,46 +180,51 @@ object MergeTreePartsPartitionsUtil extends Logging {
               }
               ret
             }))
+      .filter(part => shouldProcess(part.name))
       .toSeq
     if (selectPartsFiles.isEmpty) {
       return
     }
 
-    val maxSplitBytes = getMaxSplitBytes(sparkSession, selectPartsFiles)
-    val total_marks = selectPartsFiles.map(p => p.marks).sum
-    val total_Bytes = selectPartsFiles.map(p => p.size).sum
-    val markCntPerPartition = maxSplitBytes * total_marks / total_Bytes + 1
+    val selectRanges: Seq[MergeTreePartRange] =
+      getMergeTreePartRange(
+        selectPartsFiles,
+        database,
+        tableName,
+        relativeTablePath,
+        absoluteTablePath,
+        tableSchemaJson,
+        table,
+        clickhouseTableConfigs,
+        filterExprs,
+        output,
+        sparkSession)
 
-    val bucketingEnabled = sparkSession.sessionState.conf.bucketingEnabled
-    val shouldProcess: String => Boolean = optionalBucketSet match {
-      case Some(bucketSet) if bucketingEnabled =>
-        name =>
-          // find bucket it in name pattern of:
-          // "partition_col=1/00001/373c9386-92a4-44ef-baaf-a67e1530b602_0_006"
-          name.split("/").dropRight(1).filterNot(_.contains("=")).map(_.toInt).forall(bucketSet.get)
-      case _ =>
-        _ => true
+    if (selectRanges.isEmpty) {
+      return
     }
 
+    val maxSplitBytes = getMaxSplitBytes(sparkSession, selectRanges)
+    val total_marks = selectRanges.map(p => p.marks).sum
+    val total_Bytes = selectRanges.map(p => p.size).sum
+    // maxSplitBytes / (total_Bytes / total_marks) + 1
+    val markCntPerPartition = maxSplitBytes * total_marks / total_Bytes + 1
+
     logInfo(s"Planning scan with bin packing, max mark: $markCntPerPartition")
-    val splitFiles = selectPartsFiles
+    val splitFiles = selectRanges
       .flatMap {
         part =>
-          if (shouldProcess(part.name)) {
-            (0L until part.marks by markCntPerPartition).map {
-              offset =>
-                val remaining = part.marks - offset
-                val size = if (remaining > markCntPerPartition) markCntPerPartition else remaining
-                MergeTreePartSplit(
-                  part.name,
-                  part.dirName,
-                  part.targetNode,
-                  offset,
-                  size,
-                  size * part.size / part.marks)
-            }
-          } else {
-            None
+          (part.start until part.marks by markCntPerPartition).map {
+            offset =>
+              val remaining = part.marks - offset
+              val size = if (remaining > markCntPerPartition) markCntPerPartition else remaining
+              MergeTreePartSplit(
+                part.name,
+                part.dirName,
+                part.targetNode,
+                offset,
+                size,
+                size * part.size / part.marks)
           }
       }
 
@@ -243,12 +242,12 @@ object MergeTreePartsPartitionsUtil extends Logging {
           snapshotId,
           relativeTablePath,
           absoluteTablePath,
-          orderByKey,
-          lowCardKey,
-          minmaxIndexKey,
-          bfIndexKey,
-          setIndexKey,
-          primaryKey,
+          table.orderByKey(),
+          table.lowCardKey(),
+          table.minmaxIndexKey(),
+          table.bfIndexKey(),
+          table.setIndexKey(),
+          table.primaryKey(),
           currentFiles.toArray,
           tableSchemaJson,
           clickhouseTableConfigs
@@ -289,13 +288,9 @@ object MergeTreePartsPartitionsUtil extends Logging {
       selectedPartitions: Array[PartitionDirectory],
       tableSchemaJson: String,
       partitions: ArrayBuffer[InputPartition],
-      orderByKey: String,
-      lowCardKey: String,
-      minmaxIndexKey: String,
-      bfIndexKey: String,
-      setIndexKey: String,
-      primaryKey: String,
+      table: ClickHouseTableV2,
       clickhouseTableConfigs: Map[String, String],
+      filterExprs: Seq[Expression],
       sparkSession: SparkSession): Unit = {
 
     val selectPartsFiles = selectedPartitions
@@ -355,12 +350,12 @@ object MergeTreePartsPartitionsUtil extends Logging {
             snapshotId,
             relativeTablePath,
             absoluteTablePath,
-            orderByKey,
-            lowCardKey,
-            minmaxIndexKey,
-            bfIndexKey,
-            setIndexKey,
-            primaryKey,
+            table.orderByKey(),
+            table.lowCardKey(),
+            table.minmaxIndexKey(),
+            table.bfIndexKey(),
+            table.setIndexKey(),
+            table.primaryKey(),
             currentFiles.toArray,
             tableSchemaJson,
             clickhouseTableConfigs
@@ -370,12 +365,139 @@ object MergeTreePartsPartitionsUtil extends Logging {
     }
   }
 
-  def getMaxSplitBytes(sparkSession: SparkSession, selectedParts: Seq[AddMergeTreeParts]): Long = {
+  def getMergeTreePartRange(
+      selectPartsFiles: Seq[AddMergeTreeParts],
+      database: String,
+      tableName: String,
+      relativeTablePath: String,
+      absoluteTablePath: String,
+      tableSchemaJson: String,
+      table: ClickHouseTableV2,
+      clickhouseTableConfigs: Map[String, String],
+      filterExprs: Seq[Expression],
+      output: Seq[Attribute],
+      sparkSession: SparkSession): Seq[MergeTreePartRange] = {
+    if (
+      filterExprs.nonEmpty && sparkSession.sessionState.conf.getConf(
+        GlutenConfig.COLUMNAR_CH_NATIVE_ENABLE_DRIVER_FILTER_INDEX,
+        false)
+    ) {
+      val size_per_mark = selectPartsFiles.map(part => (part.size, part.marks)).unzip match {
+        case (l1, l2) => l1.sum / l2.sum
+      }
+
+      val partLists = new JArrayList[String]()
+      val starts = new JArrayList[JLong]()
+      val lengths = new JArrayList[JLong]()
+      selectPartsFiles.foreach(
+        part => {
+          partLists.add(part.name)
+          starts.add(0)
+          lengths.add(part.marks)
+        })
+
+      val extensionTableNode = ExtensionTableBuilder
+        .makeExtensionTable(
+          -1L,
+          -1L,
+          database,
+          tableName,
+          relativeTablePath,
+          absoluteTablePath,
+          table.orderByKey(),
+          table.lowCardKey(),
+          table.minmaxIndexKey(),
+          table.bfIndexKey(),
+          table.setIndexKey(),
+          table.primaryKey(),
+          partLists,
+          starts,
+          lengths,
+          tableSchemaJson,
+          clickhouseTableConfigs.asJava,
+          new JArrayList[String]()
+        )
+
+      val transformer = filterExprs
+        .map {
+          case ar: AttributeReference if ar.dataType == BooleanType =>
+            EqualNullSafe(ar, Literal.TrueLiteral)
+          case e => e
+        }
+        .reduceLeftOption(And)
+        .map(ExpressionConverter.replaceWithExpressionTransformer(_, output))
+
+      val typeNodes = ConverterUtils.collectAttributeTypeNodes(output)
+      val nameList = ConverterUtils.collectAttributeNamesWithoutExprId(output)
+      val columnTypeNodes = output.map {
+        attr =>
+          if (table.partitionColumns.exists(_.equals(attr.name))) {
+            new ColumnTypeNode(1)
+          } else {
+            new ColumnTypeNode(0)
+          }
+      }.asJava
+      val substraitContext = new SubstraitContext
+      val enhancement =
+        Any.pack(StringValue.newBuilder.setValue(extensionTableNode.getExtensionTableStr).build)
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(enhancement)
+      val readNode = RelBuilder.makeReadRel(
+        typeNodes,
+        nameList,
+        columnTypeNodes,
+        transformer.map(_.doTransform(substraitContext.registeredFunction)).orNull,
+        extensionNode,
+        substraitContext,
+        substraitContext.nextOperatorId("readRel")
+      )
+
+      val planBuilder = Plan.newBuilder
+      substraitContext.registeredFunction.forEach(
+        (k, v) => planBuilder.addExtensions(ExtensionBuilder.makeFunctionMapping(k, v).toProtobuf))
+
+      val filter_ranges = CHDatasourceJniWrapper.filterRangesOnDriver(
+        planBuilder.build().toByteArray,
+        readNode.toProtobuf.toByteArray
+      )
+
+      val mapper: ObjectMapper = new ObjectMapper()
+      val values: JArrayList[MergeTreePartFilterReturnedRange] =
+        mapper.readValue(
+          filter_ranges,
+          new TypeReference[JArrayList[MergeTreePartFilterReturnedRange]]() {})
+
+      val partMap = selectPartsFiles.map(part => (part.name, part)).toMap
+      values.asScala
+        .map(
+          range => {
+            val part = partMap.get(range.getPartName).orNull
+            val marks = range.getEnd - range.getBegin
+            MergeTreePartRange(
+              part.name,
+              part.dirName,
+              part.targetNode,
+              range.getBegin,
+              range.getEnd,
+              marks * size_per_mark)
+          })
+        .toSeq
+    } else {
+      selectPartsFiles
+        .map(
+          part =>
+            MergeTreePartRange(part.name, part.dirName, part.targetNode, 0, part.marks, part.size))
+        .toSeq
+    }
+  }
+
+  def getMaxSplitBytes(
+      sparkSession: SparkSession,
+      selectedRanges: Seq[MergeTreePartRange]): Long = {
     val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
     val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
     val minPartitionNum = sparkSession.sessionState.conf.filesMinPartitionNum
       .getOrElse(sparkSession.leafNodeDefaultParallelism)
-    val totalBytes = selectedParts.map(_.size + openCostInBytes).sum
+    val totalBytes = selectedRanges.map(_.size + openCostInBytes).sum
     val bytesPerCore = totalBytes / minPartitionNum
 
     Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -189,6 +189,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
     val selectRanges: Seq[MergeTreePartRange] =
       getMergeTreePartRange(
         selectPartsFiles,
+        snapshotId,
         database,
         tableName,
         relativeTablePath,
@@ -198,7 +199,8 @@ object MergeTreePartsPartitionsUtil extends Logging {
         clickhouseTableConfigs,
         filterExprs,
         output,
-        sparkSession)
+        sparkSession
+      )
 
     if (selectRanges.isEmpty) {
       return
@@ -367,6 +369,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
 
   def getMergeTreePartRange(
       selectPartsFiles: Seq[AddMergeTreeParts],
+      snapshotId: String,
       database: String,
       tableName: String,
       relativeTablePath: String,
@@ -402,6 +405,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
           -1L,
           database,
           tableName,
+          snapshotId,
           relativeTablePath,
           absoluteTablePath,
           table.orderByKey(),

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -385,7 +385,8 @@ object MergeTreePartsPartitionsUtil extends Logging {
 
     if (
       filterExprs.nonEmpty && sparkSession.sessionState.conf.getConfString(
-        enableDriverFilter) == "true"
+        enableDriverFilter,
+        "false") == "true"
     ) {
       val size_per_mark = selectPartsFiles.map(part => (part.size, part.marks)).unzip match {
         case (l1, l2) => l1.sum / l2.sum

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -365,7 +365,13 @@ object MergeTreePartsPartitionsUtil extends Logging {
         if (!currBucketParts.isEmpty) {
           val currentFiles = currBucketParts.map {
             part =>
-              MergeTreePartSplit(part.name, part.dirName, part.targetNode, part.start, part.marks, part.size)
+              MergeTreePartSplit(
+                part.name,
+                part.dirName,
+                part.targetNode,
+                part.start,
+                part.marks,
+                part.size)
           }
           val newPartition = GlutenMergeTreePartition(
             partitions.size,
@@ -523,8 +529,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
               part.bucketNum,
               0,
               part.marks,
-              part.size)
-        )
+              part.size))
         .toSeq
     }
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -1924,7 +1924,8 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | l_comment       string
                  |)
                  |USING clickhouse
-                 |CLUSTERED by (l_orderkey) SORTED by  (l_receiptdate) INTO 2 BUCKETS
+                 |CLUSTERED by (l_orderkey)
+                 |${if (sparkVersion.equals("3.2")) "" else "SORTED BY (l_receiptdate)"} INTO 2 BUCKETS
                  |LOCATION '$basePath/lineitem_mergetree_pk_pruning_by_driver_bucket'
                  |""".stripMargin)
 
@@ -1940,7 +1941,8 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | o_shippriority  bigint,
                  | o_comment       string)
                  |USING clickhouse
-                 |CLUSTERED by (o_orderkey) SORTED by  (o_orderdate) INTO 2 BUCKETS
+                 |CLUSTERED by (o_orderkey)
+                 |${if (sparkVersion.equals("3.2")) "" else "SORTED BY (o_orderdate)"} INTO 2 BUCKETS
                  |LOCATION '$basePath/orders_mergetree_pk_pruning_by_driver_bucket'
                  |""".stripMargin)
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
 
-import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.delta.catalog.ClickHouseTableV2
 import org.apache.spark.sql.delta.files.TahoeFileIndex
@@ -28,6 +28,7 @@ import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.AddMerg
 import org.apache.commons.io.filefilter.WildcardFileFilter
 
 import java.io.File
+
 import scala.io.Source
 
 // Some sqls' line length exceeds 100
@@ -1739,43 +1740,40 @@ class GlutenClickHouseMergeTreeWriteSuite
   }
 
   test("test mergetree with primary keys filter pruning by driver") {
-    spark.sql(
-      s"""
-         |DROP TABLE IF EXISTS lineitem_mergetree_pk_pruning_by_driver;
-         |""".stripMargin)
+    spark.sql(s"""
+                 |DROP TABLE IF EXISTS lineitem_mergetree_pk_pruning_by_driver;
+                 |""".stripMargin)
 
-    spark.sql(
-      s"""
-         |CREATE TABLE IF NOT EXISTS lineitem_mergetree_pk_pruning_by_driver
-         |(
-         | l_orderkey      bigint,
-         | l_partkey       bigint,
-         | l_suppkey       bigint,
-         | l_linenumber    bigint,
-         | l_quantity      double,
-         | l_extendedprice double,
-         | l_discount      double,
-         | l_tax           double,
-         | l_returnflag    string,
-         | l_linestatus    string,
-         | l_shipdate      date,
-         | l_commitdate    date,
-         | l_receiptdate   date,
-         | l_shipinstruct  string,
-         | l_shipmode      string,
-         | l_comment       string
-         |)
-         |USING clickhouse
-         |TBLPROPERTIES (orderByKey='l_shipdate,l_orderkey',
-         |               primaryKey='l_shipdate')
-         |LOCATION '$basePath/lineitem_mergetree_pk_pruning_by_driver'
-         |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE IF NOT EXISTS lineitem_mergetree_pk_pruning_by_driver
+                 |(
+                 | l_orderkey      bigint,
+                 | l_partkey       bigint,
+                 | l_suppkey       bigint,
+                 | l_linenumber    bigint,
+                 | l_quantity      double,
+                 | l_extendedprice double,
+                 | l_discount      double,
+                 | l_tax           double,
+                 | l_returnflag    string,
+                 | l_linestatus    string,
+                 | l_shipdate      date,
+                 | l_commitdate    date,
+                 | l_receiptdate   date,
+                 | l_shipinstruct  string,
+                 | l_shipmode      string,
+                 | l_comment       string
+                 |)
+                 |USING clickhouse
+                 |TBLPROPERTIES (orderByKey='l_shipdate,l_orderkey',
+                 |               primaryKey='l_shipdate')
+                 |LOCATION '$basePath/lineitem_mergetree_pk_pruning_by_driver'
+                 |""".stripMargin)
 
-    spark.sql(
-      s"""
-         | insert into table lineitem_mergetree_pk_pruning_by_driver
-         | select * from lineitem
-         |""".stripMargin)
+    spark.sql(s"""
+                 | insert into table lineitem_mergetree_pk_pruning_by_driver
+                 | select * from lineitem
+                 |""".stripMargin)
 
     val sqlStr =
       s"""

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -1903,31 +1903,32 @@ class GlutenClickHouseMergeTreeWriteSuite
                  |DROP TABLE IF EXISTS orders_mergetree_pk_pruning_by_driver_bucket;
                  |""".stripMargin)
 
-    spark.sql(s"""
-                 |CREATE TABLE IF NOT EXISTS lineitem_mergetree_pk_pruning_by_driver_bucket
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
-                 |USING clickhouse
-                 |CLUSTERED by (l_orderkey)
-                 |${if (sparkVersion.equals("3.2")) "" else "SORTED BY (l_receiptdate)"} INTO 2 BUCKETS
-                 |LOCATION '$basePath/lineitem_mergetree_pk_pruning_by_driver_bucket'
-                 |""".stripMargin)
+    spark.sql(
+      s"""
+         |CREATE TABLE IF NOT EXISTS lineitem_mergetree_pk_pruning_by_driver_bucket
+         |(
+         | l_orderkey      bigint,
+         | l_partkey       bigint,
+         | l_suppkey       bigint,
+         | l_linenumber    bigint,
+         | l_quantity      double,
+         | l_extendedprice double,
+         | l_discount      double,
+         | l_tax           double,
+         | l_returnflag    string,
+         | l_linestatus    string,
+         | l_shipdate      date,
+         | l_commitdate    date,
+         | l_receiptdate   date,
+         | l_shipinstruct  string,
+         | l_shipmode      string,
+         | l_comment       string
+         |)
+         |USING clickhouse
+         |CLUSTERED by (l_orderkey)
+         |${if (sparkVersion.equals("3.2")) "" else "SORTED BY (l_receiptdate)"} INTO 2 BUCKETS
+         |LOCATION '$basePath/lineitem_mergetree_pk_pruning_by_driver_bucket'
+         |""".stripMargin)
 
     spark.sql(s"""
                  |CREATE TABLE IF NOT EXISTS orders_mergetree_pk_pruning_by_driver_bucket (

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.GlutenConfig
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.delta.catalog.ClickHouseTableV2
@@ -1790,7 +1788,8 @@ class GlutenClickHouseMergeTreeWriteSuite
 
     Seq(("true", 2), ("false", 3)).foreach(
       conf => {
-        withSQLConf((GlutenConfig.COLUMNAR_CH_NATIVE_ENABLE_DRIVER_FILTER_INDEX.key -> conf._1)) {
+        withSQLConf(
+          ("spark.gluten.sql.columnar.backend.ch.runtime_settings.enabled_driver_filter_mergetree_index" -> conf._1)) {
           runTPCHQueryBySQL(6, sqlStr) {
             df =>
               val scanExec = collect(df.queryExecution.executedPlan) {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/TransformerApiImpl.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/TransformerApiImpl.scala
@@ -23,7 +23,7 @@ import org.apache.gluten.utils.InputPartitionsUtil
 import org.apache.gluten.vectorized.PlanEvaluatorJniWrapper
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.types._
@@ -44,7 +44,8 @@ class TransformerApiImpl extends TransformerApi with Logging {
       bucketedScan: Boolean,
       optionalBucketSet: Option[BitSet],
       optionalNumCoalescedBuckets: Option[Int],
-      disableBucketedScan: Boolean): Seq[InputPartition] = {
+      disableBucketedScan: Boolean,
+      filterExprs: Seq[Expression] = Seq.empty): Seq[InputPartition] = {
     InputPartitionsUtil(
       relation,
       selectedPartitions,

--- a/cpp-ch/local-engine/Common/MergeTreeTool.cpp
+++ b/cpp-ch/local-engine/Common/MergeTreeTool.cpp
@@ -226,6 +226,7 @@ RangesInDataParts MergeTreeTable::extractRange(DataPartsVector parts_vector) con
             ranges_in_data_part.data_part = name_index.at(part.name);
             ranges_in_data_part.part_index_in_query = 0;
             ranges_in_data_part.ranges.emplace_back(MarkRange(part.begin, part.end));
+            ranges_in_data_part.alter_conversions = std::make_shared<AlterConversions>();
             return ranges_in_data_part;
         });
     return ranges_in_data_parts;

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -68,12 +68,9 @@ CustomStorageMergeTreePtr MergeTreeRelParser::parseStorage(
     return parseMergeTreeTableString(table.value());
 }
 
-CustomStorageMergeTreePtr
-MergeTreeRelParser::parseStorage(const MergeTreeTable & merge_tree_table, ContextMutablePtr context, UUID uuid)
+CustomStorageMergeTreePtr MergeTreeRelParser::parseStorage(const MergeTreeTable & merge_tree_table, ContextMutablePtr context, UUID uuid)
 {
-    DB::Block header = TypeParser::buildBlockFromNamedStruct(
-            merge_tree_table.schema,
-            merge_tree_table.low_card_key);
+    DB::Block header = TypeParser::buildBlockFromNamedStruct(merge_tree_table.schema, merge_tree_table.low_card_key);
     auto names_and_types_list = header.getNamesAndTypesList();
     auto storage_factory = StorageMergeTreeFactory::instance();
     auto metadata = buildMetaData(names_and_types_list, context, merge_tree_table);
@@ -131,11 +128,8 @@ MergeTreeRelParser::parseStorage(const substrait::ReadRel::ExtensionTable & exte
     return parseStorage(merge_tree_table, context, uuid);
 }
 
-DB::QueryPlanPtr
-MergeTreeRelParser::parseReadRel(
-    DB::QueryPlanPtr query_plan,
-    const substrait::ReadRel & rel,
-    const substrait::ReadRel::ExtensionTable & extension_table)
+DB::QueryPlanPtr MergeTreeRelParser::parseReadRel(
+    DB::QueryPlanPtr query_plan, const substrait::ReadRel & rel, const substrait::ReadRel::ExtensionTable & extension_table)
 {
     auto merge_tree_table = parseMergeTreeTable(extension_table);
     DB::Block header = TypeParser::buildBlockFromNamedStruct(merge_tree_table.schema, merge_tree_table.low_card_key);
@@ -301,10 +295,7 @@ void MergeTreeRelParser::parseToAction(ActionsDAGPtr & filter_action, const subs
 }
 
 void MergeTreeRelParser::analyzeExpressions(
-    Conditions & res,
-    const substrait::Expression & rel,
-    std::set<Int64> & pk_positions,
-    Block & block)
+    Conditions & res, const substrait::Expression & rel, std::set<Int64> & pk_positions, Block & block)
 {
     if (rel.has_scalar_function() && getCHFunctionName(rel.scalar_function()) == "and")
     {
@@ -436,7 +427,7 @@ String MergeTreeRelParser::filterRangesOnDriver(const substrait::ReadRel & read_
         = storage_factory.getDataParts(StorageID(merge_tree_table.database, merge_tree_table.table), merge_tree_table.getPartNames());
 
     auto metadata = buildMetaData(input.getNamesAndTypesList(), context, merge_tree_table);
-    auto storage_snapshot = std::make_shared<StorageSnapshot>(*custom_storage_mergetree, metadata);;
+    auto storage_snapshot = std::make_shared<StorageSnapshot>(*custom_storage_mergetree, metadata);
 
     if (selected_parts.empty())
         throw Exception(ErrorCodes::NO_SUCH_DATA_PART, "no data part found.");

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -59,9 +59,7 @@ static Int64 findMinPosition(const NameSet & condition_table_columns, const Name
     return min_position;
 }
 
-CustomStorageMergeTreePtr MergeTreeRelParser::parseStorage(
-    const substrait::ReadRel::ExtensionTable & extension_table,
-    UUID uuid)
+MergeTreeTable MergeTreeRelParser::parseMergeTreeTable(const substrait::ReadRel::ExtensionTable & extension_table)
 {
     google::protobuf::StringValue table;
     table.ParseFromString(extension_table.detail().value());
@@ -424,7 +422,7 @@ String MergeTreeRelParser::filterRangesOnDriver(const substrait::ReadRel & read_
 
     auto storage_factory = StorageMergeTreeFactory::instance();
     std::vector<DataPartPtr> selected_parts
-        = storage_factory.getDataParts(StorageID(merge_tree_table.database, merge_tree_table.table), merge_tree_table.getPartNames());
+        = storage_factory.getDataParts(StorageID(merge_tree_table.database, merge_tree_table.table), merge_tree_table.snapshot_id, merge_tree_table.getPartNames());
 
     auto metadata = buildMetaData(input.getNamesAndTypesList(), context, merge_tree_table);
     auto storage_snapshot = std::make_shared<StorageSnapshot>(*custom_storage_mergetree, metadata);

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -443,7 +443,7 @@ String MergeTreeRelParser::filterRangesOnDriver(const substrait::ReadRel & read_
         *query_info,
         context,
         context->getSettingsRef().max_block_size,
-        1);
+        10); // TODO: Expect use driver cores.
 
     auto * read_from_mergetree = static_cast<ReadFromMergeTree *>(read_step.get());
     if (const auto & storage_prewhere_info = query_info->prewhere_info)

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -429,9 +429,7 @@ String MergeTreeRelParser::filterRangesOnDriver(const substrait::ReadRel & read_
     std::vector<DataPartPtr> selected_parts
         = storage_factory.getDataParts(StorageID(merge_tree_table.database, merge_tree_table.table), merge_tree_table.snapshot_id, merge_tree_table.getPartNames());
 
-    auto metadata = buildMetaData(input.getNamesAndTypesList(), context, merge_tree_table);
-    auto storage_snapshot = std::make_shared<StorageSnapshot>(*custom_storage_mergetree, metadata);
-
+    auto storage_snapshot = std::make_shared<StorageSnapshot>(*custom_storage_mergetree, custom_storage_mergetree->getInMemoryMetadataPtr());
     if (selected_parts.empty())
         throw Exception(ErrorCodes::NO_SUCH_DATA_PART, "no data part found.");
     auto read_step = custom_storage_mergetree->reader.readFromParts(

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
@@ -19,8 +19,11 @@
 #include <memory>
 #include <substrait/algebra.pb.h>
 
+#include <Common/MergeTreeTool.h>
 #include <Parser/RelParser.h>
 #include <Parser/SerializedPlanParser.h>
+#include <Storages/StorageMergeTreeFactory.h>
+
 
 namespace DB
 {
@@ -37,15 +40,16 @@ using namespace DB;
 class MergeTreeRelParser : public RelParser
 {
 public:
-    static std::shared_ptr<CustomStorageMergeTree> parseStorage(
-        const substrait::ReadRel::ExtensionTable & extension_table,
-        ContextMutablePtr context,
-        UUID uuid = UUIDHelpers::Nil
-        );
+    static CustomStorageMergeTreePtr
+    parseStorage(const substrait::ReadRel::ExtensionTable & extension_table, ContextMutablePtr context, UUID uuid = UUIDHelpers::Nil);
+    static CustomStorageMergeTreePtr
+    parseStorage(const MergeTreeTable & merge_tree_table, ContextMutablePtr context, UUID uuid = UUIDHelpers::Nil);
+
+    static MergeTreeTable parseMergeTreeTable(const substrait::ReadRel::ExtensionTable & extension_table);
 
     explicit MergeTreeRelParser(
-        SerializedPlanParser * plan_paser_, ContextPtr & context_, QueryContext & query_context_, ContextMutablePtr & global_context_)
-        : RelParser(plan_paser_), context(context_), query_context(query_context_), global_context(global_context_)
+        SerializedPlanParser * plan_paser_, const ContextPtr & context_)
+        : RelParser(plan_paser_), context(context_), global_context(plan_paser_->global_context)
     {
     }
 
@@ -61,13 +65,14 @@ public:
     parseReadRel(
         DB::QueryPlanPtr query_plan,
         const substrait::ReadRel & read_rel,
-        const substrait::ReadRel::ExtensionTable & extension_table,
-        std::list<const substrait::Rel *> & rel_stack_);
+        const substrait::ReadRel::ExtensionTable & extension_table);
 
     const substrait::Rel & getSingleInput(const substrait::Rel &) override
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call getSingleInput().");
     }
+
+    String filterRangesOnDriver(const substrait::ReadRel & read_rel);
 
     struct Condition
     {
@@ -98,8 +103,7 @@ private:
     void collectColumns(const substrait::Expression & rel, NameSet & columns, Block & block);
     UInt64 getColumnsSize(const NameSet & columns);
 
-    ContextPtr & context;
-    QueryContext & query_context;
+    const ContextPtr & context;
     ContextMutablePtr & global_context;
 };
 

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
@@ -19,10 +19,10 @@
 #include <memory>
 #include <substrait/algebra.pb.h>
 
-#include <Common/MergeTreeTool.h>
 #include <Parser/RelParser.h>
 #include <Parser/SerializedPlanParser.h>
 #include <Storages/StorageMergeTreeFactory.h>
+#include <Common/MergeTreeTool.h>
 
 
 namespace DB
@@ -47,25 +47,20 @@ public:
 
     static MergeTreeTable parseMergeTreeTable(const substrait::ReadRel::ExtensionTable & extension_table);
 
-    explicit MergeTreeRelParser(
-        SerializedPlanParser * plan_paser_, const ContextPtr & context_)
+    explicit MergeTreeRelParser(SerializedPlanParser * plan_paser_, const ContextPtr & context_)
         : RelParser(plan_paser_), context(context_), global_context(plan_paser_->global_context)
     {
     }
 
     ~MergeTreeRelParser() override = default;
 
-    DB::QueryPlanPtr
-    parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_) override
+    DB::QueryPlanPtr parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_) override
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call parse(), call parseReadRel instead.");
     }
 
-    DB::QueryPlanPtr
-    parseReadRel(
-        DB::QueryPlanPtr query_plan,
-        const substrait::ReadRel & read_rel,
-        const substrait::ReadRel::ExtensionTable & extension_table);
+    DB::QueryPlanPtr parseReadRel(
+        DB::QueryPlanPtr query_plan, const substrait::ReadRel & read_rel, const substrait::ReadRel::ExtensionTable & extension_table);
 
     const substrait::Rel & getSingleInput(const substrait::Rel &) override
     {

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -335,36 +335,6 @@ IQueryPlanStep * SerializedPlanParser::addRemoveNullableStep(QueryPlan & plan, c
     return step_ptr;
 }
 
-PrewhereInfoPtr SerializedPlanParser::parsePreWhereInfo(const substrait::Expression & rel, Block & input)
-{
-    auto prewhere_info = std::make_shared<PrewhereInfo>();
-    prewhere_info->prewhere_actions = std::make_shared<ActionsDAG>(input.getNamesAndTypesList());
-    std::string filter_name;
-    // for in function
-    if (rel.has_singular_or_list())
-    {
-        const auto * in_node = parseExpression(prewhere_info->prewhere_actions, rel);
-        prewhere_info->prewhere_actions->addOrReplaceInOutputs(*in_node);
-        filter_name = in_node->result_name;
-    }
-    else
-    {
-        parseFunctionWithDAG(rel, filter_name, prewhere_info->prewhere_actions, true);
-    }
-    prewhere_info->prewhere_column_name = filter_name;
-    prewhere_info->need_filter = true;
-    prewhere_info->remove_prewhere_column = true;
-    auto cols = prewhere_info->prewhere_actions->getRequiredColumnsNames();
-    // Keep it the same as the input.
-    prewhere_info->prewhere_actions->removeUnusedActions(Names{filter_name}, false, true);
-    prewhere_info->prewhere_actions->projectInput(false);
-    for (const auto & name : input.getNames())
-    {
-        prewhere_info->prewhere_actions->tryRestoreColumn(name);
-    }
-    return prewhere_info;
-}
-
 DataTypePtr wrapNullableType(substrait::Type_Nullability nullable, DataTypePtr nested_type)
 {
     return wrapNullableType(nullable == substrait::Type_Nullability_NULLABILITY_NULLABLE, nested_type);

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -504,9 +504,8 @@ QueryPlanPtr SerializedPlanParser::parseOp(const substrait::Rel & rel, std::list
                 else
                     extension_table = parseExtensionTable(split_infos.at(nextSplitInfoIndex()));
 
-                MergeTreeRelParser mergeTreeParser(this, context, query_context, global_context);
-                std::list<const substrait::Rel *> stack;
-                query_plan = mergeTreeParser.parseReadRel(std::make_unique<QueryPlan>(), read, extension_table, stack);
+                MergeTreeRelParser mergeTreeParser(this, context);
+                query_plan = mergeTreeParser.parseReadRel(std::make_unique<QueryPlan>(), read, extension_table);
                 steps = mergeTreeParser.getSteps();
             }
             break;
@@ -2226,9 +2225,8 @@ Block & LocalExecutor::getHeader()
     return header;
 }
 
-LocalExecutor::LocalExecutor(QueryContext & _query_context, ContextPtr context_)
-    : query_context(_query_context)
-    , context(context_)
+LocalExecutor::LocalExecutor(ContextPtr context_)
+    : context(context_)
 {
 }
 

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -273,7 +273,6 @@ public:
 
     DB::QueryPlanStepPtr parseReadRealWithLocalFile(const substrait::ReadRel & rel);
     DB::QueryPlanStepPtr parseReadRealWithJavaIter(const substrait::ReadRel & rel);
-    PrewhereInfoPtr parsePreWhereInfo(const substrait::Expression & rel, Block & input);
 
     static bool isReadRelFromJava(const substrait::ReadRel & rel);
     static bool isReadFromMergeTree(const substrait::ReadRel & rel);

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -213,13 +213,6 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS
 
 static const std::set<std::string> FUNCTION_NEED_KEEP_ARGUMENTS = {"alias"};
 
-struct QueryContext
-{
-    StorageSnapshotPtr storage_snapshot;
-    std::shared_ptr<const DB::StorageInMemoryMetadata> metadata;
-    std::shared_ptr<CustomStorageMergeTree> custom_storage_merge_tree;
-};
-
 DataTypePtr wrapNullableType(substrait::Type_Nullability nullable, DataTypePtr nested_type);
 DataTypePtr wrapNullableType(bool nullable, DataTypePtr nested_type);
 
@@ -286,15 +279,16 @@ public:
         materialize_inputs.emplace_back(materialize_input);
     }
 
-    void addSplitInfo(std::string & split_info)
-    {
-        split_infos.emplace_back(std::move(split_info));
-    }
+    void addSplitInfo(std::string & split_info) { split_infos.emplace_back(std::move(split_info)); }
 
     int nextSplitInfoIndex()
     {
         if (split_info_index >= split_infos.size())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "split info index out of range, split_info_index: {}, split_infos.size(): {}", split_info_index, split_infos.size());
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "split info index out of range, split_info_index: {}, split_infos.size(): {}",
+                split_info_index,
+                split_infos.size());
         return split_info_index++;
     }
 
@@ -313,7 +307,6 @@ public:
     static ContextMutablePtr global_context;
     static Context::ConfigurationPtr config;
     static SharedContextHolder shared_context;
-    QueryContext query_context;
     std::vector<QueryPlanPtr> extra_plan_holder;
 
 private:
@@ -412,7 +405,7 @@ class LocalExecutor : public BlockIterator
 {
 public:
     LocalExecutor() = default;
-    explicit LocalExecutor(QueryContext & _query_context, ContextPtr context);
+    explicit LocalExecutor(ContextPtr context);
     void execute(QueryPlanPtr query_plan);
     SparkRowInfoPtr next();
     Block * nextColumnar();
@@ -427,7 +420,6 @@ public:
     void setExtraPlanHolder(std::vector<QueryPlanPtr> & extra_plan_holder_) { extra_plan_holder = std::move(extra_plan_holder_); }
 
 private:
-    QueryContext query_context;
     std::unique_ptr<SparkRowInfo> writeBlockToSparkRow(DB::Block & block);
     QueryPipeline query_pipeline;
     std::unique_ptr<PullingPipelineExecutor> executor;

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.cpp
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.cpp
@@ -32,6 +32,55 @@ extern const int DUPLICATE_DATA_PART;
 namespace local_engine
 {
 
+
+void CustomStorageMergeTree::analysisPartsByRanges(DB::ReadFromMergeTree & source, DB::RangesInDataParts ranges_in_data_parts)
+{
+    ReadFromMergeTree::AnalysisResult result;
+    result.column_names_to_read = source.getAllColumnNames();
+    /// If there are only virtual columns in the query, you must request at least one non-virtual one.
+    if (result.column_names_to_read.empty())
+    {
+        NamesAndTypesList available_real_columns = source.getStorageMetadata()->getColumns().getAllPhysical();
+        result.column_names_to_read.push_back(ExpressionActions::getSmallestColumn(available_real_columns).name);
+    }
+
+    result.sampling = MergeTreeDataSelectSamplingData();
+    result.parts_with_ranges = ranges_in_data_parts;
+
+    size_t sum_marks = 0;
+    size_t sum_ranges = 0;
+    size_t sum_rows = 0;
+    size_t total_marks_pk = 0;
+    size_t sum_marks_pk = 0;
+
+    for (const auto & part : result.parts_with_ranges)
+    {
+        sum_ranges += part.ranges.size();
+        sum_marks += part.getMarksCount();
+        sum_rows += part.getRowsCount();
+        total_marks_pk += part.data_part->index_granularity.getMarksCountWithoutFinal();
+
+        for (auto range : part.ranges)
+            sum_marks_pk += range.getNumberOfMarks();
+    }
+
+    result.total_parts = ranges_in_data_parts.size();
+    result.parts_before_pk = ranges_in_data_parts.size();
+    result.selected_parts = ranges_in_data_parts.size();
+    result.selected_ranges = sum_ranges;
+    result.selected_marks = sum_marks;
+    result.selected_marks_pk = sum_marks_pk;
+    result.total_marks_pk = total_marks_pk;
+    result.selected_rows = sum_rows;
+
+    if (source.getQueryInfo().input_order_info)
+        result.read_type = (source.getQueryInfo().input_order_info->direction > 0)
+            ? MergeTreeReadType::InOrder
+            : MergeTreeReadType::InReverseOrder;
+
+    source.setAnalyzedResult(std::make_shared<ReadFromMergeTree::AnalysisResult>(std::move(result)));
+}
+
 void CustomStorageMergeTree::wrapRangesInDataParts(DB::ReadFromMergeTree & source, DB::RangesInDataParts ranges)
 {
     auto result = source.getAnalysisResult();

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
@@ -38,6 +38,7 @@ class CustomStorageMergeTree final : public MergeTreeData
 
 public:
     static void wrapRangesInDataParts(DB::ReadFromMergeTree & source, DB::RangesInDataParts ranges);
+    void analysisPartsByRanges(DB::ReadFromMergeTree & source, DB::RangesInDataParts ranges_in_data_parts);
     CustomStorageMergeTree(
         const StorageID & table_id_,
         const String & relative_data_path_,

--- a/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.h
+++ b/cpp-ch/local-engine/Storages/Mergetree/MetaDataHelper.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <Common/MergeTreeTool.h>
 #include <Storages/StorageMergeTreeFactory.h>
+#include <Common/MergeTreeTool.h>
 
 namespace local_engine
 {
@@ -31,4 +31,3 @@ void saveFileStatus(
     IDataPartStorage & data_part_storage);
 
 }
-

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/ExtensionTableNode.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/ExtensionTableNode.java
@@ -198,4 +198,8 @@ public class ExtensionTableNode implements SplitInfo {
   public List<String> getPartList() {
     return partList;
   }
+
+  public String getExtensionTableStr() {
+    return extensionTableStr.toString();
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/TransformerApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/TransformerApi.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.backendsapi
 
 import org.apache.gluten.substrait.expression.ExpressionNode
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
@@ -39,7 +39,8 @@ trait TransformerApi {
       bucketedScan: Boolean,
       optionalBucketSet: Option[BitSet],
       optionalNumCoalescedBuckets: Option[Int],
-      disableBucketedScan: Boolean): Seq[InputPartition]
+      disableBucketedScan: Boolean,
+      filterExprs: Seq[Expression] = Seq.empty): Seq[InputPartition]
 
   /**
    * Post process native config For example, for ClickHouse backend, sync 'spark.executor.cores' to

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -115,7 +115,8 @@ abstract class FileSourceScanExecTransformerBase(
       bucketedScan,
       optionalBucketSet,
       optionalNumCoalescedBuckets,
-      disableBucketedScan)
+      disableBucketedScan,
+      filterExprs())
   }
 
   override def getPartitionSchema: StructType = relation.partitionSchema

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -1758,11 +1758,4 @@ object GlutenConfig {
       .internal()
       .booleanConf
       .createWithDefault(true)
-
-  val COLUMNAR_CH_NATIVE_ENABLE_DRIVER_FILTER_INDEX =
-    buildConf("spark.gluten.sql.columnar.backend.ch.scan.enabledDriverFilterIndex")
-      .internal()
-      .doc("Enable driver to filter primary / secondary index when file format is mergetree.")
-      .booleanConf
-      .createWithDefault(false)
 }

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -1758,4 +1758,11 @@ object GlutenConfig {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+  val COLUMNAR_CH_NATIVE_ENABLE_DRIVER_FILTER_INDEX =
+    buildConf("spark.gluten.sql.columnar.backend.ch.scan.enabledDriverFilterIndex")
+      .internal()
+      .doc("Enable driver to filter primary / secondary index when file format is mergetree.")
+      .booleanConf
+      .createWithDefault(false)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
By changing the parameter 
`spark.gluten.sql.columnar.backend.ch.runtime_settings.enabled_driver_filter_mergetree_index`
, you can control whether to filter the primary index on the driver side.

Why do this?

When the mergetree part is too large, dividing tasks by continuous ranges may cause some  tasks to be empty. If filtered on the driver side and then split, it can be guaranteed that each task has an actual task.

(Fixes: \#5225)

## How was this patch tested?
Test BY ui

<!--StartFragment--></meta><style><!--br {mso-data-placement:same-cell;}--> td {white-space:nowrap;border:1px solid #dee0e3;font-size:10pt;font-style:normal;font-weight:normal;vertical-align:middle;word-break:normal;word-wrap:normal;}</style><byte-sheet-html-origin data-id="1713757667107" data-version="4" data-is-embed="true" data-grid-line-hidden="false" data-copy-type="col">
name | 改动前 | 改动后 | DIFF | DIFF
-- | -- | -- | -- | --
q01 | 2062 | 2050 | -12 | 1.01
q02 | 449 | 437 | -12 | 1.03
q03 | 2010 | 1993 | -17 | 1.01
q04 | 1867 | 1816 | -51 | 1.03
q05 | 3092 | 3085 | -7 | 1.00
q06 | 179 | 172 | -7 | 1.04
q07 | 2168 | 2115 | -53 | 1.03
q08 | 2698 | 2635 | -63 | 1.02
q09 | 6183 | 6162 | -21 | 1.00
q10 | 2002 | 2026 | 24 | 0.99
q11 | 600 | 604 | 4 | 0.99
q12 | 1049 | 1021 | -28 | 1.03
q13 | 3141 | 3185 | 44 | 0.99
q14 | 357 | 341 | -16 | 1.05
q15 | 756 | 744 | -12 | 1.02
q16 | 1652 | 1622 | -30 | 1.02
q17 | 1214 | 1217 | 3 | 1.00
q18 | 2699 | 2610 | -89 | 1.03
q19 | 2362 | 2360 | -2 | 1.00
q20 | 1233 | 1194 | -39 | 1.03
q21 |   |   |   |  
q22 | 935 | 939 | 4 | 1.00
  | 38708 | 38328 | -380 | 1.01

</byte-sheet-html-origin><!--EndFragment-->
