### PR TITLE
[GLUTEN-5651][CH] Fix error 'Illegal type of argument of function parseDateTimeInJodaSyntaxOrNull, expected String, got Date32' when executing to_date/to_timestamp

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.execution
 import org.apache.gluten.GlutenConfig
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
 
 class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuite {
@@ -235,7 +236,14 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
                 case project: ProjectExecTransformer => project
               }
               assert(project.size == 1)
-              assert(project.apply(0).projectList.toString().contains("from_unixtime") == conf._2)
+              assert(
+                project
+                  .apply(0)
+                  .projectList(0)
+                  .asInstanceOf[Alias]
+                  .child
+                  .toString()
+                  .contains("from_unixtime") == conf._2)
             })
         }
       })

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -49,8 +49,6 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.supported.scala.udfs", "my_add")
-//      .set("spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level", "trace")
-//      .set("spark.sql.planChangeLog.level", "error")
   }
 
   override protected val createNullableTables = true
@@ -1271,8 +1269,15 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
   }
 
   test("test 'to_date/to_timestamp'") {
-    val sql = "select to_date(concat('2022-01-0', cast(id+1 as String)), 'yyyy-MM-dd')," +
-      "to_timestamp(concat('2022-01-01 10:30:0', cast(id+1 as String)), 'yyyy-MM-dd HH:mm:ss') " +
+    val sql = "select to_date(concat('2022-01-0', cast(id+1 as String)), 'yyyy-MM-dd') as a1," +
+      "to_timestamp(concat('2022-01-01 10:30:0', cast(id+1 as String)), 'yyyy-MM-dd HH:mm:ss') as a2," +
+      "to_date(date_add(date'2024-05-07', cast(id as int)), 'yyyy-MM-dd') as a3, " +
+      "to_date(date_add(date'2024-05-07', cast(id as int)), 'yyyyMMdd') as a4, " +
+      "to_date(date_add(date'2024-05-07', cast(id as int)), 'yyyy-MM') as a5, " +
+      "to_date(date_add(date'2024-05-07', cast(id as int)), 'yyyy') as a6, " +
+      "to_date(to_timestamp(concat('2022-01-01 10:30:0', cast(id+1 as String))), 'yyyy-MM-dd HH:mm:ss') as a7, " +
+      "to_timestamp(date_add(date'2024-05-07', cast(id as int)), 'yyyy-MM') as a8, " +
+      "to_timestamp(to_timestamp(concat('2022-01-01 10:30:0', cast(id+1 as String))), 'yyyy-MM-dd HH:mm:ss') as a9 " +
       "from range(9)"
     runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix error 'Illegal type of argument of function parseDateTimeInJodaSyntaxOrNull, expected String, got Date32' when executing to_date/to_timestamp.

RC:
the spark function `to_date/to_timestamp` are mapping to the CH function `parseDateTimeInJodaSyntaxOrNull` when they execute with the specified format, but the CH function `parseDateTimeInJodaSyntaxOrNull` can not support the data type `DateType or TimestampType` as the input data type, and spark supports.

Close #5651.

(Fixes: #5651)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

