### PR TITLE
[VL] Fallback window operator when the range frame contain literal

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -292,6 +292,10 @@ object BackendSettings extends BackendSettingsApi {
           def checkLimitations(swf: SpecifiedWindowFrame, orderSpec: Seq[SortOrder]): Unit = {
             def doCheck(bound: Expression, isUpperBound: Boolean): Unit = {
               bound match {
+                case _: Literal =>
+                  throw new GlutenNotSupportException(
+                    "Window frame of type RANGE does" +
+                      " not support constant arguments in velox backend")
                 case _: SpecialFrameBoundary =>
                 case e if e.foldable =>
                   orderSpec.foreach(


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Velox Window operator does not support range frames with literal values, such as 'RANGE BETWEEN CURRENT ROW AND 2 FOLLOWING'.  And it will throw the  following issue. This PR fallback window operator to vanilla spark for this case.

```
Error Code: INVALID_ARGUMENT
Reason: (4294967295 vs. 4294967295) Window frame of type RANGE does not support constant arguments
Retriable: False
Expression: frameChannel != kConstantChannel
Function: operator()
File: /home/binweiyang/gluten/ep/build-velox/build/velox_ep/velox/exec/Window.cpp
Line: 93
Stack trace:
# 0  _ZN8facebook5velox7process10StackTraceC1Ei
# 1  _ZN8facebook5velox14VeloxExceptionC1EPKcmS3_St17basic_string_viewIcSt11char_traitsIcEES7_S7_S7_bNS1_4TypeES7_
# 2  _ZN8facebook5velox6detail14veloxCheckFailINS0_14VeloxUserErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKNS1_18VeloxCheckFailArgsET0_
# 3  _ZZN8facebook5velox4exec12_GLOBAL__N_122checkKRangeFrameBoundsERKSt10shared_ptrIKNS0_4core10WindowNodeEERKNS5_5FrameERKS3_IKNS0_7RowTypeEEENKUlRKS3_IKNS4_10ITypedExprEEE_clESM_.isra.0
# 4  _ZN8facebook5velox4exec6Window17createWindowFrameERKSt10shared_ptrIKNS0_4core10WindowNodeEERKNS5_5FrameERKS3_IKNS0_7RowTypeEE
# 5  _ZN8facebook5velox4exec6Window21createWindowFunctionsEv
# 6  _ZN8facebook5velox4exec6Window10initializeEv
# 7  _ZN8facebook5velox4exec6Driver19initializeOperatorsEv
# 8  _ZN8facebook5velox4exec6Driver11runInternalERSt10shared_ptrIS2_ERS3_INS1_13BlockingStateEERS3_INS0_9RowVectorEE
# 9  _ZN8facebook5velox4exec6Driver4nextERSt10shared_ptrINS1_13BlockingStateEE
# 10 _ZN8facebook5velox4exec4Task4nextEPN5folly10SemiFutureINS3_4UnitEEE
# 11 _ZN6gluten24WholeStageResultIterator4nextEv
# 12 Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeHasNext
# 13 0x00007ffb1ab68f683
```

## How was this patch tested?

Add new unit testing.
