### PR TITLE
[VL] Fix wrong result caused by missing metadata in hash registration 

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -372,6 +372,21 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     }
   }
 
+  test("hash") {
+    withTempView("t") {
+      Seq[(Integer, String)]((1, "a"), (2, null), (null, "b"))
+        .toDF("a", "b")
+        .createOrReplaceTempView("t")
+      runQueryAndCompare("select hash(a, b) from t") {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+      runQueryAndCompare("select xxhash64(a, b) from t") {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+    }
+
+  }
+
   test("decimal abs") {
     runQueryAndCompare("""
                          |select abs(cast (l_quantity * (-1.0) as decimal(12, 2))),

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -384,7 +384,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         checkGlutenOperatorMatch[ProjectExecTransformer]
       }
     }
-
   }
 
   test("decimal abs") {

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -36,18 +36,6 @@ using namespace facebook;
 namespace gluten {
 namespace {
 void registerFunctionOverwrite() {
-  velox::exec::registerStatefulVectorFunction(
-      "murmur3hash",
-      velox::functions::sparksql::hashWithSeedSignatures(),
-      velox::functions::sparksql::makeHashWithSeed,
-      velox::functions::sparksql::hashMetadata());
-
-  velox::exec::registerStatefulVectorFunction(
-      "xxhash64",
-      velox::functions::sparksql::xxhash64WithSeedSignatures(),
-      velox::functions::sparksql::makeXxHash64WithSeed,
-      velox::functions::sparksql::hashMetadata());
-
   velox::functions::registerUnaryNumeric<RoundFunction>({"round"});
   velox::registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});
   velox::registerFunction<RoundFunction, int16_t, int16_t, int32_t>({"round"});

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -39,12 +39,14 @@ void registerFunctionOverwrite() {
   velox::exec::registerStatefulVectorFunction(
       "murmur3hash",
       velox::functions::sparksql::hashWithSeedSignatures(),
-      velox::functions::sparksql::makeHashWithSeed);
+      velox::functions::sparksql::makeHashWithSeed,
+      velox::functions::sparksql::hashMetadata());
 
   velox::exec::registerStatefulVectorFunction(
       "xxhash64",
       velox::functions::sparksql::xxhash64WithSeedSignatures(),
-      velox::functions::sparksql::makeXxHash64WithSeed);
+      velox::functions::sparksql::makeXxHash64WithSeed,
+      velox::functions::sparksql::hashMetadata());
 
   velox::functions::registerUnaryNumeric<RoundFunction>({"round"});
   velox::registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -399,6 +399,7 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"bitwise_or", "spark_bitwise_or"},
     {"bitwise_xor", "spark_bitwise_xor"},
     {"murmur3hash", "hash_with_seed"},
+    {"xxhash64", "xxhash64_with_seed"},
     {"modulus", "remainder"},
     {"date_format", "format_datetime"},
     {"collect_set", "set_agg"}};


### PR DESCRIPTION
`velox::functions::sparksql::hashMetadata()` was missing from previous rebase. Added UT.