### PR TITLE
[GLUTEN-4914][CH][FOLLOWUP] Fix exceptions in ASTParser

### DIFF
--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1903,7 +1903,7 @@ ASTPtr ASTParser::parseToAST(const Names & names, const substrait::Expression & 
 
         auto substrait_name = function_signature.substr(0, function_signature.find(':'));
         auto func_parser = FunctionParserFactory::instance().tryGet(substrait_name, plan_parser);
-        String function_name = func_parser ? func_parser->getCHFunctionName(scalar_function)
+        String function_name = func_parser ? func_parser->getName()
                                            : SerializedPlanParser::getFunctionName(function_signature, scalar_function);
 
         ASTs ast_args;


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#4914)

`func_parser->getCHFunctionName()` still gets function name from `SCALAR_FUNCTIONS` and will parse error when get function implemented by `FunctionParser`.

## How was this patch tested?

Add UT

