### PR TITLE
[GLUTEN-4836][VL]Add support for WindowGroupLimitExec in gluten

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -274,6 +274,13 @@ object BackendSettings extends BackendSettingsApi {
     GlutenConfig.getConf.enableColumnarSortMergeJoin
   }
 
+  override def supportWindowGroupLimitExec(rankLikeFunction: Expression): Boolean = {
+    rankLikeFunction match {
+      case _: RowNumber => true
+      case _ => false
+    }
+  }
+
   override def supportWindowExec(windowFunctions: Seq[NamedExpression]): Boolean = {
     var allSupported = true
     breakable {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -913,7 +913,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   }
 }
 
-core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::WindowGroupLimitRel& windowGroupLimitRel) {
+core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(
+    const ::substrait::WindowGroupLimitRel& windowGroupLimitRel) {
   core::PlanNodePtr childNode;
   if (windowGroupLimitRel.has_input()) {
     childNode = toVeloxPlan(windowGroupLimitRel.input());

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -913,6 +913,50 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   }
 }
 
+core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::WindowGroupLimitRel& windowGroupLimitRel) {
+  core::PlanNodePtr childNode;
+  if (windowGroupLimitRel.has_input()) {
+    childNode = toVeloxPlan(windowGroupLimitRel.input());
+  } else {
+    VELOX_FAIL("Child Rel is expected in WindowGroupLimitRel.");
+  }
+  const auto& inputType = childNode->outputType();
+  // Construct partitionKeys
+    std::vector<core::FieldAccessTypedExprPtr> partitionKeys;
+    std::unordered_set<std::string> keyNames;
+    const auto& partitions = windowGroupLimitRel.partition_expressions();
+    partitionKeys.reserve(partitions.size());
+    for (const auto& partition : partitions) {
+      auto expression = exprConverter_->toVeloxExpr(partition, inputType);
+      core::FieldAccessTypedExprPtr veloxPartitionKey =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression);
+      VELOX_USER_CHECK_NOT_NULL(veloxPartitionKey, "Window Group Limit Operator only supports field partition key.");
+      // Constructs unique partition keys.
+      if (keyNames.insert(veloxPartitionKey->name()).second) {
+        partitionKeys.emplace_back(veloxPartitionKey);
+      }
+    }
+    std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
+    std::vector<core::SortOrder> sortingOrders;
+    const auto& [rawSortingKeys, rawSortingOrders] = processSortField(windowGroupLimitRel.sorts(), inputType);
+    for (vector_size_t i = 0; i < rawSortingKeys.size(); ++i) {
+      // Constructs unique sort keys and excludes keys overlapped with partition keys.
+      if (keyNames.insert(rawSortingKeys[i]->name()).second) {
+        sortingKeys.emplace_back(rawSortingKeys[i]);
+        sortingOrders.emplace_back(rawSortingOrders[i]);
+      }
+    }
+  const std::optional<std::string> rowNumberColumnName = std::nullopt;
+  return std::make_shared<core::TopNRowNumberNode>(
+          nextPlanNodeId(),
+          partitionKeys,
+          sortingKeys,
+          sortingOrders,
+          rowNumberColumnName,
+          (int32_t)windowGroupLimitRel.limit(),
+          childNode);
+}
+
 core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::SortRel& sortRel) {
   auto childNode = convertSingleInput<::substrait::SortRel>(sortRel);
   auto [sortingKeys, sortingOrders] = processSortField(sortRel.sorts(), childNode->outputType());
@@ -1197,6 +1241,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     return toVeloxPlan(rel.window());
   } else if (rel.has_write()) {
     return toVeloxPlan(rel.write());
+  } else if (rel.has_windowgrouplimit()) {
+    return toVeloxPlan(rel.windowgrouplimit());
   } else {
     VELOX_NYI("Substrait conversion not supported for Rel.");
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -74,8 +74,11 @@ class SubstraitToVeloxPlanConverter {
   /// Used to convert Substrait GenerateRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::GenerateRel& generateRel);
 
-  /// Used to convert Substrait SortRel into Velox PlanNode.
+  /// Used to convert Substrait WindowRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::WindowRel& windowRel);
+
+  /// Used to convert Substrait WindowGroupLimitRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::WindowGroupLimitRel& windowGroupLimitRel);
 
   /// Used to convert Substrait JoinRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::JoinRel& joinRel);

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -698,6 +698,10 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   return true;
 }
 
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowGroupLimitRel& windowGroupLimitRel) {
+  return true;
+}
+
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel) {
   if (sortRel.has_input() && !validate(sortRel.input())) {
     return false;
@@ -1200,6 +1204,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::Rel& rel) {
     return validate(rel.window());
   } else if (rel.has_write()) {
     return validate(rel.write());
+  } else if (rel.has_windowgrouplimit()) {
+    return validate(rel.windowgrouplimit());
   } else {
     return false;
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -761,7 +761,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowGroupLimit
         LOG_VALIDATION_MSG("in windowGroupLimitRel, the sorting key in Sort Operator only support field.");
         return false;
       }
-    exec::ExprSet exprSet({std::move(expression)}, execCtx_);
+      exec::ExprSet exprSet({std::move(expression)}, execCtx_);
     }
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -58,6 +58,9 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Window is supported.
   bool validate(const ::substrait::WindowRel& windowRel);
 
