### PR TITLE
[VL] Fix timestamp precision loss in serializer

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.h
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.h
@@ -41,6 +41,7 @@ class VeloxColumnarBatchSerializer final : public ColumnarBatchSerializer {
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
   facebook::velox::RowTypePtr rowType_;
   std::unique_ptr<facebook::velox::serializer::presto::PrestoVectorSerde> serde_;
+  facebook::velox::serializer::presto::PrestoVectorSerde::PrestoOptions options_;
 };
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -183,7 +183,9 @@ RowVectorPtr readComplexType(BufferPtr buffer, RowTypePtr& rowType, memory::Memo
   RowVectorPtr result;
   auto byteStream = toByteStream(const_cast<uint8_t*>(buffer->as<uint8_t>()), buffer->size());
   auto serde = std::make_unique<serializer::presto::PrestoVectorSerde>();
-  serde->deserialize(byteStream.get(), pool, rowType, &result, /* serdeOptions */ nullptr);
+  serializer::presto::PrestoVectorSerde::PrestoOptions options;
+  options.useLosslessTimestamp = true;
+  serde->deserialize(byteStream.get(), pool, rowType, &result, &options);
   return result;
 }
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -274,8 +274,8 @@ void VeloxShuffleWriter::setPartitionBufferSize(uint16_t newSize) {
 arrow::Result<std::shared_ptr<arrow::Buffer>> VeloxShuffleWriter::generateComplexTypeBuffers(
     facebook::velox::RowVectorPtr vector) {
   auto arena = std::make_unique<facebook::velox::StreamArena>(veloxPool_.get());
-  auto serializer = serde_.createIterativeSerializer(
-      asRowType(vector->type()), vector->size(), arena.get(), &serdeOptions_);
+  auto serializer =
+      serde_.createIterativeSerializer(asRowType(vector->type()), vector->size(), arena.get(), &serdeOptions_);
   const facebook::velox::IndexRange allRows{0, vector->size()};
   serializer->append(vector, folly::Range(&allRows, 1));
   auto serializedSize = serializer->maxSerializedSize();

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -275,7 +275,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> VeloxShuffleWriter::generateComple
     facebook::velox::RowVectorPtr vector) {
   auto arena = std::make_unique<facebook::velox::StreamArena>(veloxPool_.get());
   auto serializer = serde_.createIterativeSerializer(
-      asRowType(vector->type()), vector->size(), arena.get(), /* serdeOptions */ nullptr);
+      asRowType(vector->type()), vector->size(), arena.get(), &serdeOptions_);
   const facebook::velox::IndexRange allRows{0, vector->size()};
   serializer->append(vector, folly::Range(&allRows, 1));
   auto serializedSize = serializer->maxSerializedSize();
@@ -736,7 +736,7 @@ arrow::Status VeloxShuffleWriter::splitComplexType(const facebook::velox::RowVec
         arenas_[partition] = std::make_unique<facebook::velox::StreamArena>(veloxPool_.get());
       }
       complexTypeData_[partition] = serde_.createIterativeSerializer(
-          complexWriteType_, partition2RowCount_[partition], arenas_[partition].get(), /* serdeOptions */ nullptr);
+          complexWriteType_, partition2RowCount_[partition], arenas_[partition].get(), &serdeOptions_);
     }
     rowIndexs[partition].emplace_back(facebook::velox::IndexRange{row, 1});
   }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -202,6 +202,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
       : ShuffleWriter(numPartitions, std::move(partitionWriter), std::move(options), pool),
         veloxPool_(std::move(veloxPool)) {
     arenas_.resize(numPartitions);
+    serdeOptions_.useLosslessTimestamp = true;
   }
 
   arrow::Status init();
@@ -409,6 +410,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
   std::vector<std::unique_ptr<facebook::velox::StreamArena>> arenas_;
   facebook::velox::serializer::presto::PrestoVectorSerde serde_;
+  facebook::velox::serializer::presto::PrestoVectorSerde::PrestoOptions serdeOptions_;
 
   // stat
   enum CpuWallTimingType {


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default `PrestoVectorSerde` use millisecond precision for timestamp data. We observed timestamp prescision loseing when doing broadcast serialization. We need to fix this by setting `useLosslessTimestamp` for `PrestoVectorSerde`.

```
import org.apache.spark.sql.functions.expr
import org.apache.spark.sql.catalyst.expressions._
spark.range(0, 5).toDF("id").createOrReplaceTempView("target")
spark.range(0, 10)
        .toDF("id")
        .withColumn("timestampOne", expr("timestamp_micros(id)"))
        .createOrReplaceTempView("source")

spark.sql("SELECT unix_micros(source.timestampOne) FROM source RIGHT OUTER JOIN target ON target.id = source.id").show(false)
```
Wrong result:
```
+-------------------------+
|unix_micros(timestampOne)|
+-------------------------+
|0                        |
|0                        |
|0                        |
|0                        |
|0                        |
+-------------------------+
```
Expected result:
```
+-------------------------+
|unix_micros(timestampOne)|
+-------------------------+
|0                        |
|1                        |
|2                        |
|3                        |
|4                        |
+-------------------------+
```

## How was this patch tested?
UT

