### PR TITLE
[VL] Remove batch size limit

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -448,7 +448,6 @@ object BackendSettings extends BackendSettingsApi {
   override def shuffleSupportedCodec(): Set[String] = SHUFFLE_SUPPORTED_CODEC
 
   override def resolveNativeConf(nativeConf: java.util.Map[String, String]): Unit = {
-    checkMaxBatchSize(nativeConf)
     UDFResolver.resolveUdfConf(nativeConf)
   }
 
@@ -476,17 +475,6 @@ object BackendSettings extends BackendSettingsApi {
     GlutenConfig.getConf.enableNativeWriter.getOrElse(
       SparkShimLoader.getSparkShims.enableNativeWriteFilesByDefault()
     )
-  }
-
-  private def checkMaxBatchSize(nativeConf: java.util.Map[String, String]): Unit = {
-    if (nativeConf.containsKey(GlutenConfig.GLUTEN_MAX_BATCH_SIZE_KEY)) {
-      val maxBatchSize = nativeConf.get(GlutenConfig.GLUTEN_MAX_BATCH_SIZE_KEY).toInt
-      if (maxBatchSize > MAXIMUM_BATCH_SIZE) {
-        throw new IllegalArgumentException(
-          s"The maximum value of ${GlutenConfig.GLUTEN_MAX_BATCH_SIZE_KEY}" +
-            s" is $MAXIMUM_BATCH_SIZE for Velox backend.")
-      }
-    }
   }
 
   override def shouldRewriteCount(): Boolean = {

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -218,9 +218,6 @@ arrow::Status VeloxShuffleWriter::init() {
   supportAvx512_ = false;
 #endif
 
-  // Split record batch size should be less than 32k.
-  VELOX_CHECK_LE(options_.bufferSize, 32 * 1024);
-
   ARROW_ASSIGN_OR_RAISE(
       partitioner_, Partitioner::make(options_.partitioning, numPartitions_, options_.startPartitionId));
   DLOG(INFO) << "Create partitioning type: " << std::to_string(options_.partitioning);


### PR DESCRIPTION
Remove the batch size limitation as Velox pipeline can produce large outputs against the configured batch size.
See issue https://github.com/apache/incubator-gluten/issues/5307 and PR #5326 

Velox issue: https://github.com/facebookincubator/velox/issues/9540