### PR TITLE
[VL] Add a bad test case that final aggregate of collect_list is fallen back while partial aggregate is not

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -106,6 +106,21 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     }
   }
 
+  ignore("fallback final aggregate of collect_list") {
+    withSQLConf(
+      GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1",
+      GlutenConfig.COLUMNAR_FALLBACK_IGNORE_ROW_TO_COLUMNAR.key -> "false",
+      GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
+    ) {
+      runQueryAndCompare(
+        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_list(c2), 1) as ele FROM tmp1 group by c1)") {
+        df =>
+          val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
+          assert(columnarToRow == 1)
+      }
+    }
+  }
+
   test("fallback with AQE read") {
     runQueryAndCompare(
       """

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -114,7 +114,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
       GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
     ) {
       runQueryAndCompare(
-        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_list(c2), 1) as ele FROM tmp1 group by c1)") {
+        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_list(c2), 1) as ele FROM tmp1 GROUP BY c1)") {
         df =>
           val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
           assert(columnarToRow == 1)
@@ -130,7 +130,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
       GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
     ) {
       runQueryAndCompare(
-        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_set(c2), 1) as ele FROM tmp1 group by c1)") {
+        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_set(c2), 1) as ele FROM tmp1 GROUP BY c1)") {
         df =>
           val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
           assert(columnarToRow == 1)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -122,6 +122,22 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     }
   }
 
+  // java.lang.NullPointerException
+  ignore("fallback final aggregate of collect_set") {
+    withSQLConf(
+      GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1",
+      GlutenConfig.COLUMNAR_FALLBACK_IGNORE_ROW_TO_COLUMNAR.key -> "false",
+      GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
+    ) {
+      runQueryAndCompare(
+        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_set(c2), 1) as ele FROM tmp1 group by c1)") {
+        df =>
+          val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
+          assert(columnarToRow == 1)
+      }
+    }
+  }
+
   test("fallback with AQE read") {
     runQueryAndCompare(
       """

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -114,7 +114,8 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
       GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
     ) {
       runQueryAndCompare(
-        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_list(c2), 1) as ele FROM tmp1 GROUP BY c1)") {
+        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_list(c2), 1) as ele FROM tmp1 " +
+          "GROUP BY c1)") {
         df =>
           val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
           assert(columnarToRow == 1)
@@ -130,7 +131,8 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
       GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
     ) {
       runQueryAndCompare(
-        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_set(c2), 1) as ele FROM tmp1 GROUP BY c1)") {
+        "SELECT sum(ele) FROM (SELECT c1, element_at(collect_set(c2), 1) as ele FROM tmp1 " +
+          "GROUP BY c1)") {
         df =>
           val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
           assert(columnarToRow == 1)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -106,6 +106,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     }
   }
 
+  // java.lang.NullPointerException
   ignore("fallback final aggregate of collect_list") {
     withSQLConf(
       GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1",


### PR DESCRIPTION
With whole stage fallback enabled, we can manage to create a plan (AE=on) like:

```
Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=393]
+- HashAggregate(keys=[], functions=[partial_sum(ele#42L)], output=[sum#48L])
   +- ObjectHashAggregate(keys=[c1#14], functions=[collect_list(c2#15L, 0, 0)], output=[ele#42L])
      +- VeloxColumnarToRowExec
         +- AQEShuffleRead coalesced
            +- ShuffleQueryStage 0
               +- ColumnarExchange hashpartitioning(c1#14, 5), ENSURE_REQUIREMENTS, [c1#14, buf#50], [plan_id=315], [id=#315], [OUTPUT] List(c1:IntegerType, buf:ArrayType(LongType,false)), [OUTPUT] List(c1:IntegerType, buf:ArrayType(LongType,false))
                  +- ^(3) ProjectExecTransformer [hash(c1#14, 42) AS hash_partition_key#56, c1#14, buf#50]
                     +- ^(3) FlushableHashAggregateTransformer(keys=[c1#14], functions=[partial_collect_list(c2#15L, 0, 0)], output=[c1#14, buf#50])
                        +- ^(3) NativeFileScan parquet spark_catalog.default.tmp1[c1#14,c2#15L] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/opt/gluten/spark-warehouse/org.apache.gluten.execution.FallbackS..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c1:int,c2:bigint>
```

In the plan, only partial aggregate phase of aggregate function `collect_list` is offloaded to native. 

The we got error:

```
java.lang.NullPointerException
	at org.apache.spark.sql.catalyst.expressions.aggregate.Collect.deserialize(collect.scala:81)
	at org.apache.spark.sql.catalyst.expressions.aggregate.Collect.deserialize(collect.scala:39)
	at org.apache.spark.sql.catalyst.expressions.aggregate.TypedImperativeAggregate.merge(interfaces.scala:592)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator$$anonfun$1.$anonfun$applyOrElse$3(AggregationIterator.scala:200)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator$$anonfun$1.$anonfun$applyOrElse$3$adapted(AggregationIterator.scala:200)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator.$anonfun$generateProcessRow$7(AggregationIterator.scala:214)
	at org.apache.spark.sql.execution.aggregate.AggregationIterator.$anonfun$generateProcessRow$7$adapted(AggregationIterator.scala:208)
	at org.apache.spark.sql.execution.aggregate.ObjectAggregationIterator.processInputs(ObjectAggregationIterator.scala:169)
	at org.apache.spark.sql.execution.aggregate.ObjectAggregationIterator.<init>(ObjectAggregationIterator.scala:83)
	at org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec.$anonfun$doExecute$1(ObjectHashAggregateExec.scala:114)
	at org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec.$anonfun$doExecute$1$adapted(ObjectHashAggregateExec.scala:90)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndexInternal$2(RDD.scala:875)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndexInternal$2$adapted(RDD.scala:875)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:364)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:328)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:364)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:328)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:364)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:328)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:101)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)
	at org.apache.spark.scheduler.Task.run(Task.scala:139)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:554)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1529)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:557)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```