### PR TITLE
[GLUTEN-5324]Error message prompted during LocalLimitExec conversion …

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
@@ -692,7 +692,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           if (!enableColumnarLimit) {
             TransformHints.tagNotTransformable(
               plan,
-              "columnar limit is not enabled in GlobalLimitExec")
+              "columnar limit is not enabled in LocalLimitExec")
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
             transformer.doValidate().tagOnFallback(plan)


### PR DESCRIPTION
…#5324

## What changes were proposed in this pull request?

Error message prompted during LocalLimitExec conversion.

The message is : columnar limit is not enabled in GlobalLimitExec

This will mislead users.

After this pr：

It will be changed to ：columnar limit is not enabled in CollectLimitExec


(Fixes: \#5324)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

