### PR TITLE
[GLUTEN-5559][VL] Fix threads number setting for building gluten cpp on MacOS

### DIFF
--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -30,7 +30,18 @@ ENABLE_S3=OFF
 ENABLE_HDFS=OFF
 ENABLE_ABFS=OFF
 VELOX_HOME=
-NPROC=$(nproc --ignore=2)
+if [[ "$(uname)" == "Darwin" ]]; then
+    physical_cpu_cores=$(sysctl -n hw.physicalcpu)
+    ignore_cores=2
+    if [ "$physical_cpu_cores" -gt "$ignore_cores" ]; then
+        NPROC=${NPROC:-$(($physical_cpu_cores - $ignore_cores))}
+    else
+        NPROC=${NPROC:-$physical_cpu_cores}
+    fi
+else
+    NPROC=${NPROC:-$(nproc --ignore=2)}
+fi
+echo $NPROC
 
 for arg in "$@"; do
   case $arg in

--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -30,6 +30,7 @@ ENABLE_S3=OFF
 ENABLE_HDFS=OFF
 ENABLE_ABFS=OFF
 VELOX_HOME=
+# set default number of threads as cpu cores minus 2
 if [[ "$(uname)" == "Darwin" ]]; then
     physical_cpu_cores=$(sysctl -n hw.physicalcpu)
     ignore_cores=2

--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -42,7 +42,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 else
     NPROC=${NPROC:-$(nproc --ignore=2)}
 fi
-echo $NPROC
+echo "set default number of threads is ${NPROC}"
 
 for arg in "$@"; do
   case $arg in


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use different commands in `incubator-gluten/cpp/compile.sh` script to get the number of available processing unit in MacOS

(Fixes: \#5559)

## How was this patch tested?

I test this in my MacOS computer and it works fine.

