### PR TITLE
[GLUTEN-5731][CORE] Fix the logic to calculate rss shuffle write time

### DIFF
--- a/cpp/core/shuffle/rss/RssPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/RssPartitionWriter.cc
@@ -56,8 +56,6 @@ arrow::Status RssPartitionWriter::evict(
     bool reuseBuffers,
     bool hasComplexType) {
   rawPartitionLengths_[partitionId] += inMemoryPayload->getBufferSize();
-
-  ScopedTimer timer(&spillTime_);
   auto payloadType = (codec_ && inMemoryPayload->numRows() >= options_.compressionThreshold)
       ? Payload::Type::kCompressed
       : Payload::Type::kUncompressed;
@@ -69,6 +67,7 @@ arrow::Status RssPartitionWriter::evict(
   payload = nullptr; // Invalidate payload immediately.
 
   // Push.
+  ScopedTimer timer(&spillTime_);
   ARROW_ASSIGN_OR_RAISE(auto buffer, rssBufferOs->Finish());
   bytesEvicted_[partitionId] += rssClient_->pushPartitionData(
       partitionId, reinterpret_cast<char*>(const_cast<uint8_t*>(buffer->data())), buffer->size());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the logic to calculate the shuffle write time. Shuffle write time is currently composed of splitResult.getTotalWriteTime + splitResult.getTotalPushTime
And TotalWriteTime in the current implementation is added twice into the final shuffle write time metric. 

(Fixes: \#5731)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
E2e manual test.

