### PR TITLE
[VL] Fix literal bound fallback for window range frame

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -302,7 +302,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
           def checkLimitations(swf: SpecifiedWindowFrame, orderSpec: Seq[SortOrder]): Unit = {
             def doCheck(bound: Expression, isUpperBound: Boolean): Unit = {
               bound match {
-                case _: Literal =>
+                case e if e.foldable =>
                   throw new GlutenNotSupportException(
                     "Window frame of type RANGE does" +
                       " not support constant arguments in velox backend")

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -210,6 +210,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           }
 
           runQueryAndCompare(
+            "select max(l_partkey) over" +
+              " (partition by l_suppkey order by l_orderkey" +
+              " RANGE BETWEEN 6 PRECEDING AND CURRENT ROW) from lineitem ") {
+            checkSparkOperatorMatch[WindowExec]
+          }
+
+          runQueryAndCompare(
             "select ntile(4) over" +
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
             checkGlutenOperatorMatch[WindowExecTransformer]


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is simply a follow-up fix for https://github.com/apache/incubator-gluten/pull/5431. For constant preceding, Spark will combine the original literal bound with `Minus` expression. So we need to check whether it's foldable instead of checking whether it's literal.

## How was this patch tested?

New UT and existing UTs.

