### PR TITLE
[GLUTEN-5630][VL] Decrease peak memory by taking freeBytes into account 

### DIFF
--- a/cpp/core/memory/AllocationListener.h
+++ b/cpp/core/memory/AllocationListener.h
@@ -32,6 +32,14 @@ class AllocationListener {
   // Value of diff can be either positive or negative
   virtual void allocationChanged(int64_t diff) = 0;
 
+  virtual int64_t currentBytes() {
+    return 0;
+  }
+
+  virtual int64_t peakBytes() {
+    return 0;
+  }
+
  protected:
   AllocationListener() = default;
 };

--- a/cpp/core/memory/HbwAllocator.cc
+++ b/cpp/core/memory/HbwAllocator.cc
@@ -85,4 +85,8 @@ int64_t HbwMemoryAllocator::getBytes() const {
   return bytes_;
 }
 
+int64_t HbwMemoryAllocator::peakBytes() const {
+  return 0;
+}
+
 } // namespace gluten

--- a/cpp/core/memory/HbwAllocator.h
+++ b/cpp/core/memory/HbwAllocator.h
@@ -39,6 +39,8 @@ class HbwMemoryAllocator final : public MemoryAllocator {
 
   int64_t getBytes() const override;
 
+  int64_t peakBytes() const override;
+
  private:
   std::atomic_int64_t bytes_{0};
 };

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -29,6 +29,7 @@ bool ListenableMemoryAllocator::allocate(int64_t size, void** out) {
   }
   if (succeed) {
     bytes_ += size;
+    peakBytes_ = std::max(peakBytes_, bytes_.load());
   }
   return succeed;
 }
@@ -41,6 +42,7 @@ bool ListenableMemoryAllocator::allocateZeroFilled(int64_t nmemb, int64_t size, 
   }
   if (succeed) {
     bytes_ += size * nmemb;
+    peakBytes_ = std::max(peakBytes_, bytes_.load());
   }
   return succeed;
 }
@@ -53,6 +55,7 @@ bool ListenableMemoryAllocator::allocateAligned(uint64_t alignment, int64_t size
   }
   if (succeed) {
     bytes_ += size;
+    peakBytes_ = std::max(peakBytes_, bytes_.load());
   }
   return succeed;
 }
@@ -66,6 +69,7 @@ bool ListenableMemoryAllocator::reallocate(void* p, int64_t size, int64_t newSiz
   }
   if (succeed) {
     bytes_ += diff;
+    peakBytes_ = std::max(peakBytes_, bytes_.load());
   }
   return succeed;
 }
@@ -84,6 +88,7 @@ bool ListenableMemoryAllocator::reallocateAligned(
   }
   if (succeed) {
     bytes_ += diff;
+    peakBytes_ = std::max(peakBytes_, bytes_.load());
   }
   return succeed;
 }
@@ -102,6 +107,10 @@ bool ListenableMemoryAllocator::free(void* p, int64_t size) {
 
 int64_t ListenableMemoryAllocator::getBytes() const {
   return bytes_;
+}
+
+int64_t ListenableMemoryAllocator::peakBytes() const {
+  return peakBytes_;
 }
 
 bool StdMemoryAllocator::allocate(int64_t size, void** out) {
@@ -158,6 +167,10 @@ bool StdMemoryAllocator::free(void* p, int64_t size) {
 
 int64_t StdMemoryAllocator::getBytes() const {
   return bytes_;
+}
+
+int64_t StdMemoryAllocator::peakBytes() const {
+  return 0;
 }
 
 std::shared_ptr<MemoryAllocator> defaultMemoryAllocator() {

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -41,6 +41,8 @@ class MemoryAllocator {
   virtual bool free(void* p, int64_t size) = 0;
 
   virtual int64_t getBytes() const = 0;
+
+  virtual int64_t peakBytes() const = 0;
 };
 
 class ListenableMemoryAllocator final : public MemoryAllocator {
@@ -63,10 +65,13 @@ class ListenableMemoryAllocator final : public MemoryAllocator {
 
   int64_t getBytes() const override;
 
+  int64_t peakBytes() const override;
+
  private:
   MemoryAllocator* delegated_;
   AllocationListener* listener_;
   std::atomic_int64_t bytes_{0};
+  int64_t peakBytes_{0};
 };
 
 class StdMemoryAllocator final : public MemoryAllocator {
@@ -84,6 +89,8 @@ class StdMemoryAllocator final : public MemoryAllocator {
   bool free(void* p, int64_t size) override;
 
   int64_t getBytes() const override;
+
+  int64_t peakBytes() const override;
 
  private:
   std::atomic_int64_t bytes_{0};

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -218,7 +218,8 @@ const MemoryUsageStats VeloxMemoryManager::collectMemoryUsageStats() const {
   MemoryUsageStats stats;
   stats.set_current(listener_->currentBytes());
   stats.set_peak(listener_->peakBytes());
-  stats.mutable_children()->emplace("gluten_allocator", collectGlutenAllocatorMemoryUsageStats(glutenAlloc_.get()));
+  stats.mutable_children()->emplace(
+      "gluten::MemoryAllocator", collectGlutenAllocatorMemoryUsageStats(glutenAlloc_.get()));
   stats.mutable_children()->emplace(
       veloxAggregatePool_->name(), collectVeloxMemoryUsageStats(veloxAggregatePool_.get()));
   return stats;


### PR DESCRIPTION
## What changes were proposed in this pull request?

After this PR, the peak memory usage decreased from 1.1G to 816M, and add ListenableMemoryAllocator into memory usage dump.

```
24/05/07 16:56:14 WARN [Executor task launch worker for task 1.0 in stage 7.0 (TID 1025)] NativeMemoryManager: About to release memory manager, usage dump:
	ShuffleWriter:                    Current used bytes: 1024.0 KiB, peak bytes:  212.3 MiB
	+- ShuffleWriter_root:            Current used bytes:      0.0 B, peak bytes: 1024.0 KiB
	|  \- ShuffleWriter_default_leaf: Current used bytes:      0.0 B, peak bytes:   1408.0 B
	\- gluten_allocator:              Current used bytes:      0.0 B, peak bytes:  211.3 MiB
```

(Fixes: \#5630)
