### PR TITLE
[VL] Change VLOG to DLOG in shuffle to fix performance issue in corner cases

### DIFF
--- a/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.cc
@@ -858,8 +858,8 @@ uint32_t VeloxHashBasedShuffleWriter::calculatePartitionBufferSize(
       memLimit > 0 && bytesPerRow > 0 ? memLimit / bytesPerRow / numPartitions_ >> 2 : options_.bufferSize;
   preAllocRowCnt = std::min(preAllocRowCnt, (uint64_t)options_.bufferSize);
 
-  VLOG(9) << "Calculated partition buffer size -  memLimit: " << memLimit << ", bytesPerRow: " << bytesPerRow
-          << ", preAllocRowCnt: " << preAllocRowCnt << std::endl;
+  DLOG(INFO) << "Calculated partition buffer size -  memLimit: " << memLimit << ", bytesPerRow: " << bytesPerRow
+             << ", preAllocRowCnt: " << preAllocRowCnt << std::endl;
 
   VS_PRINTLF(preAllocRowCnt);
 
@@ -1400,7 +1400,7 @@ arrow::Result<uint32_t> VeloxHashBasedShuffleWriter::partitionBufferSizeAfterShr
 arrow::Status VeloxHashBasedShuffleWriter::preAllocPartitionBuffers(uint32_t preAllocBufferSize) {
   for (auto& pid : partitionUsed_) {
     auto newSize = std::max(preAllocBufferSize, partition2RowCount_[pid]);
-    VLOG_IF(9, partitionBufferSize_[pid] != newSize)
+    DLOG_IF(INFO, partitionBufferSize_[pid] != newSize)
         << "Actual partition buffer size - current: " << partitionBufferSize_[pid] << ", newSize: " << newSize
         << std::endl;
     // Make sure the size to be allocated is larger than the size to be filled.


### PR DESCRIPTION
Even if FLAGS_v is set to a small value, the VLOG with large verbosity is still initialized and taking lots of time.
![image](https://github.com/apache/incubator-gluten/assets/52736607/f43b1881-2e8a-4e04-b966-ce6162b33f36)


After:
![image](https://github.com/apache/incubator-gluten/assets/52736607/762ed48d-f18c-4032-85cc-3fee2dccbb67)
