### PR TITLE
[GLUTEN-5511] Fix GCC 11 warns that writing 1 byte into a region of size 0 [-Wstringop-overflow=]

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -270,7 +270,7 @@ function setup_linux {
 
   # apply patches
   sed -i 's/^  ninja -C "${BINARY_DIR}" install/  sudo ninja -C "${BINARY_DIR}" install/g' scripts/setup-helper-functions.sh
-  sed -i 's/-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17/-march=native -std=c++17 -mno-avx512f/g' scripts/setup-helper-functions.sh
+  sed -i 's/-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17/-march=native -std=c++17 -mno-avx512f -Wno-stringop-overflow/g' scripts/setup-helper-functions.sh
   if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" || "$LINUX_DISTRIBUTION" == "pop" ]]; then
     process_setup_ubuntu
   elif [[ "$LINUX_DISTRIBUTION" == "centos" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes following error popped during compilation using GCC 11:
```
..../Parquet_Read_Fuzz/ep/build-velox/build/velox_ep/./velox/vector/SelectivityVector.h:160:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  160 |       allSelected_ = false;
      |       ~~~~~~~~~~~~~^~~~~~~
```
(Fixes: \#5511)

## How was this patch tested?

N/A

