### PR TITLE
[VL] Daily Update Velox Version (2024_04_21)

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -127,7 +127,8 @@ WholeStageResultIterator::WholeStageResultIterator(
       fmt::format("Gluten_Stage_{}_TID_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
       std::move(planFragment),
       0,
-      std::move(queryCtx));
+      std::move(queryCtx),
+      velox::exec::Task::ExecutionMode::kSerial);
   if (!task_->supportsSingleThreadedExecution()) {
     throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());
   }

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_04_19
+VELOX_BRANCH=2024_04_21
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
d44a23e9d (upstream/main) Fix build failure in Meta internal test (#9556)
53f6bf761 Add execution mode enforcement (#9489)
09efd20ac Add reserved memory capacity pool in arbitrator (#9504)
c320923d4 Fix writer extended tests quality (#9552)
4ac07c8df Build fixes in fedora (clang 16) (#9550)
ea96074ef Make CallbackOnLastSignal more readable (#9548)
cb87bc8b3 Rename UnitLoaderTestToolsTests to UnitLoaderToolsTests (#9547)
d727293f2 Clear paged output stream buffers at flush time (#9546)
85393d519 Set up nightly run of window fuzzer (#9133)
52b80a7b5 Support UNKNOWN type in array_distinct (#9500)
c240cf36d Fix setup-centos8 script to use pip3.9 (#9536)
13d56e6a4 DwrfReader Refactor: DwrfReader accepts a UnitLoaderFactory (#9534)
61181013f Build boost without python in setup script (#9484)
3f5db597f Change JoinFuzzer iteration message to warning (#9509)
25f42f673 Record number of checkpoints made in SsdCacheStats (#9521)
5d633c602 Optionally use linear heuristics to estimate stripe size (#9517)
f8fde9325 Add CallbackOnLastSignal (#9506)
```