### PR TITLE
[GLUTEN-5414] [VL] Fix and enable arrow native memory pool track in CSV scan

### DIFF
--- a/ep/build-velox/src/modify_arrow.patch
+++ b/ep/build-velox/src/modify_arrow.patch
@@ -30,6 +30,33 @@ index a24f272fe..e25f78c85 100644
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
+diff --git a/java/dataset/src/main/cpp/jni_wrapper.cc b/java/dataset/src/main/cpp/jni_wrapper.cc
+index d2d976677..d7dd01ecd 100644
+--- a/java/dataset/src/main/cpp/jni_wrapper.cc
++++ b/java/dataset/src/main/cpp/jni_wrapper.cc
+@@ -126,20 +126,14 @@ class ReserveFromJava : public arrow::dataset::jni::ReservationListener {
+       : vm_(vm), java_reservation_listener_(java_reservation_listener) {}
+ 
+   arrow::Status OnReservation(int64_t size) override {
+-    JNIEnv* env;
+-    if (vm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
+-      return arrow::Status::Invalid("JNIEnv was not attached to current thread");
+-    }
++    JNIEnv* env = arrow::dataset::jni::GetEnvOrAttach(vm_);
+     env->CallObjectMethod(java_reservation_listener_, reserve_memory_method, size);
+     RETURN_NOT_OK(arrow::dataset::jni::CheckException(env));
+     return arrow::Status::OK();
+   }
+ 
+   arrow::Status OnRelease(int64_t size) override {
+-    JNIEnv* env;
+-    if (vm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
+-      return arrow::Status::Invalid("JNIEnv was not attached to current thread");
+-    }
++    JNIEnv* env = arrow::dataset::jni::GetEnvOrAttach(vm_);
+     env->CallObjectMethod(java_reservation_listener_, unreserve_memory_method, size);
+     RETURN_NOT_OK(arrow::dataset::jni::CheckException(env));
+     return arrow::Status::OK();
 diff --git a/java/pom.xml b/java/pom.xml
 index a8328576b..53a70fab8 100644
 --- a/java/pom.xml

--- a/gluten-data/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 import org.apache.arrow.c.{ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.dataset.file.{FileFormat, FileSystemDatasetFactory}
-//import org.apache.arrow.dataset.jni.NativeMemoryPool
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, Schema}

--- a/gluten-data/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.utils
 
 import org.apache.gluten.exception.SchemaMismatchException
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.memory.arrow.pool.ArrowNativeMemoryPool
 import org.apache.gluten.vectorized.ArrowWritableColumnVector
 
 import org.apache.spark.internal.Logging
@@ -30,6 +31,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.utils.{SparkArrowUtil, SparkSchemaUtil}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
 import org.apache.arrow.c.{ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.dataset.file.{FileFormat, FileSystemDatasetFactory}
 //import org.apache.arrow.dataset.jni.NativeMemoryPool
@@ -37,13 +39,12 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, Schema}
 import org.apache.hadoop.fs.FileStatus
+
 import java.net.URI
 import java.util
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-
-import org.apache.gluten.memory.arrow.pool.ArrowNativeMemoryPool
 
 object ArrowUtil extends Logging {
 

--- a/gluten-data/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
@@ -30,20 +30,20 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.utils.{SparkArrowUtil, SparkSchemaUtil}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
-
 import org.apache.arrow.c.{ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.dataset.file.{FileFormat, FileSystemDatasetFactory}
-import org.apache.arrow.dataset.jni.NativeMemoryPool
+//import org.apache.arrow.dataset.jni.NativeMemoryPool
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, Schema}
 import org.apache.hadoop.fs.FileStatus
-
 import java.net.URI
 import java.util
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
+import org.apache.gluten.memory.arrow.pool.ArrowNativeMemoryPool
 
 object ArrowUtil extends Logging {
 
@@ -144,7 +144,7 @@ object ArrowUtil extends Logging {
     val allocator = ArrowBufferAllocators.contextInstance()
     val factory = new FileSystemDatasetFactory(
       allocator,
-      NativeMemoryPool.getDefault, // TODO: wait to change
+      ArrowNativeMemoryPool.arrowPool("FileSystemDatasetFactory"),
       format,
       rewriteUri(encodedUri))
     factory


### PR DESCRIPTION
Before this patch, will throw exception
```
/__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/_build/release/third_party/arrow_ep/src/arrow_ep/java/dataset/src/main/cpp/jni_util.cc:79: Failed to update reservation while freeing bytes: JNIEnv was not attached to current thread
```
Fixed by arrow patch `AttachCurrentThread`