### PR TITLE
[VL] RAS: Remove AddTransformHintRule route from EnumeratedApplier

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -45,7 +45,6 @@ abstract class VeloxTPCHTableSupport extends VeloxWholeStageTransformerSuite {
       .set("spark.memory.offHeap.size", "2g")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      .set("spark.gluten.sql.columnar.shuffledHashJoin", "false")
     // TODO Should enable this after fix the issue of native plan detail occasional disappearance
     // .set("spark.gluten.sql.injectNativePlanStringToExplain", "true")
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -45,6 +45,7 @@ abstract class VeloxTPCHTableSupport extends VeloxWholeStageTransformerSuite {
       .set("spark.memory.offHeap.size", "2g")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      .set("spark.gluten.sql.columnar.shuffledHashJoin", "false")
     // TODO Should enable this after fix the issue of native plan detail occasional disappearance
     // .set("spark.gluten.sql.injectNativePlanStringToExplain", "true")
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
@@ -155,7 +155,7 @@ case class TransformJoin() extends TransformSingleNode with LogLevelUtil {
       plan match {
         case shj: ShuffledHashJoinExec =>
           if (BackendsApiManager.getSettings.recreateJoinExecOnFallback()) {
-            // Since https://github.com/apache/incubator-gluten/pull/5042
+            // Since https://github.com/apache/incubator-gluten/pull/408
             // Because we manually removed the build side limitation for LeftOuter, LeftSemi and
             // RightOuter, need to change the build side back if this join fallback into vanilla
             // Spark for execution.

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
@@ -155,6 +155,7 @@ case class TransformJoin() extends TransformSingleNode with LogLevelUtil {
       plan match {
         case shj: ShuffledHashJoinExec =>
           if (BackendsApiManager.getSettings.recreateJoinExecOnFallback()) {
+            // Since https://github.com/apache/incubator-gluten/pull/5042
             // Because we manually removed the build side limitation for LeftOuter, LeftSemi and
             // RightOuter, need to change the build side back if this join fallback into vanilla
             // Spark for execution.

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformSingleNode.scala
@@ -465,6 +465,7 @@ object TransformOthers {
       }
     }
 
+    // Since https://github.com/apache/incubator-gluten/pull/2701
     private def applyScanNotTransformable(plan: SparkPlan): SparkPlan = plan match {
       case plan: FileSourceScanExec =>
         val newPartitionFilters =

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedApplier.scala
@@ -120,8 +120,7 @@ class EnumeratedApplier(session: SparkSession)
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarValidationRules() :::
       List(
         (spark: SparkSession) => MergeTwoPhasesHashBaseAggregate(spark),
-        (_: SparkSession) => RewriteSparkPlanRulesManager(),
-        (_: SparkSession) => AddTransformHintRule()
+        (_: SparkSession) => RewriteSparkPlanRulesManager()
       ) :::
       List(
         (session: SparkSession) => EnumeratedTransform(session, outputsColumnar),

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementAggregate.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementAggregate.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.extension.columnar.enumerated
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.columnar.TransformHints
 import org.apache.gluten.ras.rule.{RasRule, Shape, Shapes}
 
 import org.apache.spark.sql.execution.SparkPlan

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementAggregate.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementAggregate.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 
 object ImplementAggregate extends RasRule[SparkPlan] {
   override def shift(node: SparkPlan): Iterable[SparkPlan] = node match {
-    case plan if TransformHints.isNotTransformable(plan) => List.empty
     case agg: HashAggregateExec => shiftAgg(agg)
     case _ => List.empty
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementAggregate.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementAggregate.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.extension.columnar.enumerated
 
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.execution.HashAggregateExecBaseTransformer
 import org.apache.gluten.ras.rule.{RasRule, Shape, Shapes}
 
 import org.apache.spark.sql.execution.SparkPlan
@@ -29,10 +30,14 @@ object ImplementAggregate extends RasRule[SparkPlan] {
   }
 
   private def shiftAgg(agg: HashAggregateExec): Iterable[SparkPlan] = {
-    List(implement(agg))
+    val transformer = implement(agg)
+    if (!transformer.doValidate().isValid) {
+      return List.empty
+    }
+    List(transformer)
   }
 
-  private def implement(agg: HashAggregateExec): SparkPlan = {
+  private def implement(agg: HashAggregateExec): HashAggregateExecBaseTransformer = {
     BackendsApiManager.getSparkPlanExecApiInstance
       .genHashAggregateExecTransformer(
         agg.requiredChildDistributionExpressions,

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementFilter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementFilter.scala
@@ -24,9 +24,13 @@ import org.apache.spark.sql.execution.{FilterExec, SparkPlan}
 object ImplementFilter extends RasRule[SparkPlan] {
   override def shift(node: SparkPlan): Iterable[SparkPlan] = node match {
     case FilterExec(condition, child) =>
-      List(
-        BackendsApiManager.getSparkPlanExecApiInstance
-          .genFilterExecTransformer(condition, child))
+      val out = BackendsApiManager.getSparkPlanExecApiInstance
+        .genFilterExecTransformer(condition, child)
+      if (!out.doValidate().isValid) {
+        List.empty
+      } else {
+        List(out)
+      }
     case _ =>
       List.empty
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementFilter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementFilter.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.execution.{FilterExec, SparkPlan}
 
 object ImplementFilter extends RasRule[SparkPlan] {
   override def shift(node: SparkPlan): Iterable[SparkPlan] = node match {
-    case plan if TransformHints.isNotTransformable(plan) => List.empty
     case FilterExec(condition, child) =>
       List(
         BackendsApiManager.getSparkPlanExecApiInstance

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementFilter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/ImplementFilter.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.extension.columnar.enumerated
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.columnar.TransformHints
 import org.apache.gluten.ras.rule.{RasRule, Shape, Shapes}
 
 import org.apache.spark.sql.execution.{FilterExec, SparkPlan}

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
@@ -16,12 +16,13 @@
  */
 package org.apache.gluten.planner.cost
 
-import org.apache.gluten.extension.columnar.ColumnarTransitions
+import org.apache.gluten.extension.columnar.{ColumnarTransitions, TransformJoin}
 import org.apache.gluten.planner.plan.GlutenPlanModel.GroupLeafExec
 import org.apache.gluten.ras.{Cost, CostModel}
 import org.apache.gluten.utils.PlanUtil
 
 import org.apache.spark.sql.execution.{ColumnarToRowExec, RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
 
 class GlutenCostModel {}
 
@@ -31,6 +32,8 @@ object GlutenCostModel {
   }
 
   private object RoughCostModel extends CostModel[SparkPlan] {
+    private val infLongCost = Long.MaxValue
+
     override def costOf(node: SparkPlan): GlutenCost = node match {
       case _: GroupLeafExec => throw new IllegalStateException()
       case _ => GlutenCost(longCostOf(node))
@@ -52,15 +55,18 @@ object GlutenCostModel {
     }
 
     // A very rough estimation as of now.
-    private def selfLongCostOf(node: SparkPlan): Long = node match {
-      case ColumnarToRowExec(child) => 3L
-      case RowToColumnarExec(child) => 3L
-      case ColumnarTransitions.ColumnarToRowLike(child) => 3L
-      case ColumnarTransitions.RowToColumnarLike(child) => 3L
-      case p if PlanUtil.isGlutenColumnarOp(p) => 2L
-      case p if PlanUtil.isVanillaColumnarOp(p) => 3L
-      // Other row ops. Usually a vanilla row op.
-      case _ => 5L
+    private def selfLongCostOf(node: SparkPlan): Long = {
+      node match {
+        case p: ShuffledHashJoinExec if !TransformJoin.isLegal(p) => infLongCost
+        case ColumnarToRowExec(child) => 3L
+        case RowToColumnarExec(child) => 3L
+        case ColumnarTransitions.ColumnarToRowLike(child) => 3L
+        case ColumnarTransitions.RowToColumnarLike(child) => 3L
+        case p if PlanUtil.isGlutenColumnarOp(p) => 2L
+        case p if PlanUtil.isVanillaColumnarOp(p) => 3L
+        // Other row ops. Usually a vanilla row op.
+        case _ => 5L
+      }
     }
 
     override def costComparator(): Ordering[Cost] = Ordering.Long.on {
@@ -68,6 +74,6 @@ object GlutenCostModel {
       case _ => throw new IllegalStateException("Unexpected cost type")
     }
 
-    override def makeInfCost(): Cost = GlutenCost(Long.MaxValue)
+    override def makeInfCost(): Cost = GlutenCost(infLongCost)
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
@@ -57,7 +57,8 @@ object GlutenCostModel {
     // A very rough estimation as of now.
     private def selfLongCostOf(node: SparkPlan): Long = {
       node match {
-        case p: ShuffledHashJoinExec if !TransformJoin.isLegal(p) => infLongCost
+        case p: ShuffledHashJoinExec if !TransformJoin.isLegal(p) =>
+          infLongCost
         case ColumnarToRowExec(child) => 3L
         case RowToColumnarExec(child) => 3L
         case ColumnarTransitions.ColumnarToRowLike(child) => 3L


### PR DESCRIPTION
RAS planner doesn't need tag to mark whether a vanilla Spark plan is offload-able . It just does every essential checks whenever it tries to generate offloaded plan.

The patch does some optimizations to code to remove AddTransformHintRule from EnumeratedApplier and leave the pre-validation work to RAS planner.