### PR TITLE
[VL] Provide options to combine small batches before sending to shuffle

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -271,13 +271,10 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
     }
   }
 
-  override def genColumnarShuffleExchange(
-      shuffle: ShuffleExchangeExec,
-      child: SparkPlan): SparkPlan = {
+  override def genColumnarShuffleExchange(shuffle: ShuffleExchangeExec): SparkPlan = {
+    val child = shuffle.child
     if (
-      BackendsApiManager.getSettings.supportShuffleWithProject(
-        shuffle.outputPartitioning,
-        shuffle.child)
+      BackendsApiManager.getSettings.supportShuffleWithProject(shuffle.outputPartitioning, child)
     ) {
       val (projectColumnNumber, newPartitioning, newChild) =
         addProjectionForShuffleExchange(shuffle)

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppender.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppender.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils;
+
+import org.apache.gluten.exec.Runtime;
+import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.memory.nmm.NativeMemoryManager;
+import org.apache.gluten.memory.nmm.NativeMemoryManagers;
+import org.apache.gluten.vectorized.ColumnarBatchInIterator;
+import org.apache.gluten.vectorized.ColumnarBatchOutIterator;
+
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import java.util.Iterator;
+
+public final class VeloxBatchAppender {
+  public static ColumnarBatchOutIterator create(int minOutputBatchSize, Iterator<ColumnarBatch> in) {
+    final Runtime runtime = Runtimes.contextInstance();
+    final NativeMemoryManager nmm = NativeMemoryManagers.contextInstance("VeloxBatchAppender");
+    long outHandle =
+        VeloxBatchAppenderJniWrapper.forRuntime(runtime)
+            .create(
+                nmm.getNativeInstanceHandle(), minOutputBatchSize, new ColumnarBatchInIterator(in));
+    return new ColumnarBatchOutIterator(runtime, outHandle, nmm);
+  }
+}

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppender.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppender.java
@@ -28,7 +28,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import java.util.Iterator;
 
 public final class VeloxBatchAppender {
-  public static ColumnarBatchOutIterator create(int minOutputBatchSize, Iterator<ColumnarBatch> in) {
+  public static ColumnarBatchOutIterator create(
+      int minOutputBatchSize, Iterator<ColumnarBatch> in) {
     final Runtime runtime = Runtimes.contextInstance();
     final NativeMemoryManager nmm = NativeMemoryManagers.contextInstance("VeloxBatchAppender");
     long outHandle =

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppenderJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppenderJniWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils;
+
+import org.apache.gluten.exec.Runtime;
+import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.vectorized.ColumnarBatchInIterator;
+
+public class VeloxBatchAppenderJniWrapper implements RuntimeAware {
+  private final Runtime runtime;
+
+  private VeloxBatchAppenderJniWrapper(Runtime runtime) {
+    this.runtime = runtime;
+  }
+
+  public static VeloxBatchAppenderJniWrapper forRuntime(Runtime runtime) {
+    return new VeloxBatchAppenderJniWrapper(runtime);
+  }
+
+  @Override
+  public long handle() {
+    return runtime.getHandle();
+  }
+
+  public native long create(
+      long memoryManagerHandle, int minOutputBatchSize, ColumnarBatchInIterator itr);
+}

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -203,7 +203,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
         resIter.close()
       }
       .recyclePayload(batch => batch.close())
-      .addToPipelineTime(pipelineTime)
+      .collectLifeMillis(millis => pipelineTime += millis)
       .asInterruptible(context)
       .create()
   }
@@ -246,7 +246,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
         nativeResultIterator.close()
       }
       .recyclePayload(batch => batch.close())
-      .addToPipelineTime(pipelineTime)
+      .collectLifeMillis(millis => pipelineTime += millis)
       .create()
   }
   // scalastyle:on argcount

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxAppendBatchesExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxAppendBatchesExec.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.utils.{Iterators, VeloxBatchAppender}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.collection.JavaConverters._
+
+/**
+ * An operator to coalesce input batches by appending the later batches to the one that comes
+ * earlier.
+ */
+case class VeloxAppendBatchesExec(override val child: SparkPlan, minOutputBatchSize: Int)
+  extends GlutenPlan
+  with UnaryExecNode {
+
+  override lazy val metrics: Map[String, SQLMetric] = Map(
+    "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
+    "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"),
+    "appendTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to append batches")
+  )
+
+  override def supportsColumnar: Boolean = true
+  override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val numInputRows = longMetric("numInputRows")
+    val numInputBatches = longMetric("numInputBatches")
+    val numOutputRows = longMetric("numOutputRows")
+    val numOutputBatches = longMetric("numOutputBatches")
+    val appendTime = longMetric("appendTime")
+
+    child.executeColumnar().mapPartitions {
+      in =>
+        // Append millis = Out millis - In millis.
+        val appendMillis = new AtomicLong(0L)
+
+        val appender = VeloxBatchAppender.create(
+          minOutputBatchSize,
+          Iterators
+            .wrap(in)
+            .collectReadMillis(inMillis => appendMillis.getAndAdd(-inMillis))
+            .create()
+            .map {
+              inBatch =>
+                numInputRows += inBatch.numRows()
+                numInputBatches += 1
+                inBatch
+            }
+            .asJava
+        )
+
+        val out = Iterators
+          .wrap(appender.asScala)
+          .collectReadMillis(outMillis => appendMillis.getAndAdd(outMillis))
+          .recyclePayload(_.close())
+          .recycleIterator {
+            appender.close()
+            appendTime += appendMillis.get()
+          }
+          .create()
+          .map {
+            outBatch =>
+              numOutputRows += outBatch.numRows()
+              numOutputBatches += 1
+              outBatch
+          }
+
+        out
+    }
+  }
+
+  override def output: Seq[Attribute] = child.output
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+}

