### PR TITLE
[Core] Remove getPartitionFilters from scanTransformer

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -102,8 +102,6 @@ abstract class FileSourceScanExecTransformerBase(
 
   override def getMetadataColumns(): Seq[AttributeReference] = metadataColumns
 
-  def getPartitionFilters(): Seq[Expression] = partitionFilters
-
   override def outputAttributes(): Seq[Attribute] = output
 
   override def getPartitions: Seq[InputPartition] = {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -188,10 +188,6 @@ object HiveTableScanExecTransformer {
     plan.isInstanceOf[HiveTableScanExec]
   }
 
-  def getPartitionFilters(plan: SparkPlan): Seq[Expression] = {
-    plan.asInstanceOf[HiveTableScanExec].partitionPruningPred
-  }
-
   def copyWith(plan: SparkPlan, newPartitionFilters: Seq[Expression]): SparkPlan = {
     val hiveTableScanExec = plan.asInstanceOf[HiveTableScanExec]
     hiveTableScanExec.copy(partitionPruningPred = newPartitionFilters)(sparkSession =


### PR DESCRIPTION
## What changes were proposed in this pull request?

getPartitionFilters API not use any more

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

