### PR TITLE
[GLUTEN-5890][Core] Enhance jni signature with a more readable way

### DIFF
--- a/cpp/core/jni/JniCommon.cc
+++ b/cpp/core/jni/JniCommon.cc
@@ -39,8 +39,7 @@ jmethodID gluten::JniCommonState::runtimeAwareCtxHandle() {
 
 void gluten::JniCommonState::initialize(JNIEnv* env) {
   runtimeAwareClass_ = createGlobalClassReference(env, "Lorg/apache/gluten/exec/RuntimeAware;");
-  string funcSig = getSig(typeid(jlong))
-  runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "handle", funcSig.c_str());
+  runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "handle", typeid(jlong));
   JavaVM* vm;
   if (env->GetJavaVM(&vm) != JNI_OK) {
     throw gluten::GlutenException("Unable to get JavaVM instance");

--- a/cpp/core/jni/JniCommon.cc
+++ b/cpp/core/jni/JniCommon.cc
@@ -39,7 +39,8 @@ jmethodID gluten::JniCommonState::runtimeAwareCtxHandle() {
 
 void gluten::JniCommonState::initialize(JNIEnv* env) {
   runtimeAwareClass_ = createGlobalClassReference(env, "Lorg/apache/gluten/exec/RuntimeAware;");
-  runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "handle", "()J");
+  string funcSig = getSig(typeid(jlong))
+  runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "handle", funcSig.c_str());
   JavaVM* vm;
   if (env->GetJavaVM(&vm) != JNI_OK) {
     throw gluten::GlutenException("Unable to get JavaVM instance");

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -118,6 +118,10 @@ static inline map<int, string>& buildTypeMapping(){
   type2sig[typeid(double).hash_code()] = "D";
   type2sig[typeid(jstring).hash_code()] = "Ljava/lang/String;";
   type2sig[typeid(jthrowable).hash_code()] = "Ljava/lang/Throwable;";
+  type2sig[typeid(jintArray).hash_code()] = "[I";
+  type2sig[typeid(jbyteArray).hash_code()] = "[B";
+  type2sig[typeid(jlongArray).hash_code()] = "[J";
+
   return type2sig;
 }
 

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -33,6 +33,10 @@
 static jint jniVersion = JNI_VERSION_1_8;
 static map<int, string> type2sig = buildTypeMapping();
 
+static type_info intType = typeid(int);
+static type_info 
+
+
 static inline std::string jStringToCString(JNIEnv* env, jstring string) {
   int32_t jlen, clen;
   clen = env->GetStringUTFLength(string);
@@ -117,25 +121,24 @@ static inline map<int, string>& buildTypeMapping(){
   return type2sig;
 }
 
+static inline string& getSig(const std::type_info& t){
+  return type2sig[t.hash_code()];
+}
+
 template<typename T>
 static inline string& getSig(T t){
-  return type2sig[typeid(t).hash_code()];
+  return getSig(typeid(t));
+}
+
+template <typename T, typename... Args>
+static string& getSig(T t, Args... args){
+  return getSig(t) + getSig(args);
 }
 
 template <typename T, typename... Args>
 static string& getSignature(T returnValue, Args... args){
   string returnSign = getSig(returnValue);
   return "("+ getParameterSignature(args) +")" + returnSign;
-}
-
-template <typename T, typename... Args>
-static string& getParameterSignature(T t, Args... args){
-  return getSig(t) + getParameterSignature(args);
-}
-
-template <typename T>
-static string& getParameterSignature(T t){
-  return getSig(t);
 }
 
 static inline void attachCurrentThreadAsDaemonOrThrow(JavaVM* vm, JNIEnv** out) {

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -92,6 +92,17 @@ static inline jmethodID getMethodIdOrError(JNIEnv* env, jclass thisClass, const 
   return ret;
 }
 
+template <typename T, typename... Args>
+static inline jmethodID getMethodIdOrError(JNIEnv* env, jclass thisClass, const char* name, const T return_type, Args... args) {
+  string sig = getSig(return_type, args);
+  jmethodID ret = getMethodId(env, thisClass, name, sig.c_str());
+  if (ret == nullptr) {
+    std::string errorMessage = "Unable to find method " + std::string(name) + " within signature" + std::string(sig);
+    throw gluten::GlutenException(errorMessage);
+  }
+  return ret;
+}
+
 static inline jmethodID getStaticMethodId(JNIEnv* env, jclass thisClass, const char* name, const char* sig) {
   jmethodID ret = env->GetStaticMethodID(thisClass, name, sig);
   return ret;

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -121,12 +121,17 @@ static inline map<int, string>& buildTypeMapping(){
   type2sig[typeid(jintArray).hash_code()] = "[I";
   type2sig[typeid(jbyteArray).hash_code()] = "[B";
   type2sig[typeid(jlongArray).hash_code()] = "[J";
+  type2sig[typeid(void).hash_code()] = "V";
 
   return type2sig;
 }
 
 static inline string& getSig(const std::type_info& t){
   return type2sig[t.hash_code()];
+}
+
+static inline string& getSig(){
+  return "";
 }
 
 template<typename T>
@@ -142,7 +147,7 @@ static string& getSig(T t, Args... args){
 template <typename T, typename... Args>
 static string& getSignature(T returnValue, Args... args){
   string returnSign = getSig(returnValue);
-  return "("+ getParameterSignature(args) +")" + returnSign;
+  return "("+ getSig(args) +")" + returnSign;
 }
 
 static inline void attachCurrentThreadAsDaemonOrThrow(JavaVM* vm, JNIEnv** out) {

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -128,6 +128,9 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
   arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm_, &env);
+    jlong read;
+    signature = getParameterSignature(read, reinterpret_cast<jlong>(out), nbytes);
+    jniByteInputStreamRead = getMethodIdOrError(env, jniByteInputStreamClass, "read", "(JJ)J");
     jlong read = env->CallLongMethod(jniIn_, jniByteInputStreamRead, reinterpret_cast<jlong>(out), nbytes);
     checkException(env);
     return read;
@@ -237,7 +240,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   byteArrayClass = createGlobalClassReferenceOrError(env, "[B");
 
   jniByteInputStreamClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/JniByteInputStream;");
-  jniByteInputStreamRead = getMethodIdOrError(env, jniByteInputStreamClass, "read", "(JJ)J");
   jniByteInputStreamTell = getMethodIdOrError(env, jniByteInputStreamClass, "tell", "()J");
   jniByteInputStreamClose = getMethodIdOrError(env, jniByteInputStreamClass, "close", "()V");
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -238,61 +238,77 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   gluten::getJniCommonState()->ensureInitialized(env);
   gluten::getJniErrorState()->ensureInitialized(env);
 
-  byteArrayClass = createGlobalClassReferenceOrError(env, "[B");
+  string funcSig = getSig(typeid(jbyteArray));
+  byteArrayClass = createGlobalClassReferenceOrError(env, funcSig.c_str());
 
   jniByteInputStreamClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/JniByteInputStream;");
-  jniByteInputStreamTell = getMethodIdOrError(env, jniByteInputStreamClass, "tell", "()J");
-  jniByteInputStreamClose = getMethodIdOrError(env, jniByteInputStreamClass, "close", "()V");
+  funcSig = getSig(typeid(jlong));
+  jniByteInputStreamTell = getMethodIdOrError(env, jniByteInputStreamClass, "tell", funcSig.c_str());
+  funcSig = getSig(typeid(void));
+  jniByteInputStreamClose = getMethodIdOrError(env, jniByteInputStreamClass, "close", funcSig.c_str());
 
   splitResultClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/GlutenSplitResult;");
-  splitResultConstructor = getMethodIdOrError(env, splitResultClass, "<init>", "(JJJJJJJ[J[J)V");
+  funcSig = getSig(typeid(void), typeid(jlong), typeid(jlong), typeid(jlong), typeid(jlong), typeid(jlong), typeid(jlong), typeid(jlong), typeid(jlongArray), typeid(jlongArray));
+  splitResultConstructor = getMethodIdOrError(env, splitResultClass, "<init>", funcSig.c_str());
 
   columnarBatchSerializeResultClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ColumnarBatchSerializeResult;");
+  funcSig = getSig(typeid(void), typeid(jlong), typeid(jbyteArray))
   columnarBatchSerializeResultConstructor =
-      getMethodIdOrError(env, columnarBatchSerializeResultClass, "<init>", "(J[B)V");
+      getMethodIdOrError(env, columnarBatchSerializeResultClass, "<init>", funcSig.c_str());
 
   metricsBuilderClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/metrics/Metrics;");
 
+  string funcSig = getSig(typeid(void), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray),
+                          typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray),
+                          typeid(jlongArray), typeid(jlong), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray),
+                          typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray),
+                          typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray),
+                          typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray), typeid(jlongArray),
+                          typeid(jlongArray), typeid(jlongArray));
   metricsBuilderConstructor = getMethodIdOrError(
-      env, metricsBuilderClass, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J)V");
+      env, metricsBuilderClass, "<init>", funcSig.c_str());
 
   serializedColumnarBatchIteratorClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ColumnarBatchInIterator;");
 
