### PR TITLE
[VL] CI: Gluten-it: Print planning time as well as execution time in test report

### DIFF
--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/Queries.scala
@@ -20,6 +20,7 @@ import org.apache.gluten.integration.stat.RamStat
 import org.apache.gluten.integration.tpc.{TpcRunner, TpcSuite}
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.gluten.integration.tpc.action.Actions.QuerySelector
+import org.apache.gluten.integration.tpc.action.QueriesCompare.TestResultLine
 
 case class Queries(
     scale: Double,
@@ -100,24 +101,36 @@ object Queries {
       queryId: String,
       testPassed: Boolean,
       rowCount: Option[Long],
+      planningTimeMillis: Option[Long],
       executionTimeMillis: Option[Long],
       errorMessage: Option[String])
 
+  object TestResultLine {
+    implicit object Parser extends TableFormatter.RowParser[TestResultLine] {
+      override def parse(line: TestResultLine): Seq[Any] = {
+        Seq(
+          line.queryId,
+          line.testPassed,
+          line.rowCount.getOrElse("N/A"),
+          line.planningTimeMillis.getOrElse("N/A"),
+          line.executionTimeMillis.getOrElse("N/A"))
+      }
+    }
+  }
+
   private def printResults(results: List[TestResultLine]): Unit = {
-    printf(
-      "|%15s|%15s|%30s|%30s|\n",
+    val formatter = TableFormatter.create[TestResultLine](
       "Query ID",
       "Was Passed",
       "Row Count",
+      "Plan Time (Millis)",
       "Query Time (Millis)")
+
     results.foreach { line =>
-      printf(
-        "|%15s|%15s|%30s|%30s|\n",
-        line.queryId,
-        line.testPassed,
-        line.rowCount.getOrElse("N/A"),
-        line.executionTimeMillis.getOrElse("N/A"))
+      formatter.appendRow(line)
     }
+
+    formatter.print(System.out)
   }
 
   private def aggregate(succeed: List[TestResultLine], name: String): List[TestResultLine] = {
@@ -131,6 +144,9 @@ object Queries {
           testPassed = true,
           if (r1.rowCount.nonEmpty && r2.rowCount.nonEmpty)
             Some(r1.rowCount.get + r2.rowCount.get)
+          else None,
+          if (r1.planningTimeMillis.nonEmpty && r2.planningTimeMillis.nonEmpty)
+            Some(r1.planningTimeMillis.get + r2.planningTimeMillis.get)
           else None,
           if (r1.executionTimeMillis.nonEmpty && r2.executionTimeMillis.nonEmpty)
             Some(r1.executionTimeMillis.get + r2.executionTimeMillis.get)
@@ -164,6 +180,7 @@ object Queries {
         id,
         testPassed = true,
         Some(resultRows.length),
+        Some(result.planningTimeMillis),
         Some(result.executionTimeMillis),
         None)
     } catch {
@@ -172,7 +189,7 @@ object Queries {
         println(
           s"Error running query $id. " +
             s" Error: ${error.get}")
-        TestResultLine(id, testPassed = false, None, None, error)
+        TestResultLine(id, testPassed = false, None, None, None, error)
     }
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/Queries.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.integration.stat.RamStat
 import org.apache.gluten.integration.tpc.{TpcRunner, TpcSuite}
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.gluten.integration.tpc.action.Actions.QuerySelector
-import org.apache.gluten.integration.tpc.action.QueriesCompare.TestResultLine
 
 case class Queries(
     scale: Double,

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/QueriesCompare.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/QueriesCompare.scala
@@ -101,37 +101,52 @@ object QueriesCompare {
       testPassed: Boolean,
       expectedRowCount: Option[Long],
       actualRowCount: Option[Long],
+      expectedPlanningTimeMillis: Option[Long],
+      actualPlanningTimeMillis: Option[Long],
       expectedExecutionTimeMillis: Option[Long],
       actualExecutionTimeMillis: Option[Long],
       errorMessage: Option[String])
 
+  object TestResultLine {
+    implicit object Parser extends TableFormatter.RowParser[TestResultLine] {
+      override def parse(line: TestResultLine): Seq[Any] = {
+        val timeVariation =
+          if (line.expectedExecutionTimeMillis.nonEmpty && line.actualExecutionTimeMillis.nonEmpty) {
+            Some(
+              ((line.expectedExecutionTimeMillis.get - line.actualExecutionTimeMillis.get).toDouble
+                / line.actualExecutionTimeMillis.get.toDouble) * 100)
+          } else None
+        Seq(
+          line.queryId,
+          line.testPassed,
+          line.expectedRowCount.getOrElse("N/A"),
+          line.actualRowCount.getOrElse("N/A"),
+          line.expectedPlanningTimeMillis.getOrElse("N/A"),
+          line.actualPlanningTimeMillis.getOrElse("N/A"),
+          line.expectedExecutionTimeMillis.getOrElse("N/A"),
+          line.actualExecutionTimeMillis.getOrElse("N/A"),
+          timeVariation.map("%15.2f%%".format(_)).getOrElse("N/A"))
+      }
+    }
+  }
+
   private def printResults(results: List[TestResultLine]): Unit = {
-    printf(
-      "|%15s|%15s|%30s|%30s|%30s|%30s|%30s|\n",
+    val formatter = TableFormatter.create[TestResultLine](
       "Query ID",
       "Was Passed",
       "Expected Row Count",
       "Actual Row Count",
+      "Baseline Planning Time (Millis)",
+      "Planning Time (Millis)",
       "Baseline Query Time (Millis)",
       "Query Time (Millis)",
       "Query Time Variation")
+
     results.foreach { line =>
-      val timeVariation =
-        if (line.expectedExecutionTimeMillis.nonEmpty && line.actualExecutionTimeMillis.nonEmpty) {
-          Some(
-            ((line.expectedExecutionTimeMillis.get - line.actualExecutionTimeMillis.get).toDouble
-              / line.actualExecutionTimeMillis.get.toDouble) * 100)
-        } else None
-      printf(
-        "|%15s|%15s|%30s|%30s|%30s|%30s|%30s|\n",
-        line.queryId,
-        line.testPassed,
-        line.expectedRowCount.getOrElse("N/A"),
-        line.actualRowCount.getOrElse("N/A"),
-        line.expectedExecutionTimeMillis.getOrElse("N/A"),
-        line.actualExecutionTimeMillis.getOrElse("N/A"),
-        timeVariation.map("%15.2f%%".format(_)).getOrElse("N/A"))
+      formatter.appendRow(line)
     }
+
+    formatter.print(System.out)
   }
 
   private def aggregate(succeed: List[TestResultLine], name: String): List[TestResultLine] = {
@@ -148,6 +163,12 @@ object QueriesCompare {
           else None,
           if (r1.actualRowCount.nonEmpty && r2.actualRowCount.nonEmpty)
             Some(r1.actualRowCount.get + r2.actualRowCount.get)
+          else None,
+          if (r1.expectedPlanningTimeMillis.nonEmpty && r2.expectedPlanningTimeMillis.nonEmpty)
+            Some(r1.expectedPlanningTimeMillis.get + r2.expectedPlanningTimeMillis.get)
+          else None,
+          if (r1.actualPlanningTimeMillis.nonEmpty && r2.actualPlanningTimeMillis.nonEmpty)
+            Some(r1.actualPlanningTimeMillis.get + r2.actualPlanningTimeMillis.get)
           else None,
           if (r1.expectedExecutionTimeMillis.nonEmpty && r2.expectedExecutionTimeMillis.nonEmpty)
             Some(r1.expectedExecutionTimeMillis.get + r2.expectedExecutionTimeMillis.get)
@@ -187,6 +208,8 @@ object QueriesCompare {
           testPassed = true,
           Some(expectedRows.length),
           Some(resultRows.length),
+          Some(expected.planningTimeMillis),
+          Some(result.planningTimeMillis),
           Some(expected.executionTimeMillis),
           Some(result.executionTimeMillis),
           None)
@@ -198,6 +221,8 @@ object QueriesCompare {
         testPassed = false,
         Some(expectedRows.length),
         Some(resultRows.length),
+        Some(expected.planningTimeMillis),
+        Some(result.planningTimeMillis),
         Some(expected.executionTimeMillis),
         Some(result.executionTimeMillis),
         error)
@@ -207,7 +232,7 @@ object QueriesCompare {
         println(
           s"Error running query $id. " +
             s" Error: ${error.get}")
-        TestResultLine(id, testPassed = false, None, None, None, None, error)
+        TestResultLine(id, testPassed = false, None, None, None, None, None, None, error)
     }
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/TableFormatter.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/tpc/action/TableFormatter.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gluten.integration.tpc.action
+
+import java.io.{OutputStream, PrintStream}
+import scala.collection.mutable
+
+trait TableFormatter[ROW <: Any] {
+  import TableFormatter._
+  def appendRow(row: ROW): Unit
+  def print(s: OutputStream): Unit
+}
+
+object TableFormatter {
+  def create[ROW <: Any](fields: String*)(
+      implicit parser: RowParser[ROW]): TableFormatter[ROW] = {
+    assert(fields.nonEmpty)
+    new Impl[ROW](Schema(fields), parser)
+  }
+
+  private case class Schema(fields: Seq[String])
+
+  private class Impl[ROW <: Any](schema: Schema, parser: RowParser[ROW])
+      extends TableFormatter[ROW] {
+    private val rows = mutable.ListBuffer[Seq[String]]()
+
+    override def appendRow(row: ROW): Unit = {
+      val parsed = parser.parse(row)
+      assert(parsed.size == schema.fields.size)
+      rows += parsed.map(_.toString)
+    }
+
+    override def print(s: OutputStream): Unit = {
+      val numFields = schema.fields.size
+      val widths = (0 until numFields)
+        .map { i =>
+          rows.map(_(i).length).max max schema.fields(i).length
+        }
+        .map(_ + 1)
+      val pBuilder = StringBuilder.newBuilder
+      pBuilder ++= "|"
+      widths.foreach { w =>
+        pBuilder ++= s"%${w}s|"
+      }
+      val pattern = pBuilder.toString()
+      val printer = new PrintStream(s)
+      printer.println(String.format(pattern, schema.fields: _*))
+      rows.foreach { r =>
+        printer.println(String.format(pattern, r: _*))
+      }
+      printer.flush()
+      printer.close()
+    }
+  }
+
+  trait RowParser[ROW <: Any] {
+    def parse(row: ROW): Seq[Any]
+  }
+}


### PR DESCRIPTION
`gluten-it`'s test report now includes field `planning time` for measuring planner performance.


E.g,

Before:

```
Test report: 

Summary: 5 out of 5 queries passed. 

|       Query ID|     Was Passed|            Expected Row Count|              Actual Row Count|  Baseline Query Time (Millis)|           Query Time (Millis)|          Query Time Variation|
|             q1|           true|                             4|                             4|                        102925|                          9510|                       982.28%|
|             q2|           true|                           100|                           100|                         10414|                          5918|                        75.97%|
|             q3|           true|                            10|                            10|                         28816|                         11060|                       160.54%|
|             q4|           true|                             5|                             5|                         21615|                          9776|                       121.10%|
|             q5|           true|                             5|                             5|                         43335|                         21516|                       101.50%|
```

After:

```
Test report: 

Summary: 5 out of 5 queries passed. 

| Query ID| Was Passed| Expected Row Count| Actual Row Count| Baseline Planning Time (Millis)| Planning Time (Millis)| Baseline Query Time (Millis)| Query Time (Millis)| Query Time Variation|
|       q1|       true|                  4|                4|                             515|                     51|                       105621|                9475|             1014.73%|
|       q2|       true|                100|              100|                             389|                    153|                         9560|                5712|               67.37%|
|       q3|       true|                 10|               10|                              54|                     38|                        28912|               11269|              156.56%|
|       q4|       true|                  5|                5|                              62|                     24|                        20914|                9214|              126.98%|
|       q5|       true|                  5|                5|                              65|                     59|                        43106|               21073|              104.56%|
```