### PR TITLE
[GLUTEN-5547][VL] Add config to force fallback scan for timestamp type

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -92,6 +92,9 @@ object VeloxBackendSettings extends BackendSettingsApi {
         mapType.simpleString + " is forced to fallback."
       case StructField(_, structType: StructType, _, _) =>
         structType.simpleString + " is forced to fallback."
+      case StructField(_, timestampType:TimestampType, _, _)
+          if GlutenConfig.getConf.forceParquetTimestampTypeScanFallbackEnabled =>
+        timestampType.simpleString + " is forced to fallback."
     }
     val orcTypeValidatorWithComplexTypeFallback: PartialFunction[StructField, String] = {
       case StructField(_, arrayType: ArrayType, _, _) =>
@@ -122,6 +125,9 @@ object VeloxBackendSettings extends BackendSettingsApi {
           case StructField(_, mapType: MapType, _, _)
               if mapType.valueType.isInstanceOf[ArrayType] =>
             "ArrayType as Value in MapType"
+          case StructField(_, TimestampType, _, _)
+              if GlutenConfig.getConf.forceParquetTimestampTypeScanFallbackEnabled =>
+            "TimestampType"
         }
         if (!GlutenConfig.getConf.forceComplexTypeScanFallbackEnabled) {
           validateTypes(typeValidator)

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -92,7 +92,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
         mapType.simpleString + " is forced to fallback."
       case StructField(_, structType: StructType, _, _) =>
         structType.simpleString + " is forced to fallback."
-      case StructField(_, timestampType:TimestampType, _, _)
+      case StructField(_, timestampType: TimestampType, _, _)
           if GlutenConfig.getConf.forceParquetTimestampTypeScanFallbackEnabled =>
         timestampType.simpleString + " is forced to fallback."
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -435,6 +435,19 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
   }
 
+  test("Force timestamp type scan fallback") {
+    withSQLConf(("spark.gluten.sql.parquet.timestampType.scan.fallback.enabled", "true")) {
+      runQueryAndCompare("select timestamp from type1 limit 100") {
+        df => {
+          val executedPlan = getExecutedPlan(df)
+          assert(
+            !executedPlan.exists(
+              plan => plan.find(child => child.isInstanceOf[BatchScanExecTransformer]).isDefined))
+        }
+      }
+    }
+  }
+
   test("Decimal type") {
     // Validation: BatchScan Project Aggregate Expand Sort Limit
     runQueryAndCompare(

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -437,14 +437,9 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
 
   test("Force timestamp type scan fallback") {
     withSQLConf(("spark.gluten.sql.parquet.timestampType.scan.fallback.enabled", "true")) {
-      runQueryAndCompare("select timestamp from type1 limit 100") {
-        df => {
-          val executedPlan = getExecutedPlan(df)
-          assert(
-            !executedPlan.exists(
-              plan => plan.find(child => child.isInstanceOf[BatchScanExecTransformer]).isDefined))
-        }
-      }
+      val df = spark.sql("select timestamp from type1")
+      val executedPlan = getExecutedPlan(df)
+      assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
     }
   }
 

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -114,6 +114,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def forceOrcCharTypeScanFallbackEnabled: Boolean =
     conf.getConf(VELOX_FORCE_ORC_CHAR_TYPE_SCAN_FALLBACK)
 
+  def forceParquetTimestampTypeScanFallbackEnabled: Boolean =
+    conf.getConf(VELOX_FORCE_PARQUET_TIMESTAMP_TYPE_SCAN_FALLBACK)
+
   // whether to use ColumnarShuffleManager
   def isUseColumnarShuffleManager: Boolean =
     conf
@@ -1803,6 +1806,13 @@ object GlutenConfig {
       .doc("Force fallback for orc char type scan.")
       .booleanConf
       .createWithDefault(true)
+
+  val VELOX_FORCE_PARQUET_TIMESTAMP_TYPE_SCAN_FALLBACK =
+    buildConf("spark.gluten.sql.parquet.timestampType.scan.fallback.enabled")
+      .internal()
+      .doc("Force fallback for parquet timestamp type scan.")
+      .booleanConf
+      .createWithDefault(false)
 
   val COLUMNAR_NATIVE_CAST_AGGREGATE_ENABLED =
     buildConf("spark.gluten.sql.columnar.cast.avg")


### PR DESCRIPTION
## What changes were proposed in this pull request?
To resolve #5547. 
Velox does not currently support read int64 timestamp in parquet files, so add config to force fallback for parquet timestamp type scan, default false.

## How was this patch tested?
Unit test.
