### PR TITLE
[GLUTEN-4483][CH]Improve divide

### DIFF
--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -65,6 +65,7 @@ include_directories(
         ${CMAKE_CURRENT_BINARY_DIR}/proto
         ${THRIFT_INCLUDE_DIR}
         ${CMAKE_BINARY_DIR}/contrib/thrift-cmake
+        ${CMAKE_BINARY_DIR}/contrib/llvm-project/llvm/include
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${ClickHouse_SOURCE_DIR}/src
         ${ClickHouse_SOURCE_DIR}/base
@@ -74,6 +75,8 @@ include_directories(
         ${ClickHouse_SOURCE_DIR}/contrib/azure/sdk/storage/azure-storage-blobs/inc
         ${ClickHouse_SOURCE_DIR}/contrib/azure/sdk/core/azure-core/inc
         ${ClickHouse_SOURCE_DIR}/contrib/azure/sdk/storage/azure-storage-common/inc
+        ${ClickHouse_SOURCE_DIR}/contrib/llvm-project/llvm/include
+        ${ClickHouse_SOURCE_DIR}/contrib/llvm-project/utils/bazel/llvm-project-overlay/llvm/include
 )
 
 add_subdirectory(Storages/Parquet)

--- a/cpp-ch/local-engine/Functions/SparkFunctionDivide.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDivide.cpp
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Functions/SparkFunctionDivide.h>
+
+namespace local_engine
+{
+
+REGISTER_FUNCTION(SparkDivide)
+{
+    factory.registerFunction<SparkFunctionDivide>();
+}
+
+}

--- a/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Functions/castTypeToEither.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionBinaryArithmetic.h>
+#include <Columns/IColumn.h>
+#include <DataTypes/DataTypeNumberBase.h>
+#include <DataTypes/DataTypeNullable.h>
+
+using namespace DB;
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+}
+
+namespace local_engine
+{
+
+template <typename A, typename B>
+struct SparkDivideFloatingImpl
+{
+    using ResultType = typename NumberTraits::ResultOfFloatingPointDivision<A, B>::Type;
+    static const constexpr bool allow_fixed_string = false;
+    static const constexpr bool allow_string_integer = false;
+
+    template <typename Result = ResultType>
+    static inline NO_SANITIZE_UNDEFINED Result apply(A a [[maybe_unused]], B b [[maybe_unused]])
+    {
+        return static_cast<Result>(a) / b;
+    }
+
+#if USE_EMBEDDED_COMPILER
+    static constexpr bool compilable = true;
+    static inline llvm::Value * compile(llvm::IRBuilder<> & b, llvm::Value * left, llvm::Value * right, bool)
+    {
+        if (left->getType()->isIntegerTy())
+            throw Exception(DB::ErrorCodes::LOGICAL_ERROR, "SparkDivideFloatingImpl expected a floating-point type");
+        return b.CreateFDiv(left, right);
+    }
+#endif
+};
+
+class SparkFunctionDivide : public DB::IFunction
+{
+public:
+    size_t getNumberOfArguments() const override { return 2; }
+    static constexpr auto name = "sparkDivide";
+    static DB::FunctionPtr create(DB::ContextPtr) { return std::make_shared<SparkFunctionDivide>(); }
+    SparkFunctionDivide() = default;
+    ~SparkFunctionDivide() override = default;
+    String getName() const override { return name; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+    DB::DataTypePtr getReturnTypeImpl(const DB::DataTypes &) const override
+    {
+        return DB::makeNullable(std::make_shared<const DB::DataTypeFloat64>());
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        if (arguments.size() != 2)
+            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 2", name);
+        if (!isNativeNumber(arguments[0].type) || !isNativeNumber(arguments[1].type))
+        {
+            throw Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type must be native number", name);
+        }
+        using Types = TypeList<DataTypeFloat32, DataTypeFloat64,DataTypeUInt8, DataTypeUInt16, DataTypeUInt32,
+            DataTypeUInt64, DataTypeInt8, DataTypeInt16, DataTypeInt32, DataTypeInt64>;
+        
+        ColumnPtr result = nullptr;
+        bool valid = castTypeToEither(Types{}, arguments[0].type.get(), [&](const auto & left_)
+        {
+            return castTypeToEither(Types{}, arguments[1].type.get(), [&](const auto & right_)
+            {
+                using L = typename std::decay_t<decltype(left_)>::FieldType;
+                using R = typename std::decay_t<decltype(right_)>::FieldType;
+                using T = typename NumberTraits::ResultOfFloatingPointDivision<L, R>::Type;
+                const ColumnVector<L> * vec1 = nullptr;
+                const ColumnVector<R> * vec2 = nullptr;
+                const ColumnVector<L> * const_col_left = checkAndGetColumnConstData<ColumnVector<L>>(arguments[0].column.get());
+                const ColumnVector<R> * const_col_right = checkAndGetColumnConstData<ColumnVector<R>>(arguments[1].column.get());
+                L left_const_val = 0;
+                R right_const_val = 0;
+                if (const_col_left)
+                    left_const_val = const_col_left->getElement(0);
+                else
+                    vec1 = assert_cast<const ColumnVector<L> *>(arguments[0].column.get());
+                
+                if (const_col_right)
+                {
+                    right_const_val = const_col_right->getElement(0);
+                    if (right_const_val == 0)
+                    {
+                        auto data_col = ColumnVector<T>::create(arguments[0].column->size(), 0);
+                        auto null_map_col = ColumnVector<UInt8>::create(arguments[0].column->size(), 1);
+                        result = ColumnNullable::create(std::move(data_col), std::move(null_map_col));
+                        return true;
+                    }
+                }
+                else
+                    vec2 = assert_cast<const ColumnVector<R> *>(arguments[1].column.get());
+
+                auto vec3 = ColumnVector<T>::create(input_rows_count, 0);
+                auto null_map_col = ColumnVector<UInt8>::create(input_rows_count, 0);
+                PaddedPODArray<T> & data = vec3->getData();
+                PaddedPODArray<UInt8> & null_map = null_map_col->getData();
+                for (size_t i = 0; i < input_rows_count; ++i)
+                {
+                    L l = vec1 ? vec1->getElement(i) : left_const_val;
+                    R r = vec2 ? vec2->getElement(i) : right_const_val;
+                    if (r == 0)
+                        null_map[i] = 1;
+                    else
+                        data[i] = SparkDivideFloatingImpl<L,R>::apply(l, r);
+                }
+                result = ColumnNullable::create(std::move(vec3), std::move(null_map_col));
+                return true;
+            });
+        });
+        if (!valid)
+            throw Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type is not valid", name);
+        return result;
+    }
+};
+}

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/divide.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/divide.cpp
@@ -59,15 +59,8 @@ public:
         
         if (isDecimal(removeNullable(left_arg->result_type)) || isDecimal(removeNullable(right_arg->result_type)))
             return toFunctionNode(actions_dag, "sparkDivideDecimal", {left_arg, right_arg});
-        
-        const auto * divide_node = toFunctionNode(actions_dag, "divide", {left_arg, right_arg});
-        DataTypePtr result_type = divide_node->result_type;
-
-        const auto * zero_node = addColumnToActionsDAG(actions_dag, result_type, removeNullable(result_type)->getDefault());
-        const auto * null_node = addColumnToActionsDAG(actions_dag, makeNullable(result_type), Field{});
-        const auto * is_zero_node = toFunctionNode(actions_dag, "equals", {right_arg, zero_node});
-        const auto * result_node = toFunctionNode(actions_dag, "if", {is_zero_node, null_node, divide_node});
-        return result_node;
+        else
+            return toFunctionNode(actions_dag, "sparkDivide", {left_arg, right_arg});
     }
 };
 

