### PR TITLE
[GLUTEN-5662][VL] Fix literal array conversion with nested empty array/map ahead of non-empty

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxLiteralSuite.scala
@@ -74,7 +74,9 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
   test("Array Literal") {
     validateOffloadResult("SELECT array()")
     validateOffloadResult("SELECT array(array())")
+    validateOffloadResult("SELECT array(array(), array(1, 2))")
     validateOffloadResult("SELECT array(map())")
+    validateOffloadResult("SELECT array(map(), map('red', 1))")
     validateOffloadResult("SELECT array('Spark', '5')")
     validateOffloadResult("SELECT array(5, 1, -1)")
     validateOffloadResult("SELECT array(5S, 1S, -1S)")

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -430,11 +430,21 @@ VectorPtr SubstraitVeloxExprConverter::literalsToVector(
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kIntervalDayToSecond:
       return constructFlatVector<TypeKind::BIGINT>(elementAtFunc, childSize, INTERVAL_DAY_TIME(), pool_);
+    // Handle EmptyList and List together since the children could be either case.
+    case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyList:
     case ::substrait::Expression_Literal::LiteralTypeCase::kList: {
       ArrayVectorPtr elements;
       for (int i = 0; i < childSize; i++) {
-        auto element = elementAtFunc(i);
-        ArrayVectorPtr grandVector = literalsToArrayVector(element);
+        auto child = elementAtFunc(i);
+        auto childType = child.literal_type_case();
+        ArrayVectorPtr grandVector;
+
+        if (childType == ::substrait::Expression_Literal::LiteralTypeCase::kEmptyList) {
+          auto elementType = SubstraitParser::parseType(child.empty_list().type());
+          grandVector = makeEmptyArrayVector(pool_, elementType);
+        } else {
+          grandVector = literalsToArrayVector(child);
+        }
         if (!elements) {
           elements = grandVector;
         } else {
@@ -443,11 +453,22 @@ VectorPtr SubstraitVeloxExprConverter::literalsToVector(
       }
       return elements;
     }
+    // Handle EmptyMap and Map together since the children could be either case.
+    case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyMap:
     case ::substrait::Expression_Literal::LiteralTypeCase::kMap: {
       MapVectorPtr mapVector;
       for (int i = 0; i < childSize; i++) {
-        auto element = elementAtFunc(i);
-        MapVectorPtr grandVector = literalsToMapVector(element);
+        auto child = elementAtFunc(i);
+        auto childType = child.literal_type_case();
+        MapVectorPtr grandVector;
+
+        if (childType == ::substrait::Expression_Literal::LiteralTypeCase::kEmptyMap) {
+          auto keyType = SubstraitParser::parseType(child.empty_map().key());
+          auto valueType = SubstraitParser::parseType(child.empty_map().value());
+          grandVector = makeEmptyMapVector(pool_, keyType, valueType);
+        } else {
+          grandVector = literalsToMapVector(child);
+        }
         if (!mapVector) {
           mapVector = grandVector;
         } else {
@@ -468,15 +489,6 @@ VectorPtr SubstraitVeloxExprConverter::literalsToVector(
         }
       }
       return rowVector;
-    }
-    case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyList: {
-      auto elementType = SubstraitParser::parseType(childLiteral.empty_list().type());
-      return BaseVector::wrapInConstant(1, 0, makeEmptyArrayVector(pool_, elementType));
-    }
-    case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyMap: {
-      auto keyType = SubstraitParser::parseType(childLiteral.empty_map().key());
-      auto valueType = SubstraitParser::parseType(childLiteral.empty_map().value());
-      return BaseVector::wrapInConstant(1, 0, makeEmptyMapVector(pool_, keyType, valueType));
     }
     default:
       auto veloxType = getScalarType(elementAtFunc(0));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes: #5662 

## How was this patch tested?

UT added.

Without the fix, the new added UTs would fail as:

```
== Results ==
!== Correct Answer - 1 ==                            == Gluten Answer - 1 ==
 struct<>                                            struct<>
![ArrayBuffer(WrappedArray(), WrappedArray(1, 2))]   [ArrayBuffer(WrappedArray())]


== Results ==
!== Correct Answer - 1 ==              == Gluten Answer - 1 ==
 struct<>                              struct<>
![ArrayBuffer(Map(), Map(red -> 1))]   [ArrayBuffer(Map())]
```

