### PR TITLE
[VL] Refactor parsePartitionAndMetadataColumns to parseColunTypes

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -107,35 +107,29 @@ std::vector<TypePtr> SubstraitParser::parseNamedStruct(const ::substrait::NamedS
   return typeList;
 }
 
-void SubstraitParser::parsePartitionAndMetadataColumns(
+void SubstraitParser::parseColumnTypes(
     const ::substrait::NamedStruct& namedStruct,
-    std::vector<bool>& isPartitionColumns,
-    std::vector<bool>& isMetadataColumns) {
+    std::vector<ColumnType>& columnTypes) {
   const auto& columnsTypes = namedStruct.column_types();
   if (columnsTypes.size() == 0) {
     // Regard all columns as regular columns.
-    isPartitionColumns.resize(namedStruct.names().size(), false);
-    isMetadataColumns.resize(namedStruct.names().size(), false);
+    columnTypes.resize(namedStruct.names().size(), ColumnType::kRegular);
     return;
   } else {
     VELOX_CHECK_EQ(columnsTypes.size(), namedStruct.names().size(), "Wrong size for column types and column names.");
   }
 
-  isPartitionColumns.reserve(columnsTypes.size());
-  isMetadataColumns.reserve(columnsTypes.size());
+  columnTypes.reserve(columnsTypes.size());
   for (const auto& columnType : columnsTypes) {
     switch (columnType) {
       case ::substrait::NamedStruct::NORMAL_COL:
-        isPartitionColumns.emplace_back(false);
-        isMetadataColumns.emplace_back(false);
+        columnTypes.push_back(ColumnType::kRegular);
         break;
       case ::substrait::NamedStruct::PARTITION_COL:
-        isPartitionColumns.emplace_back(true);
-        isMetadataColumns.emplace_back(false);
+        columnTypes.push_back(ColumnType::kPartitionKey);
         break;
       case ::substrait::NamedStruct::METADATA_COL:
-        isPartitionColumns.emplace_back(false);
-        isMetadataColumns.emplace_back(true);
+        columnTypes.push_back(ColumnType::kSynthesized);
         break;
       default:
         VELOX_FAIL("Unspecified column type.");

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -28,9 +28,12 @@
 
 #include <google/protobuf/wrappers.pb.h>
 
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/type/Type.h"
 
 namespace gluten {
+
+typedef ::facebook::velox::connector::hive::HiveColumnHandle::ColumnType ColumnType;
 
 /// This class contains some common functions used to parse Substrait
 /// components, and convert them into recognizable representations.
@@ -41,11 +44,10 @@ class SubstraitParser {
       const ::substrait::NamedStruct& namedStruct,
       bool asLowerCase = false);
 
-  /// Used to parse partition & metadata columns from Substrait NamedStruct.
-  static void parsePartitionAndMetadataColumns(
+  /// Used to parse column types from Substrait NamedStruct.
+  static void parseColumnTypes(
       const ::substrait::NamedStruct& namedStruct,
-      std::vector<bool>& isPartitionColumns,
-      std::vector<bool>& isMetadataColumns);
+      std::vector<ColumnType>& columnTypes);
 
   /// Parse Substrait Type to Velox type.
   static facebook::velox::TypePtr parseType(const ::substrait::Type& substraitType, bool asLowerCase = false);

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -369,11 +369,10 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WriteRel& writeR
   // Validate partition key type.
   if (writeRel.has_table_schema()) {
     const auto& tableSchema = writeRel.table_schema();
-    std::vector<bool> isMetadataColumns;
-    std::vector<bool> isPartitionColumns;
-    SubstraitParser::parsePartitionAndMetadataColumns(tableSchema, isPartitionColumns, isMetadataColumns);
+    std::vector<ColumnType> columnTypes;
+    SubstraitParser::parseColumnTypes(tableSchema, columnTypes);
     for (auto i = 0; i < types.size(); i++) {
-      if (isPartitionColumns[i]) {
+      if (columnTypes[i] == ColumnType::kPartitionKey) {
         switch (types[i]->kind()) {
           case TypeKind::BOOLEAN:
           case TypeKind::TINYINT:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox side row index meta data column support for parquet scan is ready https://github.com/facebookincubator/velox/pull/9174 , i am working now for gluten part chagne.

The row index column is a new addtional column handle type `kRowIndex` which need be passed from gluten.

This PR use to refactor ` parsePartitionAndMetadataColumns` to let it support parse `NameStruct` to store all availale [column type](https://github.com/facebookincubator/velox/blob/7d76b1d9ee814c8911d849697071acccf3e18b0c/velox/connectors/hive/TableHandle.h#L32C1-L37C14), not only `partition` column or `metadata` column into only one `ColumnType` vector, otherwise we need pass additional thrid bool vector to store for `row index` column.

(Fixes: \#5047)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

