### PR TITLE
[VL] Fix load udf library for spark local mode

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -47,15 +47,13 @@ class VeloxListenerApi extends ListenerApi {
         StaticSQLConf.SPARK_CACHE_SERIALIZER.key,
         "org.apache.spark.sql.execution.ColumnarCachedBatchSerializer")
     }
-    UDFResolver.resolveUdfConf(conf, isDriver = true)
-    initialize(conf)
+    initialize(conf, isDriver = true)
   }
 
   override def onDriverShutdown(): Unit = shutdown()
 
   override def onExecutorStart(pc: PluginContext): Unit = {
-    UDFResolver.resolveUdfConf(pc.conf(), isDriver = false)
-    initialize(pc.conf())
+    initialize(pc.conf(), isDriver = false)
   }
 
   override def onExecutorShutdown(): Unit = shutdown()
@@ -158,8 +156,9 @@ class VeloxListenerApi extends ListenerApi {
       .commit()
   }
 
-  private def initialize(conf: SparkConf): Unit = {
+  private def initialize(conf: SparkConf, isDriver: Boolean): Unit = {
     SparkDirectoryUtil.init(conf)
+    UDFResolver.resolveUdfConf(conf, isDriver = isDriver)
     val debugJni = conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_MODE, defaultValue = false) &&
       conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE, defaultValue = false)
     if (debugJni) {

--- a/cpp/velox/udf/Udaf.h
+++ b/cpp/velox/udf/Udaf.h
@@ -23,7 +23,7 @@ struct UdafEntry {
   const char* name;
   const char* dataType;
 
-  size_t numArgs;
+  int numArgs;
   const char** argTypes;
 
   const char* intermediateType{nullptr};

--- a/cpp/velox/udf/Udf.h
+++ b/cpp/velox/udf/Udf.h
@@ -23,7 +23,7 @@ struct UdfEntry {
   const char* name;
   const char* dataType;
 
-  size_t numArgs;
+  int numArgs;
   const char** argTypes;
 
   bool variableArity{false};


### PR DESCRIPTION
Fixes:

```
24/06/12 11:15:14 ERROR SparkContext: Error initializing SparkContext.
java.lang.AssertionError: assertion failed: Default instance of SparkDirectoryUtil was not set yet
        at scala.Predef$.assert(Predef.scala:223)
        at org.apache.spark.util.SparkDirectoryUtil$.get(SparkDirectoryUtil.scala:90)
        at org.apache.spark.util.SparkDirectoryUtil.get(SparkDirectoryUtil.scala)
        at org.apache.gluten.vectorized.JniWorkspace.createDefault(JniWorkspace.java:68)
        at org.apache.gluten.vectorized.JniWorkspace.getDefault(JniWorkspace.java:123)
        at org.apache.spark.sql.expression.UDFResolver$.$anonfun$getAllLibraries$1(UDFResolver.scala:299)
        at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
        at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
        at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
        at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
        at scala.collection.TraversableLike.map(TraversableLike.scala:286)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
        at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:198)
        at org.apache.spark.sql.expression.UDFResolver$.getAllLibraries(UDFResolver.scala:279)
        at org.apache.spark.sql.expression.UDFResolver$.resolveUdfConf(UDFResolver.scala:235)
        at org.apache.gluten.backendsapi.velox.VeloxListenerApi.onDriverStart(VeloxListenerApi.scala:50)
        at org.apache.gluten.GlutenDriverPlugin.init(GlutenPlugin.scala:75)
        at org.apache.spark.internal.plugin.DriverPluginContainer.$anonfun$driverPlugins$1(PluginContainer.scala:53)
        at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:293)
        at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
        at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
        at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
        at scala.collection.TraversableLike.flatMap(TraversableLike.scala:293)
        at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:290)
        at scala.collection.AbstractTraversable.flatMap(Traversable.scala:108)
        at org.apache.spark.internal.plugin.DriverPluginContainer.<init>(PluginContainer.scala:46)
        at org.apache.spark.internal.plugin.PluginContainer$.apply(PluginContainer.scala:210)
        at org.apache.spark.internal.plugin.PluginContainer$.apply(PluginContainer.scala:193)
        at org.apache.spark.SparkContext.<init>(SparkContext.scala:579)
        at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2888)
        at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:1099)
        at scala.Option.getOrElse(Option.scala:189)
        at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:1093)
        at org.apache.spark.sql.hive.thriftserver.SparkSQLEnv$.init(SparkSQLEnv.scala:64)
        at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.<init>(SparkSQLCLIDriver.scala:441)
        at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver$.main(SparkSQLCLIDriver.scala:177)
        at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.main(SparkSQLCLIDriver.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
        at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
        at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
        at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
        at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
        at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```