### PR TITLE
fix shuffle OOM if input batch is extremely large

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -306,6 +306,10 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Result<uint32_t> partitionBufferSizeAfterShrink(uint32_t partitionId) const;
 
+  bool isExtremelyLargeBatch(facebook::velox::RowVectorPtr& rv) const;
+
+  arrow::Status partitioningAndDoSplit(facebook::velox::RowVectorPtr rv, int64_t memLimit);
+
   SplitState splitState_{kInit};
 
   EvictState evictState_{kEvictable};
@@ -466,6 +470,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   }
 
   facebook::velox::CpuWallTiming cpuWallTimingList_[CpuWallTimingNum];
+  int32_t maxBatchSize_{0};
 }; // class VeloxShuffleWriter
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -192,6 +192,10 @@ class VeloxShuffleWriter final : public ShuffleWriter {
     VS_PRINT_CONTAINER(input_has_null_);
   }
 
+  int32_t maxBatchSize() const {
+    return maxBatchSize_;
+  }
+
  private:
   VeloxShuffleWriter(
       uint32_t numPartitions,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix https://github.com/apache/incubator-gluten/issues/5534
Calculating the maximum number of rows (maxBatchSize) in a batch based on the memory limit of the previous batch and the number of pre-allocated rows. If row count of current batch larger than maxBatchSize, slice it into small ones

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

