### PR TITLE
[VL][Minor] Fix warnings caused by -Wunused-but-set-variable

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -2158,8 +2158,8 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
       upperBound = getMax<NativeType>();
     }
 
-    bool lowerUnbounded = true;
-    bool upperUnbounded = true;
+    [[maybe_unused]] bool lowerUnbounded = true;
+    [[maybe_unused]] bool upperUnbounded = true;
     bool lowerExclusive = false;
     bool upperExclusive = false;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix warnings caused by -Wunused-but-set-variable
```
/root/gluten-ups/cpp/velox/substrait/SubstraitToVeloxPlan.cc:2224:90:   required from here
/root/gluten-ups/cpp/velox/substrait/SubstraitToVeloxPlan.cc:2161:10: warning: variable ‘lowerUnbounded’ set but not used [-Wunused-but-set-variable]
 2161 |     bool lowerUnbounded = true;
|          ^~~~~~~~~~~~~~        
/root/gluten-ups/cpp/velox/substrait/SubstraitToVeloxPlan.cc:2162:10: warning: variable ‘upperUnbounded’ set but not used [-Wunused-but-set-variable]
 2162 |     bool upperUnbounded = true;
|          ^~~~~~~~~~~~~~
```
## How was this patch tested?
Existed CI

