### PR TITLE
 [GLUTEN-5701][VL] Add overflow test case for from_unixtime function

### DIFF
--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -383,6 +383,9 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
               FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
               sdf2.format(new Timestamp(-1000000)))
             checkEvaluation(
+              FromUnixTime(Literal(Long.MaxValue), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(-1000)))
+            checkEvaluation(
               FromUnixTime(
                 Literal.create(null, LongType),
                 Literal.create(null, StringType),

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -381,6 +381,9 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
               FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
               sdf2.format(new Timestamp(-1000000)))
             checkEvaluation(
+              FromUnixTime(Literal(Long.MaxValue), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(-1000)))
+            checkEvaluation(
               FromUnixTime(
                 Literal.create(null, LongType),
                 Literal.create(null, StringType),

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -381,8 +381,8 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
               FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
               sdf2.format(new Timestamp(-1000000)))
             checkEvaluation(
-              FromUnixTime(Literal(Long.MaxValue / 1000), Literal(fmt2), timeZoneId),
-              sdf2.format(new Timestamp(Long.MaxValue)))
+              FromUnixTime(Literal(Long.MaxValue), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(-1000)))
             checkEvaluation(
               FromUnixTime(
                 Literal.create(null, LongType),

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -381,6 +381,9 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
               FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
               sdf2.format(new Timestamp(-1000000)))
             checkEvaluation(
+              FromUnixTime(Literal(Long.MaxValue / 1000), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(Long.MaxValue)))
+            checkEvaluation(
               FromUnixTime(
                 Literal.create(null, LongType),
                 Literal.create(null, StringType),

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -381,6 +381,9 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
               FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
               sdf2.format(new Timestamp(-1000000)))
             checkEvaluation(
+              FromUnixTime(Literal(Long.MaxValue), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(-1000)))
+            checkEvaluation(
               FromUnixTime(
                 Literal.create(null, LongType),
                 Literal.create(null, StringType),


### PR DESCRIPTION
# What changes were proposed in this pull request?
After https://github.com/facebookincubator/velox/issues/9778 is fixed, add unit test for from_unixtime with overflowed argument and query config setted time zone

Fixes: https://github.com/apache/incubator-gluten/issues/5701

# How was this patch tested?
Passed unit tests