+  string funcSig = getSig(typeid(jboolean));
   serializedColumnarBatchIteratorHasNext =
-      getMethodIdOrError(env, serializedColumnarBatchIteratorClass, "hasNext", "()Z");
+      getMethodIdOrError(env, serializedColumnarBatchIteratorClass, "hasNext", funcSig.c_str());
 
-  serializedColumnarBatchIteratorNext = getMethodIdOrError(env, serializedColumnarBatchIteratorClass, "next", "()J");
+  funcSig = getSig(typeid(jlong));
+  serializedColumnarBatchIteratorNext = getMethodIdOrError(env, serializedColumnarBatchIteratorClass, "next", funcSig.c_str());
 
   nativeColumnarToRowInfoClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/NativeColumnarToRowInfo;");
-  string nativeColumnarToRowInfoClassInitSig = getSig(typeid(void), typeid(int[]), typeid(int[]), typeid(long));
-  nativeColumnarToRowInfoConstructor = getMethodIdOrError(env, nativeColumnarToRowInfoClass, "<init>", "([I[IJ)V");
+  funcSig = getSig(typeid(void), typeid(jintArray), typeid(jintArray), typeid(jlong));
+  nativeColumnarToRowInfoConstructor = getMethodIdOrError(env, nativeColumnarToRowInfoClass, "<init>", funcSig.c_str());
 
   javaReservationListenerClass = createGlobalClassReference(
       env,
       "Lorg/apache/gluten/memory/nmm/"
       "ReservationListener;");
 