+  /// Used to validate whether the computing of this WindowGroupLimit is supported.
+  bool validate(const ::substrait::WindowGroupLimitRel& windowGroupLimitRel);
+
   /// Used to validate whether the computing of this Aggregation is supported.
   bool validate(const ::substrait::AggregateRel& aggRel);
 

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
@@ -272,6 +272,29 @@ public class RelBuilder {
         partitionExpressions, sorts);
   }
 
+  public static RelNode makeWindowGroupLimitRel(
+      RelNode input,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
+      Integer limit,
+      AdvancedExtensionNode extensionNode,
+      SubstraitContext context,
+      Long operatorId) {
+    context.registerRelToOperator(operatorId);
+    return new WindowGroupLimitRelNode(input, partitionExpressions, sorts, limit, extensionNode);
+  }
+
+  public static RelNode makeWindowGroupLimitRel(
+      RelNode input,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
+      Integer limit,
+      SubstraitContext context,
+      Long operatorId) {
+    context.registerRelToOperator(operatorId);
+    return new WindowGroupLimitRelNode(input, partitionExpressions, sorts, limit);
+  }
+
   public static RelNode makeGenerateRel(
       RelNode input,
       ExpressionNode generator,

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/WindowGroupLimitRelNode.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/WindowGroupLimitRelNode.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.substrait.rel;
+
+import org.apache.gluten.substrait.expression.ExpressionNode;
+import org.apache.gluten.substrait.extensions.AdvancedExtensionNode;
+
+import io.substrait.proto.Rel;
+import io.substrait.proto.RelCommon;
+import io.substrait.proto.SortField;
+import io.substrait.proto.WindowGroupLimitRel;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WindowGroupLimitRelNode implements RelNode, Serializable {
+  private final RelNode input;
+  private final List<ExpressionNode> partitionExpressions = new ArrayList<>();
+  private final List<SortField> sorts = new ArrayList<>();
+  private final AdvancedExtensionNode extensionNode;
+  private final Integer limit;
+
+  public WindowGroupLimitRelNode(
+      RelNode input,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
+      Integer limit) {
+    this.input = input;
+    this.partitionExpressions.addAll(partitionExpressions);
+    this.sorts.addAll(sorts);
+    this.limit = limit;
+    this.extensionNode = null;
+  }
+
+  public WindowGroupLimitRelNode(
+      RelNode input,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
+      Integer limit,
+      AdvancedExtensionNode extensionNode) {
+    this.input = input;
+    this.partitionExpressions.addAll(partitionExpressions);
+    this.sorts.addAll(sorts);
+    this.limit = limit;
+    this.extensionNode = extensionNode;
+  }
+
+  @Override
+  public Rel toProtobuf() {
+    RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
+    relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
+
+    WindowGroupLimitRel.Builder windowBuilder = WindowGroupLimitRel.newBuilder();
+    windowBuilder.setCommon(relCommonBuilder.build());
+    if (input != null) {
+      windowBuilder.setInput(input.toProtobuf());
+    }
+
+    for (int i = 0; i < partitionExpressions.size(); i++) {
+      windowBuilder.addPartitionExpressions(i, partitionExpressions.get(i).toProtobuf());
+    }
+
+    for (int i = 0; i < sorts.size(); i++) {
+      windowBuilder.addSorts(i, sorts.get(i));
+    }
+
+    windowBuilder.setLimit(limit);
+
+    if (extensionNode != null) {
+      windowBuilder.setAdvancedExtension(extensionNode.toProtobuf());
+    }
+    Rel.Builder builder = Rel.newBuilder();
+    builder.setWindowGroupLimit(windowBuilder.build());
+    return builder.build();
+  }
+}

--- a/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -328,6 +328,15 @@ message WindowRel {
   }
 }
 
