### PR TITLE
[VL] Remove unnecessary arrow compile option

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -285,8 +285,8 @@ function compile_arrow_java_module() {
     # Because arrow-bom module need the -DprocessAllModules
     mvn versions:set -DnewVersion=15.0.0-gluten -DprocessAllModules
    
-    mvn clean install -am \
-          -DskipTests -Drat.skip -Dmaven.gitcommitid.skip -Dcheckstyle.skip
+    mvn clean install -pl maven/module-info-compiler-maven-plugin -am \
+      -Dmaven.test.skip -Drat.skip -Dmaven.gitcommitid.skip -Dcheckstyle.skip
 
     # Arrow C Data Interface CPP libraries
     mvn generate-resources -P generate-libs-cdata-all-os -Darrow.c.jni.dist.dir=$ARROW_INSTALL_DIR \

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -285,7 +285,7 @@ function compile_arrow_java_module() {
     # Because arrow-bom module need the -DprocessAllModules
     mvn versions:set -DnewVersion=15.0.0-gluten -DprocessAllModules
    
-    mvn clean install -pl maven/module-info-compiler-maven-plugin -am \
+    mvn clean install -pl bom,maven/module-info-compiler-maven-plugin -am \
       -Dmaven.test.skip -Drat.skip -Dmaven.gitcommitid.skip -Dcheckstyle.skip
 
     # Arrow C Data Interface CPP libraries


### PR DESCRIPTION
`-am` maven options is helpful, just compile needed module.