### PR TITLE
[GLUTEN-5965][VL] Support pushdown "not in" to scan node

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -216,7 +216,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     // not-in with or relation
     runQueryAndCompare(
       "select l_orderkey from lineitem " +
-        "where l_partkey not in (1552, 674) and l_partkey in (1552)") {
+        "where l_partkey not in (1552, 674) or l_partkey in (1552)") {
       checkGlutenOperatorMatch[FileSourceScanExecTransformer]
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -212,6 +212,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
         "where l_partkey not in (1552, 674) and l_partkey in (1552)") {
       checkGlutenOperatorMatch[FileSourceScanExecTransformer]
     }
+
+    // not-in with or relation
+    runQueryAndCompare(
+      "select l_orderkey from lineitem " +
+        "where l_partkey not in (1552, 674) and l_partkey in (1552, 674)") {
+      checkGlutenOperatorMatch[FileSourceScanExecTransformer]
+    }
   }
 
   test("coalesce") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -216,7 +216,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     // not-in with or relation
     runQueryAndCompare(
       "select l_orderkey from lineitem " +
-        "where l_partkey not in (1552, 674) and l_partkey in (1552, 674)") {
+        "where l_partkey not in (1552, 674) and l_partkey in (1552)") {
       checkGlutenOperatorMatch[FileSourceScanExecTransformer]
     }
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1594,15 +1594,11 @@ bool SubstraitToVeloxPlanConverter::canPushdownNot(
     uint32_t fieldIdx;
     bool isFieldOrWithLiteral = fieldOrWithLiteral(notArg.value().scalar_function().arguments(), fieldIdx);
 
-    if (supportedNotFunctions.find(functionName) != supportedNotFunctions.end() && isFieldOrWithLiteral &&
-        rangeRecorders.at(fieldIdx).setCertainRangeForFunction(functionName, true /*reverse*/)) {
-      return true;
-    } else {
-      return false;
-    }
-  } else {
-    return false;
+    return (
+        supportedNotFunctions.find(functionName) != supportedNotFunctions.end() && isFieldOrWithLiteral &&
+        rangeRecorders.at(fieldIdx).setCertainRangeForFunction(functionName, true /*reverse*/));
   }
+  return false;
 }
 
 bool SubstraitToVeloxPlanConverter::canPushdownOr(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1451,7 +1451,7 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::createSubfieldFi
       if (expr.has_scalar_function()) {
         // Set its child to filter info with reverse enabled.
         setFilterInfo(expr.scalar_function(), inputTypeList, columnToFilterInfo, true);
-      } else if(expr.has_singular_or_list()) {
+      } else if (expr.has_singular_or_list()) {
         // Since currently only integer and string types in "IN" expression
         // can be pushed down, Options types should be checked
         auto singularOrList = expr.singular_or_list();
@@ -1807,7 +1807,7 @@ void SubstraitToVeloxPlanConverter::setColumnFilterInfo(
     }
   } else if (filterName == sEqual) {
     if (reverse) {
-      std::vector<variant> notValues { literalVariant.value() };
+      std::vector<variant> notValues{literalVariant.value()};
       columnFilterInfo.setNotValue(notValues);
     } else {
       columnFilterInfo.setLower(literalVariant, false);
@@ -2066,12 +2066,11 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
     // Not equal.
     if (filterInfo.notValues_.size() > 0) {
       std::set<bool> notValues;
-      for (auto v: filterInfo.notValues_) {
+      for (auto v : filterInfo.notValues_) {
         notValues.emplace(v.value<bool>());
       }
       if (notValues.size() == 1) {
-        filters[common::Subfield(inputName)] =
-          std::make_unique<common::BoolValue>(!(*notValues.begin()), nullAllowed);
+        filters[common::Subfield(inputName)] = std::make_unique<common::BoolValue>(!(*notValues.begin()), nullAllowed);
       } else {
         // if there are more than one distinct value in NOT IN list, the filter should be AlwaysFalse
         filters[common::Subfield(inputName)] = std::make_unique<common::AlwaysFalse>();

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -365,8 +365,8 @@ class SubstraitToVeloxPlanConverter {
     }
 
     // Set a list of values to be used in the push down of 'not in' expression.
-    void setNotValues(const std::vector<variant>& notValue) {
-      for (const auto& value : notValue) {
+    void setNotValues(const std::vector<variant>& notValues) {
+      for (const auto& value : notValues) {
         notValues_.emplace_back(value);
       }
       if (!initialized_) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -496,6 +496,7 @@ class SubstraitToVeloxPlanConverter {
 
   /// Create a values range to handle (not) in filter.
   /// variants: the list of values extracted from the (not) in expression.
+  //  negated: false for IN filter, true for NOT IN filter.
   /// inputName: the column input name.
   template <TypeKind KIND>
   void setInFilter(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -365,7 +365,7 @@ class SubstraitToVeloxPlanConverter {
     }
 
     // Set a list of values to be used in the push down of 'not in' expression.
-    void setNotValue(const std::vector<variant>& notValue) {
+    void setNotValues(const std::vector<variant>& notValue) {
       for (const auto& value : notValue) {
         notValues_.emplace_back(value);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support pushdown `not in` to scan node

(Fixes: \#5965)

## How was this patch tested?

UT

