### PR TITLE
[VL] Daily Update Velox Version (2024_06_13)

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -50,7 +50,7 @@ class VeloxShuffleWriter : public ShuffleWriter {
  public:
   facebook::velox::RowVectorPtr getStrippedRowVector(const facebook::velox::RowVector& rv) {
     // get new row type
-    auto rowType = rv.type()->asRow();
+    auto& rowType = rv.type()->asRow();
     auto typeChildren = rowType.children();
     typeChildren.erase(typeChildren.begin());
     auto newRowType = facebook::velox::ROW(std::move(typeChildren));

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_06_12
+VELOX_BRANCH=2024_06_13
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
Upstream Velox's New Commits:

```
7646e70a3 by Zac Wen, Prevent cache write from exceeding IOV_MAX (10142)
9ab5e27ac by Jimmy Lu, Lazy materialization of RowType::parameters (10144)
f9f6d8228 by Deepak Majeti, Add support for Centos9 Stream + GCC12 (9903)
c5814c96a by Deepak Majeti, Keep DuckDB re2 headers private (10161)
9cc123f49 by Zac Wen, Specify data type in test for tsan (10153)
73fb02e27 by Jialiang Tan, Fix writer OOM by reducing initial flush buffer reservation (10147)
4a8591348 by xiaoxmeng, Free memory from stale cache entry early (10143)
b2bab6fd7 by xiaoxmeng, Add task deletion wait support (10124)
```