### PR TITLE
[VL] Daily Update Velox Version (2024_05_17)

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -110,6 +110,7 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
 
   /// Spill.
   std::string spillStrategy_;
+  std::shared_ptr<folly::Executor> spillExecutor_ = nullptr;
 
   /// Metrics
   std::unique_ptr<Metrics> metrics_{};

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_05_16
+VELOX_BRANCH=2024_05_17
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
Upstream Velox's New Commits:
```
4bde4b03e by Masha Basmanova, Do not return dictionaries with large alphabet from Unnest (#9843)
adb47bc1c by xiaoxmeng, Let driver go off-thread waiting for memory arbitration (#9766)
2b94547ea by xiaoxmeng, Optimize the shared leaf memory pool locking (#9830)
79956c2a4 by yingsu00, Fix the issue that the splits cannot be skipped for some special case (#9707)
acb7e4235 by Giuseppe Ottaviano, Implement unlocked fast path in MemoryManager::getInstance() (#9808)
954f53c30 by Masha Basmanova, Refactor Unnest operator for readability (#9841)
2c2f8e444 by aditi-pandit, Compute updateMode HiveWriterParameter only once for the HiveDataSink (#9812)
e2c0014b2 by yanngyoung, Remove allowInputShuffle_ flag in AggregationTestBase::testReadFromFiles (#9482)
7b8e41ffc by Zac Wen, Fix flaky test AsyncDataCacheTest.shutdown (#9827)
```