### PR TITLE
[CORE] Unify the aggregate function name mapping

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
@@ -294,7 +294,7 @@ case class CHHashAggregateExecTransformer(
             ._1
             .get
         } else {
-          AggregateFunctionsBuilder.getSubstraitFunctionName(aggregateFunc).get
+          AggregateFunctionsBuilder.getSubstraitFunctionName(aggregateFunc)
         }
       ConverterUtils.genColumnNameWithExprId(resultAttr) + "#Partial#" + aggFunctionName
     }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -790,7 +790,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     Seq(
       Sig[HLLAdapter](ExpressionNames.APPROX_DISTINCT),
       Sig[UDFExpression](ExpressionNames.UDF_PLACEHOLDER),
-      Sig[UserDefinedAggregateFunction](ExpressionNames.UDF_PLACEHOLDER),
+      Sig[UserDefinedAggregateFunction](ExpressionNames.UDAF_PLACEHOLDER),
       Sig[NaNvl](ExpressionNames.NANVL),
       Sig[VeloxCollectList](ExpressionNames.COLLECT_LIST),
       Sig[VeloxCollectSet](ExpressionNames.COLLECT_SET),

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -31,7 +31,6 @@ import org.apache.gluten.utils.VeloxIntermediateData
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.expression.UserDefinedAggregateFunction
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -706,27 +705,13 @@ object VeloxAggregateFunctionsBuilder {
       aggregateFunc: AggregateFunction,
       mode: AggregateMode): Long = {
     val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
-
-    var sigName = ExpressionMappings.expressionsMap.get(aggregateFunc.getClass)
-    if (sigName.isEmpty) {
-      throw new GlutenNotSupportException(s"not currently supported: $aggregateFunc.")
-    }
-
-    aggregateFunc match {
-      case First(_, ignoreNulls) =>
-        if (ignoreNulls) sigName = Some(ExpressionNames.FIRST_IGNORE_NULL)
-      case Last(_, ignoreNulls) =>
-        if (ignoreNulls) sigName = Some(ExpressionNames.LAST_IGNORE_NULL)
-      case UserDefinedAggregateFunction(name, _, _, _, _) =>
-        sigName = Some(name)
-      case _ =>
-    }
+    val sigName = AggregateFunctionsBuilder.getSubstraitFunctionName(aggregateFunc)
 
     ExpressionBuilder.newScalarFunction(
       functionMap,
       ConverterUtils.makeFuncName(
         // Substrait-to-Velox procedure will choose appropriate companion function if needed.
-        sigName.get,
+        sigName,
         VeloxIntermediateData.getInputTypes(aggregateFunc, mode == PartialMerge || mode == Final),
         FunctionConfig.REQ
       )

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -53,6 +53,7 @@ case class UserDefinedAggregateFunction(
     children: Seq[Expression],
     override val aggBufferAttributes: Seq[AttributeReference])
   extends AggregateFunction {
+  override def prettyName: String = name
 
   override def aggBufferSchema: StructType =
     StructType(

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -323,4 +323,5 @@ object ExpressionNames {
 
   // A placeholder for native UDF functions
   final val UDF_PLACEHOLDER = "udf_placeholder"
+  final val UDAF_PLACEHOLDER = "udaf_placeholder"
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unify the special aggregate function name mapping to reduce the duplicated code, e.g., fisrt/last with ignoreNulls.

## How was this patch tested?

Pass CI
