### PR TITLE
[GLUTEN-5586] Fix multiple generate functions failure

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
@@ -53,7 +53,7 @@ abstract class GenerateExecTransformerBase(
       target =>
         val childIndex = child.output.zipWithIndex
           .collectFirst {
-            case (attr, i) if attr.name == target.name => i
+            case (attr, i) if attr.exprId == target.exprId => i
           }
           .getOrElse(
             throw new GlutenException(s"Can't found column ${target.name} in child output"))


### PR DESCRIPTION
After adding the pull-out pre project for `GenerateExecTransformer`, the child expression name can be changed. Therefore should use exprId while matching the output from child. 