### PR TITLE
[GLUTEN-5525][BUILD] Run `mvn clean` fails if a spark profile is not specified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,14 @@
     <scala.binary.version>2.12</scala.binary.version>
     <scala.version>2.12.15</scala.version>
     <spark.major.version>3</spark.major.version>
-    <sparkbundle.version>3.2</sparkbundle.version>
+    <sparkbundle.version>3.4</sparkbundle.version>
     <spark.version>3.4.2</spark.version>
-    <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
+    <sparkshim.module.name>spark34</sparkshim.module.name>
+    <sparkshim.artifactId>spark-sql-columnar-shims-spark34</sparkshim.artifactId>
+    <iceberg.version>1.5.0</iceberg.version>
+    <delta.package.name>delta-core</delta.package.name>
+    <delta.version>2.4.0</delta.version>
+    <delta.binary.version>24</delta.binary.version>
     <celeborn.version>0.3.2-incubating</celeborn.version>
     <arrow.version>14.0.1</arrow.version>
     <uniffle.version>0.8.0</uniffle.version>
@@ -129,11 +134,9 @@
     </profile>
     <profile>
       <id>spark-3.2</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <sparkbundle.version>3.2</sparkbundle.version>
+        <sparkshim.module.name>spark32</sparkshim.module.name>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
         <spark.version>3.2.2</spark.version>
 	<iceberg.version>1.3.1</iceberg.version>
@@ -146,6 +149,7 @@
       <id>spark-3.3</id>
       <properties>
         <sparkbundle.version>3.3</sparkbundle.version>
+        <sparkshim.module.name>spark33</sparkshim.module.name>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark33</sparkshim.artifactId>
         <spark.version>3.3.1</spark.version>
         <!-- keep using iceberg v1.3.1 for parquet compatibilty. -->
@@ -159,6 +163,7 @@
       <id>spark-3.4</id>
       <properties>
         <sparkbundle.version>3.4</sparkbundle.version>
+        <sparkshim.module.name>spark34</sparkshim.module.name>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark34</sparkshim.artifactId>
         <spark.version>3.4.2</spark.version>
 	<iceberg.version>1.5.0</iceberg.version>
@@ -171,6 +176,7 @@
       <id>spark-3.5</id>
       <properties>
         <sparkbundle.version>3.5</sparkbundle.version>
+        <sparkshim.module.name>spark35</sparkshim.module.name>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark35</sparkshim.artifactId>
         <spark.version>3.5.1</spark.version>
 	<iceberg.version>1.5.0</iceberg.version>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -30,6 +30,7 @@
 
   <modules>
     <module>common</module>
+    <module>${sparkshim.module.name}</module>
   </modules>
 
   <dependencies>
@@ -68,31 +69,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <profiles>
-    <profile>
-      <id>spark-3.2</id>
-      <modules>
-        <module>spark32</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>spark-3.3</id>
-      <modules>
-        <module>spark33</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>spark-3.4</id>
-      <modules>
-        <module>spark34</module>
-      </modules>
-    </profile>
-     <profile>
-      <id>spark-3.5</id>
-      <modules>
-        <module>spark35</module>
-      </modules>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix issue #5525

## How was this patch tested?
Run following command locally:
- `mvn clean`
- `mvn clean install -DskipTests`
- `mvn clean -Pbackends-velox -DskipTests`

