### PR TITLE
[TESTS] Tune spark.gluten.sql.complexType.scan.fallback.enabled to false for tests

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -324,108 +324,102 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
   }
 
   test("Array type") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
-      // Validation: BatchScan.
-      runQueryAndCompare("select array from type1") {
-        checkGlutenOperatorMatch[BatchScanExecTransformer]
-      }
-
-      // Validation: BatchScan Project Aggregate Expand Sort Limit
-      runQueryAndCompare(
-        "select int, array from type1 " +
-          " group by grouping sets(int, array) sort by array, int limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-
-      // Validation: BroadHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-      runQueryAndCompare(
-        "select type1.array from type1," +
-          " type2 where type1.array = type2.array") { _ => }
-
-      // Validation: ShuffledHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      runQueryAndCompare(
-        "select type1.array from type1," +
-          " type2 where type1.array = type2.array") { _ => }
+    // Validation: BatchScan.
+    runQueryAndCompare("select array from type1") {
+      checkGlutenOperatorMatch[BatchScanExecTransformer]
     }
+
+    // Validation: BatchScan Project Aggregate Expand Sort Limit
+    runQueryAndCompare(
+      "select int, array from type1 " +
+        " group by grouping sets(int, array) sort by array, int limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
+    }
+
+    // Validation: BroadHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+    runQueryAndCompare(
+      "select type1.array from type1," +
+        " type2 where type1.array = type2.array") { _ => }
+
+    // Validation: ShuffledHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    runQueryAndCompare(
+      "select type1.array from type1," +
+        " type2 where type1.array = type2.array") { _ => }
   }
 
   test("Map type") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
-      // Validation: BatchScan Project Limit
-      runQueryAndCompare("select map from type1 limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-      // Validation: BatchScan Project Aggregate Sort Limit
-      // TODO validate Expand operator support map type ?
-      runQueryAndCompare(
-        "select map['key'] from type1 group by map['key']" +
-          " sort by map['key'] limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-
-      // Validation: BroadHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-      runQueryAndCompare(
-        "select type1.map['key'] from type1," +
-          " type2 where type1.map['key'] = type2.map['key']") { _ => }
-
-      // Validation: ShuffledHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      runQueryAndCompare(
-        "select type1.map['key'] from type1," +
-          " type2 where type1.map['key'] = type2.map['key']") { _ => }
+    // Validation: BatchScan Project Limit
+    runQueryAndCompare("select map from type1 limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
     }
+    // Validation: BatchScan Project Aggregate Sort Limit
+    // TODO validate Expand operator support map type ?
+    runQueryAndCompare(
+      "select map['key'] from type1 group by map['key']" +
+        " sort by map['key'] limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
+    }
+
+    // Validation: BroadHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+    runQueryAndCompare(
+      "select type1.map['key'] from type1," +
+        " type2 where type1.map['key'] = type2.map['key']") { _ => }
+
+    // Validation: ShuffledHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    runQueryAndCompare(
+      "select type1.map['key'] from type1," +
+        " type2 where type1.map['key'] = type2.map['key']") { _ => }
   }
 
   test("Struct type") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
-      // Validation: BatchScan Project Limit
-      runQueryAndCompare("select struct from type1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-      // Validation: BatchScan Project Aggregate Sort Limit
-      // TODO validate Expand operator support Struct type ?
-      runQueryAndCompare(
-        "select int, struct.struct_1 from type1 " +
-          "sort by struct.struct_1 limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-            assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
-          }
-      }
-
-      // Validation: BroadHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-      runQueryAndCompare(
-        "select type1.struct.struct_1 from type1," +
-          " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
-
-      // Validation: ShuffledHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      runQueryAndCompare(
-        "select type1.struct.struct_1 from type1," +
-          " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
+    // Validation: BatchScan Project Limit
+    runQueryAndCompare("select struct from type1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
     }
+    // Validation: BatchScan Project Aggregate Sort Limit
+    // TODO validate Expand operator support Struct type ?
+    runQueryAndCompare(
+      "select int, struct.struct_1 from type1 " +
+        "sort by struct.struct_1 limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+          assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
+        }
+    }
+
+    // Validation: BroadHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+    runQueryAndCompare(
+      "select type1.struct.struct_1 from type1," +
+        " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
+
+    // Validation: ShuffledHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    runQueryAndCompare(
+      "select type1.struct.struct_1 from type1," +
+        " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
   }
 
   test("Decimal type") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -323,116 +323,108 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
   }
 
   test("Array type") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
