### PR TITLE
[GLUTEN-5620][CH] Simplify Decimal process for Remainder(%) operator

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDecimalSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDecimalSuite.scala
@@ -306,8 +306,10 @@ class GlutenClickHouseDecimalSuite
     val createSql =
       "create table decimals_test(id int, a decimal(38,18), b decimal(38,18)) using parquet"
     val inserts =
-      "insert into decimals_test values(1, 100.0, 999.0), (2, 12345.123, 12345.123), (3, 0.1234567891011, 1234.1), " +
-        "(4, 123456789123456789.0, 1.123456789123456789)"
+      "insert into decimals_test values(1, 100.0, 999.0)" +
+        ", (2, 12345.123, 12345.123)" +
+        ", (3, 0.1234567891011, 1234.1)" +
+        ", (4, 123456789123456789.0, 1.123456789123456789)"
     spark.sql(createSql)
 
     try {
@@ -315,9 +317,9 @@ class GlutenClickHouseDecimalSuite
 
       val q1 = "select id, a+b, a-b, a*b, a/b ,a%b from decimals_test order by id"
 
-      /// test operations between decimals and constants
+      // test operations between decimals and constants
       val q2 = "select id, a*10, b/10 from decimals_test order by id"
-      /// FIXME val q2 = "select id, a*10, b/10, a%20, b%30 from decimals_test order by id"
+      // FIXME val q2 = "select id, a*10, b/10, a%20, b%30 from decimals_test order by id"
 
       Seq("true", "false").foreach {
         allowPrecisionLoss =>

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1772,7 +1772,7 @@ QueryPlanPtr SerializedPlanParser::parse(const std::string & plan)
     if (logger->debug())
     {
         auto out = PlanUtil::explainPlan(*res);
-        LOG_ERROR(logger, "clickhouse plan:\n{}", out);
+        LOG_DEBUG(logger, "clickhouse plan:\n{}", out);
     }
     return res;
 }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arithmetic.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arithmetic.cpp
@@ -67,7 +67,6 @@ public:
 
     static DecimalType evalModuloDecimalType(const Int32 p1, const Int32 s1, const Int32 p2, const Int32 s2)
     {
-
         const Int32 scale = std::max(s1, s2);
         const Int32 precision = std::min(p1 - s1, p2 - s2) + scale;
         return bounded_to_click_house(precision, scale);

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arithmetic.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arithmetic.cpp
@@ -65,6 +65,14 @@ public:
         return bounded_to_click_house(precision, scale);
     }
 
+    static DecimalType evalModuloDecimalType(const Int32 p1, const Int32 s1, const Int32 p2, const Int32 s2)
+    {
+
+        const Int32 scale = std::max(s1, s2);
+        const Int32 precision = std::min(p1 - s1, p2 - s2) + scale;
+        return bounded_to_click_house(precision, scale);
+    }
+
     static DecimalType evalMultiplyDecimalType(const Int32 p1, const Int32 s1, const Int32 p2, const Int32 s2)
     {
         const Int32 scale = s1;
@@ -221,6 +229,20 @@ protected:
     }
 };
 
+class FunctionParserModulo final : public FunctionParserBinaryArithmetic
+{
+public:
+    explicit FunctionParserModulo(SerializedPlanParser * plan_parser_) : FunctionParserBinaryArithmetic(plan_parser_) { }
+    static constexpr auto name = "modulus";
+    String getName() const override { return name; }
+
+protected:
+    DecimalType internalEvalType(const Int32 p1, const Int32 s1, const Int32 p2, const Int32 s2) const override
+    {
+        return DecimalType::evalModuloDecimalType(p1, s1, p2, s2);
+    }
+};
+
 class FunctionParserDivide final : public FunctionParserBinaryArithmetic
 {
 public:
@@ -252,5 +274,6 @@ static FunctionParserRegister<FunctionParserPlus> register_plus;
 static FunctionParserRegister<FunctionParserMinus> register_minus;
 static FunctionParserRegister<FunctionParserMultiply> register_mltiply;
 static FunctionParserRegister<FunctionParserDivide> register_divide;
+static FunctionParserRegister<FunctionParserModulo> register_modulo;
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is follow up of https://github.com/apache/incubator-gluten/pull/5621,  I just support `+, -, *, /` in that PR. Let's support `%` in this PR

(Fixes: \#5620)

## How was this patch tested?

New UTs
