### PR TITLE
[VL] Following #5889, correct / simplify the table indenting algorithm

### DIFF
--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -227,7 +227,7 @@ case class TestResultLines(
     metricNames: Seq[String],
     lines: Iterable[TestResultLine]) {
   def print(): Unit = {
-    val fields = ListBuffer[String]("Query ID", "Succeed")
+    val fields = ListBuffer[String]("Query ID", "Succeeded")
     dimNames.foreach(dimName => fields.append(dimName))
     metricNames.foreach(metricName => fields.append(metricName))
     fields.append("Row Count")

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/TableRender.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/TableRender.scala
@@ -116,12 +116,14 @@ object TableRender {
         def updateWidth(field: Field, lowerBound: Int): Unit = {
           field match {
             case branch @ Field.Branch(name, children) =>
-              val childLowerBound =
-                Math.ceil((lowerBound max name.length + 2).toDouble / children.size.toDouble).toInt
-              children.foreach(child => updateWidth(child, childLowerBound))
+              val leafLowerBound =
+                Math
+                  .ceil((lowerBound max name.length + 2).toDouble / branch.leafs.size.toDouble)
+                  .toInt
+              children.foreach(child => updateWidth(child, leafLowerBound * child.leafs.size))
               val childrenWidth =
                 children.map(child => widthMap(System.identityHashCode(child))).sum
-              val width = childLowerBound * children.size max childrenWidth + children.size - 1
+              val width = childrenWidth + children.size - 1
               val hash = System.identityHashCode(branch)
               widthMap += hash -> width
             case leaf @ Field.Leaf(name) =>

--- a/tools/gluten-it/common/src/test/java/org/apache/gluten/integration/action/TableRenderTest.scala
+++ b/tools/gluten-it/common/src/test/java/org/apache/gluten/integration/action/TableRenderTest.scala
@@ -82,10 +82,28 @@ object TableRenderTest {
     Console.out.println()
   }
 
+  def case4(): Unit = {
+    val render: TableRender[Seq[String]] = TableRender.create(
+      Branch(
+        "ABBBBBBBBBBBBBBBBBBBBBBBBBBBBC",
+        List(Branch("AB", List(Leaf("A"), Leaf("B"))), Leaf("C"))),
+      Branch("DE", List(Leaf("D"), Leaf("E"))))(new RowParser[Seq[String]] {
+      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
+        val inc = rowFactory.incremental()
+        row.foreach(ceil => inc.next().write(ceil))
+      }
+    })
+
+    render.appendRow(List("aaaa", "b", "cccccc", "d", "eeeee"))
+    render.print(Console.out)
+    Console.out.println()
+  }
+
   def main(args: Array[String]): Unit = {
     case0()
     case1()
     case2()
     case3()
+    case4()
   }
 }


### PR DESCRIPTION
The patch just corrects the identing algorithm of #5889.