### PR TITLE
[CORE] Rename CoalesceExecTransformer to ColumnarCoalesceExec

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -281,7 +281,7 @@ object OffloadOthers {
           applyScanTransformer(plan)
         case plan: CoalesceExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-          CoalesceExecTransformer(plan.numPartitions, plan.child)
+          ColumnarCoalesceExec(plan.numPartitions, plan.child)
         case plan: ProjectExec =>
           val columnarChild = plan.child
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/TransformHintRule.scala
@@ -487,8 +487,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           )
           transformer.doValidate().tagOnFallback(plan)
         case plan: CoalesceExec =>
-          val transformer = CoalesceExecTransformer(plan.numPartitions, plan.child)
-          transformer.doValidate().tagOnFallback(plan)
+          ColumnarCoalesceExec(plan.numPartitions, plan.child)
+            .doValidate()
+            .tagOnFallback(plan)
         case plan: GlobalLimitExec =>
           val (limit, offset) =
             SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr renames CoalesceExecTransformer to ColumnarCoalesceExec. 
- xxxTransformer is used for operator which support offload to native
- ColumnarXXX is used for operator which support columnar but not native

## How was this patch tested?

Pass CI
