### PR TITLE
[VL] [BUG fix] Make the hasNext method can be called multi times

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -225,6 +225,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
 
     Iterators
       .wrap(nativeResultIterator.asScala)
+      .protectInvocationFlow()
       .recycleIterator {
         updateNativeMetrics(nativeResultIterator.getMetrics)
         nativeResultIterator.close()

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -231,6 +231,7 @@ object RowToVeloxColumnarExec {
     }
     Iterators
       .wrap(res)
+      .protectInvocationFlow()
       .recycleIterator {
         jniWrapper.close(r2cHandle)
       }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -272,6 +272,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
               }
             }
           })
+          .protectInvocationFlow()
           .recycleIterator {
             jniWrapper.close(deserializerHandle)
           }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -449,7 +449,8 @@ JNIEXPORT jboolean JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchOutIte
 
   auto iter = ctx->objectStore()->retrieve<ResultIterator>(iterHandle);
   if (iter == nullptr) {
-    std::string errorMessage = "failed to get batch iterator";
+    std::string errorMessage =
+        "When hasNext() is called on a closed iterator, an exception is thrown. To prevent this, consider using the protectInvocationFlow() method when creating the iterator in scala side. This will allow the hasNext() method to be called multiple times without issue.";
     throw gluten::GlutenException(errorMessage);
   }
   return iter->hasNext();

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -74,6 +74,7 @@ case class ColumnarBuildSideRelation(output: Seq[Attribute], batches: Array[Arra
           ColumnarBatches.create(Runtimes.contextInstance(), handle)
         }
       })
+      .protectInvocationFlow()
       .recycleIterator {
         jniWrapper.close(serializeHandle)
       }

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -67,6 +67,7 @@ object ExecUtil {
           row
         }
       })
+      .protectInvocationFlow()
       .recycleIterator {
         jniWrapper.nativeClose(c2rHandle)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the iterator is designed to close once the hasNext() method returns false. Therefore, if `hasNext()` is called a second time, it will throw exception [here](https://github.com/apache/incubator-gluten/blob/8ade7a9cb50910021a2c0cb6977aaaeb9a17b5ce/cpp/core/jni/JniWrapper.cc#L452). This PR adds a `protectInvocationFlow()` method to ensure that the iterator's `hasNext()` can be safely called multiple times without causing an exception.

## How was this patch tested?
locally test.
