### PR TITLE
[VL] Add independent operator for top-n processing in TakeOrderedAndProjectExecTransformer

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -768,7 +768,7 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
       case p @ LimitTransformer(SortExecTransformer(sortOrder, _, child, _), 0, count) =>
         // Since `maybeCollapseTakeOrderedAndProject` has a fixed caller
         // (TakeOrderedAndProjectExecTransformer#doExecuteColumnar), we don't have to
-        // set global/local flag for the output operator. Since
+        // set global/local flag for the output top n operator. Since
         // TakeOrderedAndProjectExecTransformer's execution code is in a way hacky and already
         // manually placed required exchanges.
         val topN = TopNTransformer(count, sortOrder, global = false, child);

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -764,7 +764,7 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
   }
 
   override def maybeCollapseTakeOrderedAndProject(plan: SparkPlan): SparkPlan = {
-    // This to-top-n optimization assumes exchange operators were already placed.
+    // This to-top-n optimization assumes exchange operators were already placed in input plan.
     plan.transformUp {
       case p @ LimitTransformer(SortExecTransformer(sortOrder, _, child, _), 0, count) =>
         val global = child.outputPartitioning.satisfies(AllTuples)

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/TopNTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/TopNTransformer.scala
@@ -16,21 +16,19 @@
  */
 package org.apache.gluten.execution
 
+import io.substrait.proto.SortField
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter}
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.metrics.{MetricsUpdater, NoopMetricsUpdater}
-import org.apache.gluten.substrait.`type`.TypeBuilder
 import org.apache.gluten.substrait.SubstraitContext
+import org.apache.gluten.substrait.`type`.TypeBuilder
 import org.apache.gluten.substrait.extensions.ExtensionBuilder
 import org.apache.gluten.substrait.rel.{RelBuilder, RelNode}
-
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, Distribution, Partitioning, SinglePartition, UnspecifiedDistribution}
+import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, Distribution, Partitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.SparkPlan
-
-import io.substrait.proto.SortField
 
 import scala.collection.JavaConverters._
 

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/TopNTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/TopNTransformer.scala
@@ -16,19 +16,21 @@
  */
 package org.apache.gluten.execution
 
-import io.substrait.proto.SortField
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter}
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.metrics.{MetricsUpdater, NoopMetricsUpdater}
-import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.`type`.TypeBuilder
+import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.extensions.ExtensionBuilder
 import org.apache.gluten.substrait.rel.{RelBuilder, RelNode}
+
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, Distribution, Partitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.SparkPlan
+
+import io.substrait.proto.SortField
 
 import scala.collection.JavaConverters._
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -275,6 +275,7 @@ class VeloxTPCHMiscSuite extends VeloxTPCHTableSupport {
     }
     assert(sortExec.size == 1)
     val result = df.collect()
+    df.explain(true)
     val expectedResult = Seq(Row(0), Row(1), Row(2), Row(3), Row(4))
     TestUtils.compareAnswers(result, expectedResult)
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -92,9 +92,11 @@ class SubstraitToVeloxPlanConverter {
   /// Convert Substrait FilterRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::FilterRel& filterRel);
 
-  /// Convert Substrait FetchRel into Velox LimitNode or TopNNode according the
-  /// different input of fetchRel.
+  /// Convert Substrait FetchRel into Velox LimitNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::FetchRel& fetchRel);
+
+  /// Convert Substrait TopNRel into Velox TopNNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::TopNRel& topNRel);
 
   /// Convert Substrait ReadRel into Velox Values Node.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ReadRel& readRel, const RowTypePtr& type);

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -403,7 +403,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
     const auto& extension = fetchRel.advanced_extension();
     std::vector<TypePtr> types;
     if (!validateInputTypes(extension, types)) {
-      LOG_VALIDATION_MSG("Unsupported input types in ExpandRel.");
+      LOG_VALIDATION_MSG("Unsupported input types in FetchRel.");
       return false;
     }
 
@@ -421,22 +421,42 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
     return false;
   }
 