-  string reserveSig = getSig(typeid(long), typeid(long));
-  reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", reserveSig);
-  string unreserveSig = getSig(typeid(long), typeid(long));
-  unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", unreserveSig);
+  funcSig = getSig(typeid(jlong), typeid(jlong));
+  reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", funcSig.c_str());
+  funcSig = getSig(typeid(jlong), typeid(jlong));
+  unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", funcSig.c_str());
 
   shuffleReaderMetricsClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ShuffleReaderMetrics;");
-  string funcSig = getSig(typeid(void), typeid(long));
+  funcSig = getSig(typeid(void), typeid(jlong));
   shuffleReaderMetricsSetDecompressTime =
       getMethodIdOrError(env, shuffleReaderMetricsClass, "setDecompressTime", funcSig.c_str());
-  funcSig = get
-  shuffleReaderMetricsSetIpcTime = getMethodIdOrError(env, shuffleReaderMetricsClass, "setIpcTime", "(J)V");
+  funcSig = getSig(typeid(void), typeid(jlong));
+  shuffleReaderMetricsSetIpcTime = getMethodIdOrError(env, shuffleReaderMetricsClass, "setIpcTime", funcSig.c_str());
+  funcSig = getSig(typeid(void), typeid(jlong));
   shuffleReaderMetricsSetDeserializeTime =
