### PR TITLE
[VL] Fix clang-format version

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run clang-format style check for C/C++ programs.
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '15'
+          clang-format-version: '12'
           check-path: ${{ matrix.path['check'] }}
           fallback-style: 'Google' # optional
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run clang-format style check for C/C++ programs.
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '12'
+          clang-format-version: '15'
           check-path: ${{ matrix.path['check'] }}
           fallback-style: 'Google' # optional
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Developer can import the code style setting to IDE and format Java/Scala code wi
 ##### C/C++ code style
 There are some code style conventions need to comply. See [CppCodingStyle.md](https://github.com/apache/incubator-gluten/blob/main/docs/developers/CppCodingStyle.md).
 
-For Velox backend, developer can just execute `dev/formatcppcode.sh` to format C/C++ code. It requires `clang-format-12`
+For Velox backend, developer can just execute `dev/formatcppcode.sh` to format C/C++ code. It requires `clang-format-15`
 installed in your development env.
 
 ### License Header

--- a/dev/formatcppcode.sh
+++ b/dev/formatcppcode.sh
@@ -1,3 +1,3 @@
 cd `dirname $0`
-find ../cpp/core -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-12 -style=file -i {} \;
-find ../cpp/velox -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-12 -style=file -i {} \;
+find ../cpp/core -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-15 -style=file -i {} \;
+find ../cpp/velox -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-15 -style=file -i {} \;

--- a/docs/developers/CppCodingStyle.md
+++ b/docs/developers/CppCodingStyle.md
@@ -30,7 +30,7 @@ Gluten CPP coding, there are a few Philosophical rules as the following.
 Many aspects of C++ coding style will be covered by clang-format, such as spacing,
 line width, indentation and ordering (for includes, using directives and etc). 
 
-* Always ensure your code is compatible with clang-format-12 for Velox backend.
+* Always ensure your code is compatible with clang-format-15 for Velox backend.
 * `dev/formatcppcode.sh` is provided for formatting Velox CPP code.
 
 ## Naming Conventions

--- a/docs/developers/NewToGluten.md
+++ b/docs/developers/NewToGluten.md
@@ -283,16 +283,16 @@ Search `update` in Manage->Settings to turn off update mode
 
 ### Clang format
 
-Now gluten uses clang-format 12 to format source files.
+Now gluten uses clang-format 15 to format source files.
 
 ```bash
-apt-get install clang-format-12
+apt-get install clang-format-15
 ```
 
 Set config in `settings.json`
 
 ```json
-"clang-format.executable": "clang-format-12",
+"clang-format.executable": "clang-format-15",
 "editor.formatOnSave": true,
 ```
 


### PR DESCRIPTION
~clang-format-12 is recommended to use according to Gluten doc, but the version used by CI is 15.
See:
https://github.com/apache/incubator-gluten/blob/main/dev/formatcppcode.sh~

Fix inconsistency in script and doc.