### PR TITLE
[GLUTEN-5611] [VL] Avoid trigger Spark memory listener when native memory request can be handled internally

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -40,6 +40,9 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
   }
 
   uint64_t growCapacity(velox::memory::MemoryPool* pool, uint64_t targetBytes) override {
+    if (targetBytes == 0) {
+      return 0;
+    }
     std::lock_guard<std::recursive_mutex> l(mutex_);
     return growPoolLocked(pool, targetBytes);
   }
@@ -66,8 +69,8 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
   uint64_t shrinkCapacity(
       const std::vector<std::shared_ptr<velox::memory::MemoryPool>>& pools,
       uint64_t targetBytes,
-      bool allowSpill = true,
-      bool allowAbort = false) override {
+      bool allowSpill,
+      bool allowAbort) override {
     facebook::velox::exec::MemoryReclaimer::Stats status;
     GLUTEN_CHECK(pools.size() == 1, "Should shrink a single pool at a time");
     std::lock_guard<std::recursive_mutex> l(mutex_); // FIXME: Do we have recursive locking for this mutex?
@@ -102,13 +105,14 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
           reserved,
           "Unexpected: Failed to reserve " + std::to_string(bytes) +
               " bytes although there is enough space, free bytes: " + std::to_string(freeBytes));
+      return 0;
     }
     listener_->allocationChanged(bytes);
     return pool->grow(bytes, bytes);
   }
 
   uint64_t releaseMemoryLocked(velox::memory::MemoryPool* pool, uint64_t bytes) {
-    uint64_t freeBytes = pool->shrink(0);
+    uint64_t freeBytes = pool->shrink(bytes);
     listener_->allocationChanged(-freeBytes);
     return freeBytes;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?


(Fixes: \#5611)
