### PR TITLE
[CORE] ASF repo config: Set required_signatures to false

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,7 +36,7 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
-      required_signatures: true
+      required_signatures: false
       required_linear_history: true
       required_conversation_resolution: true
   features:


### PR DESCRIPTION
`required_signatures:true` blocks a couple of PRs from merging. Let's disable this rule at the moment, until we come up with a BKM about signing PR commits.