-  // Check the input of fetchRel, if it's sortRel, we need to check whether the sorting key is duplicated.
-  bool topNFlag = false;
-  if (fetchRel.has_input()) {
-    topNFlag = fetchRel.input().has_sort();
-    if (topNFlag) {
-      ::substrait::SortRel sortRel = fetchRel.input().sort();
-      auto [sortingKeys, sortingOrders] = planConverter_.processSortField(sortRel.sorts(), rowType);
-      folly::F14FastSet<std::string> sortingKeyNames;
-      for (const auto& sortingKey : sortingKeys) {
-        auto result = sortingKeyNames.insert(sortingKey->name());
-        if (!result.second) {
-          LOG_VALIDATION_MSG(
-              "If the input of fetchRel is a SortRel, we will convert it to a TopNNode. In Velox, it is important to ensure unique sorting keys. However, duplicate keys were found in this case.");
-          return false;
-        }
-      }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::TopNRel& topNRel) {
+  RowTypePtr rowType = nullptr;
+  // Get and validate the input types from extension.
+  if (topNRel.has_advanced_extension()) {
+    const auto& extension = topNRel.advanced_extension();
+    std::vector<TypePtr> types;
+    if (!validateInputTypes(extension, types)) {
+      LOG_VALIDATION_MSG("Unsupported input types in TopNRel.");
+      return false;
+    }
+
+    int32_t inputPlanNodeId = 0;
+    std::vector<std::string> names;
+    names.reserve(types.size());
+    for (auto colIdx = 0; colIdx < types.size(); colIdx++) {
+      names.emplace_back(SubstraitParser::makeNodeName(inputPlanNodeId, colIdx));
+    }
+    rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+  }
+
+  if (topNRel.n() < 0) {
+    LOG_VALIDATION_MSG("N should be valid in TopNRel.");
+    return false;
+  }
+
+  auto [sortingKeys, sortingOrders] = planConverter_.processSortField(topNRel.sorts(), rowType);
+  folly::F14FastSet<std::string> sortingKeyNames;
+  for (const auto& sortingKey : sortingKeys) {
+    auto result = sortingKeyNames.insert(sortingKey->name());
+    if (!result.second) {
+      LOG_VALIDATION_MSG(
+          "Duplicate sort keys were found in TopNRel.");
+      return false;
     }
   }
 
@@ -1174,6 +1194,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::Rel& rel) {
     return validate(rel.generate());
   } else if (rel.has_fetch()) {
     return validate(rel.fetch());
+  } else if (rel.has_top_n()) {
+    return validate(rel.top_n());
   } else if (rel.has_window()) {
     return validate(rel.window());
   } else if (rel.has_write()) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -454,8 +454,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::TopNRel& topNRel
   for (const auto& sortingKey : sortingKeys) {
     auto result = sortingKeyNames.insert(sortingKey->name());
     if (!result.second) {
-      LOG_VALIDATION_MSG(
-          "Duplicate sort keys were found in TopNRel.");
+      LOG_VALIDATION_MSG("Duplicate sort keys were found in TopNRel.");
       return false;
     }
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -43,6 +43,9 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Limit is supported.
   bool validate(const ::substrait::FetchRel& fetchRel);
 
+  /// Used to validate whether the computing of this TopN is supported.
+  bool validate(const ::substrait::TopNRel& topNRel);
+
   /// Used to validate whether the computing of this Expand is supported.
   bool validate(const ::substrait::ExpandRel& expandRel);
 

--- a/docs/developers/SubstraitModifications.md
+++ b/docs/developers/SubstraitModifications.md
@@ -26,6 +26,7 @@ changed `Unbounded` in `WindowFunction` into `Unbounded_Preceding` and `Unbounde
 * Added `GenerateRel`([#574](https://github.com/apache/incubator-gluten/pull/574)).
 * Added `PartitionColumn` in `LocalFiles`([#2405](https://github.com/apache/incubator-gluten/pull/2405)).
 * Added `WriteRel` ([#3690](https://github.com/apache/incubator-gluten/pull/3690)).
+* Added `TopNRel` ([#5409](https://github.com/apache/incubator-gluten/pull/5409)).
 
 ## Modifications to type.proto
 

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
@@ -229,6 +229,27 @@ public class RelBuilder {
     return new FetchRelNode(input, offset, count, extensionNode);
   }
 
+  public static RelNode makeTopNRel(
+      RelNode input,
+      Long n,
+      List<SortField> sorts,
+      SubstraitContext context,
+      Long operatorId) {
+    context.registerRelToOperator(operatorId);
+    return new TopNNode(input, n, sorts);
+  }
+
+  public static RelNode makeTopNRel(
+      RelNode input,
+      Long n,
+      List<SortField> sorts,
+      AdvancedExtensionNode extensionNode,
+      SubstraitContext context,
+      Long operatorId) {
+    context.registerRelToOperator(operatorId);
+    return new TopNNode(input, n, sorts, extensionNode);
+  }
+
   public static RelNode makeWindowRel(
       RelNode input,
       List<WindowFunctionNode> windowFunctionNodes,

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
@@ -230,11 +230,7 @@ public class RelBuilder {
   }
 
   public static RelNode makeTopNRel(
-      RelNode input,
-      Long n,
-      List<SortField> sorts,
-      SubstraitContext context,
-      Long operatorId) {
+      RelNode input, Long n, List<SortField> sorts, SubstraitContext context, Long operatorId) {
     context.registerRelToOperator(operatorId);
     return new TopNNode(input, n, sorts);
   }

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/TopNNode.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/TopNNode.java
@@ -16,11 +16,12 @@
  */
 package org.apache.gluten.substrait.rel;
 
+import org.apache.gluten.substrait.extensions.AdvancedExtensionNode;
+
 import io.substrait.proto.Rel;
 import io.substrait.proto.RelCommon;
 import io.substrait.proto.SortField;
 import io.substrait.proto.TopNRel;
-import org.apache.gluten.substrait.extensions.AdvancedExtensionNode;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -39,7 +40,8 @@ public class TopNNode implements RelNode, Serializable {
     this.extensionNode = null;
   }
 
-  public TopNNode(RelNode input, Long count, List<SortField> sorts, AdvancedExtensionNode extensionNode) {
+  public TopNNode(
+      RelNode input, Long count, List<SortField> sorts, AdvancedExtensionNode extensionNode) {
     this.input = input;
     this.count = count;
     this.sorts.addAll(sorts);

--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/TopNNode.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/TopNNode.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.substrait.rel;
+
+import io.substrait.proto.Rel;
+import io.substrait.proto.RelCommon;
+import io.substrait.proto.SortField;
+import io.substrait.proto.TopNRel;
+import org.apache.gluten.substrait.extensions.AdvancedExtensionNode;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TopNNode implements RelNode, Serializable {
+  private final RelNode input;
+  private final Long count;
+  private final List<SortField> sorts = new ArrayList<>();
+  private final AdvancedExtensionNode extensionNode;
+
+  public TopNNode(RelNode input, Long count, List<SortField> sorts) {
+    this.input = input;
+    this.count = count;
+    this.sorts.addAll(sorts);
+    this.extensionNode = null;
+  }
+
+  public TopNNode(RelNode input, Long count, List<SortField> sorts, AdvancedExtensionNode extensionNode) {
+    this.input = input;
+    this.count = count;
+    this.sorts.addAll(sorts);
+    this.extensionNode = extensionNode;
+  }
+
+  @Override
+  public Rel toProtobuf() {
+    RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
+    relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
+
+    TopNRel.Builder topNBuilder = TopNRel.newBuilder();
+
+    if (input != null) {
+      topNBuilder.setInput(input.toProtobuf());
+    }
+
+    topNBuilder.setN(count);
+
+    for (int i = 0; i < sorts.size(); i++) {
+      topNBuilder.addSorts(i, sorts.get(i));
+    }
+
+    if (extensionNode != null) {
+      topNBuilder.setAdvancedExtension(extensionNode.toProtobuf());
+    }
+
+    Rel.Builder relBuilder = Rel.newBuilder();
+    relBuilder.setTopN(topNBuilder.build());
+    return relBuilder.build();
+  }
+}

--- a/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -268,6 +268,15 @@ message FetchRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
+// The relational operator representing TOP N calculation
+message TopNRel {
+  RelCommon common = 1;
+  Rel input = 2;
+  int64 n = 3;
+  repeated SortField sorts = 4;
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
 // The relational operator representing a GROUP BY Aggregate
 message AggregateRel {
   RelCommon common = 1;
@@ -485,6 +494,7 @@ message Rel {
     WindowRel window = 16;
     GenerateRel generate = 17;
     WriteRel write = 18;
+    TopNRel top_n = 19;
   }
 }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -705,4 +705,6 @@ trait SparkPlanExecApi {
   def genPreProjectForGenerate(generate: GenerateExec): SparkPlan
 
   def genPostProjectForGenerate(generate: GenerateExec): SparkPlan
+
+  def maybeCollapseTakeOrderedAndProject(plan: SparkPlan): SparkPlan = plan
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/LimitTransformer.scala
@@ -48,12 +48,6 @@ case class LimitTransformer(child: SparkPlan, offset: Long, count: Long)
   override protected def doValidateInternal(): ValidationResult = {
     val context = new SubstraitContext
     val operatorId = context.nextOperatorId(this.nodeName)
-    // If RAS is enabled and is capable to move limit operators up and down among the plan nodes,
-    // It might become possible that an independent limit gets to be transited to a order-by-limit.
-    // In that case, we should tuning on the validation procedure. Either to move limit validation
-    // To RAS, or re-validate it in RAS, or add properties or rules in RAS to avoid such moves.
-    //
-    // It's not a issue for now since RAS doesn't do such moves.
     val relNode = getRelNode(context, operatorId, offset, count, child.output, null, true)
 
     doNativeValidation(context, relNode)

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util.concurrent.atomic.AtomicInteger
 
+// FIXME: The operator is simply a wrapper for sort + limit + project. It's better to remove this
+//  wrapper then return the piped sub-operators to query planner directly.
 case class TakeOrderedAndProjectExecTransformer(
     limit: Long,
     sortOrder: Seq[SortOrder],


### PR DESCRIPTION
This PR adds a new physical operator TopNTransformer in Velox backend mapping to Velox's `core::TopNNode`.

By doing this, we can remove the hacky limit + sort coherent validation code, and the proxied executed plan used by `TakeOrderedAndProjectExecTransformer` will correctly map to the actual physical plan in Velox task.

This PR is a phase 1 because the actual Velox plan is still hidden by `TakeOrderedAndProjectExecTransformer` although limit+sort was replaced by top-n. We may eventually deprecate `TakeOrderedAndProjectExecTransformer` and expose more execution details to query planner.