-      getMethodIdOrError(env, shuffleReaderMetricsClass, "setDeserializeTime", "(J)V");
+      getMethodIdOrError(env, shuffleReaderMetricsClass, "setDeserializeTime", funcSig.c_str());
 
   block_stripes_class =
       createGlobalClassReferenceOrError(env, "Lorg/apache/spark/sql/execution/datasources/BlockStripes;");
-  block_stripes_constructor = env->GetMethodID(block_stripes_class, "<init>", "(J[J[II[B)V");
+  funcSig = getSig(typeid(void), typeid(jlong), typeid(jlongArray), typeid(jintArray), typeid(jint), typeid(jbyteArray));
+  block_stripes_constructor = env->GetMethodID(block_stripes_class, "<init>", funcSig.c_str());
 
   return jniVersion;
 }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -130,7 +130,8 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
     attachCurrentThreadAsDaemonOrThrow(vm_, &env);
     jlong read;
     signature = getParameterSignature(read, reinterpret_cast<jlong>(out), nbytes);
-    jniByteInputStreamRead = getMethodIdOrError(env, jniByteInputStreamClass, "read", "(JJ)J");
+    string readSig = getSig(type(long), type(long), type(long))
+    jniByteInputStreamRead = getMethodIdOrError(env, jniByteInputStreamClass, "read", readSig.c_str());
     jlong read = env->CallLongMethod(jniIn_, jniByteInputStreamRead, reinterpret_cast<jlong>(out), nbytes);
     checkException(env);
     return read;
@@ -266,6 +267,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   nativeColumnarToRowInfoClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/NativeColumnarToRowInfo;");
+  string nativeColumnarToRowInfoClassInitSig = getSig(typeid(void), typeid(int[]), typeid(int[]), typeid(long));
   nativeColumnarToRowInfoConstructor = getMethodIdOrError(env, nativeColumnarToRowInfoClass, "<init>", "([I[IJ)V");
 
   javaReservationListenerClass = createGlobalClassReference(
@@ -273,13 +275,17 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       "Lorg/apache/gluten/memory/nmm/"
       "ReservationListener;");
 
-  reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", "(J)J");
-  unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", "(J)J");
+  string reserveSig = getSig(typeid(long), typeid(long));
+  reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", reserveSig);
+  string unreserveSig = getSig(typeid(long), typeid(long));
+  unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", unreserveSig);
 
   shuffleReaderMetricsClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ShuffleReaderMetrics;");
+  string funcSig = getSig(typeid(void), typeid(long));
   shuffleReaderMetricsSetDecompressTime =
-      getMethodIdOrError(env, shuffleReaderMetricsClass, "setDecompressTime", "(J)V");
+      getMethodIdOrError(env, shuffleReaderMetricsClass, "setDecompressTime", funcSig.c_str());
+  funcSig = get
   shuffleReaderMetricsSetIpcTime = getMethodIdOrError(env, shuffleReaderMetricsClass, "setIpcTime", "(J)V");
   shuffleReaderMetricsSetDeserializeTime =
       getMethodIdOrError(env, shuffleReaderMetricsClass, "setDeserializeTime", "(J)V");

--- a/cpp/velox/jni/JniFileSystem.cc
+++ b/cpp/velox/jni/JniFileSystem.cc
@@ -415,27 +415,44 @@ void gluten::initVeloxJniFileSystem(JNIEnv* env) {
       jniFileSystemClass,
       "openFileForWrite",
       "(Ljava/lang/String;)Lorg/apache/gluten/fs/JniFilesystem$WriteFile;");
-  jniFileSystemRemove = getMethodIdOrError(env, jniFileSystemClass, "remove", "(Ljava/lang/String;)V");
+  string funcSig = getSig(typeid(void), typeid(jstring));
+  jniFileSystemRemove = getMethodIdOrError(env, jniFileSystemClass, "remove", funcSig.c_str());
+  funcSig = getSig(typeid(void), typeid(jstring), typeid(jstring), typeid(jboolean));
   jniFileSystemRename =
