### PR TITLE
[GLUTEN-5569][VL] Hide child WriteFilesExec from VeloxColumnarWriteFilesExec on UI

### DIFF
--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenSQLAppStatusListener.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenSQLAppStatusListener.scala
@@ -21,6 +21,7 @@ import org.apache.gluten.events.{GlutenBuildInfoEvent, GlutenPlanFallbackEvent}
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
+import org.apache.spark.sql.execution.ui.adjustment.PlanGraphAdjustment
 import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.status.{ElementTrackingStore, KVUtils}
 
@@ -79,6 +80,7 @@ class GlutenSQLAppStatusListener(conf: SparkConf, kvstore: ElementTrackingStore)
   }
 
   private def onSQLExtensionEnd(event: SparkListenerSQLExecutionEnd): Unit = {
+    PlanGraphAdjustment.adjust(kvstore, event.executionId)
     executionIdToDescription.remove(event.executionId)
     executionIdToFallbackEvent.remove(event.executionId)
   }

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/adjustment/PlanGraphAdjustment.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/adjustment/PlanGraphAdjustment.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.ui.adjustment
+
+import org.apache.spark.sql.execution.ui.{SparkPlanGraphEdge, SparkPlanGraphNodeWrapper, SparkPlanGraphWrapper}
+import org.apache.spark.sql.execution.ui.adjustment.PlanGraphAdjustment.register
+import org.apache.spark.status.ElementTrackingStore
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+trait PlanGraphAdjustment {
+  private val registered: AtomicBoolean = new AtomicBoolean(false)
+
+  final def ensureRegistered(): Unit = {
+    if (!registered.compareAndSet(false, true)) {
+      return
+    }
+    register(this)
+  }
+
+  final protected def findChildren(
+      graph: SparkPlanGraphWrapper,
+      node: SparkPlanGraphNodeWrapper): Seq[(SparkPlanGraphNodeWrapper, SparkPlanGraphEdge)] = {
+    val id = node.node.id
+    val out = graph.edges
+      .filter(_.toId == id)
+      .flatMap {
+        childEdge =>
+          graph.nodes
+            .filter(_.node != null)
+            .find(_.node.id == childEdge.fromId)
+            .map(childNode => (childNode, childEdge))
+      }
+    out
+  }
+
+  final protected def findParent(
+      graph: SparkPlanGraphWrapper,
+      node: SparkPlanGraphNodeWrapper): Option[(SparkPlanGraphNodeWrapper, SparkPlanGraphEdge)] = {
+    val id = node.node.id
+    val out = graph.edges
+      .filter(_.fromId == id)
+      .flatMap {
+        parentEdge =>
+          graph.nodes
+            .filter(_.node != null)
+            .find(_.node.id == parentEdge.toId)
+            .map(parentNode => (parentNode, parentEdge))
+      }
+    if (out.isEmpty) {
+      return None
+    }
+    if (out.size == 1) {
+      return Some(out.head)
+    }
+    throw new IllegalStateException("Node has multiple parents, it should not happen: " + node)
+  }
+
+  def apply(from: SparkPlanGraphWrapper): SparkPlanGraphWrapper
+}
+
+object PlanGraphAdjustment {
+  private val adjustments: ListBuffer[PlanGraphAdjustment] = mutable.ListBuffer()
+
+  private[ui] def register(adjustment: PlanGraphAdjustment): Unit = synchronized {
+    adjustments += adjustment
+  }
+
+  private[ui] def adjust(kvstore: ElementTrackingStore, executionId: Long): Unit = {
+    val graph = kvstore.read(classOf[SparkPlanGraphWrapper], executionId)
+    val out = adjustments.foldLeft(graph) {
+      case (g, a) =>
+        a.apply(g)
+    }
+    assert(out.executionId == executionId)
+    kvstore.delete(classOf[SparkPlanGraphWrapper], executionId)
+    kvstore.write(out)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-gluten/issues/5569 and https://github.com/apache/incubator-gluten/issues/5880

Before:

![image](https://github.com/apache/incubator-gluten/assets/11284395/4a843e32-07d6-4713-8fda-6bf4f3d52395)

After:

![image](https://github.com/apache/incubator-gluten/assets/11284395/c8afd4cf-267d-40c3-8c71-e4de0126d3e2)