+message WindowGroupLimitRel {
+  RelCommon common = 1;
+  Rel input = 2;
+  repeated Expression partition_expressions = 3;
+  repeated SortField sorts = 4;
+  int32 limit = 5;
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
 // The relational operator capturing simple FILTERs (as in the WHERE clause of SQL)
 message FilterRel {
   RelCommon common = 1;
@@ -495,6 +504,7 @@ message Rel {
     GenerateRel generate = 17;
     WriteRel write = 18;
     TopNRel top_n = 19;
+    WindowGroupLimitRel windowGroupLimit = 20;
   }
 }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -22,7 +22,7 @@ import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
@@ -47,6 +47,9 @@ trait BackendSettingsApi {
   def supportSortExec(): Boolean = false
   def supportSortMergeJoinExec(): Boolean = true
   def supportWindowExec(windowFunctions: Seq[NamedExpression]): Boolean = {
+    false
+  }
+  def supportWindowGroupLimitExec(rankLikeFunction: Expression): Boolean = {
     false
   }
   def supportColumnarShuffleExec(): Boolean = {
@@ -113,6 +116,8 @@ trait BackendSettingsApi {
   def alwaysFailOnMapExpression(): Boolean = false
 
   def requiredChildOrderingForWindow(): Boolean = false
+
+  def requiredChildOrderingForWindowGroupLimit(): Boolean = false
 
   def staticPartitionWriteOnly(): Boolean = false
 

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/WindowGroupLimitExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/WindowGroupLimitExecTransformer.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter}
+import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.metrics.MetricsUpdater
+import org.apache.gluten.substrait.`type`.TypeBuilder
+import org.apache.gluten.substrait.SubstraitContext
+import org.apache.gluten.substrait.extensions.ExtensionBuilder
+import org.apache.gluten.substrait.rel.{RelBuilder, RelNode}
+
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Expression, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.window.{Final, Partial, WindowGroupLimitMode}
+
+import io.substrait.proto.SortField
+
+import scala.collection.JavaConverters._
+
+case class WindowGroupLimitExecTransformer(
+    partitionSpec: Seq[Expression],
+    orderSpec: Seq[SortOrder],
+    rankLikeFunction: Expression,
+    limit: Int,
+    mode: WindowGroupLimitMode,
+    child: SparkPlan)
+  extends UnaryTransformSupport {
+
+  @transient override lazy val metrics =
+    BackendsApiManager.getMetricsApiInstance.genWindowTransformerMetrics(sparkContext)
+
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  override def metricsUpdater(): MetricsUpdater =
+    BackendsApiManager.getMetricsApiInstance.genWindowTransformerMetricsUpdater(metrics)
+
+  override def output: Seq[Attribute] = child.output
+
+  override def requiredChildDistribution: Seq[Distribution] = mode match {
+    case Partial => super.requiredChildDistribution
+    case Final =>
+      if (partitionSpec.isEmpty) {
+        AllTuples :: Nil
+      } else {
+        ClusteredDistribution(partitionSpec) :: Nil
+      }
+  }
+
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] = {
+    if (BackendsApiManager.getSettings.requiredChildOrderingForWindowGroupLimit()) {
+      // Velox StreamingTopNRowNumber need to require child order.
+      Seq(partitionSpec.map(SortOrder(_, Ascending)) ++ orderSpec)
+    } else {
+      Seq(Nil)
+    }
+  }
+
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  def getWindowGroupLimitRel(
+      context: SubstraitContext,
+      originalInputAttributes: Seq[Attribute],
+      operatorId: Long,
+      input: RelNode,
+      validation: Boolean): RelNode = {
+    val args = context.registeredFunction
+    // Partition By Expressions
+    val partitionsExpressions = partitionSpec
+      .map(
+        ExpressionConverter
+          .replaceWithExpressionTransformer(_, attributeSeq = child.output)
+          .doTransform(args))
+      .asJava
+
+    // Sort By Expressions
+    val sortFieldList =
+      orderSpec.map {
+        order =>
+          val builder = SortField.newBuilder()
+          val exprNode = ExpressionConverter
+            .replaceWithExpressionTransformer(order.child, attributeSeq = child.output)
+            .doTransform(args)
+          builder.setExpr(exprNode.toProtobuf)
+          builder.setDirectionValue(SortExecTransformer.transformSortDirection(order))
+          builder.build()
+      }.asJava
+    if (!validation) {
+      RelBuilder.makeWindowGroupLimitRel(
+        input,
+        partitionsExpressions,
+        sortFieldList,
+        limit,
+        context,
+        operatorId)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val inputTypeNodeList = originalInputAttributes
+        .map(attr => ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+        .asJava
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        BackendsApiManager.getTransformerApiInstance.packPBMessage(
+          TypeBuilder.makeStruct(false, inputTypeNodeList).toProtobuf))
+
+      RelBuilder.makeWindowGroupLimitRel(
+        input,
+        partitionsExpressions,
+        sortFieldList,
+        limit,
+        extensionNode,
+        context,
+        operatorId)
+    }
+  }
+
+  override protected def doValidateInternal(): ValidationResult = {
+    if (!BackendsApiManager.getSettings.supportWindowGroupLimitExec(rankLikeFunction)) {
+      return ValidationResult
+        .notOk(s"Found unsupported rank like function: $rankLikeFunction")
+    }
+    val substraitContext = new SubstraitContext
+    val operatorId = substraitContext.nextOperatorId(this.nodeName)
+
+    val relNode =
+      getWindowGroupLimitRel(substraitContext, child.output, operatorId, null, validation = true)
+
+    doNativeValidation(substraitContext, relNode)
+  }
+
+  override def doTransform(context: SubstraitContext): TransformContext = {
+    val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
+    val operatorId = context.nextOperatorId(this.nodeName)
+
+    val currRel =
+      getWindowGroupLimitRel(context, child.output, operatorId, childCtx.root, validation = false)
+    assert(currRel != null, "Window Group Limit Rel should be valid")
+    TransformContext(childCtx.outputAttributes, output, currRel)
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/PullOutPreProject.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/PullOutPreProject.scala
@@ -19,12 +19,13 @@ package org.apache.gluten.extension.columnar
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PullOutProjectHelper
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ExpandExec, GenerateExec, ProjectExec, SortExec, SparkPlan, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, TypedAggregateExpression}
-import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecShim}
 
 import scala.collection.mutable
 
@@ -76,9 +77,11 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
           case _ => false
         }.isDefined)
       case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) =>
