### PR TITLE
[GLUTEN-4039][VL] Add array filter function support

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -738,11 +738,11 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("array_tbl")
 
         runQueryAndCompare("select filter(value, x -> x % 2 == 1) as res from array_tbl;") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
 
         runQueryAndCompare("select filter(value, x -> x is not null) as res from array_tbl;") {
-          checkOperatorMatch[ProjectExecTransformer]
+          checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -727,4 +727,24 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
     }
   }
 
+  test("test array filter") {
+    withTempPath {
+      path =>
+        Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
+          .toDF("value")
+          .write
+          .parquet(path.getCanonicalPath)
+
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("array_tbl")
+
+        runQueryAndCompare("select filter(value, x -> x % 2 == 1) as res from array_tbl;") {
+          checkOperatorMatch[ProjectExecTransformer]
+        }
+
+        runQueryAndCompare("select filter(value, x -> x is not null) as res from array_tbl;") {
+          checkOperatorMatch[ProjectExecTransformer]
+        }
+    }
+  }
+
 }

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -276,7 +276,7 @@ core::TypedExprPtr SubstraitVeloxExprConverter::toLambdaExpr(
         SubstraitParser::findVeloxFunction(functionMap_, arg.scalar_function().function_reference());
     CHECK_EQ(veloxFunction, "namedlambdavariable");
     argumentNames.emplace_back(arg.scalar_function().arguments(0).value().literal().string());
-    argumentTypes.emplace_back(SubstraitParser::parseType(substraitFunc.output_type()));
+    argumentTypes.emplace_back(SubstraitParser::parseType(arg.scalar_function().output_type()));
   }
   auto rowType = ROW(std::move(argumentNames), std::move(argumentTypes));
   // Arg[0] -> function.

--- a/docs/velox-backend-support-progress.md
+++ b/docs/velox-backend-support-progress.md
@@ -92,6 +92,7 @@ Gluten supports 28 operators (Drag to right to see all data types)
 
 Gluten supports 199 functions. (Drag to right to see all data types)
 
+<<<<<<< HEAD
 | Spark Functions               | Velox/Presto Functions | Velox/Spark functions | Gluten | Restrictions             | BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DATE | TIMESTAMP | STRING | DECIMAL | NULL | BINARS | CALENDAR | ARRAY | MAP | STRUCT | UDT |
 |-------------------------------|------------------------|-----------------------|--------|--------------------------|---------|------|-------|-----|------|-------|--------|------|-----------|--------|---------|------|--------|----------|-------|-----|--------|-----|
 | !                             |                        | not                   | S      |                          | S       | S    | S     | S   | S    | S     | S      |      |           | S      |         |      |        |          |       |     |        |     |
@@ -279,7 +280,7 @@ Gluten supports 199 functions. (Drag to right to see all data types)
 | exists                        |                        |                       |        |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
 | explode, explode_outer        |                        |                       |        |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
 | explode_outer, explode        |                        |                       |        |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
-| filter                        | filter                 | filter                |        |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
+| filter                        | filter                 | filter                | S      | Lambda with index argument not supported |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
 | flatten                       | flatten                |                       |        |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
 | map                           | map                    | map                   | S      |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |
 | map_concat                    | map_concat             |                       |        |                          |         |      |       |     |      |       |        |      |           |        |         |      |        |          |       |     |        |     |

--- a/docs/velox-backend-support-progress.md
+++ b/docs/velox-backend-support-progress.md
@@ -92,7 +92,6 @@ Gluten supports 28 operators (Drag to right to see all data types)
 
 Gluten supports 199 functions. (Drag to right to see all data types)
 
-<<<<<<< HEAD
 | Spark Functions               | Velox/Presto Functions | Velox/Spark functions | Gluten | Restrictions             | BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DATE | TIMESTAMP | STRING | DECIMAL | NULL | BINARS | CALENDAR | ARRAY | MAP | STRUCT | UDT |
 |-------------------------------|------------------------|-----------------------|--------|--------------------------|---------|------|-------|-----|------|-------|--------|------|-----------|--------|---------|------|--------|----------|-------|-----|--------|-----|
 | !                             |                        | not                   | S      |                          | S       | S    | S     | S   | S    | S     | S      |      |           | S      |         |      |        |          |       |     |        |     |

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -220,6 +220,15 @@ trait SparkPlanExecApi {
     throw new GlutenNotSupportException("map_entries is not supported")
   }
 
+  /** Transform array filter to Substrait. */
+  def genArrayFilterTransformer(
+      substraitExprName: String,
+      argument: ExpressionTransformer,
+      function: ExpressionTransformer,
+      expr: ArrayFilter): ExpressionTransformer = {
+    throw new GlutenNotSupportException("filter(on array) is not supported")
+  }
+
   /** Transform inline to Substrait. */
   def genInlineTransformer(
       substraitExprName: String,

--- a/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -576,6 +576,13 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         e.getTransformer(childrenTransformers)
       case u: Uuid =>
         BackendsApiManager.getSparkPlanExecApiInstance.genUuidTransformer(substraitExprName, u)
+      case f: ArrayFilter =>
+        BackendsApiManager.getSparkPlanExecApiInstance.genArrayFilterTransformer(
+          substraitExprName,
+          replaceWithExpressionTransformerInternal(f.argument, attributeSeq, expressionsMap),
+          replaceWithExpressionTransformerInternal(f.function, attributeSeq, expressionsMap),
+          f
+        )
       case expr =>
         GenericExpressionTransformer(
           substraitExprName,

--- a/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
@@ -227,6 +227,7 @@ object ExpressionMappings {
     Sig[ArrayExcept](ARRAY_EXCEPT),
     Sig[ArrayRepeat](ARRAY_REPEAT),
     Sig[ArrayRemove](ARRAY_REMOVE),
+    Sig[ArrayFilter](FILTER),
     // Map functions
     Sig[CreateMap](CREATE_MAP),
     Sig[GetMapValue](GET_MAP_VALUE),

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -242,6 +242,7 @@ object ExpressionNames {
   final val ARRAY_EXCEPT = "array_except"
   final val ARRAY_REPEAT = "array_repeat"
   final val ARRAY_REMOVE = "array_remove"
+  final val FILTER = "filter"
 
   // Map functions
   final val CREATE_MAP = "map"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add partial support of `filter` function for velox backend. This PR leverages existing `filter` function in velox which supports filter with lambda function<T, boolean>.

While [SPARK-28962](https://issues.apache.org/jira/browse/SPARK-28962) introduced support for lambda with index as argument (function<T, int, boolean>), it is not implemented in velox yet. To fully support the filter function, will add the implementation in velox.

## How was this patch tested?
UT added.
