### PR TITLE
[VL] Refactor data filter in scan transformer

### DIFF
--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -193,6 +193,8 @@ trait SparkShims {
 
   def getFileStatus(partition: PartitionDirectory): Seq[FileStatus]
 
+  def isRowIndexMetadataColumn(name: String): Boolean
+
   def splitFiles(
       sparkSession: SparkSession,
       file: FileStatus,

--- a/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
@@ -189,6 +189,8 @@ class Spark32Shims extends SparkShims {
 
   def getFileStatus(partition: PartitionDirectory): Seq[FileStatus] = partition.files
 
+  def isRowIndexMetadataColumn(name: String): Boolean = false
+
   def splitFiles(
       sparkSession: SparkSession,
       file: FileStatus,

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -273,6 +273,8 @@ class Spark33Shims extends SparkShims {
 
   def getFileStatus(partition: PartitionDirectory): Seq[FileStatus] = partition.files
 
+  def isRowIndexMetadataColumn(name: String): Boolean = false
+
   def splitFiles(
       sparkSession: SparkSession,
       file: FileStatus,

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -327,6 +327,10 @@ class Spark34Shims extends SparkShims {
 
   def getFileStatus(partition: PartitionDirectory): Seq[FileStatus] = partition.files
 
+  def isRowIndexMetadataColumn(name: String): Boolean = {
+    name == FileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME
+  }
+
   def splitFiles(
       sparkSession: SparkSession,
       file: FileStatus,

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
+import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
@@ -56,7 +57,9 @@ abstract class FileSourceScanExecShim(
     case FileSourceGeneratedMetadataAttribute(attr) => attr
   }
 
-  def dataFiltersInScan: Seq[Expression] = dataFilters
+  def dataFiltersInScan: Seq[Expression] = dataFilters.filterNot(_.references.exists {
+    attr => SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)
+  })
 
   def hasUnsupportedColumns: Boolean = {
     val metadataColumnsNames = metadataColumns.map(_.name)

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Sca
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
@@ -354,6 +355,10 @@ class Spark35Shims extends SparkShims {
 
   def getFileStatus(partition: PartitionDirectory): Seq[FileStatus] =
     partition.files.map(_.fileStatus)
+
+  def isRowIndexMetadataColumn(name: String): Boolean = {
+    name == ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME
+  }
 
   def splitFiles(
       sparkSession: SparkSession,

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
+import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
@@ -59,8 +60,7 @@ abstract class FileSourceScanExecShim(
   protected lazy val driverMetricsAlias = driverMetrics
 
   def dataFiltersInScan: Seq[Expression] = dataFilters.filterNot(_.references.exists {
-    case FileSourceMetadataAttribute(_) => true
-    case _ => false
+    attr => SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)
   })
 
   def hasUnsupportedColumns: Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR do small changes:
1. Add `isRowIndexMetadataColumn` function in shim layer to check if one column is row index or not.
2.  Small change of spark 35  `datafilters` in `native scan` to support filter based on file metadata columns since velox backend support that.
3.  Don't push down `row index` column filter to scan since velox not support that.

(Fixes: \#5047)


It's dependency PR of https://github.com/apache/incubator-gluten/pull/5351

## How was this patch tested?
UT test && manually run.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