-        val window = SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+        val window = SparkShimLoader.getSparkShims
+          .getWindowGroupLimitExecShim(plan)
+          .asInstanceOf[WindowGroupLimitExecShim]
         window.orderSpec.exists(o => isNotAttribute(o.child)) ||
-          window.partitionSpec.exists(isNotAttribute)
+        window.partitionSpec.exists(isNotAttribute)
       case expand: ExpandExec => expand.projections.flatten.exists(isNotAttributeAndLiteral)
       case _ => false
     }
@@ -185,8 +188,11 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
 
       ProjectExec(window.output, newWindow)
 
-    case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) && needsPreProject(plan) =>
-      val windowLimit = SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+    case plan
+        if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) && needsPreProject(plan) =>
+      val windowLimit = SparkShimLoader.getSparkShims
+        .getWindowGroupLimitExecShim(plan)
+        .asInstanceOf[WindowGroupLimitExecShim]
       val expressionMap = new mutable.HashMap[Expression, NamedExpression]()
       // Handle orderSpec.
       val newOrderSpec = getNewSortOrder(windowLimit.orderSpec, expressionMap)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/PullOutPreProject.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/PullOutPreProject.scala
@@ -17,8 +17,8 @@
 package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PullOutProjectHelper
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -75,6 +75,10 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
             }
           case _ => false
         }.isDefined)
