### PR TITLE
[GLUTEN-5512][CH] Fix the incorrect transformer for the round function with the decimal data type

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.{AggregateFunctionRewriteRule, FlushableHas
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.{Add, Alias, ArrayExists, ArrayFilter, ArrayForAll, ArrayTransform, Ascending, Attribute, Cast, CreateNamedStruct, ElementAt, Expression, ExpressionInfo, Generator, GetArrayItem, GetMapValue, GetStructField, If, IsNaN, LambdaFunction, Literal, Murmur3Hash, NamedExpression, NaNvl, PosExplode, Round, SortOrder, StringSplit, StringTrim, TryEval, Uuid}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, HLLAdapter}
 import org.apache.spark.sql.catalyst.optimizer.BuildSide
 import org.apache.spark.sql.catalyst.plans.JoinType
@@ -571,14 +571,6 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
   /**
    * * Expressions.
    */
-
-  /** Generates a transformer for decimal round. */
-  override def genDecimalRoundTransformer(
-      substraitExprName: String,
-      child: ExpressionTransformer,
-      original: Round): ExpressionTransformer = {
-    DecimalRoundTransformer(substraitExprName, child, original)
-  }
 
   /** Generate StringSplit transformer. */
   override def genStringSplitTransformer(

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -415,13 +415,6 @@ trait SparkPlanExecApi {
    */
   def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
 
-  def genDecimalRoundTransformer(
-      substraitExprName: String,
-      child: ExpressionTransformer,
-      original: Round): ExpressionTransformer = {
-    GenericExpressionTransformer(substraitExprName, Seq(child), original)
-  }
-
   def genGetStructFieldTransformer(
       substraitExprName: String,
       childTransformer: ExpressionTransformer,

--- a/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -243,11 +243,10 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           d
         )
       case r: Round if r.child.dataType.isInstanceOf[DecimalType] =>
-        BackendsApiManager.getSparkPlanExecApiInstance.genDecimalRoundTransformer(
+        DecimalRoundTransformer(
           substraitExprName,
           replaceWithExpressionTransformerInternal(r.child, attributeSeq, expressionsMap),
-          r
-        )
+          r)
       case t: ToUnixTimestamp =>
         BackendsApiManager.getSparkPlanExecApiInstance.genUnixTimestampTransformer(
           substraitExprName,

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -849,7 +849,6 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("atan2")
     .exclude("round/bround")
     .exclude("SPARK-37388: width_bucket")
-    .excludeGlutenTest("round/bround")
   enableSuite[GlutenMiscExpressionsSuite]
   enableSuite[GlutenNondeterministicSuite]
     .exclude("MonotonicallyIncreasingID")

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.gluten.utils.BackendTestUtils
+
 import org.apache.spark.sql.GlutenTestsTrait
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
@@ -70,7 +72,13 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
         checkEvaluation(BRound(shortPi, scale), shortResults(i), EmptyRow)
         checkEvaluation(BRound(intPi, scale), intResultsB(i), EmptyRow)
         checkEvaluation(BRound(longPi, scale), longResults(i), EmptyRow)
-        checkEvaluation(BRound(floatPi, scale), bRoundFloatResults(i), EmptyRow)
+        checkEvaluation(
+          BRound(floatPi, scale),
+          // the velox backend will fallback when executing bround,
+          // so uses the same excepted results with the vanilla spark
+          if (BackendTestUtils.isCHBackendLoaded()) floatResults(i) else bRoundFloatResults(i),
+          EmptyRow
+        )
     }
 
     val bdResults: Seq[BigDecimal] = Seq(

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -853,7 +853,6 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("unhex")
     .exclude("atan2")
     .exclude("round/bround/floor/ceil")
-    .excludeGlutenTest("round/bround/floor/ceil")
     .exclude("SPARK-36922: Support ANSI intervals for SIGN/SIGNUM")
     .exclude("SPARK-35926: Support YearMonthIntervalType in width-bucket function")
     .exclude("SPARK-35925: Support DayTimeIntervalType in width-bucket function")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.gluten.utils.BackendTestUtils
+
 import org.apache.spark.sql.GlutenTestsTrait
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
@@ -125,7 +127,13 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
         checkEvaluation(BRound(shortPi, scale), shortResults(i), EmptyRow)
         checkEvaluation(BRound(intPi, scale), intResultsB(i), EmptyRow)
         checkEvaluation(BRound(longPi, scale), longResults(i), EmptyRow)
-        checkEvaluation(BRound(floatPi, scale), bRoundFloatResults(i), EmptyRow)
+        checkEvaluation(
+          BRound(floatPi, scale),
+          // the velox backend will fallback when executing bround,
+          // so uses the same excepted results with the vanilla spark
+          if (BackendTestUtils.isCHBackendLoaded()) floatResults(i) else bRoundFloatResults(i),
+          EmptyRow
+        )
         checkEvaluation(
           checkDataTypeAndCast(RoundFloor(Literal(doublePi), Literal(scale))),
           doubleResultsFloor(i),

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.sql.shims.spark33
 
 import org.apache.gluten.execution.datasource.GlutenParquetWriterInjects
 import org.apache.gluten.expression.{ExpressionNames, Sig}
-import org.apache.gluten.expression.ExpressionNames.{KNOWN_NULLABLE, TIMESTAMP_ADD}
+import org.apache.gluten.expression.ExpressionNames.{CEIL, FLOOR, KNOWN_NULLABLE, TIMESTAMP_ADD}
 import org.apache.gluten.sql.shims.{ShimDescriptor, SparkShims}
 
 import org.apache.spark._
@@ -67,7 +67,9 @@ class Spark33Shims extends SparkShims {
       Sig[Csc](ExpressionNames.CSC),
       Sig[KnownNullable](KNOWN_NULLABLE),
       Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
-      Sig[TimestampAdd](TIMESTAMP_ADD)
+      Sig[TimestampAdd](TIMESTAMP_ADD),
+      Sig[RoundFloor](FLOOR),
+      Sig[RoundCeil](CEIL)
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[CH] Fix the incorrect transformer for the round function with the decimal data type.

When transforming the round function with the decimal data type, it only transformers the `child` expression, but missing the `scale` expression, which will lead to the incorrect results when executing the `round(decimal_data, x)`.

Close #5512.

(Fixes: #5512)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

