### PR TITLE
[VL] Minor refactors on ColumnarRuleApplier

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/ColumnarRuleApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/ColumnarRuleApplier.scala
@@ -16,8 +16,44 @@
  */
 package org.apache.gluten.extension.columnar
 
+import org.apache.gluten.GlutenConfig
+import org.apache.gluten.metrics.GlutenTimeMetric
+import org.apache.gluten.utils.LogLevelUtil
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.execution.SparkPlan
 
 trait ColumnarRuleApplier {
   def apply(plan: SparkPlan, outputsColumnar: Boolean): SparkPlan
+}
+
+object ColumnarRuleApplier {
+  class Executor(phase: String, rules: Seq[Rule[SparkPlan]]) extends RuleExecutor[SparkPlan] {
+    private val batch: Batch =
+      Batch(s"Columnar (Phase [$phase])", Once, rules.map(r => new LoggedRule(r)): _*)
+
+    // TODO Remove this exclusion then pass Spark's idempotence check.
+    override protected val excludedOnceBatches: Set[String] = Set(batch.name)
+
+    override protected def batches: Seq[Batch] = List(batch)
+  }
+
+  private class LoggedRule(delegate: Rule[SparkPlan])
+    extends Rule[SparkPlan]
+    with Logging
+    with LogLevelUtil {
+    // Columnar plan change logging added since https://github.com/apache/incubator-gluten/pull/456.
+    private val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
+    override val ruleName: String = delegate.ruleName
+
+    override def apply(plan: SparkPlan): SparkPlan = GlutenTimeMetric.withMillisTime {
+      logOnLevel(
+        transformPlanLogLevel,
+        s"Preparing to apply rule $ruleName on plan:\n${plan.toString}")
+      val out = delegate.apply(plan)
+      logOnLevel(transformPlanLogLevel, s"Plan after applied rule $ruleName:\n${plan.toString}")
+      out
+    }(t => logOnLevel(transformPlanLogLevel, s"Applying rule $ruleName took $t ms."))
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedApplier.scala
@@ -22,13 +22,12 @@ import org.apache.gluten.extension.columnar._
 import org.apache.gluten.extension.columnar.MiscColumnarRules.{RemoveGlutenTableCacheColumnarToRow, RemoveTopmostColumnarToRow, RewriteSubqueryBroadcast}
 import org.apache.gluten.extension.columnar.transition.{InsertTransitions, RemoveTransitions}
 import org.apache.gluten.extension.columnar.util.AdaptiveContext
-import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.utils.{LogLevelUtil, PhysicalPlanSelector}
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.rules.{PlanChangeLogger, Rule}
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarCollapseTransformStages, GlutenFallbackReporter, SparkPlan}
 import org.apache.spark.util.SparkRuleUtil
 
@@ -47,41 +46,25 @@ class EnumeratedApplier(session: SparkSession)
   with LogLevelUtil {
   // An empirical value.
   private val aqeStackTraceIndex = 16
-
-  private lazy val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
-  private lazy val planChangeLogger = new PlanChangeLogger[SparkPlan]()
-
   private val adaptiveContext = AdaptiveContext(session, aqeStackTraceIndex)
 
   override def apply(plan: SparkPlan, outputsColumnar: Boolean): SparkPlan =
     PhysicalPlanSelector.maybe(session, plan) {
-      val transformed = transformPlan(transformRules(outputsColumnar), plan, "transform")
+      val transformed = transformPlan("transform", transformRules(outputsColumnar), plan)
       val postPlan = maybeAqe {
-        transformPlan(postRules(), transformed, "post")
+        transformPlan("post", postRules(), transformed)
       }
-      val finalPlan = transformPlan(finalRules(), postPlan, "final")
+      val finalPlan = transformPlan("final", finalRules(), postPlan)
       finalPlan
     }
 
   private def transformPlan(
-      getRules: List[SparkSession => Rule[SparkPlan]],
-      plan: SparkPlan,
-      step: String) = GlutenTimeMetric.withMillisTime {
-    logOnLevel(
-      transformPlanLogLevel,
-      s"${step}ColumnarTransitions preOverriden plan:\n${plan.toString}")
-    val overridden = getRules.foldLeft(plan) {
-      (p, getRule) =>
-        val rule = getRule(session)
-        val newPlan = rule(p)
-        planChangeLogger.logRule(rule.ruleName, p, newPlan)
-        newPlan
-    }
-    logOnLevel(
-      transformPlanLogLevel,
-      s"${step}ColumnarTransitions afterOverriden plan:\n${overridden.toString}")
-    overridden
-  }(t => logOnLevel(transformPlanLogLevel, s"${step}Transform SparkPlan took: $t ms."))
+      phase: String,
+      rules: Seq[Rule[SparkPlan]],
+      plan: SparkPlan): SparkPlan = {
+    val executor = new ColumnarRuleApplier.Executor(phase, rules)
+    executor.execute(plan)
+  }
 
   private def maybeAqe[T](f: => T): T = {
     adaptiveContext.setAdaptiveContext()
@@ -96,55 +79,63 @@ class EnumeratedApplier(session: SparkSession)
    * Rules to let planner create a suggested Gluten plan being sent to `fallbackPolicies` in which
    * the plan will be breakdown and decided to be fallen back or not.
    */
-  private def transformRules(outputsColumnar: Boolean): List[SparkSession => Rule[SparkPlan]] = {
+  private def transformRules(outputsColumnar: Boolean): Seq[Rule[SparkPlan]] = {
     List(
-      (_: SparkSession) => RemoveTransitions,
-      (spark: SparkSession) => FallbackOnANSIMode(spark),
-      (spark: SparkSession) => PlanOneRowRelation(spark),
-      (_: SparkSession) => FallbackEmptySchemaRelation(),
-      (_: SparkSession) => RewriteSubqueryBroadcast()
+      RemoveTransitions,
+      FallbackOnANSIMode(session),
+      PlanOneRowRelation(session),
+      FallbackEmptySchemaRelation(),
+      RewriteSubqueryBroadcast()
     ) :::
-      BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarValidationRules() :::
-      List((spark: SparkSession) => MergeTwoPhasesHashBaseAggregate(spark)) :::
+      BackendsApiManager.getSparkPlanExecApiInstance
+        .genExtendedColumnarValidationRules()
+        .map(_(session)) :::
+      List(MergeTwoPhasesHashBaseAggregate(session)) :::
       List(
-        (session: SparkSession) => EnumeratedTransform(session, outputsColumnar),
-        (_: SparkSession) => RemoveTransitions
+        EnumeratedTransform(session, outputsColumnar),
+        RemoveTransitions
       ) :::
       List(
-        (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),
-        (spark: SparkSession) => RewriteTransformer(spark),
-        (_: SparkSession) => EnsureLocalSortRequirements,
-        (_: SparkSession) => CollapseProjectExecTransformer
+        RemoveNativeWriteFilesSortAndProject(),
+        RewriteTransformer(session),
+        EnsureLocalSortRequirements,
+        CollapseProjectExecTransformer
       ) :::
-      BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarTransformRules() :::
+      BackendsApiManager.getSparkPlanExecApiInstance
+        .genExtendedColumnarTransformRules()
+        .map(_(session)) :::
       SparkRuleUtil
-        .extendedColumnarRules(session, GlutenConfig.getConf.extendedColumnarTransformRules) :::
-      List((_: SparkSession) => InsertTransitions(outputsColumnar))
+        .extendedColumnarRules(session, GlutenConfig.getConf.extendedColumnarTransformRules)
+        .map(_(session)) :::
+      List(InsertTransitions(outputsColumnar))
   }
 
   /**
    * Rules applying to non-fallen-back Gluten plans. To do some post cleanup works on the plan to
    * make sure it be able to run and be compatible with Spark's execution engine.
    */
-  private def postRules(): List[SparkSession => Rule[SparkPlan]] =
-    List(
-      (s: SparkSession) => RemoveTopmostColumnarToRow(s, adaptiveContext.isAdaptiveContext())) :::
-      BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarPostRules() :::
-      List((_: SparkSession) => ColumnarCollapseTransformStages(GlutenConfig.getConf)) :::
-      SparkRuleUtil.extendedColumnarRules(session, GlutenConfig.getConf.extendedColumnarPostRules)
+  private def postRules(): Seq[Rule[SparkPlan]] =
+    List(RemoveTopmostColumnarToRow(session, adaptiveContext.isAdaptiveContext())) :::
+      BackendsApiManager.getSparkPlanExecApiInstance
+        .genExtendedColumnarPostRules()
+        .map(_(session)) :::
+      List(ColumnarCollapseTransformStages(GlutenConfig.getConf)) :::
+      SparkRuleUtil
+        .extendedColumnarRules(session, GlutenConfig.getConf.extendedColumnarPostRules)
+        .map(_(session))
 
   /*
    * Rules consistently applying to all input plans after all other rules have been applied, despite
    * whether the input plan is fallen back or not.
    */
-  private def finalRules(): List[SparkSession => Rule[SparkPlan]] = {
+  private def finalRules(): Seq[Rule[SparkPlan]] = {
     List(
       // The rule is required despite whether the stage is fallen back or not. Since
       // ColumnarCachedBatchSerializer is statically registered to Spark without a columnar rule
       // when columnar table cache is enabled.
-      (s: SparkSession) => RemoveGlutenTableCacheColumnarToRow(s),
-      (s: SparkSession) => GlutenFallbackReporter(GlutenConfig.getConf, s),
-      (_: SparkSession) => RemoveTransformHintRule()
+      RemoveGlutenTableCacheColumnarToRow(session),
+      GlutenFallbackReporter(GlutenConfig.getConf, session),
+      RemoveTransformHintRule()
     )
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
@@ -90,7 +90,7 @@ class HeuristicApplier(session: SparkSession)
    * Rules to let planner create a suggested Gluten plan being sent to `fallbackPolicies` in which
    * the plan will be breakdown and decided to be fallen back or not.
    */
-  private def transformRules(outputsColumnar: Boolean): List[SparkSession => Rule[SparkPlan]] = {
+  private def transformRules(outputsColumnar: Boolean): Seq[SparkSession => Rule[SparkPlan]] = {
     List(
       (_: SparkSession) => RemoveTransitions,
       (spark: SparkSession) => FallbackOnANSIMode(spark),
@@ -122,7 +122,7 @@ class HeuristicApplier(session: SparkSession)
    * Rules to add wrapper `FallbackNode`s on top of the input plan, as hints to make planner fall
    * back the whole input plan to the original vanilla Spark plan.
    */
-  private def fallbackPolicies(): List[SparkSession => Rule[SparkPlan]] = {
+  private def fallbackPolicies(): Seq[SparkSession => Rule[SparkPlan]] = {
     List(
       (_: SparkSession) =>
         ExpandFallbackPolicy(adaptiveContext.isAdaptiveContext(), adaptiveContext.originalPlan()))
@@ -132,7 +132,7 @@ class HeuristicApplier(session: SparkSession)
    * Rules applying to non-fallen-back Gluten plans. To do some post cleanup works on the plan to
    * make sure it be able to run and be compatible with Spark's execution engine.
    */
-  private def postRules(): List[SparkSession => Rule[SparkPlan]] =
+  private def postRules(): Seq[SparkSession => Rule[SparkPlan]] =
     List(
       (s: SparkSession) => RemoveTopmostColumnarToRow(s, adaptiveContext.isAdaptiveContext())) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarPostRules() :::
@@ -143,7 +143,7 @@ class HeuristicApplier(session: SparkSession)
    * Rules consistently applying to all input plans after all other rules have been applied, despite
    * whether the input plan is fallen back or not.
    */
-  private def finalRules(): List[SparkSession => Rule[SparkPlan]] = {
+  private def finalRules(): Seq[SparkSession => Rule[SparkPlan]] = {
     List(
       // The rule is required despite whether the stage is fallen back or not. Since
       // ColumnarCachedBatchSerializer is statically registered to Spark without a columnar rule

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
@@ -48,7 +48,7 @@ class HeuristicApplier(session: SparkSession)
   }
 
   // Visible for testing.
-  def withTransformRules(transformRules: List[SparkSession => Rule[SparkPlan]]): Rule[SparkPlan] =
+  def withTransformRules(transformRules: Seq[SparkSession => Rule[SparkPlan]]): Rule[SparkPlan] =
     plan =>
       PhysicalPlanSelector.maybe(session, plan) {
         val finalPlan = prepareFallback(plan) {


### PR DESCRIPTION
1. Reuse more code between `HeuristicApplier` and `EnumeratedApplier`
2. Extract columnar rule logging code out into `LoggedRule`
3. Refine columnar rule log messages
4. Adopt Spark's `RuleExecutor`, which means user could measure on columnar rules' execution time by setting a tracker in driver code.
5. `Planning Time` in gluten-it's test report is made more accurate when AQE is on by leveraging 4's method.