### PR TITLE
[VL] Make the maxBatchSize check consistent

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -481,10 +481,10 @@ object BackendSettings extends BackendSettingsApi {
   private def checkMaxBatchSize(nativeConf: java.util.Map[String, String]): Unit = {
     if (nativeConf.containsKey(GlutenConfig.GLUTEN_MAX_BATCH_SIZE_KEY)) {
       val maxBatchSize = nativeConf.get(GlutenConfig.GLUTEN_MAX_BATCH_SIZE_KEY).toInt
-      if (maxBatchSize > MAXIMUM_BATCH_SIZE) {
+      if (maxBatchSize >= MAXIMUM_BATCH_SIZE) {
         throw new IllegalArgumentException(
           s"The maximum value of ${GlutenConfig.GLUTEN_MAX_BATCH_SIZE_KEY}" +
-            s" is $MAXIMUM_BATCH_SIZE for Velox backend.")
+            s" should be less than $MAXIMUM_BATCH_SIZE for Velox backend.")
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
A minor change to make the `maxBatchSize` consistent with the check in `VeloxShuffleWriter` 

https://github.com/apache/incubator-gluten/blob/main/cpp/velox/shuffle/VeloxShuffleWriter.cc#L222 