-      // Validation: BatchScan.
-      runQueryAndCompare("select array from type1") {
-        checkGlutenOperatorMatch[BatchScanExecTransformer]
-      }
-
-      // Validation: BatchScan Project Aggregate Expand Sort Limit
-      runQueryAndCompare(
-        "select int, array from type1 " +
-          " group by grouping sets(int, array) sort by array, int limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-
-      // Validation: BroadHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-      runQueryAndCompare(
-        "select type1.array from type1," +
-          " type2 where type1.array = type2.array") { _ => }
-
-      // Validation: ShuffledHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      runQueryAndCompare(
-        "select type1.array from type1," +
-          " type2 where type1.array = type2.array") { _ => }
+    // Validation: BatchScan.
+    runQueryAndCompare("select array from type1") {
+      checkGlutenOperatorMatch[BatchScanExecTransformer]
     }
+
+    // Validation: BatchScan Project Aggregate Expand Sort Limit
+    runQueryAndCompare(
+      "select int, array from type1 " +
+        " group by grouping sets(int, array) sort by array, int limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
+    }
+
+    // Validation: BroadHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+    runQueryAndCompare(
+      "select type1.array from type1," +
+        " type2 where type1.array = type2.array") { _ => }
+
+    // Validation: ShuffledHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    runQueryAndCompare(
+      "select type1.array from type1," +
+        " type2 where type1.array = type2.array") { _ => }
   }
 
   test("Map type") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
-      // Validation: BatchScan Project Limit
-      runQueryAndCompare("select map from type1 limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-      // Validation: BatchScan Project Aggregate Sort Limit
-      // TODO validate Expand operator support map type ?
-      runQueryAndCompare(
-        "select map['key'] from type1 group by map['key']" +
-          " sort by map['key'] limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-
-      // Validation: BroadHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-      runQueryAndCompare(
-        "select type1.map['key'] from type1," +
-          " type2 where type1.map['key'] = type2.map['key']") { _ => }
-
-      // Validation: ShuffledHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      runQueryAndCompare(
-        "select type1.map['key'] from type1," +
-          " type2 where type1.map['key'] = type2.map['key']") { _ => }
+    // Validation: BatchScan Project Limit
+    runQueryAndCompare("select map from type1 limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
     }
+    // Validation: BatchScan Project Aggregate Sort Limit
+    // TODO validate Expand operator support map type ?
+    runQueryAndCompare(
+      "select map['key'] from type1 group by map['key']" +
+        " sort by map['key'] limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
+    }
+
+    // Validation: BroadHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+    runQueryAndCompare(
+      "select type1.map['key'] from type1," +
+        " type2 where type1.map['key'] = type2.map['key']") { _ => }
+
+    // Validation: ShuffledHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    runQueryAndCompare(
+      "select type1.map['key'] from type1," +
+        " type2 where type1.map['key'] = type2.map['key']") { _ => }
   }
 
   test("Struct type") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
-      // Validation: BatchScan Project Limit
-      runQueryAndCompare("select struct from type1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          }
-      }
-      // Validation: BatchScan Project Aggregate Sort Limit
-      // TODO validate Expand operator support Struct type ?
-      runQueryAndCompare(
-        "select int, struct.struct_1 from type1 " +
-          "sort by struct.struct_1 limit 1") {
-        df =>
-          {
-            val executedPlan = getExecutedPlan(df)
-            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-            assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
-          }
-      }
-
-      // Validation: BroadHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-      runQueryAndCompare(
-        "select type1.struct.struct_1 from type1," +
-          " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
-
-      // Validation: ShuffledHashJoin, Filter, Project
-      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      runQueryAndCompare(
-        "select type1.struct.struct_1 from type1," +
-          " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
+    // Validation: BatchScan Project Limit
+    runQueryAndCompare("select struct from type1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+        }
     }
+    // Validation: BatchScan Project Aggregate Sort Limit
+    // TODO validate Expand operator support Struct type ?
+    runQueryAndCompare(
+      "select int, struct.struct_1 from type1 " +
+        "sort by struct.struct_1 limit 1") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+          assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
+        }
+    }
+
+    // Validation: BroadHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+    runQueryAndCompare(
+      "select type1.struct.struct_1 from type1," +
+        " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
+
+    // Validation: ShuffledHashJoin, Filter, Project
+    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    runQueryAndCompare(
+      "select type1.struct.struct_1 from type1," +
+        " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
   }
 
   test("Force complex type scan fallback") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "true")) {
-      val df = spark.sql("select struct from type1")
-      val executedPlan = getExecutedPlan(df)
-      assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-    }
+    val df = spark.sql("select struct from type1")
+    val executedPlan = getExecutedPlan(df)
+    assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
   }
 
   test("Force timestamp type scan fallback") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -422,9 +422,11 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
   }
 
   test("Force complex type scan fallback") {
-    val df = spark.sql("select struct from type1")
-    val executedPlan = getExecutedPlan(df)
-    assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "true") {
+      val df = spark.sql("select struct from type1")
+      val executedPlan = getExecutedPlan(df)
+      assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+    }
   }
 
   test("Force timestamp type scan fallback") {

--- a/gluten-core/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
@@ -100,6 +100,7 @@ abstract class WholeStageTransformerSuite
       .set("spark.memory.offHeap.size", "1024MB")
       .set("spark.ui.enabled", "false")
       .set("spark.gluten.ui.enabled", "false")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
   }
 
   protected def checkFallbackOperators(df: DataFrame, num: Int): Unit = {
@@ -297,9 +298,6 @@ abstract class WholeStageTransformerSuite
       val df = spark.sql(sqlStr)
       expected = df.collect()
     }
