### PR TITLE
[GLUTEN-5701][VL] Add unit test for from_unixtime function

### DIFF
--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -381,6 +381,9 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
               FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
               sdf2.format(new Timestamp(-1000000)))
             checkEvaluation(
+              FromUnixTime(Literal(Long.MAX_VALUE / 1000), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(Long.MAX_VALUE)))
+            checkEvaluation(
               FromUnixTime(
                 Literal.create(null, LongType),
                 Literal.create(null, StringType),


### PR DESCRIPTION
## What changes were proposed in this pull request?

After [Velox issue](https://github.com/facebookincubator/velox/issues/9778) is fixed, add unit test for from_unixtime with overflowed argument and query config setted time zone

Fixes: \#5701

## How was this patch tested?

Passed unit tests

