### PR TITLE
[VL] Fix shuffle with null type failure

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -1682,26 +1682,56 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  test("Fix shuffle with round robin partitioning fail") {
-    def checkNullTypeRepartition(df: => DataFrame, numProject: Int): Unit = {
-      var expected: Array[Row] = null
-      withSQLConf("spark.sql.execution.sortBeforeRepartition" -> "false") {
-        expected = df.collect()
-      }
-      val actual = df
-      checkAnswer(actual, expected)
-      assert(
-        collect(actual.queryExecution.executedPlan) { case p: ProjectExec => p }.size == numProject
-      )
-    }
+  test("Fix shuffle with null type failure") {
+    // single and other partitioning
+    Seq("1", "2").foreach {
+      numShufflePartitions =>
+        withSQLConf("spark.sql.shuffle.partitions" -> numShufflePartitions) {
+          def checkNullTypeRepartition(df: => DataFrame, numProject: Int): Unit = {
+            var expected: Array[Row] = null
+            withSQLConf("spark.sql.execution.sortBeforeRepartition" -> "false") {
+              expected = df.collect()
+            }
+            val actual = df
+            checkAnswer(actual, expected)
+            assert(
+              collect(actual.queryExecution.executedPlan) {
+                case p: ProjectExec => p
+              }.size == numProject
+            )
+            assert(
+              collect(actual.queryExecution.executedPlan) {
+                case shuffle: ColumnarShuffleExchangeExec => shuffle
+              }.size == 1
+            )
+          }
 
-    checkNullTypeRepartition(
-      spark.table("lineitem").selectExpr("l_orderkey", "null as x").repartition(),
-      0
-    )
-    checkNullTypeRepartition(
-      spark.table("lineitem").selectExpr("null as x", "null as y").repartition(),
-      1
-    )
+          // hash
+          checkNullTypeRepartition(
+            spark
+              .table("lineitem")
+              .selectExpr("l_orderkey", "null as x")
+              .repartition($"l_orderkey"),
+            0
+          )
+          // range
+          checkNullTypeRepartition(
+            spark
+              .table("lineitem")
+              .selectExpr("l_orderkey", "null as x")
+              .repartitionByRange($"l_orderkey"),
+            0
+          )
+          // round robin
+          checkNullTypeRepartition(
+            spark.table("lineitem").selectExpr("l_orderkey", "null as x").repartition(),
+            0
+          )
+          checkNullTypeRepartition(
+            spark.table("lineitem").selectExpr("null as x", "null as y").repartition(),
+            1
+          )
+        }
+    }
   }
 }

--- a/cpp/core/shuffle/Payload.cc
+++ b/cpp/core/shuffle/Payload.cc
@@ -327,6 +327,8 @@ arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>> BlockPayload::deseria
       case arrow::ListType::type_id: {
         hasComplexDataType = true;
       } break;
+      case arrow::NullType::type_id:
+        break;
       default: {
         buffers.emplace_back();
         ARROW_ASSIGN_OR_RAISE(buffers.back(), readBuffer());

--- a/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.cc
@@ -130,6 +130,14 @@ arrow::Status collectFlatVectorBufferStringView(
 }
 
 template <>
+arrow::Status collectFlatVectorBuffer<facebook::velox::TypeKind::UNKNOWN>(
+    facebook::velox::BaseVector* vector,
+    std::vector<std::shared_ptr<arrow::Buffer>>& buffers,
+    arrow::MemoryPool* pool) {
+  return arrow::Status::OK();
+}
+
+template <>
 arrow::Status collectFlatVectorBuffer<facebook::velox::TypeKind::VARCHAR>(
     facebook::velox::BaseVector* vector,
     std::vector<std::shared_ptr<arrow::Buffer>>& buffers,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The query would fail if the shuffle partition > 1:
```
spark.sql("select c1 , null as c2 from t1").repartition($"c1').collect
```
the reason is that, before shuffle writer does not write anything for null type but the shuffle read try to read buffer which is an invalid memory address, then it causes oom.

```
Caused by: java.lang.RuntimeException: Error during calling Java code from native code: org.apache.gluten.memory.memtarget.ThrowOnOomMemoryTarget$OutOfMemoryException: Not enough spark off-heap execution memory. Acquired: 127.4 TiB, granted: 864.0 MiB. Try tweaking config option spark.memory.offHeap.size to get larger space to run this application (if spark.gluten.memory.dynamic.offHeap.sizing.enabled is not enabled).
Current config settings:
	spark.gluten.memory.offHeap.size.in.bytes=1024.0 MiB
	spark.gluten.memory.task.offHeap.size.in.bytes=102.4 MiB
	spark.gluten.memory.conservative.task.offHeap.size.in.bytes=51.2 MiB
	spark.memory.offHeap.enabled=true
	spark.gluten.memory.dynamic.offHeap.sizing.enabled=false
Memory consumer stats:
	Task.10:                                      Current used bytes: 160.0 MiB, peak bytes:        N/A
	\- Gluten.Tree.10:                            Current used bytes: 160.0 MiB, peak bytes: 1024.0 MiB
	   \- root.10:                                Current used bytes: 160.0 MiB, peak bytes: 1024.0 MiB
	      +- ShuffleReader.0:                     Current used bytes: 152.0 MiB, peak bytes: 1016.0 MiB
	      |  \- single:                           Current used bytes: 152.0 MiB, peak bytes:  160.0 MiB
	      |     +- gluten::MemoryAllocator:       Current used bytes: 144.0 MiB, peak bytes:  144.0 MiB
	      |     \- ShuffleReader_root:            Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |        \- ShuffleReader_default_leaf: Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- ArrowContextInstance.0:              Current used bytes:   8.0 MiB, peak bytes:    8.0 MiB
	      \- OverAcquire.DummyTarget.20:          Current used bytes:     0.0 B, peak bytes:   48.0 MiB

```

## How was this patch tested?

Add test