-    // By default we will fallabck complex type scan but here we should allow
-    // to test support of complex type
-    spark.conf.set("spark.gluten.sql.complexType.scan.fallback.enabled", "false");
     val df = spark.sql(sqlStr)
     if (cache) {
       df.cache()

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
@@ -117,6 +117,7 @@ object GlutenSQLTestsBaseTrait {
       .set("spark.sql.warehouse.dir", warehouse)
       .set("spark.ui.enabled", "false")
       .set("spark.gluten.ui.enabled", "false")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
     // Avoid static evaluation by spark catalyst. But there are some UT issues
     // coming from spark, e.g., expecting SparkException is thrown, but the wrapped
     // exception is thrown.

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
@@ -39,9 +39,7 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5182: Fix failed to parse post join filters") {
-    withSQLConf(
-      "spark.sql.hive.convertMetastoreParquet" -> "false",
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_5182_0;")
       sql("DROP TABLE IF EXISTS test_5182_1;")
       sql(
@@ -78,27 +76,23 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5249: Reading csv may throw Unexpected empty column") {
-    withSQLConf(
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false"
-    ) {
-      sql("DROP TABLE IF EXISTS test_5249;")
-      sql(
-        "CREATE TABLE test_5249 (name STRING, uid STRING) " +
-          "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
-          "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
-          "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
-      sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
-      val df = spark.sql(
-        "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
-          "group by name, uid with cube;")
-      checkAnswer(
-        df,
-        Seq(
-          Row("name_1", "id_1", 1),
-          Row("name_1", null, 1),
-          Row(null, "id_1", 1),
-          Row(null, null, 1)))
-    }
+    sql("DROP TABLE IF EXISTS test_5249;")
+    sql(
+      "CREATE TABLE test_5249 (name STRING, uid STRING) " +
+        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
+        "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
+        "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
+    sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
+    val df = spark.sql(
+      "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
+        "group by name, uid with cube;")
+    checkAnswer(
+      df,
+      Seq(
+        Row("name_1", "id_1", 1),
+        Row("name_1", null, 1),
+        Row(null, "id_1", 1),
+        Row(null, null, 1)))
     spark.sessionState.catalog.dropTable(
       TableIdentifier("test_5249"),
       ignoreIfNotExists = true,

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -29,6 +29,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
   }
 
   testGluten("hive orc scan") {
@@ -49,9 +50,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("avoid unnecessary filter binding for subfield during scan") {
-    withSQLConf(
-      "spark.sql.hive.convertMetastoreParquet" -> "false",
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")
       sql(
         "CREATE TABLE test_subfield (name STRING, favorite_color STRING, " +

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
@@ -39,9 +39,7 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5182: Fix failed to parse post join filters") {
-    withSQLConf(
-      "spark.sql.hive.convertMetastoreParquet" -> "false",
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_5182_0;")
       sql("DROP TABLE IF EXISTS test_5182_1;")
       sql(
@@ -78,27 +76,23 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5249: Reading csv may throw Unexpected empty column") {
-    withSQLConf(
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false"
-    ) {
-      sql("DROP TABLE IF EXISTS test_5249;")
-      sql(
-        "CREATE TABLE test_5249 (name STRING, uid STRING) " +
-          "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
-          "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
-          "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
-      sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
-      val df = spark.sql(
-        "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
-          "group by name, uid with cube;")
-      checkAnswer(
-        df,
-        Seq(
-          Row("name_1", "id_1", 1),
-          Row("name_1", null, 1),
-          Row(null, "id_1", 1),
-          Row(null, null, 1)))
-    }
+    sql("DROP TABLE IF EXISTS test_5249;")
+    sql(
+      "CREATE TABLE test_5249 (name STRING, uid STRING) " +
+        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
+        "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
+        "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
+    sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
+    val df = spark.sql(
+      "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
+        "group by name, uid with cube;")
+    checkAnswer(
+      df,
+      Seq(
+        Row("name_1", "id_1", 1),
+        Row("name_1", null, 1),
+        Row(null, "id_1", 1),
+        Row(null, null, 1)))
     spark.sessionState.catalog.dropTable(
       TableIdentifier("test_5249"),
       ignoreIfNotExists = true,

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -32,6 +32,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
   }
 
   testGluten("hive orc scan") {
@@ -115,9 +116,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("avoid unnecessary filter binding for subfield during scan") {
-    withSQLConf(
-      "spark.sql.hive.convertMetastoreParquet" -> "false",
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")
       sql(
         "CREATE TABLE test_subfield (name STRING, favorite_color STRING," +

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
@@ -39,9 +39,7 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5182: Fix failed to parse post join filters") {
-    withSQLConf(
-      "spark.sql.hive.convertMetastoreParquet" -> "false",
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_5182_0;")
       sql("DROP TABLE IF EXISTS test_5182_1;")
       sql(
@@ -78,27 +76,23 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5249: Reading csv may throw Unexpected empty column") {
-    withSQLConf(
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false"
-    ) {
-      sql("DROP TABLE IF EXISTS test_5249;")
-      sql(
-        "CREATE TABLE test_5249 (name STRING, uid STRING) " +
-          "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
-          "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
-          "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
-      sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
-      val df = spark.sql(
-        "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
-          "group by name, uid with cube;")
-      checkAnswer(
-        df,
-        Seq(
-          Row("name_1", "id_1", 1),
-          Row("name_1", null, 1),
-          Row(null, "id_1", 1),
-          Row(null, null, 1)))
-    }
+    sql("DROP TABLE IF EXISTS test_5249;")
+    sql(
+      "CREATE TABLE test_5249 (name STRING, uid STRING) " +
+        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
+        "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
+        "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
+    sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
+    val df = spark.sql(
+      "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
+        "group by name, uid with cube;")
+    checkAnswer(
+      df,
+      Seq(
+        Row("name_1", "id_1", 1),
+        Row("name_1", null, 1),
+        Row(null, "id_1", 1),
+        Row(null, null, 1)))
     spark.sessionState.catalog.dropTable(
       TableIdentifier("test_5249"),
       ignoreIfNotExists = true,

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -29,6 +29,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
   }
 
   testGluten("hive orc scan") {

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -392,126 +392,120 @@ class GlutenInsertSuite
   }
 
   testGluten("SPARK-39557 INSERT INTO statements with tables with array defaults") {
-    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
-      import testImplicits._
-      // Positive tests: array types are supported as default values.
-      case class Config(dataSource: String, useDataFrames: Boolean = false)
-      Seq(
-        Config("parquet"),
-        Config("parquet", useDataFrames = true),
-        Config("orc"),
-        Config("orc", useDataFrames = true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            sql("alter table t add column s array<int> default array(1, 2)")
-            checkAnswer(spark.table("t"), Row(false, null))
-            sql("insert into t(i) values (true)")
-            checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Seq(1, 2))))
+    import testImplicits._
+    // Positive tests: array types are supported as default values.
+    case class Config(dataSource: String, useDataFrames: Boolean = false)
+    Seq(
+      Config("parquet"),
+      Config("parquet", useDataFrames = true),
+      Config("orc"),
+      Config("orc", useDataFrames = true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
-      // Negative tests: provided array element types must match their corresponding DEFAULT
-      // declarations, if applicable.
-      val incompatibleDefault =
-        "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
-          "table column s has a DEFAULT value with type"
-      Seq(Config("parquet"), Config("parquet", true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            assert(intercept[AnalysisException] {
-              sql("alter table t add column s array<int> default array('abc', 'def')")
-            }.getMessage.contains(incompatibleDefault))
+          sql("alter table t add column s array<int> default array(1, 2)")
+          checkAnswer(spark.table("t"), Row(false, null))
+          sql("insert into t(i) values (true)")
+          checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Seq(1, 2))))
+        }
+    }
+    // Negative tests: provided array element types must match their corresponding DEFAULT
+    // declarations, if applicable.
+    val incompatibleDefault =
+      "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
+        "table column s has a DEFAULT value with type"
+    Seq(Config("parquet"), Config("parquet", true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
+          assert(intercept[AnalysisException] {
+            sql("alter table t add column s array<int> default array('abc', 'def')")
+          }.getMessage.contains(incompatibleDefault))
+        }
     }
   }
 
   testGluten("SPARK-39557 INSERT INTO statements with tables with struct defaults") {
-    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
 
-      import testImplicits._
-      // Positive tests: struct types are supported as default values.
-      case class Config(dataSource: String, useDataFrames: Boolean = false)
-      Seq(
-        Config("parquet"),
-        Config("parquet", useDataFrames = true),
-        Config("orc"),
-        Config("orc", useDataFrames = true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            sql(
-              "alter table t add column s struct<x boolean, y string> default struct(true, 'abc')")
-            checkAnswer(spark.table("t"), Row(false, null))
-            sql("insert into t(i) values (true)")
-            checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Row(true, "abc"))))
+    import testImplicits._
+    // Positive tests: struct types are supported as default values.
+    case class Config(dataSource: String, useDataFrames: Boolean = false)
+    Seq(
+      Config("parquet"),
+      Config("parquet", useDataFrames = true),
+      Config("orc"),
+      Config("orc", useDataFrames = true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
+          sql("alter table t add column s struct<x boolean, y string> default struct(true, 'abc')")
+          checkAnswer(spark.table("t"), Row(false, null))
+          sql("insert into t(i) values (true)")
+          checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Row(true, "abc"))))
+        }
+    }
 
-      // Negative tests: provided map element types must match their corresponding DEFAULT
-      // declarations, if applicable.
-      val incompatibleDefault =
-        "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
-          "table column s has a DEFAULT value with type"
-      Seq(Config("parquet"), Config("parquet", true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            assert(intercept[AnalysisException] {
-              sql("alter table t add column s struct<x boolean, y string> default struct(42, 56)")
-            }.getMessage.contains(incompatibleDefault))
+    // Negative tests: provided map element types must match their corresponding DEFAULT
+    // declarations, if applicable.
+    val incompatibleDefault =
+      "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
+        "table column s has a DEFAULT value with type"
+    Seq(Config("parquet"), Config("parquet", true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
+          assert(intercept[AnalysisException] {
+            sql("alter table t add column s struct<x boolean, y string> default struct(42, 56)")
+          }.getMessage.contains(incompatibleDefault))
+        }
     }
   }
 
   ignoreGluten("SPARK-39557 INSERT INTO statements with tables with map defaults") {
-    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
 
-      import testImplicits._
-      // Positive tests: map types are supported as default values.
-      case class Config(dataSource: String, useDataFrames: Boolean = false)
-      Seq(
-        Config("parquet"),
-        Config("parquet", useDataFrames = true),
-        Config("orc"),
-        Config("orc", useDataFrames = true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            sql("alter table t add column s map<boolean, string> default map(true, 'abc')")
-            checkAnswer(spark.table("t"), Row(false, null))
-            sql("insert into t(i) select true")
-            checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Map(true -> "abc"))))
+    import testImplicits._
+    // Positive tests: map types are supported as default values.
+    case class Config(dataSource: String, useDataFrames: Boolean = false)
+    Seq(
+      Config("parquet"),
+      Config("parquet", useDataFrames = true),
+      Config("orc"),
+      Config("orc", useDataFrames = true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-          withTable("t") {
-            sql(s"""
+          sql("alter table t add column s map<boolean, string> default map(true, 'abc')")
+          checkAnswer(spark.table("t"), Row(false, null))
+          sql("insert into t(i) select true")
+          checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Map(true -> "abc"))))
+        }
+        withTable("t") {
+          sql(s"""
             create table t(
               i int,
               s struct<
@@ -525,61 +519,60 @@ class GlutenInsertSuite
                 array(
                   map(false, 'def', true, 'jkl'))))
               using ${config.dataSource}""")
-            sql("insert into t select 1, default")
-            sql("alter table t alter column s drop default")
-            if (config.useDataFrames) {
-              Seq((2, null)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select 2, default")
-            }
-            sql("""
+          sql("insert into t select 1, default")
+          sql("alter table t alter column s drop default")
+          if (config.useDataFrames) {
+            Seq((2, null)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select 2, default")
+          }
+          sql("""
             alter table t alter column s
             set default struct(
               array(
                 struct(3, 4)),
               array(
                 map(false, 'mno', true, 'pqr')))""")
-            sql("insert into t select 3, default")
-            sql("""
+          sql("insert into t select 3, default")
+          sql("""
             alter table t
             add column t array<
               map<boolean, string>>
             default array(
               map(true, 'xyz'))""")
-            sql("insert into t(i, s) select 4, default")
-            checkAnswer(
-              spark.table("t"),
-              Seq(
-                Row(1, Row(Seq(Row(1, 2)), Seq(Map(false -> "def", true -> "jkl"))), null),
-                Row(2, null, null),
-                Row(3, Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))), null),
-                Row(
-                  4,
-                  Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))),
-                  Seq(Map(true -> "xyz")))
-              )
+          sql("insert into t(i, s) select 4, default")
+          checkAnswer(
+            spark.table("t"),
+            Seq(
+              Row(1, Row(Seq(Row(1, 2)), Seq(Map(false -> "def", true -> "jkl"))), null),
+              Row(2, null, null),
+              Row(3, Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))), null),
+              Row(
+                4,
+                Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))),
+                Seq(Map(true -> "xyz")))
             )
+          )
+        }
+    }
+    // Negative tests: provided map element types must match their corresponding DEFAULT
+    // declarations, if applicable.
+    val incompatibleDefault =
+      "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
+        "table column s has a DEFAULT value with type"
+    Seq(Config("parquet"), Config("parquet", true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
-      // Negative tests: provided map element types must match their corresponding DEFAULT
-      // declarations, if applicable.
-      val incompatibleDefault =
-        "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
-          "table column s has a DEFAULT value with type"
-      Seq(Config("parquet"), Config("parquet", true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            assert(intercept[AnalysisException] {
-              sql("alter table t add column s map<boolean, string> default map(42, 56)")
-            }.getMessage.contains(incompatibleDefault))
-          }
-      }
+          assert(intercept[AnalysisException] {
+            sql("alter table t add column s map<boolean, string> default map(42, 56)")
+          }.getMessage.contains(incompatibleDefault))
+        }
     }
   }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQueryCHSuite.scala
@@ -39,9 +39,7 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5182: Fix failed to parse post join filters") {
-    withSQLConf(
-      "spark.sql.hive.convertMetastoreParquet" -> "false",
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_5182_0;")
       sql("DROP TABLE IF EXISTS test_5182_1;")
       sql(
@@ -78,27 +76,23 @@ class GlutenHiveSQLQueryCHSuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("5249: Reading csv may throw Unexpected empty column") {
-    withSQLConf(
-      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false"
-    ) {
-      sql("DROP TABLE IF EXISTS test_5249;")
-      sql(
-        "CREATE TABLE test_5249 (name STRING, uid STRING) " +
-          "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
-          "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
-          "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
-      sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
-      val df = spark.sql(
-        "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
-          "group by name, uid with cube;")
-      checkAnswer(
-        df,
-        Seq(
-          Row("name_1", "id_1", 1),
-          Row("name_1", null, 1),
-          Row(null, "id_1", 1),
-          Row(null, null, 1)))
-    }
+    sql("DROP TABLE IF EXISTS test_5249;")
+    sql(
+      "CREATE TABLE test_5249 (name STRING, uid STRING) " +
+        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
+        "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' " +
+        "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';")
+    sql("INSERT INTO test_5249 VALUES('name_1', 'id_1');")
+    val df = spark.sql(
+      "SELECT name, uid, count(distinct uid) total_uid_num from test_5249 " +
+        "group by name, uid with cube;")
+    checkAnswer(
+      df,
+      Seq(
+        Row("name_1", "id_1", 1),
+        Row("name_1", null, 1),
+        Row(null, "id_1", 1),
+        Row(null, null, 1)))
     spark.sessionState.catalog.dropTable(
       TableIdentifier("test_5249"),
       ignoreIfNotExists = true,

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -29,6 +29,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
   }
 
   testGluten("hive orc scan") {

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -392,126 +392,120 @@ class GlutenInsertSuite
   }
 
   testGluten("SPARK-39557 INSERT INTO statements with tables with array defaults") {
-    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
-      import testImplicits._
-      // Positive tests: array types are supported as default values.
-      case class Config(dataSource: String, useDataFrames: Boolean = false)
-      Seq(
-        Config("parquet"),
-        Config("parquet", useDataFrames = true),
-        Config("orc"),
-        Config("orc", useDataFrames = true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            sql("alter table t add column s array<int> default array(1, 2)")
-            checkAnswer(spark.table("t"), Row(false, null))
-            sql("insert into t(i) values (true)")
-            checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Seq(1, 2))))
+    import testImplicits._
+    // Positive tests: array types are supported as default values.
+    case class Config(dataSource: String, useDataFrames: Boolean = false)
+    Seq(
+      Config("parquet"),
+      Config("parquet", useDataFrames = true),
+      Config("orc"),
+      Config("orc", useDataFrames = true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
-      // Negative tests: provided array element types must match their corresponding DEFAULT
-      // declarations, if applicable.
-      val incompatibleDefault =
-        "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
-          "table column `s` has a DEFAULT value"
-      Seq(Config("parquet"), Config("parquet", true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            assert(intercept[AnalysisException] {
-              sql("alter table t add column s array<int> default array('abc', 'def')")
-            }.getMessage.contains(incompatibleDefault))
+          sql("alter table t add column s array<int> default array(1, 2)")
+          checkAnswer(spark.table("t"), Row(false, null))
+          sql("insert into t(i) values (true)")
+          checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Seq(1, 2))))
+        }
+    }
+    // Negative tests: provided array element types must match their corresponding DEFAULT
+    // declarations, if applicable.
+    val incompatibleDefault =
+      "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
+        "table column `s` has a DEFAULT value"
+    Seq(Config("parquet"), Config("parquet", true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
+          assert(intercept[AnalysisException] {
+            sql("alter table t add column s array<int> default array('abc', 'def')")
+          }.getMessage.contains(incompatibleDefault))
+        }
     }
   }
 
   testGluten("SPARK-39557 INSERT INTO statements with tables with struct defaults") {
-    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
 
-      import testImplicits._
-      // Positive tests: struct types are supported as default values.
-      case class Config(dataSource: String, useDataFrames: Boolean = false)
-      Seq(
-        Config("parquet"),
-        Config("parquet", useDataFrames = true),
-        Config("orc"),
-        Config("orc", useDataFrames = true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            sql(
-              "alter table t add column s struct<x boolean, y string> default struct(true, 'abc')")
-            checkAnswer(spark.table("t"), Row(false, null))
-            sql("insert into t(i) values (true)")
-            checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Row(true, "abc"))))
+    import testImplicits._
+    // Positive tests: struct types are supported as default values.
+    case class Config(dataSource: String, useDataFrames: Boolean = false)
+    Seq(
+      Config("parquet"),
+      Config("parquet", useDataFrames = true),
+      Config("orc"),
+      Config("orc", useDataFrames = true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
+          sql("alter table t add column s struct<x boolean, y string> default struct(true, 'abc')")
+          checkAnswer(spark.table("t"), Row(false, null))
+          sql("insert into t(i) values (true)")
+          checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Row(true, "abc"))))
+        }
+    }
 
-      // Negative tests: provided map element types must match their corresponding DEFAULT
-      // declarations, if applicable.
-      val incompatibleDefault =
-        "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
-          "table column `s` has a DEFAULT value"
-      Seq(Config("parquet"), Config("parquet", true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            assert(intercept[AnalysisException] {
-              sql("alter table t add column s struct<x boolean, y string> default struct(42, 56)")
-            }.getMessage.contains(incompatibleDefault))
+    // Negative tests: provided map element types must match their corresponding DEFAULT
+    // declarations, if applicable.
+    val incompatibleDefault =
+      "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
+        "table column `s` has a DEFAULT value"
+    Seq(Config("parquet"), Config("parquet", true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
+          assert(intercept[AnalysisException] {
+            sql("alter table t add column s struct<x boolean, y string> default struct(42, 56)")
+          }.getMessage.contains(incompatibleDefault))
+        }
     }
   }
 
   ignoreGluten("SPARK-39557 INSERT INTO statements with tables with map defaults") {
-    withSQLConf("spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
 
-      import testImplicits._
-      // Positive tests: map types are supported as default values.
-      case class Config(dataSource: String, useDataFrames: Boolean = false)
-      Seq(
-        Config("parquet"),
-        Config("parquet", useDataFrames = true),
-        Config("orc"),
-        Config("orc", useDataFrames = true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            sql("alter table t add column s map<boolean, string> default map(true, 'abc')")
-            checkAnswer(spark.table("t"), Row(false, null))
-            sql("insert into t(i) select true")
-            checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Map(true -> "abc"))))
+    import testImplicits._
+    // Positive tests: map types are supported as default values.
+    case class Config(dataSource: String, useDataFrames: Boolean = false)
+    Seq(
+      Config("parquet"),
+      Config("parquet", useDataFrames = true),
+      Config("orc"),
+      Config("orc", useDataFrames = true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-          withTable("t") {
-            sql(s"""
+          sql("alter table t add column s map<boolean, string> default map(true, 'abc')")
+          checkAnswer(spark.table("t"), Row(false, null))
+          sql("insert into t(i) select true")
+          checkAnswer(spark.table("t"), Seq(Row(false, null), Row(true, Map(true -> "abc"))))
+        }
+        withTable("t") {
+          sql(s"""
             create table t(
               i int,
               s struct<
@@ -525,61 +519,60 @@ class GlutenInsertSuite
                 array(
                   map(false, 'def', true, 'jkl'))))
               using ${config.dataSource}""")
-            sql("insert into t select 1, default")
-            sql("alter table t alter column s drop default")
-            if (config.useDataFrames) {
-              Seq((2, null)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select 2, default")
-            }
-            sql("""
+          sql("insert into t select 1, default")
+          sql("alter table t alter column s drop default")
+          if (config.useDataFrames) {
+            Seq((2, null)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select 2, default")
+          }
+          sql("""
             alter table t alter column s
             set default struct(
               array(
                 struct(3, 4)),
               array(
                 map(false, 'mno', true, 'pqr')))""")
-            sql("insert into t select 3, default")
-            sql("""
+          sql("insert into t select 3, default")
+          sql("""
             alter table t
             add column t array<
               map<boolean, string>>
             default array(
               map(true, 'xyz'))""")
-            sql("insert into t(i, s) select 4, default")
-            checkAnswer(
-              spark.table("t"),
-              Seq(
-                Row(1, Row(Seq(Row(1, 2)), Seq(Map(false -> "def", true -> "jkl"))), null),
-                Row(2, null, null),
-                Row(3, Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))), null),
-                Row(
-                  4,
-                  Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))),
-                  Seq(Map(true -> "xyz")))
-              )
+          sql("insert into t(i, s) select 4, default")
+          checkAnswer(
+            spark.table("t"),
+            Seq(
+              Row(1, Row(Seq(Row(1, 2)), Seq(Map(false -> "def", true -> "jkl"))), null),
+              Row(2, null, null),
+              Row(3, Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))), null),
+              Row(
+                4,
+                Row(Seq(Row(3, 4)), Seq(Map(false -> "mno", true -> "pqr"))),
+                Seq(Map(true -> "xyz")))
             )
+          )
+        }
+    }
+    // Negative tests: provided map element types must match their corresponding DEFAULT
+    // declarations, if applicable.
+    val incompatibleDefault =
+      "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
+        "table column `s` has a DEFAULT value"
+    Seq(Config("parquet"), Config("parquet", true)).foreach {
+      config =>
+        withTable("t") {
+          sql(s"create table t(i boolean) using ${config.dataSource}")
+          if (config.useDataFrames) {
+            Seq((false)).toDF.write.insertInto("t")
+          } else {
+            sql("insert into t select false")
           }
-      }
-      // Negative tests: provided map element types must match their corresponding DEFAULT
-      // declarations, if applicable.
-      val incompatibleDefault =
-        "Failed to execute ALTER TABLE ADD COLUMNS command because the destination " +
-          "table column `s` has a DEFAULT value"
-      Seq(Config("parquet"), Config("parquet", true)).foreach {
-        config =>
-          withTable("t") {
-            sql(s"create table t(i boolean) using ${config.dataSource}")
-            if (config.useDataFrames) {
-              Seq((false)).toDF.write.insertInto("t")
-            } else {
-              sql("insert into t select false")
-            }
-            assert(intercept[AnalysisException] {
-              sql("alter table t add column s map<boolean, string> default map(42, 56)")
-            }.getMessage.contains(incompatibleDefault))
-          }
-      }
+          assert(intercept[AnalysisException] {
+            sql("alter table t add column s map<boolean, string> default map(42, 56)")
+          }.getMessage.contains(incompatibleDefault))
+        }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr tunes `spark.gluten.sql.complexType.scan.fallback.enabled` to false for tests, so that we can make sure native scan can pass all tests for complex type.

This pr also narrows the usage of  `spark.gluten.sql.complexType.scan.fallback.enabled`, we do not need to specify it for each test.

## How was this patch tested?

Pass CI