--- a/cpp-ch/local-engine/tests/CMakeLists.txt
+++ b/cpp-ch/local-engine/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ if (ENABLE_BENCHMARKS)
         benchmark_unix_timestamp_function.cpp
         benchmark_spark_floor_function.cpp
         benchmark_cast_float_function.cpp
-        benchmark_to_datetime_function.cpp)
+        benchmark_to_datetime_function.cpp
+        benchmark_spark_divide_function.cpp)
     target_link_libraries(benchmark_local_engine PRIVATE gluten_clickhouse_backend_libs ch_contrib::gbenchmark_all loggers ch_parquet)
 endif()

--- a/cpp-ch/local-engine/tests/benchmark_spark_divide_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_divide_function.cpp
@@ -43,7 +43,7 @@ static Block createDataBlock(String name1, String name2, size_t rows)
     {
         double d = i * 1.0;
         column1->insert(d);
-        column2->insert(d-1);
+        column2->insert(0);
     }
     ColumnWithTypeAndName col_type_name_1(std::move(column1), type, name1);
     ColumnWithTypeAndName col_type_name_2(std::move(column2), type, name2);

--- a/cpp-ch/local-engine/tests/benchmark_spark_divide_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_divide_function.cpp
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Columns/IColumn.h>
+#include <Core/Block.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/SparkFunctionDivide.h>
+#include <Parser/SerializedPlanParser.h>
+#include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/IQueryPlanStep.h>
+#include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <Processors/Executors/PipelineExecutor.h>
+#include <Processors/Sources/BlocksSource.h>
+#include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <benchmark/benchmark.h>
+
+using namespace DB;
+
+static Block createDataBlock(String name1, String name2, size_t rows)
+{
+    auto type = DataTypeFactory::instance().get("Float64");
+    auto column1 = type->createColumn();
+    auto column2 = type->createColumn();
+    for (size_t i = 0; i < rows; ++i)
+    {
+        double d = i * 1.0;
+        column1->insert(d);
+        column2->insert(d-1);
+    }
+    ColumnWithTypeAndName col_type_name_1(std::move(column1), type, name1);
+    ColumnWithTypeAndName col_type_name_2(std::move(column2), type, name2);
+    Block block;
+    block.insert(col_type_name_1);
+    block.insert(col_type_name_2);
+    return std::move(block);
+}
+
+
+static std::string join(const ActionsDAG::NodeRawConstPtrs & v, char c)
+{
+    std::string res;
+    for (size_t i = 0; i < v.size(); ++i)
+    {
+        if (i)
+            res += c;
+        res += v[i]->result_name;
+    }
+    return res;
+}
+
+static const ActionsDAG::Node * addFunction(ActionsDAGPtr & actions_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args)
+{
+    auto function_builder = FunctionFactory::instance().get(function, local_engine::SerializedPlanParser::global_context);
+    std::string args_name = join(args, ',');
+    auto result_name = function + "(" + args_name + ")";
+    return &actions_dag->addFunction(function_builder, args, result_name);
+}
+
+static void BM_CHDivideFunction(benchmark::State & state)
+{
+    ActionsDAGPtr dag = std::make_shared<ActionsDAG>();
+    Block block = createDataBlock("d1", "d2", 30000000);
+    ColumnWithTypeAndName col1 = block.getByPosition(0);
+    ColumnWithTypeAndName col2 = block.getByPosition(1);
+    const ActionsDAG::Node * left_arg = &dag->addColumn(col1);
+    const ActionsDAG::Node * right_arg = &dag->addColumn(col2);
+    addFunction(dag, "divide", {left_arg, right_arg});
+    ExpressionActions expr_actions(dag);
+    for (auto _ : state)
+        expr_actions.execute(block);
+}
+
+static void BM_SparkDivideFunction(benchmark::State & state)
+{
+    ActionsDAGPtr dag = std::make_shared<ActionsDAG>();
+    Block block = createDataBlock("d1", "d2", 30000000);
+    ColumnWithTypeAndName col1 = block.getByPosition(0);
+    ColumnWithTypeAndName col2 = block.getByPosition(1);
+    const ActionsDAG::Node * left_arg = &dag->addColumn(col1);
+    const ActionsDAG::Node * right_arg = &dag->addColumn(col2);
+    addFunction(dag, "sparkDivide", {left_arg, right_arg});
+    ExpressionActions expr_actions(dag);
+    for (auto _ : state)
+        expr_actions.execute(block);
+}
+
+static void BM_GlutenDivideFunctionParser(benchmark::State & state)
+{
+    ActionsDAGPtr dag = std::make_shared<ActionsDAG>();
+    Block block = createDataBlock("d1", "d2", 30000000);
+    ColumnWithTypeAndName col1 = block.getByPosition(0);
+    ColumnWithTypeAndName col2 = block.getByPosition(1);
+    const ActionsDAG::Node * left_arg = &dag->addColumn(col1);
+    const ActionsDAG::Node * right_arg = &dag->addColumn(col2);
+    const ActionsDAG::Node * divide_arg = addFunction(dag, "divide", {left_arg, right_arg});
+    DataTypePtr float64_type = std::make_shared<DataTypeFloat64>();
+    ColumnWithTypeAndName col_zero(float64_type->createColumnConst(1, 0), float64_type, toString(0));
+    ColumnWithTypeAndName col_null(float64_type->createColumnConst(1, Field{}), float64_type, "null");
+    const ActionsDAG::Node * zero_arg = &dag->addColumn(col_zero);
+    const ActionsDAG::Node * null_arg = &dag->addColumn(col_null);
+    const ActionsDAG::Node * equals_arg = addFunction(dag, "equals", {right_arg, zero_arg});
+    const ActionsDAG::Node * if_arg = addFunction(dag, "if", {equals_arg, null_arg, divide_arg});
+    ExpressionActions expr_actions(dag);
+    for (auto _ : state)
+        expr_actions.execute(block);
+}
+
+BENCHMARK(BM_CHDivideFunction)->Unit(benchmark::kMillisecond)->Iterations(10);
+BENCHMARK(BM_SparkDivideFunction)->Unit(benchmark::kMillisecond)->Iterations(10);
+BENCHMARK(BM_GlutenDivideFunctionParser)->Unit(benchmark::kMillisecond)->Iterations(10);


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#4483)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

