### PR TITLE
[VL] Use MemConfig to replace MemConfigMutable, which makes the code cleaner and may also lead to some performance improvements.

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -191,7 +191,9 @@ void VeloxBackend::initConnector() {
   std::unordered_map<std::string, std::string> connectorConfMap = backendConf_->values();
 
   auto hiveConf = getHiveConfig(backendConf_);
-  connectorConfMap.insert(hiveConf.values().begin(), hiveConf.values().end());
+  for (auto& [k, v] : hiveConf->valuesCopy()) {
+    connectorConfMap[k] = v;
+  }
 
 #ifdef ENABLE_ABFS
   const auto& confValue = backendConf_->values();

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -258,8 +258,4 @@ VeloxBackend* VeloxBackend::get() {
   return instance_.get();
 }
 
-std::shared_ptr<facebook::velox::Config> VeloxBackend::getBackendConf() const {
-  return backendConf_;
-}
-
 } // namespace gluten

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -61,13 +61,13 @@ gluten::Runtime* veloxRuntimeFactory(const std::unordered_map<std::string, std::
 } // namespace
 
 void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf) {
-  backendConf_ = std::make_shared<facebook::velox::core::MemConfigMutable>(conf);
+  backendConf_ = std::make_shared<facebook::velox::core::MemConfig>(conf);
 
   // Register Velox runtime factory
   gluten::Runtime::registerFactory(gluten::kVeloxRuntimeKind, veloxRuntimeFactory);
 
   if (backendConf_->get<bool>(kDebugModeEnabled, false)) {
-    LOG(INFO) << "VeloxBackend config:" << printConfig(backendConf_->valuesCopy());
+    LOG(INFO) << "VeloxBackend config:" << printConfig(backendConf_->values());
   }
 
   // Init glog and log level.
@@ -188,46 +188,37 @@ void VeloxBackend::initCache() {
 
 void VeloxBackend::initConnector() {
   // The configs below are used at process level.
-  auto connectorConf = std::make_shared<facebook::velox::core::MemConfigMutable>(backendConf_->valuesCopy());
+  std::unordered_map<std::string, std::string> connectorConfMap = backendConf_->values();
 
   auto hiveConf = getHiveConfig(backendConf_);
-  for (auto& [k, v] : hiveConf->valuesCopy()) {
-    connectorConf->setValue(k, v);
-  }
+  connectorConfMap.insert(hiveConf.values().begin(), hiveConf.values().end());
 
 #ifdef ENABLE_ABFS
-  const auto& confValue = backendConf_->valuesCopy();
+  const auto& confValue = backendConf_->values();
   for (auto& [k, v] : confValue) {
     if (k.find("fs.azure.account.key") == 0) {
-      connectorConf->setValue(k, v);
+      connectorConfMap[k] = v;
     } else if (k.find("spark.hadoop.fs.azure.account.key") == 0) {
       constexpr int32_t accountKeyPrefixLength = 13;
-      connectorConf->setValue(k.substr(accountKeyPrefixLength), v);
+      connectorConfMap[k.substr(accountKeyPrefixLength)] = v;
     }
   }
 #endif
+  connectorConfMap[velox::connector::hive::HiveConfig::kEnableFileHandleCache] =
+      backendConf_->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false";
 
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kEnableFileHandleCache,
-      backendConf_->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false");
-
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kMaxCoalescedBytes,
-      backendConf_->get<std::string>(kMaxCoalescedBytes, "67108864")); // 64M
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kMaxCoalescedDistanceBytes,
-      backendConf_->get<std::string>(kMaxCoalescedDistanceBytes, "1048576")); // 1M
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kPrefetchRowGroups, backendConf_->get<std::string>(kPrefetchRowGroups, "1"));
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kLoadQuantum,
-      backendConf_->get<std::string>(kLoadQuantum, "268435456")); // 256M
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kFooterEstimatedSize,
-      backendConf_->get<std::string>(kDirectorySizeGuess, "32768")); // 32K
-  connectorConf->setValue(
-      velox::connector::hive::HiveConfig::kFilePreloadThreshold,
-      backendConf_->get<std::string>(kFilePreloadThreshold, "1048576")); // 1M
+  connectorConfMap[velox::connector::hive::HiveConfig::kMaxCoalescedBytes] =
+      backendConf_->get<std::string>(kMaxCoalescedBytes, "67108864"); // 64M
+  connectorConfMap[velox::connector::hive::HiveConfig::kMaxCoalescedDistanceBytes] =
+      backendConf_->get<std::string>(kMaxCoalescedDistanceBytes, "1048576"); // 1M
+  connectorConfMap[velox::connector::hive::HiveConfig::kPrefetchRowGroups] =
+      backendConf_->get<std::string>(kPrefetchRowGroups, "1");
+  connectorConfMap[velox::connector::hive::HiveConfig::kLoadQuantum] =
+      backendConf_->get<std::string>(kLoadQuantum, "268435456"); // 256M
+  connectorConfMap[velox::connector::hive::HiveConfig::kFooterEstimatedSize] =
+      backendConf_->get<std::string>(kDirectorySizeGuess, "32768"); // 32K
+  connectorConfMap[velox::connector::hive::HiveConfig::kFilePreloadThreshold] =
+      backendConf_->get<std::string>(kFilePreloadThreshold, "1048576"); // 1M
 
   // set cache_prefetch_min_pct default as 0 to force all loads are prefetched in DirectBufferInput.
   FLAGS_cache_prefetch_min_pct = backendConf_->get<int>(kCachePrefetchMinPct, 0);
