### PR TITLE
[VL] Avoid using debug instance of JniWorkspace in VeloxBloomFilterTest

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/ListenerApiImpl.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/ListenerApiImpl.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.datasources.velox.{VeloxOrcWriterInjects, 
 import org.apache.spark.sql.expression.UDFResolver
 import org.apache.spark.sql.internal.GlutenConfigUtil
 import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.util.SparkDirectoryUtil
 
 import org.apache.commons.lang3.StringUtils
 
@@ -140,6 +141,7 @@ class ListenerApiImpl extends ListenerApi {
   }
 
   private def initialize(conf: SparkConf): Unit = {
+    SparkDirectoryUtil.init(conf)
     val debugJni = conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_MODE, defaultValue = false) &&
       conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE, defaultValue = false)
     if (debugJni) {

--- a/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
+++ b/backends-velox/src/test/java/org/apache/spark/util/sketch/VeloxBloomFilterTest.java
@@ -18,7 +18,6 @@ package org.apache.spark.util.sketch;
 
 import org.apache.gluten.backendsapi.ListenerApi;
 import org.apache.gluten.backendsapi.velox.ListenerApiImpl;
-import org.apache.gluten.vectorized.JniWorkspace;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.util.TaskResources$;
@@ -32,7 +31,6 @@ public class VeloxBloomFilterTest {
 
   @BeforeClass
   public static void setup() {
-    JniWorkspace.enableDebug();
     final ListenerApi api = new ListenerApiImpl();
     api.onDriverStart(new SparkConf());
   }

--- a/gluten-core/src/main/java/org/apache/gluten/vectorized/JniWorkspace.java
+++ b/gluten-core/src/main/java/org/apache/gluten/vectorized/JniWorkspace.java
@@ -65,7 +65,8 @@ public class JniWorkspace {
   private static JniWorkspace createDefault() {
     try {
       final String tempRoot =
-          SparkDirectoryUtil.namespace("jni")
+          SparkDirectoryUtil.get()
+              .namespace("jni")
               .mkChildDirRandomly(UUID.randomUUID().toString())
               .getAbsolutePath();
       return createOrGet(tempRoot);

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.util
 
-import org.apache.spark.SparkEnv
+import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 
 import _root_.org.apache.gluten.exception.GlutenException
@@ -30,8 +30,8 @@ import java.nio.file.Paths
  * Manages Gluten's local directories, for storing jars, libs, spill files, or other temporary
  * stuffs.
  */
-object SparkDirectoryUtil extends Logging {
-  private val ROOTS = Utils.getConfiguredLocalDirs(SparkEnv.get.conf).flatMap {
+class SparkDirectoryUtil private (roots: Array[String]) extends Logging {
+  private val ROOTS = roots.flatMap {
     rootDir =>
       try {
         val localDir = Utils.createDirectory(rootDir, "gluten")
@@ -62,6 +62,33 @@ object SparkDirectoryUtil extends Logging {
     val namespace = new Namespace(ROOTS, name)
     NAMESPACE_MAPPING.put(name, namespace)
     namespace
+  }
+}
+
+object SparkDirectoryUtil extends Logging {
+  private var INSTANCE: SparkDirectoryUtil = _
+
+  def init(conf: SparkConf): Unit = synchronized {
+    val roots = Utils.getConfiguredLocalDirs(conf)
+    init(roots)
+  }
+
+  private def init(roots: Array[String]): Unit = synchronized {
+    if (INSTANCE == null) {
+      INSTANCE = new SparkDirectoryUtil(roots)
+      return
+    }
+    if (INSTANCE.ROOTS.toSet != roots.toSet) {
+      logWarning(
+        s"Reinitialize SparkDirectoryUtil with different root dirs: old: ${INSTANCE.ROOTS
+            .mkString("Array(", ", ", ")")}, new: ${roots.mkString("Array(", ", ", ")")}"
+      )
+    }
+  }
+
+  def get(): SparkDirectoryUtil = synchronized {
+    assert(INSTANCE != null, "Default instance of SparkDirectoryUtil was not set yet")
+    INSTANCE
   }
 }
 

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -90,7 +90,8 @@ public class NativePlanEvaluator {
     final long memoryManagerHandle = nmm.getNativeInstanceHandle();
 
     final String spillDirPath =
-        SparkDirectoryUtil.namespace("gluten-spill")
+        SparkDirectoryUtil.get()
+            .namespace("gluten-spill")
             .mkChildDirRoundRobin(UUID.randomUUID().toString())
             .getAbsolutePath();
 

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -56,6 +56,7 @@ class ColumnarShuffleWriter[K, V](
   private var mapStatus: MapStatus = _
 
   private val localDirs = SparkDirectoryUtil
+    .get()
     .namespace("shuffle-write")
     .all
     .map(_.getAbsolutePath)


### PR DESCRIPTION
This is a minor fix to let VeloxBloomFilterTest use regular code path to get JniWorkspace, with some minor refactors.