性能测试
端到端性能测试：test_tbl(a float, b float) 数据量6000W行，其中b取值全部为0 测试SQL: `select count(1) from test_tbl where a/b is NULL`， 测试三次：
该PR 优化前：1.381s 1.343s 1.35s;
该PR优化后：1.073s 1.127s 1.137s

通过开发完成的 benchmark_spark_divide_function.cpp 测试 新的divide 函数， 对比CH 的divide函数，以及过去使用FunctionParser的divide 的性能差异，如下
```
2024-01-22 16:51:29.252 <Warning> SignalHandler: LD_PRELOAD is not set, SignalHandler is disabled
2024-01-22T16:51:29+08:00
Running ./benchmark_local_engine
Run on (32 X 2100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 1024 KiB (x16)
  L3 Unified 11264 KiB (x2)
Load Average: 13.31, 24.04, 42.68
--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
BM_CHDivideFunction/iterations:10                  268 ms          260 ms           10
BM_SparkDivideFunction/iterations:10               243 ms          243 ms           10
BM_GlutenDivideFunctionParser/iterations:10        322 ms          322 ms           10
```

可见， 新的`SparkDivideFunction` 相对于CH 的`Divide` 大约有10% 左右的提升，相对于Gluten 的`FunctionParser` 的实现约有30% ~ 40% 左右的提升


