### PR TITLE
[CORE] Fix negative buffer size

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -153,7 +153,7 @@ object RowToVeloxColumnarExec {
         }
         val rowLength = new ListBuffer[Long]()
         var rowCount = 0
-        var offset = 0
+        var offset = 0L
         val sizeInBytes = row.getSizeInBytes
         // allocate buffer based on 1st row, but if first row is very big, this will cause OOM
         // maybe we should optimize to list ArrayBuf to native to avoid buf close and allocate
@@ -182,7 +182,7 @@ object RowToVeloxColumnarExec {
             val unsafeRow = convertToUnsafeRow(row)
             val sizeInBytes = unsafeRow.getSizeInBytes
             if ((offset + sizeInBytes) > arrowBuf.capacity()) {
-              val tmpBuf = arrowAllocator.buffer(((offset + sizeInBytes) * 2).toLong)
+              val tmpBuf = arrowAllocator.buffer((offset + sizeInBytes) * 2)
               tmpBuf.setBytes(0, arrowBuf, 0, offset)
               arrowBuf.close()
               arrowBuf = tmpBuf


### PR DESCRIPTION
## What changes were proposed in this pull request?
The buffer size may overflow before convert to Long.

We got an error in `RowToVeloxColumnarExec`,

```
io.glutenproject.exception.GlutenException: java.lang.RuntimeException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Operator::getOutput failed for [operator: ValueStream, plan node ID: 0]: Error during calling Java code from native code: java.lang.IllegalArgumentException: the requested size must be non-negative
 at io.glutenproject.shaded.org.apache.arrow.util.Preconditions.checkArgument(Preconditions.java:136)
 at io.glutenproject.shaded.org.apache.arrow.memory.BaseAllocator.buffer(BaseAllocator.java:291)
 at io.glutenproject.shaded.org.apache.arrow.memory.RootAllocator.buffer(RootAllocator.java:29)
 at io.glutenproject.shaded.org.apache.arrow.memory.BaseAllocator.buffer(BaseAllocator.java:280)
 at io.glutenproject.shaded.org.apache.arrow.memory.RootAllocator.buffer(RootAllocator.java:29)
 at io.glutenproject.execution.RowToVeloxColumnarExec$$anon$1.nativeConvert(RowToVeloxColumnarExec.scala:184)
 at io.glutenproject.execution.RowToVeloxColumnarExec$$anon$1.next(RowToVeloxColumnarExec.scala:225)
 at io.glutenproject.execution.RowToVeloxColumnarExec$$anon$1.next(RowToVeloxColumnarExec.scala:134)
 at io.glutenproject.utils.IteratorCompleter.next(Iterators.scala:77)
 at io.glutenproject.utils.PayloadCloser.next(Iterators.scala:39)
 at scala.collection.convert.Wrappers$IteratorWrapper.next(Wrappers.scala:33)
 at io.glutenproject.vectorized.GeneralInIterator.nextColumnarBatch(GeneralInIterator.java:38)
 at io.glutenproject.vectorized.ColumnarBatchInIterator.next(ColumnarBatchInIterator.java:33)
 at io.glutenproject.vectorized.ColumnarBatchOutIterator.nativeHasNext(Native Method)
```

## How was this patch tested?

Manually test

