### PR TITLE
[VL] RAS: Validate against all offloaded plan nodes to decide whether to do this offload

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
@@ -105,13 +105,13 @@ object RasOffload {
           validator.validate(from) match {
             case Validator.Passed =>
               val offloaded = base.offload(from)
-              offloaded match {
-                case t: GlutenPlan if !t.doValidate().isValid =>
-                  // 4. If native validation fails on the offloaded node, return the
-                  // original one.
-                  from
-                case other =>
-                  other
+              val offloadedNodes = offloaded.collect[GlutenPlan] { case t: GlutenPlan => t }
+              if (offloadedNodes.exists(!_.doValidate().isValid)) {
+                // 4. If native validation fails on the offloaded node, return the
+                // original one.
+                from
+              } else {
+                offloaded
               }
             case Validator.Failed(reason) =>
               from


### PR DESCRIPTION
This is a minor fix for RAS extracted from PR https://github.com/apache/incubator-gluten/pull/5927.

E.g., if a shuffle exchange is going to be offloaded into velox project + velox shuffle exchange, the project node will be validated by RAS no matter the offload rule did it or not, after applying this patch. This could guard against any cases that developer didn't do native validations in the offload rule.