-      getMethodIdOrError(env, jniFileSystemClass, "rename", "(Ljava/lang/String;Ljava/lang/String;Z)V");
+      getMethodIdOrError(env, jniFileSystemClass, "rename", funcSig.c_str());
+  funcSig = getSig(typeid(void), typeid(jstring));
   jniFileSystemExists = getMethodIdOrError(env, jniFileSystemClass, "exists", "(Ljava/lang/String;)Z");
+  //We don't have the jstringArray, so we pass the exact description for it
+  string funcSig = getSig(typeid(jstring[]), typeid(jstring));
   jniFileSystemList = getMethodIdOrError(env, jniFileSystemClass, "list", "(Ljava/lang/String;)[Ljava/lang/String;");
-  jniFileSystemMkdir = getMethodIdOrError(env, jniFileSystemClass, "mkdir", "(Ljava/lang/String;)V");
-  jniFileSystemRmdir = getMethodIdOrError(env, jniFileSystemClass, "rmdir", "(Ljava/lang/String;)V");
+  funcSig = getSig(typeid(void), typeid(jstring));
+  jniFileSystemMkdir = getMethodIdOrError(env, jniFileSystemClass, "mkdir", funcSig.c_str());
+  funcSig = getSig(typeid(void), typeid(jstring));
+  jniFileSystemRmdir = getMethodIdOrError(env, jniFileSystemClass, "rmdir", funcSig.c_str());
 
   // methods in JniFilesystem$ReadFile
-  jniReadFilePread = getMethodIdOrError(env, jniReadFileClass, "pread", "(JJJ)V");
-  jniReadFileShouldCoalesce = getMethodIdOrError(env, jniReadFileClass, "shouldCoalesce", "()Z");
-  jniReadFileSize = getMethodIdOrError(env, jniReadFileClass, "size", "()J");
-  jniReadFileMemoryUsage = getMethodIdOrError(env, jniReadFileClass, "memoryUsage", "()J");
-  jniReadFileGetNaturalReadSize = getMethodIdOrError(env, jniReadFileClass, "getNaturalReadSize", "()J");
-  jniReadFileClose = getMethodIdOrError(env, jniReadFileClass, "close", "()V");
+  funcSig = getSig(typeid(void), typeid(jlong), typeid(jlong), typeid(jlong));
+  jniReadFilePread = getMethodIdOrError(env, jniReadFileClass, "pread", funcSig.c_str());
+  funcSig = getSig(typeid(jboolean));
+  jniReadFileShouldCoalesce = getMethodIdOrError(env, jniReadFileClass, "shouldCoalesce", funcSig.c_str());
+  funcSig = getSig(typeid(jlong));
+  jniReadFileSize = getMethodIdOrError(env, jniReadFileClass, "size", funcSig.c_str());
+  funcSig = getSig(typeid(jlong));
+  jniReadFileMemoryUsage = getMethodIdOrError(env, jniReadFileClass, "memoryUsage", funcSig.c_str());
+  funcSig = getSig(typeid(jlong));
+  jniReadFileGetNaturalReadSize = getMethodIdOrError(env, jniReadFileClass, "getNaturalReadSize", funcSig.c_str());
+  funcSig = getSig(typeid(void));
+  jniReadFileClose = getMethodIdOrError(env, jniReadFileClass, "close", funcSig.c_str());
 
   // methods in JniFilesystem$WriteFile
