### PR TITLE
[VL] Support fallback processing of velox_bloom_filter_agg

### DIFF
--- a/backends-velox/src/main/java/org/apache/spark/util/sketch/VeloxBloomFilter.java
+++ b/backends-velox/src/main/java/org/apache/spark/util/sketch/VeloxBloomFilter.java
@@ -33,6 +33,15 @@ public class VeloxBloomFilter extends BloomFilter {
     handle = jni.init(data);
   }
 
+  private VeloxBloomFilter(int capacity) {
+    jni = VeloxBloomFilterJniWrapper.create();
+    handle = jni.empty(capacity);
+  }
+
+  public static VeloxBloomFilter empty(int capacity) {
+    return new VeloxBloomFilter(capacity);
+  }
+
   public static VeloxBloomFilter readFrom(InputStream in) {
     try {
       byte[] all = IOUtils.toByteArray(in);
@@ -72,7 +81,8 @@ public class VeloxBloomFilter extends BloomFilter {
 
   @Override
   public boolean putLong(long item) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    jni.insertLong(handle, item);
+    return true;
   }
 
   @Override
@@ -117,6 +127,7 @@ public class VeloxBloomFilter extends BloomFilter {
 
   @Override
   public void writeTo(OutputStream out) throws IOException {
-    throw new UnsupportedOperationException("Not yet implemented");
+    byte[] data = jni.serialize(handle);
+    out.write(data);
   }
 }

--- a/backends-velox/src/main/java/org/apache/spark/util/sketch/VeloxBloomFilterJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/spark/util/sketch/VeloxBloomFilterJniWrapper.java
@@ -36,7 +36,13 @@ public class VeloxBloomFilterJniWrapper implements RuntimeAware {
     return runtime.getHandle();
   }
 
+  public native long empty(int capacity);
+
   public native long init(byte[] data);
 
+  public native void insertLong(long handle, long item);
+
   public native boolean mightContainLong(long handle, long item);
+
+  public native byte[] serialize(long handle);
 }

--- a/backends-velox/src/main/java/org/apache/spark/util/sketch/VeloxBloomFilterJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/spark/util/sketch/VeloxBloomFilterJniWrapper.java
@@ -44,5 +44,7 @@ public class VeloxBloomFilterJniWrapper implements RuntimeAware {
 
   public native boolean mightContainLong(long handle, long item);
 
+  public native void mergeFrom(long handle, long other);
+
   public native byte[] serialize(long handle);
 }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/BloomFilterMightContainJointRewriteRule.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/BloomFilterMightContainJointRewriteRule.scala
@@ -28,8 +28,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 case class BloomFilterMightContainJointRewriteRule(spark: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (
-      !(GlutenConfig.getConf.enableNativeBloomFilter &&
-        GlutenConfig.getConf.enableColumnarHashAgg)
+      !(GlutenConfig.getConf.enableNativeBloomFilter)
     ) {
       return plan
     }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/BloomFilterMightContainJointRewriteRule.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/BloomFilterMightContainJointRewriteRule.scala
@@ -27,9 +27,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 
 case class BloomFilterMightContainJointRewriteRule(spark: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    if (
-      !(GlutenConfig.getConf.enableNativeBloomFilter)
-    ) {
+    if (!(GlutenConfig.getConf.enableNativeBloomFilter)) {
       return plan
     }
     val out = plan.transformWithSubqueries {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/VeloxBloomFilterAggregate.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/VeloxBloomFilterAggregate.scala
@@ -22,9 +22,10 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.trees.TernaryLike
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.util.TaskResources
-import org.apache.spark.util.sketch.BloomFilter
+import org.apache.spark.util.sketch.{BloomFilter, VeloxBloomFilter}
 
 /**
  * Velox's bloom-filter implementation uses different algorithms internally comparing to vanilla
@@ -48,6 +49,12 @@ case class VeloxBloomFilterAggregate(
     inputAggBufferOffset)
 
   override def prettyName: String = "velox_bloom_filter_agg"
+
+  // Mark as lazy so that `estimatedNumItems` is not evaluated during tree transformation.
+  private lazy val estimatedNumItems: Long =
+    Math.min(
+      estimatedNumItemsExpression.eval().asInstanceOf[Number].longValue,
+      SQLConf.get.getConf(SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS))
 
   override def first: Expression = child
 
@@ -75,27 +82,44 @@ case class VeloxBloomFilterAggregate(
     if (!TaskResources.inSparkTask()) {
       throw new UnsupportedOperationException("velox_bloom_filter_agg is not evaluable on Driver")
     }
-    ???
+    VeloxBloomFilter.empty(Math.toIntExact(estimatedNumItems))
   }
 
-  override def update(buffer: BloomFilter, input: InternalRow): BloomFilter =
-    throw new UnsupportedOperationException()
+  override def update(buffer: BloomFilter, input: InternalRow): BloomFilter = {
+    assert(buffer.isInstanceOf[VeloxBloomFilter])
+    val value = child.eval(input)
+    // Ignore null values.
+    if (value == null) {
+      return buffer
+    }
+    buffer.putLong(value.asInstanceOf[Long])
+    buffer
+  }
 
-  override def merge(buffer: BloomFilter, input: BloomFilter): BloomFilter =
-    throw new UnsupportedOperationException()
+  override def merge(buffer: BloomFilter, input: BloomFilter): BloomFilter = {
+    assert(buffer.isInstanceOf[VeloxBloomFilter])
+    assert(input.isInstanceOf[VeloxBloomFilter])
+    buffer.asInstanceOf[VeloxBloomFilter].mergeInPlace(input)
+  }
 
-  override def eval(buffer: BloomFilter): Any = throw new UnsupportedOperationException()
+  override def eval(buffer: BloomFilter): Any = {
+    assert(buffer.isInstanceOf[VeloxBloomFilter])
+    serialize(buffer)
+  }
 
-  override def serialize(buffer: BloomFilter): Array[Byte] =
-    throw new UnsupportedOperationException()
+  override def serialize(buffer: BloomFilter): Array[Byte] = {
+    assert(buffer.isInstanceOf[VeloxBloomFilter])
+    buffer.asInstanceOf[VeloxBloomFilter].serialize()
+  }
 
-  override def deserialize(storageFormat: Array[Byte]): BloomFilter =
-    throw new UnsupportedOperationException()
+  override def deserialize(bytes: Array[Byte]): BloomFilter = {
+    VeloxBloomFilter.readFrom(bytes)
+  }
 
-  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate =
-    throw new UnsupportedOperationException()
+  override def withNewMutableAggBufferOffset(newOffset: Int): VeloxBloomFilterAggregate =
+    copy(mutableAggBufferOffset = newOffset)
 
-  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate =
-    throw new UnsupportedOperationException()
+  override def withNewInputAggBufferOffset(newOffset: Int): VeloxBloomFilterAggregate =
+    copy(inputAggBufferOffset = newOffset)
 
 }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/VeloxBloomFilterAggregate.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/VeloxBloomFilterAggregate.scala
@@ -54,7 +54,10 @@ case class VeloxBloomFilterAggregate(
   private lazy val estimatedNumItems: Long =
     Math.min(
       estimatedNumItemsExpression.eval().asInstanceOf[Number].longValue,
-      SQLConf.get.getConf(SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS))
+      SQLConf.get
+        .getConfString("spark.sql.optimizer.runtime.bloomFilter.maxNumItems", "4000000")
+        .toLong
+    )
 
   override def first: Expression = child
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/VeloxBloomFilterAggregate.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/VeloxBloomFilterAggregate.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.trees.TernaryLike
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.util.TaskResources
 import org.apache.spark.util.sketch.BloomFilter
 
 /**
@@ -70,7 +71,12 @@ case class VeloxBloomFilterAggregate(
       numBitsExpression = newNumBitsExpression)
   }
 
-  override def createAggregationBuffer(): BloomFilter = throw new UnsupportedOperationException()
+  override def createAggregationBuffer(): BloomFilter = {
+    if (!TaskResources.inSparkTask()) {
+      throw new UnsupportedOperationException("velox_bloom_filter_agg is not evaluable on Driver")
+    }
+    ???
+  }
 
   override def update(buffer: BloomFilter, input: InternalRow): BloomFilter =
     throw new UnsupportedOperationException()

--- a/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
+++ b/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
@@ -27,9 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
 import java.nio.ByteBuffer;
 
 public class VeloxBloomFilterTest {
@@ -61,7 +58,9 @@ public class VeloxBloomFilterTest {
     TaskResources$.MODULE$.runUnsafe(
         () -> {
           final BloomFilter filter = VeloxBloomFilter.readFrom(buf.array());
-          Assert.assertThrows("Bloom-filter is not initialized", RuntimeException.class,
+          Assert.assertThrows(
+              "Bloom-filter is not initialized",
+              RuntimeException.class,
               new ThrowingRunnable() {
                 @Override
                 public void run() throws Throwable {
@@ -115,7 +114,6 @@ public class VeloxBloomFilterTest {
             Assert.assertTrue(filter1.mightContainLong(i));
           }
 
-
           final BloomFilter filter2 = VeloxBloomFilter.empty(10000);
           final int start2 = 1000;
           final int end2 = 3000;
@@ -139,7 +137,6 @@ public class VeloxBloomFilterTest {
           for (int i = start1; i < end2; i++) {
             Assert.assertTrue(filter1.mightContainLong(i));
           }
-
 
           // Check false positives.
           checkFalsePositives(filter1, end2);

--- a/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
+++ b/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
@@ -90,15 +90,21 @@ public class VeloxBloomFilterTest {
           final int attemptCount = 5000000;
 
           int falsePositives = 0;
+          int negativeFalsePositives = 0;
 
           for (int i = attemptStart; i < attemptStart + attemptCount; i++) {
             if (filter.mightContainLong(i)) {
               falsePositives++;
             }
+            if (filter.mightContainLong(-i)) {
+              negativeFalsePositives++;
+            }
           }
 
           Assert.assertTrue(falsePositives > 0);
           Assert.assertTrue(falsePositives < attemptCount);
+          Assert.assertTrue(negativeFalsePositives > 0);
+          Assert.assertTrue(negativeFalsePositives < attemptCount);
 
           return null;
         });

--- a/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
+++ b/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
@@ -72,20 +72,21 @@ public class VeloxBloomFilterTest {
     TaskResources$.MODULE$.runUnsafe(
         () -> {
           final BloomFilter filter = VeloxBloomFilter.empty(10000);
-          final int numItems = 1000;
-          for (int i = 0; i < numItems; i++) {
+          final int numItems = 2000;
+          final int halfNumItems = numItems / 2;
+          for (int i = -halfNumItems; i < halfNumItems; i++) {
             Assert.assertFalse(filter.mightContainLong(i));
           }
-          for (int i = 0; i < numItems; i++) {
+          for (int i = -halfNumItems; i < halfNumItems; i++) {
             filter.putLong(i);
             Assert.assertTrue(filter.mightContainLong(i));
           }
-          for (int i = 0; i < numItems; i++) {
+          for (int i = -halfNumItems; i < halfNumItems; i++) {
             Assert.assertTrue(filter.mightContainLong(i));
           }
 
           // Check false positives.
-          final int attemptStart = 1000;
+          final int attemptStart = halfNumItems;
           final int attemptCount = 5000000;
 
           int falsePositives = 0;

--- a/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
+++ b/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
@@ -72,7 +72,7 @@ public class VeloxBloomFilterTest {
     TaskResources$.MODULE$.runUnsafe(
         () -> {
           final BloomFilter filter = VeloxBloomFilter.empty(10000);
-          int numItems = 1000;
+          final int numItems = 1000;
           for (int i = 0; i < numItems; i++) {
             Assert.assertFalse(filter.mightContainLong(i));
           }
@@ -83,6 +83,21 @@ public class VeloxBloomFilterTest {
           for (int i = 0; i < numItems; i++) {
             Assert.assertTrue(filter.mightContainLong(i));
           }
+
+          // Check false positives.
+          final int attemptStart = 1000;
+          final int attemptCount = 5000000;
+
+          int falsePositives = 0;
+
+          for (int i = attemptStart; i < attemptStart + attemptCount; i++) {
+            if (filter.mightContainLong(i)) {
+              falsePositives++;
+            }
+          }
+
+          Assert.assertTrue(falsePositives > 0);
+          Assert.assertTrue(falsePositives < attemptCount);
 
           return null;
         });

--- a/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
+++ b/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
@@ -25,6 +25,7 @@ import org.apache.spark.util.TaskResources$;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class VeloxBloomFilterTest {
   }
 
   @Test
-  public void testEmpty1() {
+  public void testEmpty() {
     TaskResources$.MODULE$.runUnsafe(
         () -> {
           final BloomFilter filter = VeloxBloomFilter.empty(10000);
@@ -53,16 +54,20 @@ public class VeloxBloomFilterTest {
   }
 
   @Test
-  public void testEmpty2() {
+  public void testMalformed() {
     final ByteBuffer buf = ByteBuffer.allocate(5);
     buf.put((byte) 1); // kBloomFilterV1
     buf.putInt(0); // size
     TaskResources$.MODULE$.runUnsafe(
         () -> {
           final BloomFilter filter = VeloxBloomFilter.readFrom(buf.array());
-          for (int i = 0; i < 1000; i++) {
-            Assert.assertFalse(filter.mightContainLong(i));
-          }
+          Assert.assertThrows("Bloom-filter is not initialized", RuntimeException.class,
+              new ThrowingRunnable() {
+                @Override
+                public void run() throws Throwable {
+                  filter.mightContainLong(0);
+                }
+              });
           return null;
         });
   }
@@ -86,25 +91,58 @@ public class VeloxBloomFilterTest {
           }
 
           // Check false positives.
-          final int attemptStart = halfNumItems;
-          final int attemptCount = 5000000;
+          checkFalsePositives(filter, halfNumItems);
 
-          int falsePositives = 0;
-          int negativeFalsePositives = 0;
+          return null;
+        });
+  }
 
-          for (int i = attemptStart; i < attemptStart + attemptCount; i++) {
-            if (filter.mightContainLong(i)) {
-              falsePositives++;
-            }
-            if (filter.mightContainLong(-i)) {
-              negativeFalsePositives++;
-            }
+  @Test
+  public void testMerge() {
+    TaskResources$.MODULE$.runUnsafe(
+        () -> {
+          final BloomFilter filter1 = VeloxBloomFilter.empty(10000);
+          final int start1 = 0;
+          final int end1 = 2000;
+          for (int i = start1; i < end1; i++) {
+            Assert.assertFalse(filter1.mightContainLong(i));
+          }
+          for (int i = start1; i < end1; i++) {
+            filter1.putLong(i);
+            Assert.assertTrue(filter1.mightContainLong(i));
+          }
+          for (int i = start1; i < end1; i++) {
+            Assert.assertTrue(filter1.mightContainLong(i));
           }
 
-          Assert.assertTrue(falsePositives > 0);
-          Assert.assertTrue(falsePositives < attemptCount);
-          Assert.assertTrue(negativeFalsePositives > 0);
-          Assert.assertTrue(negativeFalsePositives < attemptCount);
+
+          final BloomFilter filter2 = VeloxBloomFilter.empty(10000);
+          final int start2 = 1000;
+          final int end2 = 3000;
+          for (int i = start2; i < end2; i++) {
+            Assert.assertFalse(filter2.mightContainLong(i));
+          }
+          for (int i = start2; i < end2; i++) {
+            filter2.putLong(i);
+            Assert.assertTrue(filter2.mightContainLong(i));
+          }
+          for (int i = start2; i < end2; i++) {
+            Assert.assertTrue(filter2.mightContainLong(i));
+          }
+
+          try {
+            filter1.mergeInPlace(filter2);
+          } catch (IncompatibleMergeException e) {
+            throw new RuntimeException(e);
+          }
+
+          for (int i = start1; i < end2; i++) {
+            Assert.assertTrue(filter1.mightContainLong(i));
+          }
+
+
+          // Check false positives.
+          checkFalsePositives(filter1, end2);
 
           return null;
         });
@@ -114,30 +152,40 @@ public class VeloxBloomFilterTest {
   public void testSerde() {
     TaskResources$.MODULE$.runUnsafe(
         () -> {
-          final BloomFilter filter = VeloxBloomFilter.empty(10000);
+          final VeloxBloomFilter filter = VeloxBloomFilter.empty(10000);
           for (int i = 0; i < 1000; i++) {
             filter.putLong(i);
           }
 
-          final ByteArrayOutputStream o = new ByteArrayOutputStream();
-          try {
-            filter.writeTo(o);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-          byte[] data1 = o.toByteArray();
+          byte[] data1 = filter.serialize();
 
-          final BloomFilter filter2 = VeloxBloomFilter.readFrom(data1);
-          final ByteArrayOutputStream o2 = new ByteArrayOutputStream();
-          try {
-            filter2.writeTo(o2);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-          byte[] data2 = o2.toByteArray();
+          final VeloxBloomFilter filter2 = VeloxBloomFilter.readFrom(data1);
+          byte[] data2 = filter2.serialize();
 
           Assert.assertArrayEquals(data2, data1);
           return null;
         });
+  }
+
+  private static void checkFalsePositives(BloomFilter filter, int start) {
+    final int attemptStart = start;
+    final int attemptCount = 5000000;
+
+    int falsePositives = 0;
+    int negativeFalsePositives = 0;
+
+    for (int i = attemptStart; i < attemptStart + attemptCount; i++) {
+      if (filter.mightContainLong(i)) {
+        falsePositives++;
+      }
+      if (filter.mightContainLong(-i)) {
+        negativeFalsePositives++;
+      }
+    }
+
+    Assert.assertTrue(falsePositives > 0);
+    Assert.assertTrue(falsePositives < attemptCount);
+    Assert.assertTrue(negativeFalsePositives > 0);
+    Assert.assertTrue(negativeFalsePositives < attemptCount);
   }
 }

--- a/gluten-data/src/main/java/org/apache/gluten/exec/RuntimeAware.java
+++ b/gluten-data/src/main/java/org/apache/gluten/exec/RuntimeAware.java
@@ -21,5 +21,9 @@ package org.apache.gluten.exec;
  * for further native processing.
  */
 public interface RuntimeAware {
+  default boolean isCompatibleWith(RuntimeAware other) {
+    return handle() == other.handle();
+  }
+
   long handle();
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -115,7 +115,7 @@ class GlutenBloomFilterAggregateQuerySuite
     }
   }
 
-  testGluten("Test bloom_filter_agg fallback with might_contain offloaded") {
+  testGluten("Test bloom_filter_agg agg fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
     val numBits = GlutenConfig.getConf.veloxBloomFilterMaxNumBits

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -68,7 +68,7 @@ class GlutenBloomFilterAggregateQuerySuite
       Row(null))
   }
 
-  testGluten("Test bloom_filter_agg fallback") {
+  testGluten("Test bloom_filter_agg filter fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
     val numBits = GlutenConfig.getConf.veloxBloomFilterMaxNumBits
@@ -110,6 +110,39 @@ class GlutenBloomFilterAggregateQuerySuite
             df.queryExecution.executedPlan
           )
         }
+      }
+    }
+  }
+
+  testGluten("Test bloom_filter_agg agg fallback") {
+    val table = "bloom_filter_test"
+    val numEstimatedItems = 5000000L
+    val numBits = GlutenConfig.getConf.veloxBloomFilterMaxNumBits
+    val sqlString = s"""
+                       |SELECT col positive_membership_test
+                       |FROM $table
+                       |WHERE might_contain(
+                       |            (SELECT bloom_filter_agg(col,
+                       |              cast($numEstimatedItems as long),
+                       |              cast($numBits as long))
+                       |             FROM $table), col)
+                      """.stripMargin
+
+    withTempView(table) {
+      (Seq(Long.MinValue, 0, Long.MaxValue) ++ (1L to 200000L))
+        .toDF("col")
+        .createOrReplaceTempView(table)
+      withSQLConf(
+        GlutenConfig.COLUMNAR_HASHAGG_ENABLED.key -> "false"
+      ) {
+        val df = spark.sql(sqlString)
+        df.collect
+        assert(
+          collectWithSubqueries(df.queryExecution.executedPlan) {
+            case h if h.isInstanceOf[HashAggregateExecBaseTransformer] => h
+          }.isEmpty,
+          df.queryExecution.executedPlan
+        )
       }
     }
   }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -69,7 +69,7 @@ class GlutenBloomFilterAggregateQuerySuite
       Row(null))
   }
 
-  testGluten("Test bloom_filter_agg fallback") {
+  testGluten("Test bloom_filter_agg filter fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
     val numBits = GlutenConfig.getConf.veloxBloomFilterMaxNumBits
@@ -115,7 +115,7 @@ class GlutenBloomFilterAggregateQuerySuite
     }
   }
 
-  testGluten("Test bloom_filter_agg fallback with might_contain offloaded") {
+  testGluten("Test bloom_filter_agg agg fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
     val numBits = GlutenConfig.getConf.veloxBloomFilterMaxNumBits


### PR DESCRIPTION
Support fallback row-based processing of agg function `velox_bloom_filter_agg`. Which means we will always use Velox's bloom-filter implementation not matter the resident operators of bloom filter functions are fallen back / disabled or not, so long as Gluten plugin + Velox backend is enabled. So we will get rid of all possible bloom-filter compatibility issues in Velox backend once and for all. 