### PR TITLE
[GLUTEN-3582][CH] Using ParquetBlockInputFormat instead of VectorizedParquetBlockInputFormat for complex type

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseHiveTableSuite.scala
@@ -111,6 +111,7 @@ class GlutenClickHouseHiveTableSuite
         getClass.getResource("/").getPath + "tests-working-home/spark-warehouse")
       .set("spark.hive.exec.dynamic.partition.mode", "nonstrict")
       .set("spark.gluten.supported.hive.udfs", "my_add")
+      .set("spark.gluten.sql.columnar.backend.ch.runtime_config.use_local_format", "true")
       .setMaster("local[*]")
   }
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ParquetFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ParquetFormatFile.h
@@ -55,8 +55,10 @@ public:
 
     String getFileFormat() const override { return "Parquet"; }
 
+    static bool pageindex_reader_support(const DB::Block & header);
+
 private:
-    bool use_local_format;
+    bool use_pageindex_reader;
     std::mutex mutex;
     std::optional<size_t> total_rows;
 

--- a/cpp-ch/local-engine/tests/gtest_parquet_read.cpp
+++ b/cpp-ch/local-engine/tests/gtest_parquet_read.cpp
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#include <Storages/SubstraitSource/ParquetFormatFile.h>
+
+
 #include "config.h"
 
 #if USE_PARQUET
@@ -137,6 +140,32 @@ TEST(ParquetRead, ReadSchema)
 {
     readSchema("alltypes/alltypes_notnull.parquet");
     readSchema("alltypes/alltypes_null.parquet");
+}
+
+TEST(ParquetRead, VerifyPageindexReaderSupport)
+{
+    EXPECT_FALSE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("alltypes/alltypes_notnull.parquet")))));
+    EXPECT_FALSE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("alltypes/alltypes_null.parquet")))));
+
+
+    EXPECT_FALSE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("array.parquet")))));
+    EXPECT_TRUE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("date.parquet")))));
+    EXPECT_TRUE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("datetime64.parquet")))));
+    EXPECT_TRUE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("decimal.parquet")))));
+    EXPECT_TRUE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("iris.parquet")))));
+    EXPECT_FALSE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("map.parquet")))));
+    EXPECT_TRUE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("sample.parquet")))));
+    EXPECT_FALSE(local_engine::ParquetFormatFile::pageindex_reader_support(
+        toBlockRowType(local_engine::test::readParquetSchema(local_engine::test::data_file("struct.parquet")))));
 }
 
 TEST(ParquetRead, ReadDataNotNull)


### PR DESCRIPTION
## What changes were proposed in this pull request?

We introduce `VectorizedParquetBlockInputFormat` in https://github.com/apache/incubator-gluten/pull/4634, which onlu support primitive type, for complex type we fallback to `ParquetBlockInputFormat`

(Fixes: \#3582)

## How was this patch tested?

`GlutenClickHouseHiveTableSuite` includes test on complex type parquet,  setting `spark.gluten.sql.columnar.backend.ch.runtime_config.use_local_format`  to true
