### PR TITLE
[VL] Update supportColumnarShuffleExec for Velox to consider enableColumnarShuffle config

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -361,9 +361,10 @@ object VeloxBackendSettings extends BackendSettingsApi {
   }
 
   override def supportColumnarShuffleExec(): Boolean = {
-    GlutenConfig.getConf.isUseColumnarShuffleManager ||
-    GlutenConfig.getConf.isUseCelebornShuffleManager ||
-    GlutenConfig.getConf.isUseUniffleShuffleManager
+    GlutenConfig.getConf.enableColumnarShuffle && (
+      GlutenConfig.getConf.isUseColumnarShuffleManager ||
+      GlutenConfig.getConf.isUseCelebornShuffleManager ||
+      GlutenConfig.getConf.isUseUniffleShuffleManager)
   }
 
   override def enableJoinKeysRewrite(): Boolean = false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update supportColumnarShuffleExec for Velox to consider enableColumnarShuffle config. Currently if `spark.gluten.sql.columnar.shuffle` is set to false, fallback does not happen.

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