--- a/cpp/core/jni/JniCommon.cc
+++ b/cpp/core/jni/JniCommon.cc
@@ -65,3 +65,61 @@ gluten::Runtime* gluten::getRuntime(JNIEnv* env, jobject runtimeAware) {
   GLUTEN_CHECK(ctx != nullptr, "FATAL: resource instance should not be null.");
   return ctx;
 }
+
+std::unique_ptr<gluten::JniColumnarBatchIterator> gluten::makeJniColumnarBatchIterator(
+    JNIEnv* env,
+    jobject jColumnarBatchItr,
+    gluten::Runtime* runtime,
+    std::shared_ptr<ArrowWriter> writer) {
+  return std::make_unique<JniColumnarBatchIterator>(env, jColumnarBatchItr, runtime, writer);
+}
+
+gluten::JniColumnarBatchIterator::JniColumnarBatchIterator(
+    JNIEnv* env,
+    jobject jColumnarBatchItr,
+    gluten::Runtime* runtime,
+    std::shared_ptr<ArrowWriter> writer)
+    : runtime_(runtime), writer_(writer) {
+  // IMPORTANT: DO NOT USE LOCAL REF IN DIFFERENT THREAD
+  if (env->GetJavaVM(&vm_) != JNI_OK) {
+    std::string errorMessage = "Unable to get JavaVM instance";
+    throw gluten::GlutenException(errorMessage);
+  }
+  serializedColumnarBatchIteratorClass_ =
+      createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ColumnarBatchInIterator;");
+  serializedColumnarBatchIteratorHasNext_ =
+      getMethodIdOrError(env, serializedColumnarBatchIteratorClass_, "hasNext", "()Z");
+  serializedColumnarBatchIteratorNext_ = getMethodIdOrError(env, serializedColumnarBatchIteratorClass_, "next", "()J");
+  jColumnarBatchItr_ = env->NewGlobalRef(jColumnarBatchItr);
+}
+
+gluten::JniColumnarBatchIterator::~JniColumnarBatchIterator() {
+  JNIEnv* env;
+  attachCurrentThreadAsDaemonOrThrow(vm_, &env);
+  env->DeleteGlobalRef(jColumnarBatchItr_);
+  env->DeleteGlobalRef(serializedColumnarBatchIteratorClass_);
+  vm_->DetachCurrentThread();
+}
+
+std::shared_ptr<gluten::ColumnarBatch> gluten::JniColumnarBatchIterator::next() {
+  JNIEnv* env;
+  attachCurrentThreadAsDaemonOrThrow(vm_, &env);
+  if (!env->CallBooleanMethod(jColumnarBatchItr_, serializedColumnarBatchIteratorHasNext_)) {
+    checkException(env);
+    return nullptr; // stream ended
+  }
+
+  checkException(env);
+  jlong handle = env->CallLongMethod(jColumnarBatchItr_, serializedColumnarBatchIteratorNext_);
+  checkException(env);
+  auto batch = runtime_->objectStore()->retrieve<ColumnarBatch>(handle);
+  if (writer_ != nullptr) {
+    // save snapshot of the batch to file
+    std::shared_ptr<ArrowSchema> schema = batch->exportArrowSchema();
+    std::shared_ptr<ArrowArray> array = batch->exportArrowArray();
+    auto rb = gluten::arrowGetOrThrow(arrow::ImportRecordBatch(array.get(), schema.get()));
+    GLUTEN_THROW_NOT_OK(writer_->initWriter(*(rb->schema().get())));
+    GLUTEN_THROW_NOT_OK(writer_->writeInBatches(rb));
+  }
+  return batch;
+}

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -327,6 +327,7 @@ set(VELOX_SRCS
     utils/VeloxArrowUtils.cc
     utils/ConfigExtractor.cc
     utils/Common.cc
+    utils/VeloxBatchAppender.cc
     )
 
 if (ENABLE_HDFS)