-  jniWriteFileAppend = getMethodIdOrError(env, jniWriteFileClass, "append", "(JJ)V");
-  jniWriteFileFlush = getMethodIdOrError(env, jniWriteFileClass, "flush", "()V");
-  jniWriteFileClose = getMethodIdOrError(env, jniWriteFileClass, "close", "()V");
-  jniWriteFileSize = getMethodIdOrError(env, jniWriteFileClass, "size", "()J");
+  funcSig = getSig(typeid(void), typeid(jlong), typeid(jlong));
+  jniWriteFileAppend = getMethodIdOrError(env, jniWriteFileClass, "append", funcSig.c_str());
+  funcSig = getSig(typeid(void));
+  jniWriteFileFlush = getMethodIdOrError(env, jniWriteFileClass, "flush", funcSig.c_str());
+  funcSig = getSig(typeid(void));
+  jniWriteFileClose = getMethodIdOrError(env, jniWriteFileClass, "close", funcSig.c_str());
+  funcSig = getSig(typeid(jlong));
+  jniWriteFileSize = getMethodIdOrError(env, jniWriteFileClass, "size", funcSig.c_str());
 }
 
 void gluten::finalizeVeloxJniFileSystem(JNIEnv* env) {

--- a/cpp/velox/jni/JniFileSystem.cc
+++ b/cpp/velox/jni/JniFileSystem.cc
@@ -400,59 +400,51 @@ void gluten::initVeloxJniFileSystem(JNIEnv* env) {
   }
 
   // classes
-  jniFileSystemClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/fs/JniFilesystem;");
-  jniReadFileClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/fs/JniFilesystem$ReadFile;");
-  jniWriteFileClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/fs/JniFilesystem$WriteFile;");
+  bindNativeTypeToJni(typeid(JniFileSystem), "Lorg/apache/gluten/fs/JniFilesystem;");
+  jniFileSystemClass = createGlobalClassReferenceOrError(env, typeid(JniFileSystem));
+  bindNativeTypeToJni(typeid(JniReadFile), "Lorg/apache/gluten/fs/JniFilesystem$ReadFile;");
+  jniReadFileClass = createGlobalClassReferenceOrError(env, typeid(JniReadFile));
+  bindNativeTypeToJni(typeid(JniWriteFile), "Lorg/apache/gluten/fs/JniFilesystem$WriteFile;");
+  jniWriteFileClass = createGlobalClassReferenceOrError(env, typeid(JniWriteFile));
 
   // methods in JniFilesystem
   jniGetFileSystem =
-      getStaticMethodIdOrError(env, jniFileSystemClass, "getFileSystem", "()Lorg/apache/gluten/fs/JniFilesystem;");
-  jniIsCapableForNewFile = getStaticMethodIdOrError(env, jniFileSystemClass, "isCapableForNewFile", "(J)Z");
+      getStaticMethodIdOrError(env, jniFileSystemClass, "getFileSystem", typeid(JniFileSystem));
+  jlong size;
+  jniIsCapableForNewFile = getStaticMethodIdOrError(env, jniFileSystemClass, "isCapableForNewFile",  typeid(jboolean), size);
+  jstring path;
   jniFileSystemOpenFileForRead = getMethodIdOrError(
-      env, jniFileSystemClass, "openFileForRead", "(Ljava/lang/String;)Lorg/apache/gluten/fs/JniFilesystem$ReadFile;");
+      env, jniFileSystemClass, "openFileForRead", typeid(JniReadFile), path);
   jniFileSystemOpenFileForWrite = getMethodIdOrError(
-      env,
-      jniFileSystemClass,
-      "openFileForWrite",
-      "(Ljava/lang/String;)Lorg/apache/gluten/fs/JniFilesystem$WriteFile;");
-  string funcSig = getSig(typeid(void), typeid(jstring));
-  jniFileSystemRemove = getMethodIdOrError(env, jniFileSystemClass, "remove", funcSig.c_str());
-  funcSig = getSig(typeid(void), typeid(jstring), typeid(jstring), typeid(jboolean));
+      env, jniFileSystemClass, "openFileForWrite", typeid(JniWriteFile), path);
+  jniFileSystemRemove = getMethodIdOrError(env, jniFileSystemClass, "remove", typeid(void), path);
+  jstring oldPath;
+  jstring newPath;
+  jboolean overwrite;
   jniFileSystemRename =
