### PR TITLE
[VL] Fall back collect_set, min and max when input is complex type

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1045,6 +1045,16 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
           LOG_VALIDATION_MSG("Validation failed for function " + funcName + " resolve type in AggregateRel.");
           return false;
         }
+        static const std::unordered_set<std::string> notSupportComplexTypeAggFuncs = {"set_agg", "min", "max"};
+        if (notSupportComplexTypeAggFuncs.find(baseFuncName) != notSupportComplexTypeAggFuncs.end() &&
+            exec::isRawInput(funcStep)) {
+          auto type = binder.tryResolveType(signature->argumentTypes()[0]);
+          if (type->isArray() || type->isMap() || type->isRow()) {
+            LOG_VALIDATION_MSG("Validation failed for function " + baseFuncName + " complex type is not supported.");
+            return false;
+          }
+        }
+
         resolved = true;
         break;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/incubator-gluten/issues/4763#issuecomment-2138401401

```
Caused by: java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: ROW comparison not supported for values that contain nulls
Retriable: False
Expression: !decoded.base()->containsNullAt(indices[index])
Function: checkNestedNulls
File: /var/git/gluten/ep/build-velox/build/velox_ep/velox/functions/lib/CheckNestedNulls.cpp
Line: 34
```

Now we use Presto Velox impl for these 3 functions, there is behavior mismatch between Presto and Spark for complex types, we should disable them before implementing them separately for Spark in Velox.

## How was this patch tested?

UT.

