### PR TITLE
[VL][DOC] Fix certificate expired when build on CentOS 7

### DIFF
--- a/docs/developers/docker_centos7.md
+++ b/docs/developers/docker_centos7.md
@@ -25,6 +25,7 @@ yum -y install \
     java-1.8.0-openjdk-devel \
     ninja-build \
     wget \
+    ca-certificates \
     sudo
 
 # gluten need maven version >=3.6.3


### PR DESCRIPTION
## What changes were proposed in this pull request?
Build error:
```
--2024-04-29 09:21:36--  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
Resolving repo.anaconda.com (repo.anaconda.com)... 104.16.191.158, 104.16.32.241, 2606:4700::6810:bf9e, ...
Connecting to repo.anaconda.com (repo.anaconda.com)|104.16.191.158|:443... connected.
ERROR: cannot verify repo.anaconda.com's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=E1':
  Issued certificate has expired.
To connect to repo.anaconda.com insecurely, use `--no-check-certificate'.
```

## How was this patch tested?
Local test.
Execute within container：wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh

