### PR TITLE
[CORE] ExpandFallbackPolicy should propagate fallback reason to vanilla SparkPlan

### DIFF
--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -22,8 +22,8 @@ import org.apache.gluten.execution.FileSourceScanExecTransformer
 import org.apache.gluten.utils.BackendTestUtils
 
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
-import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.{GlutenSQLTestsTrait, Row}
+import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.ui.{GlutenSQLAppStatusStore, SparkListenerSQLExecutionStart}

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.{GlutenSQLTestsTrait, Row}
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.ui.{GlutenSQLAppStatusStore, SparkListenerSQLExecutionStart}
 import org.apache.spark.status.ElementTrackingStore
 
@@ -168,17 +169,51 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
     withSQLConf(GlutenConfig.EXPRESSION_BLACK_LIST.key -> "add") {
       try {
         val df = spark.sql("select sum(id + 1) from range(10)")
-        spark.sparkContext.listenerBus.waitUntilEmpty()
         df.collect()
+        spark.sparkContext.listenerBus.waitUntilEmpty()
         val project = find(df.queryExecution.executedPlan) {
           _.isInstanceOf[ProjectExec]
         }
         assert(project.isDefined)
-        events.exists(
-          _.fallbackNodeToReason.values.toSet
-            .contains("Project: Not supported to map spark function name"))
+        assert(
+          events.exists(_.fallbackNodeToReason.values.toSet
+            .exists(_.contains("Not supported to map spark function name"))))
       } finally {
         spark.sparkContext.removeSparkListener(listener)
+      }
+    }
+  }
+
+  test("ExpandFallbackPolicy should propagate fallback reason to vanilla SparkPlan") {
+    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
+    val listener = new SparkListener {
+      override def onOtherEvent(event: SparkListenerEvent): Unit = {
+        event match {
+          case e: GlutenPlanFallbackEvent => events.append(e)
+          case _ =>
+        }
+      }
+    }
+    spark.sparkContext.addSparkListener(listener)
+    spark.range(10).selectExpr("id as c1", "id as c2").write.format("parquet").saveAsTable("t")
+    withTable("t") {
+      withSQLConf(
+        GlutenConfig.EXPRESSION_BLACK_LIST.key -> "max",
+        GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
+        try {
+          val df = spark.sql("select c2, max(c1) as id from t group by c2")
+          df.collect()
+          spark.sparkContext.listenerBus.waitUntilEmpty()
+          val agg = collect(df.queryExecution.executedPlan) { case a: HashAggregateExec => a }
+          assert(agg.size == 2)
+          assert(
+            events.count(
+              _.fallbackNodeToReason.values.toSet.exists(_.contains(
+                "Could not find a valid substrait mapping name for max"
+              ))) == 2)
+        } finally {
+          spark.sparkContext.removeSparkListener(listener)
+        }
       }
     }
   }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.{GlutenSQLTestsTrait, Row}
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.ui.{GlutenSQLAppStatusStore, SparkListenerSQLExecutionStart}
 import org.apache.spark.status.ElementTrackingStore
 
@@ -168,17 +169,51 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
     withSQLConf(GlutenConfig.EXPRESSION_BLACK_LIST.key -> "add") {
       try {
         val df = spark.sql("select sum(id + 1) from range(10)")
-        spark.sparkContext.listenerBus.waitUntilEmpty()
         df.collect()
+        spark.sparkContext.listenerBus.waitUntilEmpty()
         val project = find(df.queryExecution.executedPlan) {
           _.isInstanceOf[ProjectExec]
         }
         assert(project.isDefined)
-        events.exists(
-          _.fallbackNodeToReason.values.toSet
-            .contains("Project: Not supported to map spark function name"))
+        assert(
+          events.exists(_.fallbackNodeToReason.values.toSet
+            .exists(_.contains("Not supported to map spark function name"))))
       } finally {
         spark.sparkContext.removeSparkListener(listener)
+      }
+    }
+  }
+
+  test("ExpandFallbackPolicy should propagate fallback reason to vanilla SparkPlan") {
+    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
+    val listener = new SparkListener {
+      override def onOtherEvent(event: SparkListenerEvent): Unit = {
+        event match {
+          case e: GlutenPlanFallbackEvent => events.append(e)
+          case _ =>
+        }
+      }
+    }
+    spark.sparkContext.addSparkListener(listener)
+    spark.range(10).selectExpr("id as c1", "id as c2").write.format("parquet").saveAsTable("t")
+    withTable("t") {
+      withSQLConf(
+        GlutenConfig.EXPRESSION_BLACK_LIST.key -> "max",
+        GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
+        try {
+          val df = spark.sql("select c2, max(c1) as id from t group by c2")
+          df.collect()
+          spark.sparkContext.listenerBus.waitUntilEmpty()
+          val agg = collect(df.queryExecution.executedPlan) { case a: HashAggregateExec => a }
+          assert(agg.size == 2)
+          assert(
+            events.count(
+              _.fallbackNodeToReason.values.toSet.exists(_.contains(
+                "Could not find a valid substrait mapping name for max"
+              ))) == 2)
+        } finally {
+          spark.sparkContext.removeSparkListener(listener)
+        }
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr makes ExpandFallbackPolicy propagate fallback reason to vanilla SparkPlan. The real fallback reason should not be overwritten by ExpandFallbackPolicy's fallback reason.

## How was this patch tested?

add test
