### PR TITLE
[GLUTEN-5981][CH] Make the result be null when the queried field in `get_json_object` is `null`

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseFunctionSuite.scala
@@ -179,4 +179,15 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
         |""".stripMargin
     )(df => checkFallbackOperators(df, 0))
   }
+
+  test("GLUTEN-5981 null value from get_json_object") {
+    spark.sql("create table json_t1 (a string) using parquet")
+    spark.sql("insert into json_t1 values ('{\"a\":null}')")
+    runQueryAndCompare(
+      """
+        |SELECT get_json_object(a, '$.a') is null from json_t1
+        |""".stripMargin
+    )(df => checkFallbackOperators(df, 0))
+    spark.sql("drop table json_t1")
+  }
 }

--- a/cpp-ch/local-engine/Functions/SparkFunctionGetJsonObject.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionGetJsonObject.h
@@ -113,6 +113,8 @@ public:
         JSONStringSerializer serializer(*col_str);
         if (elements.size() == 1) [[likely]]
         {
+            if (elements[0].isNull())
+                return false;
             nullable_col_str.getNullMapData().push_back(0);
             if (elements[0].isString())
             {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #5981

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