@@ -238,7 +229,7 @@ void VeloxBackend::initConnector() {
   }
   velox::connector::registerConnector(std::make_shared<velox::connector::hive::HiveConnector>(
       kHiveConnectorId,
-      std::make_shared<facebook::velox::core::MemConfig>(connectorConf->valuesCopy()),
+      std::make_shared<facebook::velox::core::MemConfig>(std::move(connectorConfMap)),
       ioExecutor_.get()));
 }
 
@@ -265,7 +256,7 @@ VeloxBackend* VeloxBackend::get() {
   return instance_.get();
 }
 
-const std::shared_ptr<const facebook::velox::Config> VeloxBackend::getBackendConf() const {
+std::shared_ptr<facebook::velox::Config> VeloxBackend::getBackendConf() const {
   return backendConf_;
 }
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -53,7 +53,9 @@ class VeloxBackend {
 
   facebook::velox::cache::AsyncDataCache* getAsyncDataCache() const;
 
-  const std::shared_ptr<const facebook::velox::Config> getBackendConf() const;
+  std::shared_ptr<facebook::velox::Config> getBackendConf() const {
+    return backendConf_;
+  }
 
   void tearDown() {
     // Destruct IOThreadPoolExecutor will join all threads.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -90,7 +90,7 @@ class VeloxBackend {
   std::string cachePathPrefix_;
   std::string cacheFilePrefix_;
 
-  std::shared_ptr<const facebook::velox::Config> backendConf_;
+  std::shared_ptr<facebook::velox::Config> backendConf_;
 };
 
 } // namespace gluten

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -256,11 +256,11 @@ std::unique_ptr<ColumnarBatchSerializer> VeloxRuntime::createColumnarBatchSerial
 }
 
 void VeloxRuntime::dumpConf(const std::string& path) {
-  const auto& backendConf = VeloxBackend::get()->getBackendConf()->values();
-  auto allConf = backendConf;
+  const auto& backendConfMap = VeloxBackend::get()->getBackendConf()->values();
+  auto allConfMap = backendConfMap;
 
   for (const auto& pair : confMap_) {
-    allConf.insert_or_assign(pair.first, pair.second);
+    allConfMap.insert_or_assign(pair.first, pair.second);
   }
 
   // Open file "velox.conf" for writing, automatically creating it if it doesn't exist,
@@ -273,13 +273,13 @@ void VeloxRuntime::dumpConf(const std::string& path) {
 
   // Calculate the maximum key length for alignment.
   size_t maxKeyLength = 0;
-  for (const auto& pair : allConf) {
+  for (const auto& pair : allConfMap) {
     maxKeyLength = std::max(maxKeyLength, pair.first.length());
   }
 
   // Write each key-value pair to the file with adjusted spacing for alignment
   outFile << "[Backend Conf]" << std::endl;
-  for (const auto& pair : backendConf) {
+  for (const auto& pair : backendConfMap) {
     outFile << std::left << std::setw(maxKeyLength + 1) << pair.first << ' ' << pair.second << std::endl;
   }
   outFile << std::endl << "[Session Conf]" << std::endl;

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -55,7 +55,7 @@ namespace gluten {
 
 VeloxRuntime::VeloxRuntime(const std::unordered_map<std::string, std::string>& confMap) : Runtime(confMap) {
   // Refresh session config.
-  veloxCfg_ = std::make_shared<const facebook::velox::core::MemConfigMutable>(confMap_);
+  veloxCfg_ = std::make_shared<facebook::velox::core::MemConfig>(confMap_);
   debugModeEnabled_ = veloxCfg_->get<bool>(kDebugModeEnabled, false);
   FLAGS_minloglevel = veloxCfg_->get<uint32_t>(kGlogSeverityLevel, FLAGS_minloglevel);
   FLAGS_v = veloxCfg_->get<uint32_t>(kGlogVerboseLevel, FLAGS_v);
@@ -256,7 +256,7 @@ std::unique_ptr<ColumnarBatchSerializer> VeloxRuntime::createColumnarBatchSerial
 }
 
 void VeloxRuntime::dumpConf(const std::string& path) {
-  auto backendConf = VeloxBackend::get()->getBackendConf()->valuesCopy();
+  const auto& backendConf = VeloxBackend::get()->getBackendConf()->values();
   auto allConf = backendConf;
 
   for (const auto& pair : confMap_) {

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -132,7 +132,7 @@ class VeloxRuntime final : public Runtime {
 
  private:
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;
-  std::shared_ptr<const facebook::velox::Config> veloxCfg_;
+  std::shared_ptr<facebook::velox::Config> veloxCfg_;
   bool debugModeEnabled_{false};
 
   std::unordered_map<int32_t, std::shared_ptr<ColumnarBatch>> emptySchemaBatchLoopUp_;

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -62,7 +62,7 @@ WholeStageResultIterator::WholeStageResultIterator(
     const std::unordered_map<std::string, std::string>& confMap,
     const SparkTaskInfo& taskInfo)
     : memoryManager_(memoryManager),
-      veloxCfg_(std::make_shared<const facebook::velox::core::MemConfigMutable>(confMap)),
+      veloxCfg_(std::make_shared<facebook::velox::core::MemConfig>(confMap)),
       taskInfo_(taskInfo),
       veloxPlan_(planNode),
       scanNodeIds_(scanNodeIds),

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -103,7 +103,7 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
   VeloxMemoryManager* memoryManager_;
 
   /// Config, task and plan.
-  const std::shared_ptr<const Config> veloxCfg_;
+  std::shared_ptr<Config> veloxCfg_;
   const SparkTaskInfo taskInfo_;
   std::shared_ptr<facebook::velox::exec::Task> task_;
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;

--- a/cpp/velox/operators/writer/VeloxParquetDatasourceABFS.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasourceABFS.h
@@ -42,10 +42,8 @@ class VeloxParquetDatasourceABFS final : public VeloxParquetDatasource {
       std::shared_ptr<arrow::Schema> schema)
       : VeloxParquetDatasource(filePath, veloxPool, sinkPool, schema) {}
   void init(const std::unordered_map<std::string, std::string>& sparkConfs) override {
-    auto confs = std::make_shared<facebook::velox::core::MemConfigMutable>(sparkConfs);
-    auto hiveConfs = getHiveConfig(confs);
-    auto fileSystem = filesystems::getFileSystem(
-        filePath_, std::make_shared<facebook::velox::core::MemConfig>(hiveConfs->valuesCopy()));
+    auto hiveConf = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
+    auto fileSystem = filesystems::getFileSystem(filePath_, hiveConf->valuesCopy());
     auto* abfsFileSystem = dynamic_cast<filesystems::abfs::AbfsFileSystem*>(fileSystem.get());
     sink_ = std::make_unique<dwio::common::WriteFileSink>(
         abfsFileSystem->openFileForWrite(filePath_, {{}, sinkPool_.get()}), filePath_);

--- a/cpp/velox/operators/writer/VeloxParquetDatasourceABFS.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasourceABFS.h
@@ -43,7 +43,7 @@ class VeloxParquetDatasourceABFS final : public VeloxParquetDatasource {
       : VeloxParquetDatasource(filePath, veloxPool, sinkPool, schema) {}
   void init(const std::unordered_map<std::string, std::string>& sparkConfs) override {
     auto hiveConf = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
-    auto fileSystem = filesystems::getFileSystem(filePath_, hiveConf->valuesCopy());
+    auto fileSystem = filesystems::getFileSystem(filePath_, hiveConf);
     auto* abfsFileSystem = dynamic_cast<filesystems::abfs::AbfsFileSystem*>(fileSystem.get());
     sink_ = std::make_unique<dwio::common::WriteFileSink>(
         abfsFileSystem->openFileForWrite(filePath_, {{}, sinkPool_.get()}), filePath_);

--- a/cpp/velox/operators/writer/VeloxParquetDatasourceHDFS.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasourceHDFS.h
@@ -42,8 +42,8 @@ class VeloxParquetDatasourceHDFS final : public VeloxParquetDatasource {
       std::shared_ptr<arrow::Schema> schema)
       : VeloxParquetDatasource(filePath, veloxPool, sinkPool, schema) {}
   void init(const std::unordered_map<std::string, std::string>& sparkConfs) override {
-    auto hiveConfs = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
-    sink_ = dwio::common::FileSink::create(filePath_, {.connectorProperties = hiveConfs, .pool = sinkPool_.get()});
+    auto hiveConf = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
+    sink_ = dwio::common::FileSink::create(filePath_, {.connectorProperties = hiveConf, .pool = sinkPool_.get()});
     VeloxParquetDatasource::init(sparkConfs);
   }
 };

--- a/cpp/velox/operators/writer/VeloxParquetDatasourceHDFS.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasourceHDFS.h
@@ -42,12 +42,8 @@ class VeloxParquetDatasourceHDFS final : public VeloxParquetDatasource {
       std::shared_ptr<arrow::Schema> schema)
       : VeloxParquetDatasource(filePath, veloxPool, sinkPool, schema) {}
   void init(const std::unordered_map<std::string, std::string>& sparkConfs) override {
-    auto confs = std::make_shared<facebook::velox::core::MemConfigMutable>(sparkConfs);
-    auto hiveConfs = getHiveConfig(confs);
-    sink_ = dwio::common::FileSink::create(
-        filePath_,
-        {.connectorProperties = std::make_shared<facebook::velox::core::MemConfig>(hiveConfs->valuesCopy()),
-         .pool = sinkPool_.get()});
+    auto hiveConfs = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
+    sink_ = dwio::common::FileSink::create(filePath_, {.connectorProperties = hiveConfs, .pool = sinkPool_.get()});
     VeloxParquetDatasource::init(sparkConfs);
   }
 };

--- a/cpp/velox/operators/writer/VeloxParquetDatasourceS3.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasourceS3.h
@@ -42,12 +42,8 @@ class VeloxParquetDatasourceS3 final : public VeloxParquetDatasource {
       std::shared_ptr<arrow::Schema> schema)
       : VeloxParquetDatasource(filePath, veloxPool, sinkPool, schema) {}
   void init(const std::unordered_map<std::string, std::string>& sparkConfs) override {
-    auto confs = std::make_shared<facebook::velox::core::MemConfigMutable>(sparkConfs);
-    auto hiveConfs = getHiveConfig(confs);
-    sink_ = dwio::common::FileSink::create(
-        filePath_,
-        {.connectorProperties = std::make_shared<facebook::velox::core::MemConfig>(hiveConfs->valuesCopy()),
-         .pool = sinkPool_.get()});
+    auto hiveConfs = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
+    sink_ = dwio::common::FileSink::create(filePath_, {.connectorProperties = hiveConfs, .pool = sinkPool_.get()});
     VeloxParquetDatasource::init(sparkConfs);
   }
 };

--- a/cpp/velox/operators/writer/VeloxParquetDatasourceS3.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasourceS3.h
@@ -42,8 +42,8 @@ class VeloxParquetDatasourceS3 final : public VeloxParquetDatasource {
       std::shared_ptr<arrow::Schema> schema)
       : VeloxParquetDatasource(filePath, veloxPool, sinkPool, schema) {}
   void init(const std::unordered_map<std::string, std::string>& sparkConfs) override {
-    auto hiveConfs = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
-    sink_ = dwio::common::FileSink::create(filePath_, {.connectorProperties = hiveConfs, .pool = sinkPool_.get()});
+    auto hiveConf = getHiveConfig(std::make_shared<facebook::velox::core::MemConfig>(sparkConfs));
+    sink_ = dwio::common::FileSink::create(filePath_, {.connectorProperties = hiveConf, .pool = sinkPool_.get()});
     VeloxParquetDatasource::init(sparkConfs);
   }
 };

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1076,9 +1076,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   std::vector<TypePtr> veloxTypeList;
   std::vector<ColumnType> columnTypes;
   // Convert field names into lower case when not case-sensitive.
-  std::shared_ptr<const facebook::velox::Config> veloxCfg =
-      std::make_shared<const facebook::velox::core::MemConfigMutable>(confMap_);
-  bool asLowerCase = !veloxCfg->get<bool>(kCaseSensitive, false);
+  facebook::velox::core::MemConfig veloxCfg(confMap_);
+  bool asLowerCase = !veloxCfg.get<bool>(kCaseSensitive, false);
   if (readRel.has_base_schema()) {
     const auto& baseSchema = readRel.base_schema();
     colNameList.reserve(baseSchema.names().size());

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1076,8 +1076,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   std::vector<TypePtr> veloxTypeList;
   std::vector<ColumnType> columnTypes;
   // Convert field names into lower case when not case-sensitive.
-  facebook::velox::core::MemConfig veloxCfg(confMap_);
-  bool asLowerCase = !veloxCfg.get<bool>(kCaseSensitive, false);
+  std::unique_ptr<facebook::velox::Config> veloxCfg = std::make_unique<facebook::velox::core::MemConfig>(confMap_);
+  bool asLowerCase = !veloxCfg->get<bool>(kCaseSensitive, false);
   if (readRel.has_base_schema()) {
     const auto& baseSchema = readRel.base_schema();
     colNameList.reserve(baseSchema.names().size());

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -141,8 +141,8 @@ std::shared_ptr<facebook::velox::core::MemConfig> getHiveConfig(std::shared_ptr<
   }
 #endif
 
-  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kEnableFileHandleCache] = 
-      conf->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false");
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kEnableFileHandleCache] =
+      conf->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false";
 
   return std::make_shared<facebook::velox::core::MemConfig>(std::move(hiveConfMap));
 }

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -52,9 +52,8 @@ std::string getConfigValue(
   return got->second;
 }
 
-std::shared_ptr<facebook::velox::core::MemConfigMutable> getHiveConfig(
-    const std::shared_ptr<const facebook::velox::Config>& conf) {
-  auto hiveConf = std::make_shared<facebook::velox::core::MemConfigMutable>();
+std::shared_ptr<facebook::velox::core::MemConfig> getHiveConfig(std::shared_ptr<facebook::velox::Config> conf) {
+  std::unordered_map<std::string, std::string> hiveConfMap;
 
 #ifdef ENABLE_S3
   std::string awsAccessKey = conf->get<std::string>("spark.hadoop.fs.s3a.access.key", "");
@@ -82,24 +81,23 @@ std::shared_ptr<facebook::velox::core::MemConfigMutable> getHiveConfig(
   }
 
   if (useInstanceCredentials) {
-    hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3UseInstanceCredentials, "true");
+    hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3UseInstanceCredentials] = "true";
   } else if (!iamRole.empty()) {
-    hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3IamRole, iamRole);
+    hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3IamRole] = iamRole;
     if (!iamRoleSessionName.empty()) {
-      hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3IamRoleSessionName, iamRoleSessionName);
+      hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3IamRoleSessionName] = iamRoleSessionName;
     }
   } else {
-    hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3AwsAccessKey, awsAccessKey);
-    hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3AwsSecretKey, awsSecretKey);
+    hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3AwsAccessKey] = awsAccessKey;
+    hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3AwsSecretKey] = awsSecretKey;
   }
   // Only need to set s3 endpoint when not use instance credentials.
   if (!useInstanceCredentials) {
-    hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3Endpoint, awsEndpoint);
+    hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3Endpoint] = awsEndpoint;
   }
