### PR TITLE
[GLUTEN-5953][VL] Prevent pushdown filters with unsupported data types to scan node

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
@@ -18,11 +18,13 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.velox.VeloxBackendSettings
+import org.apache.gluten.benchmarks.RandomParquetDataGenerator
 import org.apache.gluten.utils.VeloxFileSystemValidationJniWrapper
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.GreaterThan
 import org.apache.spark.sql.execution.ScalarSubquery
+import org.apache.spark.sql.types._
 
 class VeloxScanSuite extends VeloxWholeStageTransformerSuite {
   protected val rootPath: String = getClass.getResource("/").getPath
@@ -117,5 +119,35 @@ class VeloxScanSuite extends VeloxWholeStageTransformerSuite {
     assert(
       !VeloxFileSystemValidationJniWrapper.allSupportedByRegisteredFileSystems(
         Array("file:/test_path/", "unsupported://test_path")))
+  }
+
+  test("unsupported data type scan filter pushdown") {
+    withTempView("t") {
+      withTempDir {
+        dir =>
+          val path = dir.getAbsolutePath
+          val schema = StructType(
+            Array(
+              StructField("short_decimal_field", DecimalType(5, 2), true),
+              StructField("long_decimal_field", DecimalType(32, 8), true),
+              StructField("binary_field", BinaryType, true),
+              StructField("timestamp_field", TimestampType, true)
+            ))
+          RandomParquetDataGenerator(0).generateRandomData(spark, schema, 10, Some(path))
+          spark.catalog.createTable("t", path, "parquet")
+          runQueryAndCompare(
+            """select * from t where long_decimal_field = 3.14)""".stripMargin
+          )(checkGlutenOperatorMatch[FileSourceScanExecTransformer])
+          runQueryAndCompare(
+            """select * from t where short_decimal_field = 3.14""".stripMargin
+          )(checkGlutenOperatorMatch[FileSourceScanExecTransformer])
+          runQueryAndCompare(
+            """select * from t where binary_field = '3.14'""".stripMargin
+          )(checkGlutenOperatorMatch[FileSourceScanExecTransformer])
+          runQueryAndCompare(
+            """select * from t where timestamp_field = current_timestamp()""".stripMargin
+          )(checkGlutenOperatorMatch[FileSourceScanExecTransformer])
+      }
+    }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
@@ -136,7 +136,7 @@ class VeloxScanSuite extends VeloxWholeStageTransformerSuite {
           RandomParquetDataGenerator(0).generateRandomData(spark, schema, 10, Some(path))
           spark.catalog.createTable("t", path, "parquet")
           runQueryAndCompare(
-            """select * from t where long_decimal_field = 3.14)""".stripMargin
+            """select * from t where long_decimal_field = 3.14""".stripMargin
           )(checkGlutenOperatorMatch[FileSourceScanExecTransformer])
           runQueryAndCompare(
             """select * from t where short_decimal_field = 3.14""".stripMargin

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1709,8 +1709,8 @@ bool SubstraitToVeloxPlanConverter::isPushdownSupported(TypePtr inputType) {
 }
 
 bool SubstraitToVeloxPlanConverter::canPushdownScalarFunction(
-  const ::substrait::Expression_ScalarFunction& function,
-  const std::vector<TypePtr>& veloxTypeList) {
+    const ::substrait::Expression_ScalarFunction& function,
+    const std::vector<TypePtr>& veloxTypeList) {
   for (const auto& arg : function.arguments()) {
     if (arg.value().has_scalar_function()) {
       const auto& scalarFunction = arg.value().scalar_function();

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1705,7 +1705,7 @@ bool SubstraitToVeloxPlanConverter::isPushdownSupported(TypePtr inputType) {
     case TypeKind::HUGEINT:
       return false;
     default:
-      return false;
+      return true;
   }
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1614,8 +1614,10 @@ bool SubstraitToVeloxPlanConverter::canPushdownFunction(
     return false;
   }
 
-  // check whether data type is supported or not
-  if (!veloxTypeList.empty() && fieldIdx < veloxTypeList.size() && !isPushdownSupported(veloxTypeList.at(fieldIdx))) {
+  // Check whether data type is supported or not
+  if (!veloxTypeList.empty() &&
+      fieldIdx < veloxTypeList.size() &&
+      !isPushdownSupported(veloxTypeList.at(fieldIdx))) {
     return false;
   }
 
@@ -1696,7 +1698,7 @@ bool SubstraitToVeloxPlanConverter::canPushdownOr(
 }
 
 bool SubstraitToVeloxPlanConverter::isPushdownSupported(TypePtr inputType) {
-  // keep the same with mapToFilters
+  // Keep the same with mapToFilters
   switch (inputType->kind()) {
     case TypeKind::TIMESTAMP:
     case TypeKind::VARBINARY:

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1615,9 +1615,7 @@ bool SubstraitToVeloxPlanConverter::canPushdownFunction(
   }
 
   // Check whether data type is supported or not
-  if (!veloxTypeList.empty() &&
-      fieldIdx < veloxTypeList.size() &&
-      !isPushdownSupported(veloxTypeList.at(fieldIdx))) {
+  if (!veloxTypeList.empty() && fieldIdx < veloxTypeList.size() && !isPushdownSupported(veloxTypeList.at(fieldIdx))) {
     return false;
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1610,14 +1610,12 @@ bool SubstraitToVeloxPlanConverter::canPushdownFunction(
   }
 
   // The arg should be field or field with literal.
-  if(!fieldOrWithLiteral(scalarFunction.arguments(), fieldIdx)) {
+  if (!fieldOrWithLiteral(scalarFunction.arguments(), fieldIdx)) {
     return false;
   }
 
   // check whether data type is supported or not
-  if (!veloxTypeList.empty() &&
-      fieldIdx < veloxTypeList.size() &&
-      !isPushdownSupported(veloxTypeList.at(fieldIdx))) {
+  if (!veloxTypeList.empty() && fieldIdx < veloxTypeList.size() && !isPushdownSupported(veloxTypeList.at(fieldIdx))) {
     return false;
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -451,7 +451,8 @@ class SubstraitToVeloxPlanConverter {
   static bool canPushdownFunction(
       const ::substrait::Expression_ScalarFunction& scalarFunction,
       const std::string& filterName,
-      uint32_t& fieldIdx);
+      uint32_t& fieldIdx,
+      const std::vector<TypePtr>& veloxTypeList);
 
   /// Returns whether a NOT function can be pushed down.
   bool canPushdownNot(
@@ -475,11 +476,6 @@ class SubstraitToVeloxPlanConverter {
 
   /// Check whether the data type is supported to pushdown.
   static bool isPushdownSupported(TypePtr inputType);
-
-  /// Check whether the scalar function contains data type that doesn't to pushdown.
-  static bool canPushdownScalarFunction(
-      const ::substrait::Expression_ScalarFunction& scalarFunction,
-      const std::vector<TypePtr>& veloxTypeList);
 
   /// Extract the scalar function, and set the filter info for different types
   /// of columns. If reverse is true, the opposite filter info will be set.

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -473,6 +473,13 @@ class SubstraitToVeloxPlanConverter {
   /// 'or' expression are effective on the same column.
   static bool childrenFunctionsOnSameField(const ::substrait::Expression_ScalarFunction& function);
 
+  /// Check whether the data type is supported to pushdown.
+  static bool isPushdownSupported(TypePtr inputType);
+  /// Check whether the scalar function contains data type that doesn't to pushdown.
+  static bool canPushdownScalarFunction(
+      const ::substrait::Expression_ScalarFunction& scalarFunction,
+      const std::vector<TypePtr>& veloxTypeList);
+
   /// Extract the scalar function, and set the filter info for different types
   /// of columns. If reverse is true, the opposite filter info will be set.
   void setFilterInfo(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -475,6 +475,7 @@ class SubstraitToVeloxPlanConverter {
 
   /// Check whether the data type is supported to pushdown.
   static bool isPushdownSupported(TypePtr inputType);
+
   /// Check whether the scalar function contains data type that doesn't to pushdown.
   static bool canPushdownScalarFunction(
       const ::substrait::Expression_ScalarFunction& scalarFunction,

--- a/gluten-core/src/test/scala/org/apache/gluten/benchmarks/RandomParquetDataGenerator.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/benchmarks/RandomParquetDataGenerator.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types._
 
 import com.github.javafaker.Faker
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
 import java.util.Random
 
 case class RandomParquetDataGenerator(initialSeed: Long = 0L) extends Logging {
@@ -67,7 +67,7 @@ case class RandomParquetDataGenerator(initialSeed: Long = 0L) extends Logging {
       case DoubleType =>
         faker.number().randomDouble(2, Double.MinValue.toLong, Double.MaxValue.toLong)
       case DateType => new Date(faker.date().birthday().getTime)
-//      case TimestampType => new Timestamp(faker.date().birthday().getTime)
+      case TimestampType => new Timestamp(faker.date().birthday().getTime)
       case t: DecimalType =>
         BigDecimal(
           faker.number().randomDouble(t.scale, 0, Math.pow(10, t.precision - t.scale).toLong))
@@ -124,7 +124,7 @@ case class RandomParquetDataGenerator(initialSeed: Long = 0L) extends Logging {
     () => StructField(fieldName, FloatType, nullable = true),
     () => StructField(fieldName, DoubleType, nullable = true),
     () => StructField(fieldName, DateType, nullable = true),
-//    () => StructField(fieldName, TimestampType, nullable = true),
+    () => StructField(fieldName, TimestampType, nullable = true),
     () => StructField(fieldName, DecimalType(10, 2), nullable = true),
     () => StructField(fieldName, DecimalType(30, 10), nullable = true)
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prevent pushdown filters with unsupported data types to scan node in case the scan fallback to vanilla scan operator

(Fixes: \#5953)

## How was this patch tested?

UT
