### PR TITLE
[GLUTEN-4422][CORE] Fix core dump caused by spill on closed iterator

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -544,7 +544,12 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchOutIterat
   auto ctx = gluten::getRuntime(env, wrapper);
 
   auto it = ctx->objectStore()->retrieve<ResultIterator>(iterHandle);
-  return it->spillFixedSize(size);
+  if (it == nullptr) {
+    LOG(WARNING) << "Try to spill on a closed iterator!";
+    return 0L;
+  } else {
+    return it->spillFixedSize(size);
+  }
   JNI_METHOD_END(kInvalidResourceHandle)
 }
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -549,7 +549,6 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchOutIterat
     throw gluten::GlutenException(errorMessage);
   }
   return it->spillFixedSize(size);
-
   JNI_METHOD_END(kInvalidResourceHandle)
 }
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -545,11 +545,11 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchOutIterat
 
   auto it = ctx->objectStore()->retrieve<ResultIterator>(iterHandle);
   if (it == nullptr) {
-    LOG(WARNING) << "Try to spill on a closed iterator!";
-    return 0L;
-  } else {
-    return it->spillFixedSize(size);
+    std::string errorMessage = "Invalid result iter handle " + std::to_string(iterHandle);
+    throw gluten::GlutenException(errorMessage);
   }
+  return it->spillFixedSize(size);
+
   JNI_METHOD_END(kInvalidResourceHandle)
 }
 

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -80,7 +80,11 @@ public class ColumnarBatchOutIterator extends GeneralOutIterator implements Runt
   }
 
   public long spill(long size) {
-    return nativeSpill(iterHandle, size);
+    if (!closed.get()) {
+      return nativeSpill(iterHandle, size);
+    } else {
+      return 0L;
+    }
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a chance that `nativeSpill` is called after iterator is closed.  We can ignore this.

(Fixes: \#4422)

