### PR TITLE
[GLUTEN-5502][VL] UnsafeProjection is only constructed once when converting rows to columns

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -124,6 +124,8 @@ object RowToVeloxColumnarExec {
     val arrowAllocator = ArrowBufferAllocators.contextInstance()
     val memoryManager = NativeMemoryManagers.contextInstance("RowToColumnar")
     val cSchema = ArrowSchema.allocateNew(arrowAllocator)
+    val factory = UnsafeProjection
+    val converter = factory.create(schema)
     val r2cHandle =
       try {
         ArrowAbiUtil.exportSchema(arrowAllocator, arrowSchema, cSchema)
@@ -213,8 +215,6 @@ object RowToVeloxColumnarExec {
         row match {
           case unsafeRow: UnsafeRow => unsafeRow
           case _ =>
-            val factory = UnsafeProjection
-            val converter = factory.create(schema)
             converter.apply(row)
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
UnsafeProjection is only constructed once when converting rows to columns;
If the schema contains fields structured as maps, constructing UnsafeProjection will be time-consuming.


[(Fixes: \#5502)](https://github.com/apache/incubator-gluten/issues/5502)

## How was this patch tested?

through exist uts