-  hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3SSLEnabled, sslEnabled ? "true" : "false");
-  hiveConf->setValue(
-      facebook::velox::connector::hive::HiveConfig::kS3PathStyleAccess, pathStyleAccess ? "true" : "false");
-  hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kS3LogLevel, awsSdkLogLevel);
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3SSLEnabled] = sslEnabled ? "true" : "false";
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3PathStyleAccess] = pathStyleAccess ? "true" : "false";
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kS3LogLevel] = awsSdkLogLevel;
 #endif
 
 #ifdef ENABLE_GCS
@@ -118,8 +116,8 @@ std::shared_ptr<facebook::velox::core::MemConfigMutable> getHiveConfig(
     }
 
     if (!gcsEndpoint.empty() && !gcsScheme.empty()) {
-      hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kGCSScheme, gcsScheme);
-      hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kGCSEndpoint, gcsEndpoint);
+      hiveConfMap[facebook::velox::connector::hive::HiveConfig::kGCSScheme] = gcsScheme;
+      hiveConfMap[facebook::velox::connector::hive::HiveConfig::kGCSEndpoint] = gcsEndpoint;
     }
   }
 
@@ -133,7 +131,7 @@ std::shared_ptr<facebook::velox::core::MemConfigMutable> getHiveConfig(
         auto stream = std::ifstream(gsAuthServiceAccountJsonKeyfile.value());
         stream.exceptions(std::ios::badbit);
         std::string gsAuthServiceAccountJson = std::string(std::istreambuf_iterator<char>(stream.rdbuf()), {});
-        hiveConf->setValue(facebook::velox::connector::hive::HiveConfig::kGCSCredentials, gsAuthServiceAccountJson);
+        hiveConfMap[facebook::velox::connector::hive::HiveConfig::kGCSCredentials] = gsAuthServiceAccountJson;
       } else {
         LOG(WARNING) << "STARTUP: conf spark.hadoop.fs.gs.auth.type is set to SERVICE_ACCOUNT_JSON_KEYFILE, "
                         "however conf spark.hadoop.fs.gs.auth.service.account.json.keyfile is not set";
@@ -143,11 +141,10 @@ std::shared_ptr<facebook::velox::core::MemConfigMutable> getHiveConfig(
   }
 #endif
 
-  hiveConf->setValue(
-      facebook::velox::connector::hive::HiveConfig::kEnableFileHandleCache,
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kEnableFileHandleCache] = 
       conf->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false");
 
-  return hiveConf;
+  return std::make_shared<facebook::velox::core::MemConfig>(std::move(hiveConfMap));
 }
 
 } // namespace gluten

--- a/cpp/velox/utils/ConfigExtractor.h
+++ b/cpp/velox/utils/ConfigExtractor.h
@@ -33,7 +33,6 @@ std::string getConfigValue(
     const std::string& key,
     const std::optional<std::string>& fallbackValue);
 
-std::shared_ptr<facebook::velox::core::MemConfigMutable> getHiveConfig(
-    const std::shared_ptr<const facebook::velox::Config>& conf);
+std::shared_ptr<facebook::velox::core::MemConfig> getHiveConfig(std::shared_ptr<facebook::velox::Config> conf);
 
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, in the Gluten code, once `velox::core::MemConfigMutable` is initialized, the key-value pairs are not modified anymore. This scenario is better suited for using `velox::core::MemConfig`. `MemConfigMutable` is suitable for scenarios where key-value pairs are modified by multiple threads.


## How was this patch tested?
existed ci