### PR TITLE
[VL][Doc] Remove spark.gluten.sql.columnar.backend.lib config from example

### DIFF
--- a/docs/get-started/Work-with-pyspark.ipynb
+++ b/docs/get-started/Work-with-pyspark.ipynb
@@ -41,7 +41,6 @@
     "conf.set(\"spark.driver.extraClassPath\", nativesql_jars)\n",
     "conf.set(\"spark.executor.extraClassPath\", nativesql_jars)\n",
     "conf.set(\"spark.plugins\", \"org.apache.gluten.GlutenPlugin\")\n",
-    "conf.set(\"spark.gluten.sql.columnar.backend.lib\", \"velox\")\n",
     "conf.set(\"spark.gluten.loadLibFromJar\", \"false\")\n",
     "conf.set(\"spark.shuffle.manager\", \"org.apache.spark.shuffle.sort.ColumnarShuffleManager\")\n",
     "sc = SparkContext(conf=conf)\n",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removing the config `spark.gluten.sql.columnar.backend.lib` from sample notebook since it is no longer used to set the backend engine.