+      case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) =>
+        val window = SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+        window.orderSpec.exists(o => isNotAttribute(o.child)) ||
+          window.partitionSpec.exists(isNotAttribute)
       case expand: ExpandExec => expand.projections.flatten.exists(isNotAttributeAndLiteral)
       case _ => false
     }
@@ -180,6 +184,29 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
       )
 
       ProjectExec(window.output, newWindow)
+
+    case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) && needsPreProject(plan) =>
+      val windowLimit = SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+      val expressionMap = new mutable.HashMap[Expression, NamedExpression]()
+      // Handle orderSpec.
+      val newOrderSpec = getNewSortOrder(windowLimit.orderSpec, expressionMap)
+
+      // Handle partitionSpec.
+      val newPartitionSpec =
+        windowLimit.partitionSpec.map(replaceExpressionWithAttribute(_, expressionMap))
+
+      val newWindowLimitShim = windowLimit.copy(
+        orderSpec = newOrderSpec,
+        partitionSpec = newPartitionSpec,
+        child = ProjectExec(
+          eliminateProjectList(windowLimit.child.outputSet, expressionMap.values.toSeq),
+          windowLimit.child)
+      )
+
+      val newWindowLimit = SparkShimLoader.getSparkShims
+        .getWindowGroupLimitExec(newWindowLimitShim)
+
+      ProjectExec(plan.output, newWindowLimit)
 
     case expand: ExpandExec if needsPreProject(expand) =>
       val expressionMap = new mutable.HashMap[Expression, NamedExpression]()

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/RewriteSparkPlanRulesManager.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/RewriteSparkPlanRulesManager.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.extension.{RewriteCollect, RewriteIn}
-
+import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
@@ -58,6 +58,7 @@ class RewriteSparkPlanRulesManager private (rewriteRules: Seq[Rule[SparkPlan]])
         case _: FileSourceScanExec => true
         case _: ExpandExec => true
         case _: GenerateExec => true
+        case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) => true
         case _ => false
       }
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/RewriteSparkPlanRulesManager.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/RewriteSparkPlanRulesManager.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.extension.{RewriteCollect, RewriteIn}
 import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.EvalPythonExec
-import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecShim}
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 import org.apache.spark.sql.types.StringType
 
