### PR TITLE
[VL] Substrait-to-Velox: Support nested complex type signature parsing

### DIFF
--- a/cpp/velox/substrait/VeloxSubstraitSignature.cc
+++ b/cpp/velox/substrait/VeloxSubstraitSignature.cc
@@ -72,6 +72,48 @@ std::string VeloxSubstraitSignature::toSubstraitSignature(const TypePtr& type) {
   }
 }
 
+namespace {
+using index = std::string::size_type;
+
+index findEnclosingPos(std::string text, index from, char left, char right) {
+  VELOX_CHECK(left != right)
+  VELOX_CHECK(text.at(from) == left)
+  int32_t stackedLeftChars = 0;
+  for (index idx = from; idx < text.size(); idx++) {
+    const char ch = text.at(idx);
+    if (ch == left) {
+      stackedLeftChars++;
+    }
+    if (ch == right) {
+      stackedLeftChars--;
+    }
+    if (stackedLeftChars == 0) {
+      return idx;
+    }
+  }
+  VELOX_FAIL("Unable to find enclose character from text: " + text)
+}
+
+index findSansNesting(std::string text, index from, char target, char left, char right) {
+  VELOX_CHECK(left != right)
+  VELOX_CHECK(target != left && target != right)
+  int32_t stackedLeftChars = 0;
+  for (index idx = from; idx < text.size(); idx++) {
+    const char ch = text.at(idx);
+    if (ch == left) {
+      stackedLeftChars++;
+    }
+    if (ch == right) {
+      stackedLeftChars--;
+    }
+    if (ch == target && stackedLeftChars == 0) {
+      return idx;
+    }
+  }
+  return std::string::npos;
+}
+} // namespace
+
 TypePtr VeloxSubstraitSignature::fromSubstraitSignature(const std::string& signature) {
   if (signature == "bool") {
     return BOOLEAN();
@@ -123,7 +165,7 @@ TypePtr VeloxSubstraitSignature::fromSubstraitSignature(const std::string& signa
 
   auto parseNestedTypeSignature = [&](const std::string& signature) -> std::vector<TypePtr> {
     auto start = signature.find_first_of('<');
-    auto end = signature.find_last_of('>');
+    auto end = findEnclosingPos(signature, start, '<', '>');
     VELOX_CHECK(
         end - start > 1,
         "Native validation failed due to: more information is needed to create nested type for {}",
@@ -132,30 +174,25 @@ TypePtr VeloxSubstraitSignature::fromSubstraitSignature(const std::string& signa
     std::string childrenTypes = signature.substr(start + 1, end - start - 1);
 
     // Split the types with delimiter.
-    std::string delimiter = ",";
-    std::size_t pos;
+    const char delimiter = ',';
     std::vector<TypePtr> types;
-    while ((pos = childrenTypes.find(delimiter)) != std::string::npos) {
-      auto typeStr = childrenTypes.substr(0, pos);
-      std::size_t endPos = pos;
-      if (startWith(typeStr, "dec") || startWith(typeStr, "struct") || startWith(typeStr, "map") ||
-          startWith(typeStr, "list")) {
-        endPos = childrenTypes.find(">") + 1;
-        if (endPos > pos) {
-          typeStr += childrenTypes.substr(pos, endPos - pos);
-        } else {
-          // For nested case, the end '>' could missing,
-          // so the last position is treated as end.
-          typeStr += childrenTypes.substr(pos);
-          endPos = childrenTypes.size();
-        }
+    size_t typeStart = 0;
+    while (true) {
+      if (typeStart == childrenTypes.size()) {
+        break;
       }
+      VELOX_CHECK(typeStart < childrenTypes.size())
+      const size_t typeEnd = findSansNesting(childrenTypes, typeStart, delimiter, '<', '>');
+      if (typeEnd == std::string::npos) {
+        std::string typeStr = childrenTypes.substr(typeStart);
+        types.emplace_back(fromSubstraitSignature(typeStr));
+        break;
+      }
+      std::string typeStr = childrenTypes.substr(typeStart, typeEnd - typeStart);
       types.emplace_back(fromSubstraitSignature(typeStr));
-      childrenTypes.erase(0, endPos + delimiter.length());
+      typeStart = typeEnd + 1;
     }
-    if (childrenTypes.size() > 0 && !startWith(childrenTypes, ">")) {
-      types.emplace_back(fromSubstraitSignature(childrenTypes));
-    }
+
     return types;
   };
 
@@ -172,6 +209,10 @@ TypePtr VeloxSubstraitSignature::fromSubstraitSignature(const std::string& signa
   if (startWith(signature, "struct")) {
     // Struct type name is in the format of struct<T1,T2,...,Tn>.
     auto types = parseNestedTypeSignature(signature);
+    if (types.empty()) {
+      VELOX_UNSUPPORTED(
+          "VeloxSubstraitSignature::fromSubstraitSignature: Unrecognizable struct type signature {}.", signature);
+    }
     std::vector<std::string> names(types.size());
     for (int i = 0; i < types.size(); i++) {
       names[i] = "";
@@ -183,22 +224,20 @@ TypePtr VeloxSubstraitSignature::fromSubstraitSignature(const std::string& signa
     // Map type name is in the format of map<T1,T2>.
     auto types = parseNestedTypeSignature(signature);
     if (types.size() != 2) {
-      VELOX_UNSUPPORTED("Substrait type signature conversion to Velox type not supported for {}.", signature);
+      VELOX_UNSUPPORTED(
+          "VeloxSubstraitSignature::fromSubstraitSignature: Unrecognizable map type signature {}.", signature);
     }
     return MAP(std::move(types)[0], std::move(types)[1]);
   }
 
   if (startWith(signature, "list")) {
-    auto listStart = signature.find_first_of('<');
-    auto listEnd = signature.find_last_of('>');
-    VELOX_CHECK(
-        listEnd - listStart > 1,
-        "Native validation failed due to: more information is needed to create ListType: {}",
-        signature);
-
-    auto elementTypeStr = signature.substr(listStart + 1, listEnd - listStart - 1);
-    auto elementType = fromSubstraitSignature(elementTypeStr);
-    return ARRAY(elementType);
+    // Array type name is in the format of list<T>.
+    auto types = parseNestedTypeSignature(signature);
+    if (types.size() != 1) {
+      VELOX_UNSUPPORTED(
+          "VeloxSubstraitSignature::fromSubstraitSignature: Unrecognizable list type signature {}.", signature);
+    }
+    return ARRAY(std::move(types)[0]);
   }
 
   VELOX_UNSUPPORTED("Substrait type signature conversion to Velox type not supported for {}.", signature);

--- a/cpp/velox/tests/VeloxSubstraitSignatureTest.cc
+++ b/cpp/velox/tests/VeloxSubstraitSignatureTest.cc
@@ -138,6 +138,13 @@ TEST_F(VeloxSubstraitSignatureTest, fromSubstraitSignature) {
   ASSERT_EQ(type->childAt(0)->childAt(0)->childAt(1)->kind(), TypeKind::VARCHAR);
   type = fromSubstraitSignature("struct<struct<struct<i8,dec<19,2>>>>");
   ASSERT_EQ(type->childAt(0)->childAt(0)->childAt(1)->kind(), TypeKind::HUGEINT);
+  type = fromSubstraitSignature("struct<fp32,struct<struct<i8,dec<19,2>,list<i32>,map<i16,i32>>>>");
+  ASSERT_EQ(type->childAt(0)->kind(), TypeKind::REAL);
+  ASSERT_EQ(type->childAt(1)->childAt(0)->childAt(0)->kind(), TypeKind::TINYINT);
+  ASSERT_EQ(type->childAt(1)->childAt(0)->childAt(1)->kind(), TypeKind::HUGEINT);
+  ASSERT_EQ(type->childAt(1)->childAt(0)->childAt(2)->childAt(0)->kind(), TypeKind::INTEGER);
+  ASSERT_EQ(type->childAt(1)->childAt(0)->childAt(3)->childAt(0)->kind(), TypeKind::SMALLINT);
+  ASSERT_EQ(type->childAt(1)->childAt(0)->childAt(3)->childAt(1)->kind(), TypeKind::INTEGER);
   ASSERT_ANY_THROW(fromSubstraitSignature("other")->kind());
 
   // Map type test.


### PR DESCRIPTION
There is a bug occurs when parsing Substrait nested complex type signature.

For example:

Signature:

```
struct<fp32,struct<struct<i8,dec<19,2>,list<i32>,map<i16,i32>>>>
```

Error:

```
unknown file: Failure
C++ exception with description "Exception: VeloxUserError
Error Source: USER
Error Code: UNSUPPORTED
Reason: Substrait type signature conversion to Velox type not supported for i32>,map<i16,i32>>.
```

The bug also causes **unexpected fallbacks** on some operators that are actually capable to offload, for example when delta lake initializes its metadata queries, the aggregate operator may be fallen back due to this issue:

```
ColumnarExchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=299], [id=#299], [OUTPUT] List(set:ArrayType(StructType(StructField(appId,StringType,true),StructField(version,LongType,false),StructField(lastUpdated,LongType,true)),false), count:LongType, sum:LongType, last:StructType(StructField(id,StringType,true),StructField(name,StringType,true),StructField(description,StringType,true),StructField(format,StructType(StructField(provider,StringType,true),StructField(options,MapType(StringType,StringType,true),true)),true),StructField(schemaString,StringType,true),StructField(partitionColumns,ArrayType(StringType,true),true),StructField(configuration,MapType(StringType,StringType,true),true),StructField(createdTime,LongType,true)), valueSet:BooleanType, count:LongType, last:StructType(StructField(minReaderVersion,IntegerType,false),StructField(minWriterVersion,IntegerType,false),StructField(readerFeatures,ArrayType(StringType,true),true),StructField(writerFeatures,ArrayType(StringType,true),true)), valueSet:BooleanType, count:LongType, count:LongType, count:LongType), [OUTPUT] List(set:ArrayType(StructType(StructField(appId,StringType,true),StructField(version,LongType,false),StructField(lastUpdated,LongType,true)),false), count:LongType, sum:LongType, last:StructType(StructField(id,StringType,true),StructField(name,StringType,true),StructField(description,StringType,true),StructField(format,StructType(StructField(provider,StringType,true),StructField(options,MapType(StringType,StringType,true),true)),true),StructField(schemaString,StringType,true),StructField(partitionColumns,ArrayType(StringType,true),true),StructField(configuration,MapType(StringType,StringType,true),true),StructField(createdTime,LongType,true)), valueSet:BooleanType, count:LongType, last:StructType(StructField(minReaderVersion,IntegerType,false),StructField(minWriterVersion,IntegerType,false),StructField(readerFeatures,ArrayType(StringType,true),true),StructField(writerFeatures,ArrayType(StringType,true),true)), valueSet:BooleanType, count:LongType, count:LongType, count:LongType)
+- RowToVeloxColumnar
   +- SortAggregate(key=[], functions=[partial_velox_collect_set(txn#390) FILTER (WHERE isnotnull(txn#390)), partial_count(protocol#394), partial_sum(add#391.size), partial_last(metaData#393, true), partial_count(metaData#393), partial_last(protocol#394, true), partial_count(remove#392), partial_count(add#391), partial_count(txn#390)], output=[set#512, count#513L, sum#514L, last#515, valueSet#516, count#517L, last#518, valueSet#519, count#520L, count#521L, count#522L])
      +- VeloxColumnarToRowExec
         +- ^(6) ProjectExecTransformer [txn#390, add#391, remove#392, metaData#393, protocol#394]
            +- ^(6) InputIteratorTransformer[txn#390, add#391, remove#392, metaData#393, protocol#394, cdc#395, commitInfo#396]
               +- ^(6) InputAdapter
                  +- ^(6) RowToVeloxColumnar
                     +- ^(6) Scan ExistingRDD Delta Table State #0 - file:/opt/gluten/spark-warehouse/org.apache.gluten.execution.VeloxTPCHDeltaSuite/part/_delta_log[txn#390,add#391,remove#392,metaData#393,protocol#394,cdc#395,commitInfo#396]
```

The patch works relevant code a bit to fix the bug and to make the code support arbitrary level of signature nesting.