-      getMethodIdOrError(env, jniFileSystemClass, "rename", funcSig.c_str());
-  funcSig = getSig(typeid(void), typeid(jstring));
-  jniFileSystemExists = getMethodIdOrError(env, jniFileSystemClass, "exists", "(Ljava/lang/String;)Z");
+      getMethodIdOrError(env, jniFileSystemClass, "rename", typeid(void), oldPath, newPath, overwrite);
+  jniFileSystemExists = getMethodIdOrError(env, jniFileSystemClass, "exists", typeid(void), path);
   //We don't have the jstringArray, so we pass the exact description for it
-  string funcSig = getSig(typeid(jstring[]), typeid(jstring));
-  jniFileSystemList = getMethodIdOrError(env, jniFileSystemClass, "list", "(Ljava/lang/String;)[Ljava/lang/String;");
-  funcSig = getSig(typeid(void), typeid(jstring));
-  jniFileSystemMkdir = getMethodIdOrError(env, jniFileSystemClass, "mkdir", funcSig.c_str());
-  funcSig = getSig(typeid(void), typeid(jstring));
-  jniFileSystemRmdir = getMethodIdOrError(env, jniFileSystemClass, "rmdir", funcSig.c_str());
+  jniFileSystemList = getMethodIdOrError(env, jniFileSystemClass, "list", typeid(jstring[]), path);
+  jniFileSystemMkdir = getMethodIdOrError(env, jniFileSystemClass, "mkdir", typeid(void), path);
+  jniFileSystemRmdir = getMethodIdOrError(env, jniFileSystemClass, "rmdir", typeid(void), path);
 
   // methods in JniFilesystem$ReadFile
-  funcSig = getSig(typeid(void), typeid(jlong), typeid(jlong), typeid(jlong));
-  jniReadFilePread = getMethodIdOrError(env, jniReadFileClass, "pread", funcSig.c_str());
-  funcSig = getSig(typeid(jboolean));
-  jniReadFileShouldCoalesce = getMethodIdOrError(env, jniReadFileClass, "shouldCoalesce", funcSig.c_str());
-  funcSig = getSig(typeid(jlong));
-  jniReadFileSize = getMethodIdOrError(env, jniReadFileClass, "size", funcSig.c_str());
-  funcSig = getSig(typeid(jlong));
-  jniReadFileMemoryUsage = getMethodIdOrError(env, jniReadFileClass, "memoryUsage", funcSig.c_str());
-  funcSig = getSig(typeid(jlong));
-  jniReadFileGetNaturalReadSize = getMethodIdOrError(env, jniReadFileClass, "getNaturalReadSize", funcSig.c_str());
-  funcSig = getSig(typeid(void));
-  jniReadFileClose = getMethodIdOrError(env, jniReadFileClass, "close", funcSig.c_str());
+  jlong offset;
+  jlong length;
+  jlong buf;
+  jniReadFilePread = getMethodIdOrError(env, jniReadFileClass, "pread", typeid(void, offset, length, buf));
+  jniReadFileShouldCoalesce = getMethodIdOrError(env, jniReadFileClass, "shouldCoalesce", typeid(jboolean));
+  jniReadFileSize = getMethodIdOrError(env, jniReadFileClass, "size", typeid(jlong));
+  jniReadFileMemoryUsage = getMethodIdOrError(env, jniReadFileClass, "memoryUsage", typeid(jlong));
+  jniReadFileGetNaturalReadSize = getMethodIdOrError(env, jniReadFileClass, "getNaturalReadSize", typeid(jlong));
+  jniReadFileClose = getMethodIdOrError(env, jniReadFileClass, "close", typeid(void));
 
   // methods in JniFilesystem$WriteFile
