### PR TITLE
[GLUTEN-5741][CH] Fix core dump when executor exits

### DIFF
--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -201,6 +201,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM * vm, void * /*reserved*/)
 
 JNIEXPORT void JNI_OnUnload(JavaVM * vm, void * /*reserved*/)
 {
+    LOG_INFO(&Poco::Logger::get("jni"), "start jni onUnload");
     local_engine::BackendFinalizerUtil::finalizeGlobally();
 
     JNIEnv * env;


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#5741 #5744)

https://github.com/apache/incubator-gluten/blob/10182a52d409cb659169cbfe1d7f1869d9205dce/gluten-core/src/main/java/org/apache/gluten/vectorized/JniLibLoader.java#L131

When running on yarn cluster, `libPath` is a symbolic link existed on the working directory of yarn container, like `/data5/hadoop/yarn/local/usercache/xumingyong/appcache/application_1710462985812_777680/container_e57_1710462985812_777680_01_000321/./libch.so`. It's an `APPLICATION` level resource and will be removed when container exits. So it may have been removed here when reading real path, which causes `Files.isSymbolicLink(Paths.get(libPath))` return false in that the library (e.g. libch.so) cannot be unload and the method `JNI_OnUnload` cannot be invoked (which casuses core dump). As a workaround, we can read real path when loading the library.

## How was this patch tested?

 manual tests



