### PR TITLE
[GLUTEN-5565][VL][BUILD] Fix setup-macos.sh: folly is installed twice

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -314,8 +314,6 @@ function setup_macos {
     echo "Unsupport s3"
     exit 1
   fi
-
-  sed -i '' $'/^  run_and_time install_double_conversion/a\\\n  run_and_time install_folly\\\n' scripts/setup-macos.sh
 }
 
 if [ $OS == 'Linux' ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes: #5565

## How was this patch tested?

Manually compared velox_ep/scripts/setup-macos.sh before and after this PR:

<img width="1517" alt="image" src="https://github.com/apache/incubator-gluten/assets/88070094/31999ac3-92e5-4146-956d-6f4e6fd8582c">


