### PR TITLE
[GLUTEN-5331]Update the doc of Build Gluten with Velox Backend #5331

### DIFF
--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -540,7 +540,7 @@ After the set-up, you can now build Gluten with HBM. Below command is used to en
 ```bash
 cd /path/to/gluten
 
-## The script builds two jars for spark 3.2.2 and 3.3.1.
+## The script builds four jars for spark 3.2.2, 3.3.1, 3.4.2 and 3.5.1.
 ./dev/buildbundle-veloxbe.sh --enable_hbm=ON
 ```
 
@@ -626,7 +626,7 @@ exit
 ```bash
 cd /path/to/gluten
 
-## The script builds two jars for spark 3.2.2 and 3.3.1.
+## The script builds four jars for spark 3.2.2, 3.3.1, 3.4.2 and 3.5.1.
 ./dev/buildbundle-veloxbe.sh --enable_qat=ON
 ```
 
@@ -722,7 +722,7 @@ After the set-up, you can now build Gluten with QAT. Below command is used to en
 ```bash
 cd /path/to/gluten
 
-## The script builds two jars for spark 3.2.2 and 3.3.1.
+## The script builds four jars for spark 3.2.2, 3.3.1, 3.4.2 and 3.5.1.
 ./dev/buildbundle-veloxbe.sh --enable_iaa=ON
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the doc of Build Gluten with Velox Backend

The script buildbundle-veloxbe.sh will build 3.2.2, 3.3.1, 3.4.2, and 3.5.1, and the current description is not accurate.



(Fixes: \#5331)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

