### PR TITLE
[GLUTEN-5898][CH] Fix regexp_extract function use bracket has diff behaver with spark

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -724,10 +724,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
            |  from regexp_extract_bracket
           """.stripMargin
 
-      runQueryAndCompare(
-        sql_str) {
-        _ =>
-      }
+      runQueryAndCompare(sql_str) { _ => }
     }
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -708,4 +708,27 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
 
   }
 
+  test("GLUTEN-5897: fix regexp_extract with bracket") {
+    withTable("regexp_extract_bracket") {
+      sql("create table regexp_extract_bracket(a String) using parquet")
+      sql(
+        """
+          |insert into regexp_extract_bracket values ('123.123abc-abc'),('123-LOW'),('123]abc-abc')
+          |""".stripMargin)
+
+      val sql_str =
+        s"""select
+           |    regexp_extract(a, '([0-9][[\\.][0-9]]*)', 1)
+           |  , regexp_extract(a, '([0-9][[\\.][0-9]]*)', 1)
+           |  , regexp_extract(a, '([0-9][[]]]*)', 1)
+           |  from regexp_extract_bracket
+          """.stripMargin
+
+      runQueryAndCompare(
+        sql_str) {
+        _ =>
+      }
+    }
+  }
+
 }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/regexp_extract.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/regexp_extract.cpp
@@ -90,6 +90,7 @@ private:
         ReadBufferFromString buf(str);
         std::stack<String> strs;
         strs.emplace("");
+        bool nead_right_bracket = false;
 
         while (!buf.eof())
         {
@@ -112,27 +113,33 @@ private:
                     {
                         // "abc[abc]abc"
                         strs.top().append("[").append(back).append("]");
+                        nead_right_bracket = false;
                     }
                     else
                     {
+                        // "abc[a[abc]c]abc"
                         strs.top().append(back);
+                        nead_right_bracket = true;
                     }
                 }
             }
             else
             {
-                // "abc[abc\[]abc"
-                if (*buf.position() == '\\' && (*(buf.position() + 1) == '[' || *(buf.position() + 1) == ']'))
-                    ++buf.position();
-
                 strs.top() += *buf.position();
             }
 
             ++buf.position();
         }
 
-        if (strs.size() != 1)
+        if (nead_right_bracket && strs.size() != 1)
             throw_message();
+
+        while (strs.size() != 1)
+        {
+            String back = strs.top();
+            strs.pop();
+            strs.top().append("[").append(back);
+        }
 
         return strs.top();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

select regexp_extract('1-A', '([0-9][[.][0-9]]*)', 1)

Spark behavior:
1
actual behavior:
``

(Fixes: \#5898)

## How was this patch tested?

Test by ut

