### PR TITLE
[CORE][VL] RAS: Group expansion support

### DIFF
--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/Ras.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/Ras.scala
@@ -31,7 +31,7 @@ trait Optimization[T <: AnyRef] {
       constraintSet: PropertySet[T],
       altConstraintSets: Seq[PropertySet[T]]): RasPlanner[T]
 
-  def propSetsOf(plan: T): PropertySet[T]
+  def propSetOf(plan: T): PropertySet[T]
 
   def withNewConfig(confFunc: RasConfig => RasConfig): Optimization[T]
 }
@@ -49,7 +49,7 @@ object Optimization {
 
   implicit class OptimizationImplicits[T <: AnyRef](opt: Optimization[T]) {
     def newPlanner(plan: T): RasPlanner[T] = {
-      opt.newPlanner(plan, opt.propSetsOf(plan), List.empty)
+      opt.newPlanner(plan, opt.propSetOf(plan), List.empty)
     }
     def newPlanner(plan: T, constraintSet: PropertySet[T]): RasPlanner[T] = {
       opt.newPlanner(plan, constraintSet, List.empty)
@@ -131,7 +131,7 @@ class Ras[T <: AnyRef] private (
     RasPlanner(this, altConstraintSets, constraintSet, plan)
   }
 
-  override def propSetsOf(plan: T): PropertySet[T] = propertySetFactory().get(plan)
+  override def propSetOf(plan: T): PropertySet[T] = propertySetFactory().get(plan)
 
   private[ras] def withNewChildren(node: T, newChildren: Seq[T]): T = {
     val oldChildren = planModel.childrenOf(node)

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/RasNode.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/RasNode.scala
@@ -54,7 +54,7 @@ trait CanonicalNode[T <: AnyRef] extends RasNode[T] {
 object CanonicalNode {
   def apply[T <: AnyRef](ras: Ras[T], canonical: T): CanonicalNode[T] = {
     assert(ras.isCanonical(canonical))
-    val propSet = ras.propSetsOf(canonical)
+    val propSet = ras.propSetOf(canonical)
     val children = ras.planModel.childrenOf(canonical)
     new CanonicalNodeImpl[T](ras, canonical, propSet, children.size)
   }

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/best/BestFinder.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/best/BestFinder.scala
@@ -52,12 +52,10 @@ object BestFinder {
 
   private[best] def newBest[T <: AnyRef](
       ras: Ras[T],
-      allGroups: Seq[RasGroup[T]],
       group: RasGroup[T],
       groupToCosts: Map[Int, KnownCostGroup[T]]): Best[T] = {
 
     val bestPath = groupToCosts(group.id()).best()
-    val bestRoot = bestPath.rasPath.node()
     val winnerNodes = groupToCosts.map { case (id, g) => InGroupNode(id, g.bestNode) }.toSeq
     val costsMap = mutable.Map[InGroupNode.HashKey, Cost]()
     groupToCosts.foreach {

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/best/GroupBasedBestFinder.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/best/GroupBasedBestFinder.scala
@@ -43,7 +43,7 @@ private class GroupBasedBestFinder[T <: AnyRef](
         s"Best path not found. Memo state (Graphviz): \n" +
           s"${memoState.formatGraphvizWithoutBest(groupId)}")
     }
-    BestFinder.newBest(ras, allGroups, group, groupToCosts)
+    BestFinder.newBest(ras, group, groupToCosts)
   }
 
   private def fillBests(group: RasGroup[T]): Map[Int, KnownCostGroup[T]] = {

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/dp/DpZipperAlgo.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/dp/DpZipperAlgo.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable
  *
  * Two major issues are handled by the base algo internally:
  *
- *   1. Cycle exclusion:
+ * 1. Cycle exclusion:
  *
  * The algo will withdraw the recursive call when found a cycle. Cycle is detected via the
  * comparison function passed by DpZipperAlgoDef#idOfX and DpZipperAlgoDef#idOfY. When a cycle is

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/dp/DpZipperAlgo.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/dp/DpZipperAlgo.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable
  *
  * Two major issues are handled by the base algo internally:
  *
- * 1. Cycle exclusion:
+ *   1. Cycle exclusion:
  *
  * The algo will withdraw the recursive call when found a cycle. Cycle is detected via the
  * comparison function passed by DpZipperAlgoDef#idOfX and DpZipperAlgoDef#idOfY. When a cycle is

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/path/OutputFilter.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/path/OutputFilter.scala
@@ -17,14 +17,15 @@
 package org.apache.gluten.ras.path
 
 import org.apache.gluten.ras.{CanonicalNode, GroupNode}
-import org.apache.gluten.ras.path.FilterWizard.FilterAction
-import org.apache.gluten.ras.path.OutputWizard.OutputAction
+import org.apache.gluten.ras.path.FilterWizard.{FilterAction, FilterAdvanceAction}
+import org.apache.gluten.ras.path.OutputWizard.{AdvanceAction, OutputAction}
 import org.apache.gluten.ras.util.CycleDetector
 
 trait FilterWizard[T <: AnyRef] {
   import FilterWizard._
   def omit(can: CanonicalNode[T]): FilterAction[T]
-  def omit(group: GroupNode[T], offset: Int, count: Int): FilterAction[T]
+  def omit(group: GroupNode[T]): FilterAction[T]
+  def advance(offset: Int, count: Int): FilterAdvanceAction[T]
 }
 
 object FilterWizard {
@@ -39,6 +40,11 @@ object FilterWizard {
     def omit[T <: AnyRef]: Omit[T] = Omit.INSTANCE.asInstanceOf[Omit[T]]
 
     case class Continue[T <: AnyRef](newWizard: FilterWizard[T]) extends FilterAction[T]
+  }
+
+  sealed trait FilterAdvanceAction[T <: AnyRef]
+  object FilterAdvanceAction {
+    case class Continue[T <: AnyRef](newWizard: FilterWizard[T]) extends FilterAdvanceAction[T]
   }
 }
 
@@ -55,12 +61,15 @@ object FilterWizards {
       FilterAction.Continue(this)
     }
 
-    override def omit(group: GroupNode[T], offset: Int, count: Int): FilterAction[T] = {
+    override def omit(group: GroupNode[T]): FilterAction[T] = {
       if (detector.contains(group)) {
         return FilterAction.omit
       }
       FilterAction.Continue(new OmitCycles(detector.append(group)))
     }
+
+    override def advance(offset: Int, count: Int): FilterAdvanceAction[T] =
+      FilterAdvanceAction.Continue(this)
   }
 
   private object OmitCycles {
@@ -98,16 +107,26 @@ object OutputFilter {
       }
     }
 
-    override def advance(group: GroupNode[T], offset: Int, count: Int): OutputAction[T] = {
-      filterWizard.omit(group: GroupNode[T], offset: Int, count: Int) match {
+    override def visit(group: GroupNode[T]): OutputAction[T] = {
+      filterWizard.omit(group: GroupNode[T]) match {
         case FilterAction.Omit() => OutputAction.stop
         case FilterAction.Continue(newFilterWizard) =>
-          outputWizard.advance(group, offset, count) match {
+          outputWizard.visit(group) match {
             case stop @ OutputAction.Stop(_) => stop
             case OutputAction.Continue(drain, newOutputWizard) =>
               OutputAction.Continue(drain, new OutputFilterImpl(newOutputWizard, newFilterWizard))
           }
       }
+    }
+
+    override def advance(offset: Int, count: Int): OutputWizard.AdvanceAction[T] = {
+      val newOutputWizard = outputWizard.advance(offset, count) match {
+        case AdvanceAction.Continue(newWizard) => newWizard
+      }
+      val newFilterWizard = filterWizard.advance(offset, count) match {
+        case FilterAdvanceAction.Continue(newWizard) => newWizard
+      }
+      AdvanceAction.Continue(new OutputFilterImpl(newOutputWizard, newFilterWizard))
     }
 
     override def withPathKey(newKey: PathKey): OutputWizard[T] =

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/path/Pattern.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/path/Pattern.scala
@@ -90,20 +90,19 @@ object Pattern {
 
   private case class PatternImpl[T <: AnyRef](root: Node[T]) extends Pattern[T] {
     override def matches(path: RasPath[T], depth: Int): Boolean = {
-      assert(depth >= 1)
+      assert(depth >= 0)
       assert(depth <= path.height())
       def dfs(remainingDepth: Int, patternN: Node[T], n: PathNode[T]): Boolean = {
         assert(remainingDepth >= 0)
-        assert(n.self().isCanonical)
         if (remainingDepth == 0) {
+          return true
+        }
+        if (patternN.skip()) {
           return true
         }
         val can = n.self().asCanonical()
         if (patternN.abort(can)) {
           return false
-        }
-        if (patternN.skip()) {
-          return true
         }
         if (!patternN.matches(can)) {
           return false

--- a/gluten-ras/common/src/main/scala/org/apache/gluten/ras/rule/Shape.scala
+++ b/gluten-ras/common/src/main/scala/org/apache/gluten/ras/rule/Shape.scala
@@ -33,8 +33,18 @@ object Shapes {
     new FixedHeight[T](height)
   }
 
+  def pattern[T <: AnyRef](pattern: org.apache.gluten.ras.path.Pattern[T]): Shape[T] = {
+    new Pattern(pattern)
+  }
+
   def none[T <: AnyRef](): Shape[T] = {
     new None()
+  }
+
+  private class Pattern[T <: AnyRef](pattern: org.apache.gluten.ras.path.Pattern[T])
+    extends Shape[T] {
+    override def wizard(): OutputWizard[T] = OutputWizards.withPattern(pattern)
+    override def identify(path: RasPath[T]): Boolean = pattern.matches(path, path.height())
   }
 
   private class FixedHeight[T <: AnyRef](height: Int) extends Shape[T] {

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/RasSuite.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/RasSuite.scala
@@ -202,6 +202,7 @@ abstract class RasSuite extends AnyFunSuite {
   test(s"Group expansion - fixed height") {
     object AddUnary extends RasRule[TestNode] {
       override def shift(node: TestNode): Iterable[TestNode] = {
+        assert(node.isInstanceOf[Group])
         List(Unary(50, node))
       }
 
@@ -234,6 +235,7 @@ abstract class RasSuite extends AnyFunSuite {
   test(s"Group expansion - pattern") {
     object AddUnary extends RasRule[TestNode] {
       override def shift(node: TestNode): Iterable[TestNode] = {
+        assert(node.isInstanceOf[Group])
         List(Unary(50, node))
       }
 

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/RasSuiteBase.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/RasSuiteBase.scala
@@ -163,7 +163,7 @@ object RasSuiteBase {
 
   implicit class MemoLikeImplicits[T <: AnyRef](val memo: MemoLike[T]) {
     def memorize(ras: Ras[T], node: T): RasGroup[T] = {
-      memo.memorize(node, ras.propSetsOf(node))
+      memo.memorize(node, ras.propSetOf(node))
     }
   }
 

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/mock/MockMemoState.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/mock/MockMemoState.scala
@@ -48,6 +48,11 @@ case class MockMemoState[T <: AnyRef] private (
   override def getCluster(key: RasClusterKey): RasCluster[T] = clusterLookup(key)
 
   override def getGroup(id: Int): RasGroup[T] = allGroups(id)
+
+  override def clusterDummyGroupLookup(): Map[RasClusterKey, RasGroup[T]] = Map.empty
+
+  override def getDummyGroup(key: RasClusterKey): RasGroup[T] =
+    throw new UnsupportedOperationException()
 }
 
 object MockMemoState {

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/mock/MockRasPath.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/mock/MockRasPath.scala
@@ -27,7 +27,7 @@ object MockRasPath {
 
   def mock[T <: AnyRef](ras: Ras[T], node: T, keys: PathKeySet): RasPath[T] = {
     val memo = Memo(ras)
-    val g = memo.memorize(node, ras.propSetsOf(node))
+    val g = memo.memorize(node, ras.propSetOf(node))
     val state = memo.newState()
     val groupSupplier = state.asGroupSupplier()
     assert(g.nodes(state).size == 1)

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/path/PathFinderSuite.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/path/PathFinderSuite.scala
@@ -20,6 +20,7 @@ import org.apache.gluten.ras.{CanonicalNode, Ras, RasGroup}
 import org.apache.gluten.ras.RasSuiteBase._
 import org.apache.gluten.ras.mock.MockMemoState
 import org.apache.gluten.ras.rule.RasRule
+
 import org.scalatest.funsuite.AnyFunSuite
 
 class PathFinderSuite extends AnyFunSuite {

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/path/WizardSuite.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/path/WizardSuite.scala
@@ -178,8 +178,22 @@ class WizardSuite extends AnyFunSuite {
       finder.find(node1).map(_.plan()).toSeq
     }
 
+    def findWithPatternsFromGroup(patterns: Seq[Pattern[TestNode]]): Seq[TestNode] = {
+      val builder = PathFinder.builder(ras, state)
+      val finder = patterns
+        .foldLeft(builder) {
+          case (builder, pattern) =>
+            builder.output(OutputWizards.withPattern(pattern))
+        }
+        .build()
+      finder.find(groupA.asGroup(ras)).map(_.plan()).toSeq
+    }
+
+    assert(findWithPatternsFromGroup(List(Pattern.ignore[TestNode].build())) == List(Group(0)))
+
     assert(
       findWithPatterns(List(Pattern.any[TestNode].build())) == List(Binary(n1, Group(1), Group(2))))
+
     assert(
       findWithPatterns(
         List(

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/specific/DistributedSuite.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/specific/DistributedSuite.scala
@@ -242,6 +242,7 @@ object DistributedSuite {
 
   case object NoneDistribution extends Distribution {
     override def satisfies(other: Property[TestNode]): Boolean = other match {
+      case AnyDistribution => true
       case _: Distribution => false
       case _ => throw new UnsupportedOperationException()
     }
@@ -296,6 +297,7 @@ object DistributedSuite {
 
   case object NoneOrdering extends Ordering {
     override def satisfies(other: Property[TestNode]): Boolean = other match {
+      case AnyOrdering => true
       case _: Ordering => false
       case _ => throw new UnsupportedOperationException()
     }


### PR DESCRIPTION
Group expansion is useful for writing simple enforcer rule that adds unary node (e.g., sort, exchange, c2r, r2c). Prior to this, we had to operate on at least one non-group node in rule. The fix adds support of group expansion so the path finding effort can be minimized during applying such rules.