-  funcSig = getSig(typeid(void), typeid(jlong), typeid(jlong));
-  jniWriteFileAppend = getMethodIdOrError(env, jniWriteFileClass, "append", funcSig.c_str());
-  funcSig = getSig(typeid(void));
-  jniWriteFileFlush = getMethodIdOrError(env, jniWriteFileClass, "flush", funcSig.c_str());
-  funcSig = getSig(typeid(void));
-  jniWriteFileClose = getMethodIdOrError(env, jniWriteFileClass, "close", funcSig.c_str());
-  funcSig = getSig(typeid(jlong));
-  jniWriteFileSize = getMethodIdOrError(env, jniWriteFileClass, "size", funcSig.c_str());
+  jniWriteFileAppend = getMethodIdOrError(env, jniWriteFileClass, "append", typeid(void), length, buf);
+  jniWriteFileFlush = getMethodIdOrError(env, jniWriteFileClass, "flush", typeid(void));
+  jniWriteFileClose = getMethodIdOrError(env, jniWriteFileClass, "close", typeid(void));
+  jniWriteFileSize = getMethodIdOrError(env, jniWriteFileClass, "size", typeid(jlong));
 }
 
 void gluten::finalizeVeloxJniFileSystem(JNIEnv* env) {

--- a/cpp/velox/jni/JniFileSystem.cc
+++ b/cpp/velox/jni/JniFileSystem.cc
@@ -87,6 +87,7 @@ class JniReadFile : public facebook::velox::ReadFile {
   std::string_view pread(uint64_t offset, uint64_t length, void* buf) const override {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm, &env);
+    call
     env->CallVoidMethod(
         obj_, jniReadFilePread, static_cast<jlong>(offset), static_cast<jlong>(length), reinterpret_cast<jlong>(buf));
     checkException(env);

--- a/cpp/velox/jni/JniUdf.cc
+++ b/cpp/velox/jni/JniUdf.cc
@@ -41,10 +41,13 @@ void gluten::initVeloxJniUDF(JNIEnv* env) {
   udfResolverClass = createGlobalClassReferenceOrError(env, kUdfResolverClassPath.c_str());
 
   // methods
-  string funcSig = getSig(typeid(void), typeid(jstring), typeid(jbyteArray), typeid(jbyteArray), typeid(jboolean));
-  registerUDFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDF", funcSig.c_str());
-  funcSig = getSig(typeid(void), typeid(jstring), typeid(jbyteArray), typeid(jbyteArray), typeid(jbyteArray), typeid(jboolean));
-  registerUDAFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDAF", funcSig.c_str());
+  jstring name;
+  jbyteArray returnType;
+  jbyteArray argTypes;
+  jbyteArray intermediateTypes;
+  jboolean variableArity;
+  registerUDFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDF", typeid(void), name, returnType, argTypes, variableArity);
+  registerUDAFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDAF", typeid(void), name, returnType, argTypes, intermediateTypes, variableArity);
 }
 
 void gluten::finalizeVeloxJniUDF(JNIEnv* env) {

--- a/cpp/velox/jni/JniUdf.cc
+++ b/cpp/velox/jni/JniUdf.cc
@@ -41,8 +41,10 @@ void gluten::initVeloxJniUDF(JNIEnv* env) {
   udfResolverClass = createGlobalClassReferenceOrError(env, kUdfResolverClassPath.c_str());
 
   // methods
-  registerUDFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDF", "(Ljava/lang/String;[B[BZ)V");
-  registerUDAFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDAF", "(Ljava/lang/String;[B[B[BZ)V");
+  string funcSig = getSig(typeid(void), typeid(jstring), typeid(jbyteArray), typeid(jbyteArray), typeid(jboolean));
+  registerUDFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDF", funcSig.c_str());
+  funcSig = getSig(typeid(void), typeid(jstring), typeid(jbyteArray), typeid(jbyteArray), typeid(jbyteArray), typeid(jboolean));
+  registerUDAFMethod = getMethodIdOrError(env, udfResolverClass, "registerUDAF", funcSig.c_str());
 }
 
 void gluten::finalizeVeloxJniUDF(JNIEnv* env) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is to optimize current const text in code like "([B)V", which means the jbooleanArray with void return.
So we currently have this way for optimize:
We use typeid to get the hash of the type and  build a map from type_info.hash_code to the signature.

## How was this patch tested?

This is test in ut, for all the value equals to previous values.
And check for all single value.