@@ -630,8 +630,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar window group limit is not enabled in WindowGroupLimitExec")
           } else {
-            val windowGroupLimitPlan =
-              SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+            val windowGroupLimitPlan = SparkShimLoader.getSparkShims
+              .getWindowGroupLimitExecShim(plan)
+              .asInstanceOf[WindowGroupLimitExecShim]
             val transformer = WindowGroupLimitExecTransformer(
               windowGroupLimitPlan.partitionSpec,
               windowGroupLimitPlan.orderSpec,

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.EvalPythonExec
-import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecShim}
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 sealed trait TransformSingleNode extends Logging {
@@ -409,8 +409,9 @@ object TransformOthers {
             plan.orderSpec,
             plan.child)
         case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) =>
-          val windowGroupLimitPlan =
-            SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+          val windowGroupLimitPlan = SparkShimLoader.getSparkShims
+            .getWindowGroupLimitExecShim(plan)
+            .asInstanceOf[WindowGroupLimitExecShim]
           WindowGroupLimitExecTransformer(
             windowGroupLimitPlan.partitionSpec,
             windowGroupLimitPlan.orderSpec,

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
@@ -408,6 +408,17 @@ object TransformOthers {
             plan.partitionSpec,
             plan.orderSpec,
             plan.child)
+        case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) =>
+          val windowGroupLimitPlan =
+            SparkShimLoader.getSparkShims.getWindowGroupLimitExecShim(plan)
+          WindowGroupLimitExecTransformer(
+            windowGroupLimitPlan.partitionSpec,
+            windowGroupLimitPlan.orderSpec,
+            windowGroupLimitPlan.rankLikeFunction,
+            windowGroupLimitPlan.limit,
+            windowGroupLimitPlan.mode,
+            windowGroupLimitPlan.child
+          )
         case plan: GlobalLimitExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           val child = plan.child

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.execution.{WindowExecTransformer, WindowGroupLimitExecTransformer}
+
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.gluten.execution.WindowExecTransformer
-
+import org.apache.gluten.execution.{WindowExecTransformer, WindowGroupLimitExecTransformer}
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
@@ -87,6 +86,94 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
       assert(
         getExecutedPlan(df).exists {
           case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+
+  testGluten("Filter on row number") {
+    withTable("customer") {
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
+      val query =
+        """
+          |SELECT * from (SELECT
+          |  c_custkey,
+          |  c_acctbal,
+          |  row_number() OVER (
+          |    PARTITION BY c_nationkey,
+          |    "a"
+          |    ORDER BY
+          |      c_custkey,
+          |      "a"
+          |  ) AS row_num
+          |FROM
+          |   customer ORDER BY 1, 2) where row_num <=2
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, BigDecimal(638841L, 2), 1),
+          Row(4953, BigDecimal(603728L, 2), 1),
+          Row(9954, BigDecimal(758725L, 2), 1),
+          Row(35403, BigDecimal(603470L, 2), 2),
+          Row(35803, BigDecimal(528487L, 2), 1),
+          Row(61065, BigDecimal(728477L, 2), 1),
+          Row(95337, BigDecimal(91561L, 2), 2),
+          Row(127412, BigDecimal(462141L, 2), 2),
+          Row(148303, BigDecimal(430230L, 2), 2)
+        )
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowGroupLimitExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+
+  testGluten("Filter on rank") {
+    withTable("customer") {
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
+      val query =
+        """
+          |SELECT * from (SELECT
+          |  c_custkey,
+          |  c_acctbal,
+          |  rank() OVER (
+          |    PARTITION BY c_nationkey,
+          |    "a"
+          |    ORDER BY
+          |      c_custkey,
+          |      "a"
+          |  ) AS rank
+          |FROM
+          |   customer ORDER BY 1, 2) where rank <=2
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, BigDecimal(638841L, 2), 1),
+          Row(4953, BigDecimal(603728L, 2), 1),
+          Row(9954, BigDecimal(758725L, 2), 1),
+          Row(35403, BigDecimal(603470L, 2), 2),
+          Row(35803, BigDecimal(528487L, 2), 1),
+          Row(61065, BigDecimal(728477L, 2), 1),
+          Row(95337, BigDecimal(91561L, 2), 2),
+          Row(127412, BigDecimal(462141L, 2), 2),
+          Row(148303, BigDecimal(430230L, 2), 2)
+        )
+      )
+      assert(
+        !getExecutedPlan(df).exists {
+          case _: WindowGroupLimitExecTransformer => true
           case _ => false
         }
       )

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -67,6 +67,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableColumnarWindow: Boolean = conf.getConf(COLUMNAR_WINDOW_ENABLED)
 
+  def enableColumnarWindowGroupLimit: Boolean = conf.getConf(COLUMNAR_WINDOW_GROUP_LIMIT_ENABLED)
+
   def veloxColumnarWindowType: String = conf.getConfString(COLUMNAR_VELOX_WINDOW_TYPE.key)
 
   def enableColumnarShuffledHashJoin: Boolean = conf.getConf(COLUMNAR_SHUFFLED_HASH_JOIN_ENABLED)
@@ -768,6 +770,13 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.columnar.window")
       .internal()
       .doc("Enable or disable columnar window.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COLUMNAR_WINDOW_GROUP_LIMIT_ENABLED =
+    buildConf("spark.gluten.sql.columnar.window.group.limit")
+      .internal()
+      .doc("Enable or disable columnar window group limit.")
       .booleanConf
       .createWithDefault(true)
 

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, GlobalLimitExec, SparkPlan, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
-import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WindowGroupLimitExecShim, WriteJobDescription, WriteTaskResult}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
@@ -131,9 +131,9 @@ trait SparkShims {
 
   def isWindowGroupLimitExec(plan: SparkPlan): Boolean = false
 
-  def getWindowGroupLimitExecShim(plan: SparkPlan): WindowGroupLimitExecShim = null
+  def getWindowGroupLimitExecShim(plan: SparkPlan): SparkPlan = null
 
-  def getWindowGroupLimitExec(windowGroupLimitPlan: WindowGroupLimitExecShim): SparkPlan = null
+  def getWindowGroupLimitExec(windowGroupLimitPlan: SparkPlan): SparkPlan = null
 
   def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = (plan.limit, 0)
 

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, GlobalLimitExec, SparkPlan, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
-import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WriteJobDescription, WriteTaskResult}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WindowGroupLimitExecShim, WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
@@ -128,6 +128,12 @@ trait SparkShims {
   def replaceMightContain[T](
       expr: Expression,
       mightContainReplacer: (Expression, Expression) => BinaryExpression): Expression
+
+  def isWindowGroupLimitExec(plan: SparkPlan): Boolean = false
+
+  def getWindowGroupLimitExecShim(plan: SparkPlan): WindowGroupLimitExecShim = null
+
+  def getWindowGroupLimitExec(windowGroupLimitPlan: WindowGroupLimitExecShim): SparkPlan = null
 
   def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = (plan.limit, 0)
 

--- a/shims/common/src/main/scala/org/apache/spark/sql/execution/datasources/WindowGroupLimitExecShim.scala
+++ b/shims/common/src/main/scala/org/apache/spark/sql/execution/datasources/WindowGroupLimitExecShim.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, SortOrder}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.window.WindowGroupLimitMode
+
+case class WindowGroupLimitExecShim(
+    partitionSpec: Seq[Expression],
+    orderSpec: Seq[SortOrder],
+    rankLikeFunction: Expression,
+    limit: Int,
+    mode: WindowGroupLimitMode,
+    child: SparkPlan)

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.window
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+sealed trait WindowGroupLimitMode
+
+case object Partial extends WindowGroupLimitMode
+
+case object Final extends WindowGroupLimitMode
+
+case class WindowGroupLimitExecShim(
+    partitionSpec: Seq[Expression],
+    orderSpec: Seq[SortOrder],
+    rankLikeFunction: Expression,
+    limit: Int,
+    mode: WindowGroupLimitMode,
+    child: SparkPlan)
+  extends UnaryExecNode {
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} doesn't support doExecute")
+  }
+
+  override def output: Seq[Attribute] = child.output
+}

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.window
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+sealed trait WindowGroupLimitMode
+
+case object Partial extends WindowGroupLimitMode
+
+case object Final extends WindowGroupLimitMode
+
+case class WindowGroupLimitExecShim(
+    partitionSpec: Seq[Expression],
+    orderSpec: Seq[SortOrder],
+    rankLikeFunction: Expression,
+    limit: Int,
+    mode: WindowGroupLimitMode,
+    child: SparkPlan)
+  extends UnaryExecNode {
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} doesn't support doExecute")
+  }
+
+  override def output: Seq[Attribute] = child.output
+}

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.window
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+sealed trait WindowGroupLimitMode
+
+case object Partial extends WindowGroupLimitMode
+
+case object Final extends WindowGroupLimitMode
+
+case class WindowGroupLimitExecShim(
+    partitionSpec: Seq[Expression],
+    orderSpec: Seq[SortOrder],
+    rankLikeFunction: Expression,
+    limit: Int,
+    mode: WindowGroupLimitMode,
+    child: SparkPlan)
+  extends UnaryExecNode {
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} doesn't support doExecute")
+  }
+
+  override def output: Seq[Attribute] = child.output
+}

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -43,6 +43,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
+import org.apache.spark.sql.execution.window.WindowGroupLimitExec
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
@@ -248,6 +249,34 @@ class Spark35Shims extends SparkShims {
 
   override def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = {
     (getLimit(plan.limit, plan.offset), plan.offset)
+  }
+
+  override def isWindowGroupLimitExec(plan: SparkPlan): Boolean = plan match {
+    case _: WindowGroupLimitExec => true
+    case _ => false
+  }
+
+  override def getWindowGroupLimitExecShim(plan: SparkPlan): WindowGroupLimitExecShim = {
+    val windowGroupLimitPlan = plan.asInstanceOf[WindowGroupLimitExec]
+    WindowGroupLimitExecShim(
+      windowGroupLimitPlan.partitionSpec,
+      windowGroupLimitPlan.orderSpec,
+      windowGroupLimitPlan.rankLikeFunction,
+      windowGroupLimitPlan.limit,
+      windowGroupLimitPlan.mode,
+      windowGroupLimitPlan.child
+    )
+  }
+
+  override def getWindowGroupLimitExec(windowGroupLimitPlan: WindowGroupLimitExecShim): SparkPlan = {
+    WindowGroupLimitExec(
+      windowGroupLimitPlan.partitionSpec,
+      windowGroupLimitPlan.orderSpec,
+      windowGroupLimitPlan.rankLikeFunction,
+      windowGroupLimitPlan.limit,
+      windowGroupLimitPlan.mode,
+      windowGroupLimitPlan.child
+    )
   }
 
   override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
-import org.apache.spark.sql.execution.window.WindowGroupLimitExec
+import org.apache.spark.sql.execution.window.{WindowGroupLimitExec, WindowGroupLimitExecShim}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
@@ -268,14 +268,15 @@ class Spark35Shims extends SparkShims {
     )
   }
 