--- a/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.h
@@ -303,15 +303,6 @@ class VeloxHashBasedShuffleWriter : public VeloxShuffleWriter {
 
   arrow::Status partitioningAndDoSplit(facebook::velox::RowVectorPtr rv, int64_t memLimit);
 
-  void initAccumulateDataset(facebook::velox::RowVectorPtr& rv) {
-    if (accumulateDataset_) {
-      return;
-    }
-    std::vector<facebook::velox::VectorPtr> children(rv->children().size(), nullptr);
-    accumulateDataset_ =
-        std::make_shared<facebook::velox::RowVector>(veloxPool_.get(), rv->type(), nullptr, 0, std::move(children));
-  }
-
   BinaryArrayResizeState binaryArrayResizeState_{};
 
   bool hasComplexType_ = false;

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -124,10 +124,6 @@ class VeloxShuffleWriter : public ShuffleWriter {
 
   int32_t maxBatchSize_{0};
 
-  uint32_t accumulateRows_{0};
-
-  facebook::velox::RowVectorPtr accumulateDataset_;
-
   enum EvictState { kEvictable, kUnevictable };
 
   // stat

--- a/cpp/velox/utils/VeloxBatchAppender.cc
+++ b/cpp/velox/utils/VeloxBatchAppender.cc
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VeloxBatchAppender.h"
+
+namespace gluten {
+
+gluten::VeloxBatchAppender::VeloxBatchAppender(
+    facebook::velox::memory::MemoryPool* pool,
+    int32_t minOutputBatchSize,
+    std::unique_ptr<ColumnarBatchIterator> in)
+    : pool_(pool), minOutputBatchSize_(minOutputBatchSize), in_(std::move(in)) {}
+
+std::shared_ptr<ColumnarBatch> VeloxBatchAppender::next() {
+  auto cb = in_->next();
+  if (cb == nullptr) {
+    // Input iterator was drained.
+    return nullptr;
+  }
+  if (cb->numRows() >= minOutputBatchSize_) {
+    // Fast flush path.
+    return cb;
+  }
+
+  auto vb = VeloxColumnarBatch::from(pool_, cb);
+  auto rv = vb->getRowVector();
+  auto buffer = facebook::velox::RowVector::createEmpty(rv->type(), pool_);
+  buffer->append(rv.get());
+
+  for (auto nextCb = in_->next(); nextCb != nullptr; nextCb = in_->next()) {
+    auto nextVb = VeloxColumnarBatch::from(pool_, nextCb);
+    auto nextRv = nextVb->getRowVector();
+    buffer->append(nextRv.get());
+    if (buffer->size() >= minOutputBatchSize_) {
+      // Buffer is full.
+      break;
+    }
+  }
+  return std::make_shared<VeloxColumnarBatch>(buffer);
+}
+
+int64_t VeloxBatchAppender::spillFixedSize(int64_t size) {
+  return in_->spillFixedSize(size);
+}
+} // namespace gluten

--- a/cpp/velox/utils/VeloxBatchAppender.h
+++ b/cpp/velox/utils/VeloxBatchAppender.h
@@ -34,7 +34,6 @@ class VeloxBatchAppender : public ColumnarBatchIterator {
   int64_t spillFixedSize(int64_t size) override;
 
  private:
-
   facebook::velox::memory::MemoryPool* pool_;
   const int32_t minOutputBatchSize_;
   std::unique_ptr<ColumnarBatchIterator> in_;

--- a/cpp/velox/utils/VeloxBatchAppender.h
+++ b/cpp/velox/utils/VeloxBatchAppender.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "memory/ColumnarBatchIterator.h"
+#include "memory/VeloxColumnarBatch.h"
+#include "utils/exception.h"
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace gluten {
+class VeloxBatchAppender : public ColumnarBatchIterator {
+ public:
+  VeloxBatchAppender(
+      facebook::velox::memory::MemoryPool* pool,
+      int32_t minOutputBatchSize,
+      std::unique_ptr<ColumnarBatchIterator> in);
+
+  std::shared_ptr<ColumnarBatch> next() override;
+
+  int64_t spillFixedSize(int64_t size) override;
+
+ private:
+
+  facebook::velox::memory::MemoryPool* pool_;
+  const int32_t minOutputBatchSize_;
+  std::unique_ptr<ColumnarBatchIterator> in_;
+};
+} // namespace gluten

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -101,7 +101,7 @@ trait SparkPlanExecApi {
       aggregateExpressions: Seq[AggregateExpression],
       aggregateAttributes: Seq[Attribute]): HashAggregateExecPullOutBaseHelper
 
-  def genColumnarShuffleExchange(shuffle: ShuffleExchangeExec, newChild: SparkPlan): SparkPlan
+  def genColumnarShuffleExchange(shuffle: ShuffleExchangeExec): SparkPlan
 
   /** Generate ShuffledHashJoinExecTransformer. */
   def genShuffledHashJoinExecTransformer(

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -31,8 +31,7 @@ public class ColumnarBatchOutIterator extends GeneralOutIterator implements Runt
   private final long iterHandle;
   private final NativeMemoryManager nmm;
 
-  public ColumnarBatchOutIterator(Runtime runtime, long iterHandle, NativeMemoryManager nmm)
-      throws IOException {
+  public ColumnarBatchOutIterator(Runtime runtime, long iterHandle, NativeMemoryManager nmm) {
     super();
     this.runtime = runtime;
     this.iterHandle = iterHandle;

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -187,6 +187,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def columnarShuffleCompressionThreshold: Int =
     conf.getConf(COLUMNAR_SHUFFLE_COMPRESSION_THRESHOLD)
 
+  // FIXME: Not clear: MIN or MAX ?
   def maxBatchSize: Int = conf.getConf(COLUMNAR_MAX_BATCH_SIZE)
 
   def shuffleWriterBufferSize: Int = conf
@@ -294,6 +295,14 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def veloxBloomFilterNumBits: Long = conf.getConf(COLUMNAR_VELOX_BLOOM_FILTER_NUM_BITS)
 
   def veloxBloomFilterMaxNumBits: Long = conf.getConf(COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS)
+
+  def veloxCoalesceBatchesBeforeShuffle: Boolean =
+    conf.getConf(COLUMNAR_VELOX_COALESCE_BATCHES_BEFORE_SHUFFLE)
+
+  def veloxMinBatchSizeForShuffle: Int =
+    conf
+      .getConf(COLUMNAR_VELOX_MIN_BATCH_SIZE_FOR_SHUFFLE)
+      .getOrElse(conf.getConf(COLUMNAR_MAX_BATCH_SIZE))
 
   def chColumnarShufflePreferSpill: Boolean = conf.getConf(COLUMNAR_CH_SHUFFLE_PREFER_SPILL_ENABLED)
 
@@ -1394,6 +1403,23 @@ object GlutenConfig {
       .intConf
       .checkValue(_ > 0, "must be a positive number")
       .createWithDefault(10000)
+
+  val COLUMNAR_VELOX_COALESCE_BATCHES_BEFORE_SHUFFLE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.coalesceBatchesBeforeShuffle")
+      .internal()
+      .doc(s"If true, combine small columnar batches together before sending to shuffle. " +
+        s"The default minimum output batch size is equal to $GLUTEN_MAX_BATCH_SIZE_KEY")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_VELOX_MIN_BATCH_SIZE_FOR_SHUFFLE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.minBatchSizeForShuffle")
+      .internal()
+      .doc(s"The minimum batch size for shuffle. If the batch size is smaller than this value, " +
+        s"it will be combined with other batches before sending to shuffle. Only functions when " +
+        s"${COLUMNAR_VELOX_COALESCE_BATCHES_BEFORE_SHUFFLE.key} is set to true.")
+      .intConf
+      .createOptional
 
   val COLUMNAR_CH_SHUFFLE_PREFER_SPILL_ENABLED =
     buildConf("spark.gluten.sql.columnar.backend.ch.shuffle.preferSpill")


### PR DESCRIPTION
It's observed that Velox hash-based shuffle is slowed down by small input batches.

The patch:

1. Adds two options:
   - `spark.gluten.sql.columnar.backend.velox.coalesceBatchesBeforeShuffle`
      (Default: false) Set to true to combine small batches with minimal batch size determined by `spark.gluten.sql.columnar.maxBatchSize`. (Note the misnaming of `maxBatchSize` in Gluten, it might tend to be `minBatchSize` or just `batchSize`)
   - `spark.gluten.sql.columnar.backend.velox.minBatchSizeForShuffle`
      (Optional) Set to override the minimal batch size used by `coalesceBatchesBeforeShuffle`.
2. Does essential code refactors and cleanups. 

### Comparisons

(spark.gluten.sql.columnar.backend.velox.coalesceBatchesBeforeShuffle=false/true)

Q31 total time, before and after (SF1000 partitioned table, scan partitions 112, shuffle partitions 112):

![image](https://github.com/apache/incubator-gluten/assets/11284395/c7224fdb-bc7d-49ef-85b2-09c14db50014)

Closer look at exchange, before and after:

![image](https://github.com/apache/incubator-gluten/assets/11284395/27d777cf-0b9f-4681-8f47-5cb07e5f2f52)

![image](https://github.com/apache/incubator-gluten/assets/11284395/d5c91ea9-d3be-4fd6-9c63-61266f022a7d)
