### PR TITLE
[GLUTEN-6091][CH] Avoid using LD_PRELOAD in child process

### DIFF
--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -894,6 +894,9 @@ void BackendInitializerUtil::init(std::string * plan)
                 cleanup_threads,
                 0, // We don't need any threads one all the parts will be deleted
                 cleanup_threads);
+
+            // Avoid using LD_PRELOAD in child process
+            unsetenv("LD_PRELOAD");
         });
 }
 

--- a/cpp-ch/local-engine/Functions/CMakeLists.txt
+++ b/cpp-ch/local-engine/Functions/CMakeLists.txt
@@ -59,6 +59,10 @@ if(TARGET ch_rust::blake3)
   list(APPEND PRIVATE_LIBS ch_rust::blake3)
 endif()
 
+if (TARGET ch_contrib::gwp_asan)
+    list(APPEND PRIVATE_LIBS ch_contrib::gwp_asan)
+endif()
+
 list(APPEND OBJECT_LIBS $<TARGET_OBJECTS:gluten_spark_functions_obj>)
 
 target_link_libraries(gluten_spark_functions_obj PRIVATE ${PRIVATE_LIBS})

--- a/cpp-ch/local-engine/Functions/CMakeLists.txt
+++ b/cpp-ch/local-engine/Functions/CMakeLists.txt
@@ -59,7 +59,7 @@ if(TARGET ch_rust::blake3)
   list(APPEND PRIVATE_LIBS ch_rust::blake3)
 endif()
 
-if (TARGET ch_contrib::gwp_asan)
+if(TARGET ch_contrib::gwp_asan)
   list(APPEND PRIVATE_LIBS ch_contrib::gwp_asan)
 endif()
 

--- a/cpp-ch/local-engine/Functions/CMakeLists.txt
+++ b/cpp-ch/local-engine/Functions/CMakeLists.txt
@@ -60,7 +60,7 @@ if(TARGET ch_rust::blake3)
 endif()
 
 if (TARGET ch_contrib::gwp_asan)
-    list(APPEND PRIVATE_LIBS ch_contrib::gwp_asan)
+  list(APPEND PRIVATE_LIBS ch_contrib::gwp_asan)
 endif()
 
 list(APPEND OBJECT_LIBS $<TARGET_OBJECTS:gluten_spark_functions_obj>)


### PR DESCRIPTION
## What changes were proposed in this pull request?
(Fixes: \#6091)

See #6091 for issue description. This PR does 2 things:
1. unset `LD_PRELOAD` 
2. add missing gwp_asan dependency for `gluten_spark_functions` to avoid mering https://github.com/apache/incubator-gluten/pull/6083



## How was this patch tested?

Using existed UTs
