### PR TITLE
[VL] Add a bad test case when bloom_filter_agg is fallen back while might_contain is not

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
@@ -324,7 +324,7 @@ case class FallbackBloomFilterAggIfNeeded() extends Rule[SparkPlan] {
         case a: org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec =>
           tagNotTransformableRecursive(a.executedPlan)
         case _ =>
-          p.children.map(tagNotTransformableRecursive)
+          p.children.foreach(tagNotTransformableRecursive)
       }
     }
 

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -46,6 +46,7 @@ import org.apache.spark.sql.sources.{GlutenBucketedReadWithoutHiveSupportSuite, 
 class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenStringFunctionsSuite]
   enableSuite[GlutenBloomFilterAggregateQuerySuite]
+    .excludeGlutenTest("Test bloom_filter_agg fallback with might_contain offloaded")
   enableSuite[GlutenDataSourceV2DataFrameSessionCatalogSuite]
   enableSuite[GlutenDataSourceV2DataFrameSuite]
   enableSuite[GlutenDataSourceV2FunctionSuite]


### PR DESCRIPTION
So far the case fails with error

```
org.apache.gluten.exception.GlutenException: java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: (1 vs. 0)
Retriable: False
Expression: kBloomFilterV1 == version
Function: merge
File: ../.././velox/common/base/BloomFilter.h
Line: 67
Stack trace:
# 0  std::shared_ptr<facebook::velox::VeloxException::State const> facebook::velox::VeloxException::State::make<facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1}>(facebook::velox::VeloxException::Type, facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1})
# 1  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 2  facebook::velox::VeloxUserError::VeloxUserError(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, std::basic_string_view<char, std::char_traits<char> >)
# 3  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxUserError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 4  facebook::velox::BloomFilter<std::allocator<unsigned long> >::merge(char const*)
# 5  facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>::initialize(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, facebook::velox::StringView const*, long const*)
# 6  void facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> >::unpackInitialize<2, facebook::velox::StringView, long>(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&, facebook::velox::StringView const*, long const*) const
# 7  void facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> >::unpackInitialize<1, facebook::velox::StringView>(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&, facebook::velox::StringView const*) const
# 8  void facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> >::unpackInitialize<0>(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&) const
# 9  facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> >::SimpleFunctionAdapter(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&)
# 10 std::_MakeUniq<facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> > >::__single_object std::make_unique<facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> >, std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&>(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, facebook::velox::core::QueryConfig const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&)
# 11 facebook::velox::exec::SimpleFunctionAdapterFactoryImpl<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::BloomFilterMightContainFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, bool, facebook::velox::ConstantChecker<facebook::velox::Varbinary, long>, facebook::velox::Varbinary, long> >::createVectorFunction(std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&, facebook::velox::core::QueryConfig const&) const
# 12 facebook::velox::exec::(anonymous namespace)::compileRewrittenExpression(std::shared_ptr<facebook::velox::core::ITypedExpr const> const&, facebook::velox::exec::(anonymous namespace)::Scope*, facebook::velox::core::QueryConfig const&, facebook::velox::memory::MemoryPool*, std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool)
# 13 facebook::velox::exec::(anonymous namespace)::compileExpression(std::shared_ptr<facebook::velox::core::ITypedExpr const> const&, facebook::velox::exec::(anonymous namespace)::Scope*, facebook::velox::core::QueryConfig const&, facebook::velox::memory::MemoryPool*, std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool)
# 14 facebook::velox::exec::compileExpressions(std::vector<std::shared_ptr<facebook::velox::core::ITypedExpr const>, std::allocator<std::shared_ptr<facebook::velox::core::ITypedExpr const> > > const&, facebook::velox::core::ExecCtx*, facebook::velox::exec::ExprSet*, bool)
# 15 facebook::velox::exec::ExprSet::ExprSet(std::vector<std::shared_ptr<facebook::velox::core::ITypedExpr const>, std::allocator<std::shared_ptr<facebook::velox::core::ITypedExpr const> > > const&, facebook::velox::core::ExecCtx*, bool)
# 16 std::_MakeUniq<facebook::velox::exec::ExprSet>::__single_object std::make_unique<facebook::velox::exec::ExprSet, std::vector<std::shared_ptr<facebook::velox::core::ITypedExpr const>, std::allocator<std::shared_ptr<facebook::velox::core::ITypedExpr const> > >, facebook::velox::core::ExecCtx*&>(std::vector<std::shared_ptr<facebook::velox::core::ITypedExpr const>, std::allocator<std::shared_ptr<facebook::velox::core::ITypedExpr const> > >&&, facebook::velox::core::ExecCtx*&)
# 17 facebook::velox::exec::makeExprSetFromFlag(std::vector<std::shared_ptr<facebook::velox::core::ITypedExpr const>, std::allocator<std::shared_ptr<facebook::velox::core::ITypedExpr const> > >&&, facebook::velox::core::ExecCtx*)
# 18 facebook::velox::exec::FilterProject::initialize()
# 19 facebook::velox::exec::Driver::initializeOperators()
# 20 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 21 facebook::velox::exec::Driver::next(std::shared_ptr<facebook::velox::exec::BlockingState>&)
# 22 facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
# 23 gluten::WholeStageResultIterator::next()
# 24 gluten::ResultIterator::getNext()
# 25 gluten::ResultIterator::hasNext()
# 26 Java_org_apache_gluten_vectorized_ColumnarBatchOutIterator_nativeHasNext
# 27 0x00007ff779018507

	at org.apache.gluten.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:39)
	at scala.collection.convert.Wrappers$JIteratorWrapper.hasNext(Wrappers.scala:45)
	at org.apache.gluten.utils.IteratorCompleter.hasNext(Iterators.scala:69)
	at org.apache.gluten.utils.PayloadCloser.hasNext(Iterators.scala:35)
	at org.apache.gluten.utils.PipelineTimeAccumulator.hasNext(Iterators.scala:98)
	at scala.collection.Iterator.isEmpty(Iterator.scala:387)
	at scala.collection.Iterator.isEmpty$(Iterator.scala:387)
	at org.apache.gluten.utils.PipelineTimeAccumulator.isEmpty(Iterators.scala:88)
	at org.apache.gluten.execution.VeloxColumnarToRowExec$.toRowIterator(VeloxColumnarToRowExec.scala:119)
	at org.apache.gluten.execution.VeloxColumnarToRowExec.$anonfun$doExecuteInternal$1(VeloxColumnarToRowExec.scala:83)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitions$2(RDD.scala:855)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitions$2$adapted(RDD.scala:855)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:365)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:329)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:365)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:329)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

Refer to our previous effort on co-fallback of `blook_filter_agg` and `might_contain`: https://github.com/apache/incubator-gluten/pull/3994