### PR TITLE
spark 3.5: fix and enable all ut for GlutenFileMetadataStructSuite

### DIFF
--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -737,10 +737,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenFileFormatWriterSuite]
   enableSuite[GlutenFileIndexSuite]
   enableSuite[GlutenFileMetadataStructSuite]
-    // Disbale as failed in Spark3.5.
-    .exclude("SPARK-41896: Filter on row_index and a stored column at the same time")
-    .exclude("SPARK-43450: Filter on full _metadata column struct")
-    .exclude("SPARK-43450: Filter on aliased _metadata.row_index")
   enableSuite[GlutenParquetV1AggregatePushDownSuite]
   enableSuite[GlutenParquetV2AggregatePushDownSuite]
   enableSuite[GlutenOrcV1AggregatePushDownSuite]

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, DynamicPruningExpression, Expression, FileSourceConstantMetadataAttribute, FileSourceGeneratedMetadataAttribute, FileSourceMetadataAttribute, PlanExpression, Predicate}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
-import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetUtils}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
@@ -66,6 +66,7 @@ abstract class FileSourceScanExecShim(
     // TODO, fallback if user define same name column due to we can't right now
     // detect which column is metadata column which is user defined column.
     val metadataColumnsNames = metadataColumns.map(_.name)
+    metadataColumnsNames.contains(ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME) ||
     output
       .filterNot(metadataColumns.toSet)
       .exists(v => metadataColumnsNames.contains(v.name)) ||


### PR DESCRIPTION
Fix Spark 35 UT of GlutenFileMetadataStructSuite


SPARK-41896: Filter on row_index and a stored column at the same time
SPARK-43450: Filter on full _metadata column struct
SPARK-43450: Filter on aliased _metadata.row_index

[(Fixes: \#ISSUE-ID)](https://github.com/apache/incubator-gluten/issues/5341)

## How was this patch tested?

manually test with UT run


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

