### PR TITLE
[GLUTEN-5405][CH] Add rewrite todate function

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -22,7 +22,7 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution._
 import org.apache.gluten.expression._
 import org.apache.gluten.expression.ConverterUtils.FunctionConfig
-import org.apache.gluten.extension.{CountDistinctWithoutExpand, FallbackBroadcastHashJoin, FallbackBroadcastHashJoinPrepQueryStage}
+import org.apache.gluten.extension.{CountDistinctWithoutExpand, FallbackBroadcastHashJoin, FallbackBroadcastHashJoinPrepQueryStage, RewriteToDateExpresstionRule}
 import org.apache.gluten.extension.columnar.AddTransformHintRule
 import org.apache.gluten.extension.columnar.MiscColumnarRules.TransformPreOverrides
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
@@ -573,7 +573,9 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
    * @return
    */
   override def genExtendedAnalyzers(): List[SparkSession => Rule[LogicalPlan]] = {
-    List(spark => new RewriteDateTimestampComparisonRule(spark, spark.sessionState.conf))
+    List(
+      spark => new RewriteToDateExpresstionRule(spark, spark.sessionState.conf),
+      spark => new RewriteDateTimestampComparisonRule(spark, spark.sessionState.conf))
   }
 
   /**

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -228,7 +228,7 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
 
     Seq(("true", false), ("false", true)).foreach(
       conf => {
-        withSQLConf((GlutenConfig.ENABLE_REWRITE_DATE_CONVERSION.key, conf._1)) {
+        withSQLConf((GlutenConfig.ENABLE_CH_REWRITE_DATE_CONVERSION.key, conf._1)) {
           runSql(sqlStr)(
             df => {
               val project = df.queryExecution.executedPlan.collect {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.GlutenConfig
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
 
@@ -209,5 +211,33 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
           |""".stripMargin
       runSql(sql, noFallBack = true) { _ => }
     }
+  }
+
+  test("test rewrite date conversion") {
+    val sqlStr =
+      """
+        |SELECT
+        |to_date(
+        |  from_unixtime(
+        |    unix_timestamp(date_format(l_shipdate, 'yyyyMMdd'), 'yyyyMMdd')
+        |  )
+        |)
+        |FROM lineitem
+        |limit 10
+        |""".stripMargin
+
+    Seq(("true", false), ("false", true)).foreach(
+      conf => {
+        withSQLConf((GlutenConfig.ENABLE_REWRITE_DATE_CONVERSION.key, conf._1)) {
+          runSql(sqlStr)(
+            df => {
+              val project = df.queryExecution.executedPlan.collect {
+                case project: ProjectExecTransformer => project
+              }
+              assert(project.size == 1)
+              assert(project.apply(0).projectList.toString().contains("from_unixtime") == conf._2)
+            })
+        }
+      })
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHOptimizeRuleBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHOptimizeRuleBenchmark.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.benchmarks
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+
+object CHOptimizeRuleBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark {
+
+  protected lazy val appName = "CHOptimizeRuleBenchmark"
+  protected lazy val thrdNum = "1"
+  protected lazy val memorySize = "4G"
+  protected lazy val offheapSize = "4G"
+
+  def beforeAll(): Unit = {}
+
+  override def getSparkSession: SparkSession = {
+    beforeAll()
+    val conf = getSparkConf
+      .setIfMissing("spark.sql.columnVector.offheap.enabled", "true")
+      .set("spark.gluten.sql.columnar.separate.scan.rdd.for.ch", "true")
+
+    SparkSession.builder.config(conf).getOrCreate()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val (parquetDir, readFileCnt, scanSchema, executedCnt, executedVanilla) =
+      if (mainArgs.isEmpty) {
+        ("/data/tpch-data-sf1/parquet/lineitem", 3, "l_orderkey,l_receiptdate", 5, true)
+      } else {
+        (mainArgs(0), mainArgs(1).toInt, mainArgs(2), mainArgs(3).toInt, mainArgs(4).toBoolean)
+      }
+
+    val parquetReadBenchmark =
+      new Benchmark(s"OptimizeRuleBenchmark", 10, output = output)
+
+    parquetReadBenchmark.addCase(s"ClickHouse rewrite dateConversion: false", executedCnt) {
+      _ => testToDateNotOptimize(parquetDir)
+    }
+
+    parquetReadBenchmark.addCase(s"ClickHouse rewrite dateConversion: true", executedCnt) {
+      _ => testToDateOptimize(parquetDir)
+    }
+
+    parquetReadBenchmark.run()
+  }
+
+  def testToDateNotOptimize(parquetDir: String): Unit = {
+    withSQLConf(("spark.gluten.sql.rewrite.dateConversion", "false")) {
+      spark
+        .sql(s"""
+                |select
+                |to_date(
+                |  from_unixtime(
+                |    unix_timestamp(date_format(l_shipdate, 'yyyyMMdd'), 'yyyyMMdd')
+                |  )
+                |)
+                |from parquet.`$parquetDir`
+                |
+                |""".stripMargin)
+        .collect()
+    }
+  }
+
+  def testToDateOptimize(parquetDir: String): Unit = {
+    withSQLConf(("spark.gluten.sql.rewrite.dateConversion", "true")) {
+      spark
+        .sql(s"""
+                |select
+                |to_date(
+                |  from_unixtime(
+                |    unix_timestamp(date_format(l_shipdate, 'yyyyMMdd'), 'yyyyMMdd')
+                |  )
+                |)
+                |from parquet.`$parquetDir`
+                |
+                |""".stripMargin)
+        .collect()
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -566,7 +566,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           throw new UnsupportedOperationException(s"Not support expression TimestampAdd.")
         }
         val add = timestampAdd.asInstanceOf[BinaryExpression]
-        TimestampAddTransform(
+        TimestampAddTransformer(
           substraitExprName,
           extract.get.head,
           replaceWithExpressionTransformerInternal(add.left, attributeSeq, expressionsMap),

--- a/gluten-core/src/main/scala/org/apache/gluten/expression/TimestampAddTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/expression/TimestampAddTransformer.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types.DataType
 
 import com.google.common.collect.Lists
 
-case class TimestampAddTransform(
+case class TimestampAddTransformer(
     substraitExprName: String,
     unit: String,
     left: ExpressionTransformer,

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
@@ -80,7 +80,7 @@ class RewriteToDateExpresstionRule(session: SparkSession, conf: SQLConf)
           && fromUnixTime.left.asInstanceOf[UnixTimestamp].left.dataType.isInstanceOf[StringType] =>
       val unixTimestamp = fromUnixTime.left.asInstanceOf[UnixTimestamp]
       val newLeft = unixTimestamp.left
-      ParseToDate(newLeft, Option.empty, Option.empty)
+      new ParseToDate(newLeft)
     case _ => toDate
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.gluten.GlutenConfig
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+// If users query data through BI tools.
+// The BI tools may generate SQL similar to
+// `to_date(
+//   from_unixtime(
+//     unix_timestamp(stringType, 'yyyyMMdd')
+//   )
+// )`
+// to convert string strings to dates.
+// Under ch backend, the StringType can be directly converted into DateType,
+//     and the functions `from_unixtime` and `unix_timestamp` can be optimized here.
+// Optimized result is `to_date(stringType)`
+class RewriteToDateExpresstionRule(session: SparkSession, conf: SQLConf)
+  extends Rule[LogicalPlan]
+  with Logging {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (
+      plan.resolved &&
+      GlutenConfig.getConf.enableGluten &&
+      GlutenConfig.getConf.enableRewriteDateConversion
+    ) {
+      visitPlan(plan)
+    } else {
+      plan
+    }
+  }
+
+  private def visitPlan(plan: LogicalPlan): LogicalPlan = plan match {
+    case project: Project =>
+      val newProjectList = project.projectList.map(expr => visitExpression(expr))
+      val newProject = Project(newProjectList, project.child)
+      newProject
+    case other =>
+      val children = other.children.map(visitPlan)
+      other.withNewChildren(children)
+  }
+
+  private def visitExpression(expression: NamedExpression): NamedExpression = expression match {
+    case Alias(c, _) if c.isInstanceOf[ParseToDate] =>
+      val newToDate = rewriteParseToDate(c.asInstanceOf[ParseToDate])
+      if (!newToDate.fastEquals(c))
+        Alias(newToDate, newToDate.toString())()
+      else
+        expression
+    case _ => expression
+  }
+
+  private def rewriteParseToDate(toDate: ParseToDate): Expression = toDate.left match {
+    case fromUnixTime: FromUnixTime
+        if fromUnixTime.left.isInstanceOf[UnixTimestamp]
+          && fromUnixTime.left.asInstanceOf[UnixTimestamp].left.dataType.isInstanceOf[StringType] =>
+      val unixTimestamp = fromUnixTime.left.asInstanceOf[UnixTimestamp]
+      val newLeft = unixTimestamp.left
+      ParseToDate(newLeft, Option.empty, Option.empty)
+    case _ => toDate
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
@@ -45,7 +45,7 @@ class RewriteToDateExpresstionRule(session: SparkSession, conf: SQLConf)
     if (
       plan.resolved &&
       GlutenConfig.getConf.enableGluten &&
-      GlutenConfig.getConf.enableRewriteDateConversion
+      GlutenConfig.getConf.enableCHRewriteDateConversion
     ) {
       visitPlan(plan)
     } else {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
@@ -66,10 +66,11 @@ class RewriteToDateExpresstionRule(session: SparkSession, conf: SQLConf)
   private def visitExpression(expression: NamedExpression): NamedExpression = expression match {
     case Alias(c, _) if c.isInstanceOf[ParseToDate] =>
       val newToDate = rewriteParseToDate(c.asInstanceOf[ParseToDate])
-      if (!newToDate.fastEquals(c))
+      if (!newToDate.fastEquals(c)) {
         Alias(newToDate, newToDate.toString())()
-      else
+      } else {
         expression
+      }
     case _ => expression
   }
 

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -94,8 +94,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableRewriteDateTimestampComparison: Boolean =
     conf.getConf(ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON)
 
-  def enableRewriteDateConversion: Boolean =
-    conf.getConf(ENABLE_REWRITE_DATE_CONVERSION)
+  def enableCHRewriteDateConversion: Boolean =
+    conf.getConf(ENABLE_CH_REWRITE_DATE_CONVERSION)
 
   def enableCommonSubexpressionEliminate: Boolean =
     conf.getConf(ENABLE_COMMON_SUBEXPRESSION_ELIMINATE)
@@ -1591,8 +1591,8 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
-  val ENABLE_REWRITE_DATE_CONVERSION =
-    buildConf("spark.gluten.sql.rewrite.dateConversion")
+  val ENABLE_CH_REWRITE_DATE_CONVERSION =
+    buildConf("spark.gluten.sql.columnar.backend.ch.rewrite.dateConversion")
       .internal()
       .doc(
         "Rewrite the conversion between date and string."

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -94,6 +94,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableRewriteDateTimestampComparison: Boolean =
     conf.getConf(ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON)
 
+  def enableRewriteDateConversion: Boolean =
+    conf.getConf(ENABLE_REWRITE_DATE_CONVERSION)
+
   def enableCommonSubexpressionEliminate: Boolean =
     conf.getConf(ENABLE_COMMON_SUBEXPRESSION_ELIMINATE)
 
@@ -1585,6 +1588,16 @@ object GlutenConfig {
       .internal()
       .doc("Rewrite the comparision between date and timestamp to timestamp comparison."
         + "For example `from_unixtime(ts) > date` will be rewritten to `ts > to_unixtime(date)`")
+      .booleanConf
+      .createWithDefault(true)
+
+  val ENABLE_REWRITE_DATE_CONVERSION =
+    buildConf("spark.gluten.sql.rewrite.dateConversion")
+      .internal()
+      .doc(
+        "Rewrite the conversion between date and string."
+          + "For example `to_date(from_unixtime(unix_timestamp(stringType, 'yyyyMMdd')))`"
+          + " will be rewritten to `to_date(stringType)`")
       .booleanConf
       .createWithDefault(true)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If users query data through BI tools.
The BI tools may generate SQL similar to
```
to_date(
  from_unixtime(
    unix_timestamp(stringType, 'yyyyMMdd')
  )
 )
```
to convert string strings to dates.
Under ch backend, the StringType can be directly converted into DateType,
    and the functions `from_unixtime` and `unix_timestamp` can be optimized here.
Optimized result is `to_date(stringType)` by use
```
spark.gluten.sql.rewrite.dateConversion=true
```

Notice:
When this parameter is turned on, there may be inconsistent results, because ch is compatible with a lot of date parsing, and when format is yyyy-MM-dd , spark returns null, but ch parses normally.

(Fixes: \#5405)

## How was this patch tested?

Test by ut

| OptimizeRuleBenchmark    | Best Time(ms) | Avg Time(ms) | Stdev(ms) | Rate(M/s) | Per Row(ns) | Relative |
| -------- | ------- | ------- | ------- | ------- | ------- | ------- |
| ClickHouse rewrite dateConversion: false  | 6597 | 7576 | 1278 | 0.0 | 659716914.8 | 1.0X| 
| ClickHouse rewrite dateConversion: true | 3780 | 3865 | 98 | 0.0 | 378002746.3 | 1.7X |
             
