### PR TITLE
[GLUTEN-5457][CH] Fix merge cause an error log when use mergetree

### DIFF
--- a/cpp-ch/local-engine/Storages/Mergetree/MergeSparkMergeTreeTask.cpp
+++ b/cpp-ch/local-engine/Storages/Mergetree/MergeSparkMergeTreeTask.cpp
@@ -179,6 +179,8 @@ void MergeSparkMergeTreeTask::finish()
         ThreadFuzzer::maybeInjectSleep();
         ThreadFuzzer::maybeInjectMemoryLimitException();
     }
+
+    new_part->is_temp = false;
 }
 
 ContextMutablePtr MergeSparkMergeTreeTask::createTaskContext() const


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix merge cause an error log when use mergetree

(Fixes: \#5457)

## How was this patch tested?

By `GlutenClickHouseMergeTreeOptimizeSuite`

