### PR TITLE
[CORE] Add a compilation-time check to forbid case-class inheritance 

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/HashPartitioningWrapper.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/HashPartitioningWrapper.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 
 // A wrapper for HashPartitioning to remain original hash expressions.
 // Only used by CH backend when shuffle hash expressions contains non-field expression.
+@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
 class HashPartitioningWrapper(
     original: Seq[Expression],
     newExpr: Seq[Expression],

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -39,6 +39,7 @@ import java.{util => ju}
 
 import scala.collection.JavaConverters._
 
+@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
 class ClickHouseTableV2(
     override val spark: SparkSession,
     override val path: Path,
@@ -268,6 +269,7 @@ class ClickHouseTableV2(
   }
 }
 
+@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
 class TempClickHouseTableV2(
     override val spark: SparkSession,
     override val catalogTable: Option[CatalogTable] = None)

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
@@ -28,6 +28,7 @@ import java.util.{List => JList}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
 class AddMergeTreeParts(
     val database: String,
     val table: String,

--- a/pom.xml
+++ b/pom.xml
@@ -615,6 +615,20 @@
           <artifactId>scala-maven-plugin</artifactId>
           <version>${scala.compiler.version}</version>
           <configuration>
+            <compilerPlugins>
+              <compilerPlugin>
+                <groupId>org.wartremover</groupId>
+                <artifactId>wartremover_${scala.binary.version}</artifactId>
+                <version>3.1.6</version>
+              </compilerPlugin>
+            </compilerPlugins>
+            <dependencies>
+              <dependency>
+                <groupId>io.github.zhztheplayer.scalawarts</groupId>
+                <artifactId>scalawarts</artifactId>
+                <version>0.1.0</version>
+              </dependency>
+            </dependencies>
             <recompileMode>${scala.recompile.mode}</recompileMode>
             <args>
               <arg>-Wconf:msg=While parsing annotations in:silent</arg>
@@ -622,6 +636,7 @@
               <arg>-Xfatal-warnings</arg>
               <arg>-deprecation</arg>
               <arg>-feature</arg>
+              <arg>-P:wartremover:traverser:io.github.zhztheplayer.scalawarts.InheritFromCaseClass</arg>
             </args>
           </configuration>
           <executions>


### PR DESCRIPTION
This uses Scala linter `wartremover` and its maven plugin. And I wrote a custom wart for this.

The jar including the custom wart:
https://central.sonatype.com/artifact/io.github.zhztheplayer.scalawarts/scalawarts

Source code:
https://github.com/zhztheplayer/scalawarts

Wartremover:
https://github.com/wartremover/wartremover

After this patch, once a class tends to inherit a case class, compiler will raise an error:

```
error: [wartremover:InheritFromCaseClass] case class is not inheritable: MyClass is trying to inherit List(class CaseClazz)
```

To suppress that error, add an annotation before the class definition:

```
@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
class MyClass extends CaseClazz{...}
```

In the other hand, I'll try upstreaming the code of `InheritFromCaseClass` to wartremover main stream. After that we'll remove the dependency to `io.github.zhztheplayer.scalawarts`.