-  override def getWindowGroupLimitExec(windowGroupLimitPlan: WindowGroupLimitExecShim): SparkPlan = {
+  override def getWindowGroupLimitExec(windowGroupLimitPlan: SparkPlan): SparkPlan = {
+    val windowGroupLimitExecShim = windowGroupLimitPlan.asInstanceOf[WindowGroupLimitExecShim]
     WindowGroupLimitExec(
-      windowGroupLimitPlan.partitionSpec,
-      windowGroupLimitPlan.orderSpec,
-      windowGroupLimitPlan.rankLikeFunction,
-      windowGroupLimitPlan.limit,
-      windowGroupLimitPlan.mode,
-      windowGroupLimitPlan.child
+      windowGroupLimitExecShim.partitionSpec,
+      windowGroupLimitExecShim.orderSpec,
+      windowGroupLimitExecShim.rankLikeFunction,
+      windowGroupLimitExecShim.limit,
+      windowGroupLimitExecShim.mode,
+      windowGroupLimitExecShim.child
     )
   }
 

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/window/WindowGroupLimitExecShim.scala
@@ -14,11 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.execution.datasources
+package org.apache.spark.sql.execution.window
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, SortOrder}
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.window.WindowGroupLimitMode
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
 case class WindowGroupLimitExecShim(
     partitionSpec: Seq[Expression],
@@ -27,3 +28,14 @@ case class WindowGroupLimitExecShim(
     limit: Int,
     mode: WindowGroupLimitMode,
     child: SparkPlan)
+  extends UnaryExecNode {
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} doesn't support doExecute")
+  }
+
+  override def output: Seq[Attribute] = child.output
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a new operator named WindowGroupLimitExec introduced in spark 3.5 for optimizing window with rank like function with filter on it. https://github.com/apache/spark/pull/38799. This PR maps this operator with row number function to TopNRowNumberNode in velox. Currently velox doesn't support TopN for rank and dense_rank. There is an issue opened in velox for it https://github.com/facebookincubator/velox/discussions/9404. Once that support gets added in velox this new operator in Gluten can be extended to support those.

(Partially Fixes: \#4836)

## How was this patch tested?

Added new UT

