### PR TITLE
[CH] add throttler to GlutenHDFSDisk

### DIFF
--- a/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskHDFS.cpp
+++ b/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskHDFS.cpp
@@ -17,6 +17,8 @@
 
 #include "GlutenDiskHDFS.h"
 #include <ranges>
+
+#include <Common/Throttler.h>
 #include <Parser/SerializedPlanParser.h>
 #if USE_HDFS
 
@@ -70,6 +72,15 @@ DiskObjectStoragePtr GlutenDiskHDFS::createDiskObjectStorage()
         config_prefix);
 }
 
-
+std::unique_ptr<DB::WriteBufferFromFileBase> GlutenDiskHDFS::writeFile(
+    const String & path,
+    size_t buf_size,
+    DB::WriteMode mode,
+    const DB::WriteSettings & settings)
+{
+    if (throttler)
+        throttler->add(1);
+    return DiskObjectStorage::writeFile(path, buf_size, mode, settings);
+}
 }
 #endif


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a write speed limit to HDFS to avoid TCP port exhaustion due to too many small files and too fast write rate.

## How was this patch tested?

unit tests， manual test


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

