### PR TITLE
[VL] Fix undefined symbol with qat

### DIFF
--- a/cpp/CMake/BuildQATzip.cmake
+++ b/cpp/CMake/BuildQATzip.cmake
@@ -76,12 +76,16 @@ macro(build_qatzip)
       "${OSAL_LIBRARY}"
       Threads::Threads)
 
+  # Fix libudev.so not get linked.
+  set(QATZIP_LINK_OPTIONS "-Wl,--no-as-needed")
+
   add_library(qatzip::qatzip STATIC IMPORTED)
   set_target_properties(
     qatzip::qatzip
     PROPERTIES IMPORTED_LOCATION "${QATZIP_STATIC_LIB_TARGETS}"
                INTERFACE_INCLUDE_DIRECTORIES "${QATZIP_INCLUDE_DIR}"
-               INTERFACE_LINK_LIBRARIES "${QATZIP_LINK_LIBRARIES}")
+               INTERFACE_LINK_LIBRARIES "${QATZIP_LINK_LIBRARIES}"
+               INTERFACE_LINK_OPTIONS "${QATZIP_LINK_OPTIONS}")
 
   add_dependencies(qatzip::qatzip qatzip_ep)
 endmacro()


### PR DESCRIPTION
Below linking error is found with latest QAT driver. Use "-Wl,--no-as-needed" to force link libudev.so
![image](https://github.com/apache/incubator-gluten/assets/52736607/7519dbf8-c732-4733-89d4-e1d9d1e5965c)
