### PR TITLE
[VL] Gluten-it: Reuse Spark sessions that share same configuration

### DIFF
--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -367,7 +367,7 @@ jobs:
           cd tools/gluten-it \
           && GLUTEN_IT_JVM_ARGS=-Xmx6G sbin/gluten-it.sh queries \
             --local --preset=velox --benchmark-type=ds --error-on-memleak -s=30.0  --off-heap-size=8g --threads=12 --shuffle-partitions=72 --iterations=1 \
-            --skip-data-gen  --random-kill-tasks
+            --skip-data-gen  --random-kill-tasks --no-session-reuse
 
   # run-tpc-test-ubuntu-sf30:
   #   needs: build-native-lib-centos-7

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
@@ -18,9 +18,6 @@ package org.apache.gluten.integration.command;
 
 import com.google.common.base.Preconditions;
 import org.apache.gluten.integration.BaseMixin;
-import org.apache.gluten.integration.action.Dim;
-import org.apache.gluten.integration.action.DimKv;
-import org.apache.gluten.integration.action.DimValue;
 import org.apache.commons.lang3.ArrayUtils;
 import picocli.CommandLine;
 import scala.Tuple2;
@@ -67,17 +64,17 @@ public class Parameterized implements Callable<Integer> {
   public Integer call() throws Exception {
     final Map<String, Map<String, List<Map.Entry<String, String>>>> parsed = new LinkedHashMap<>();
 
-    final Seq<scala.collection.immutable.Set<DimKv>> excludedCombinations = JavaConverters.asScalaBufferConverter(Arrays.stream(excludedDims).map(d -> {
+    final Seq<scala.collection.immutable.Set<org.apache.gluten.integration.action.Parameterized.DimKv>> excludedCombinations = JavaConverters.asScalaBufferConverter(Arrays.stream(excludedDims).map(d -> {
       final Matcher m = excludedDimsPattern.matcher(d);
       Preconditions.checkArgument(m.matches(), "Unrecognizable excluded dims: " + d);
-      Set<DimKv> out = new HashSet<>();
+      Set<org.apache.gluten.integration.action.Parameterized.DimKv> out = new HashSet<>();
       final String[] dims = d.split(",");
       for (String dim : dims) {
         final String[] kv = dim.split(":");
         Preconditions.checkArgument(kv.length == 2, "Unrecognizable excluded dims: " + d);
-        out.add(new DimKv(kv[0], kv[1]));
+        out.add(new org.apache.gluten.integration.action.Parameterized.DimKv(kv[0], kv[1]));
       }
-      return JavaConverters.asScalaSetConverter(out).asScala().<DimKv>toSet();
+      return JavaConverters.asScalaSetConverter(out).asScala().<org.apache.gluten.integration.action.Parameterized.DimKv>toSet();
     }).collect(Collectors.toList())).asScala();
 
     // parse dims
@@ -121,11 +118,11 @@ public class Parameterized implements Callable<Integer> {
     }
 
     // Convert Map<String, Map<String, List<Map.Entry<String, String>>>> to List<Dim>
-    Seq<Dim> parsedDims = JavaConverters.asScalaBufferConverter(
+    Seq<org.apache.gluten.integration.action.Parameterized.Dim> parsedDims = JavaConverters.asScalaBufferConverter(
         parsed.entrySet().stream().map(e ->
-            new Dim(e.getKey(), JavaConverters.asScalaBufferConverter(
+            new org.apache.gluten.integration.action.Parameterized.Dim(e.getKey(), JavaConverters.asScalaBufferConverter(
                 e.getValue().entrySet().stream().map(e2 ->
-                    new DimValue(e2.getKey(), JavaConverters.asScalaBufferConverter(
+                    new org.apache.gluten.integration.action.Parameterized.DimValue(e2.getKey(), JavaConverters.asScalaBufferConverter(
                         e2.getValue().stream().map(e3 -> new Tuple2<>(e3.getKey(), e3.getValue()))
                             .collect(Collectors.toList())).asScala())).collect(Collectors.toList())).asScala()
             )).collect(Collectors.toList())).asScala();

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
@@ -130,7 +130,7 @@ public class Parameterized implements Callable<Integer> {
     org.apache.gluten.integration.action.Parameterized parameterized =
         new org.apache.gluten.integration.action.Parameterized(dataGenMixin.getScale(),
             dataGenMixin.genPartitionedData(), queriesMixin.queries(),
-            queriesMixin.explain(), queriesMixin.iterations(), warmupIterations, parsedDims,
+            queriesMixin.explain(), queriesMixin.iterations(), warmupIterations, queriesMixin.noSessionReuse(), parsedDims,
             excludedCombinations, metrics);
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), parameterized));
   }

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
@@ -42,7 +42,7 @@ public class Queries implements Callable<Integer> {
   public Integer call() throws Exception {
     org.apache.gluten.integration.action.Queries queries =
         new org.apache.gluten.integration.action.Queries(dataGenMixin.getScale(), dataGenMixin.genPartitionedData(), queriesMixin.queries(),
-            queriesMixin.explain(), queriesMixin.iterations(), randomKillTasks);
+            queriesMixin.explain(), queriesMixin.iterations(), randomKillTasks, queriesMixin.noSessionReuse());
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), queries));
   }
 }

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/QueriesCompare.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/QueriesCompare.java
@@ -40,7 +40,7 @@ public class QueriesCompare implements Callable<Integer> {
     org.apache.gluten.integration.action.QueriesCompare queriesCompare =
         new org.apache.gluten.integration.action.QueriesCompare(dataGenMixin.getScale(),
             dataGenMixin.genPartitionedData(), queriesMixin.queries(),
-            queriesMixin.explain(), queriesMixin.iterations());
+            queriesMixin.explain(), queriesMixin.iterations(), queriesMixin.noSessionReuse());
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), queriesCompare));
   }
 }

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/QueriesMixin.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/QueriesMixin.java
@@ -42,12 +42,19 @@ public class QueriesMixin {
   @CommandLine.Option(names = {"--iterations"}, description = "How many iterations to run", defaultValue = "1")
   private int iterations;
 
+  @CommandLine.Option(names = {"--no-session-reuse"}, description = "Recreate new Spark session each time a query is about to run", defaultValue = "false")
+  private boolean noSessionReuse;
+
   public boolean explain() {
     return explain;
   }
 
   public int iterations() {
     return iterations;
+  }
+
+  public boolean noSessionReuse() {
+    return noSessionReuse;
   }
 
   public Actions.QuerySelector queries() {

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -131,7 +131,13 @@ class Parameterized(
         // warm up
         (0 until warmupIterations).foreach { iteration =>
           println(s"Warming up: Running query $queryId (iteration $iteration)...")
-          Parameterized.warmUp(runner, sessionSwitcher.spark(), queryId, coordinate, suite.desc())
+          try {
+            Parameterized.warmUp(runner, sessionSwitcher.spark(), queryId, coordinate, suite.desc())
+          } finally {
+            if (noSessionReuse) {
+              sessionSwitcher.renewSession()
+            }
+          }
         }
 
         // run
@@ -149,7 +155,7 @@ class Parameterized(
                 metrics)
             } finally {
               if (noSessionReuse) {
-                sessionSwitcher.close()
+                sessionSwitcher.renewSession()
               }
             }
           TestResultLine.CoordMark(iteration, queryId, r)

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -136,6 +136,7 @@ class Parameterized(
           } finally {
             if (noSessionReuse) {
               sessionSwitcher.renewSession()
+              runner.createTables(suite.tableCreator(), sessionSwitcher.spark())
             }
           }
         }
@@ -156,6 +157,7 @@ class Parameterized(
             } finally {
               if (noSessionReuse) {
                 sessionSwitcher.renewSession()
+                runner.createTables(suite.tableCreator(), sessionSwitcher.spark())
               }
             }
           TestResultLine.CoordMark(iteration, queryId, r)

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -122,8 +122,7 @@ class Parameterized(
 
     val marks: Seq[CoordMark] = coordinates.flatMap { entry =>
       val coordinate = entry._1
-      val appName = "Parameterized %s".format(coordinate)
-      sessionSwitcher.useSession(coordinate.toString, appName)
+      sessionSwitcher.useSession(coordinate.toString, "Parameterized %s".format(coordinate))
       runner.createTables(suite.tableCreator(), sessionSwitcher.spark())
 
       runQueryIds.flatMap { queryId =>

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
@@ -56,6 +56,7 @@ case class Queries(
         } finally {
           if (noSessionReuse) {
             sessionSwitcher.renewSession()
+            runner.createTables(suite.tableCreator(), sessionSwitcher.spark())
           }
         }
       }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
@@ -55,7 +55,7 @@ case class Queries(
             randomKillTasks)
         } finally {
           if (noSessionReuse) {
-            sessionSwitcher.close()
+            sessionSwitcher.renewSession()
           }
         }
       }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
@@ -16,12 +16,12 @@
  */
 package org.apache.gluten.integration.action
 
-import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.gluten.integration.QueryRunner.QueryResult
 import org.apache.gluten.integration.action.Actions.QuerySelector
 import org.apache.gluten.integration.action.TableRender.RowParser.FieldAppender.RowAppender
 import org.apache.gluten.integration.stat.RamStat
 import org.apache.gluten.integration.{QueryRunner, Suite, TableCreator}
-import org.apache.spark.sql.{SparkSession, SparkSessionSwitcher}
+import org.apache.spark.sql.{SparkSession}
 
 case class Queries(
     scale: Double,
@@ -31,6 +31,7 @@ case class Queries(
     iterations: Int,
     randomKillTasks: Boolean)
     extends Action {
+  import Queries._
 
   override def execute(suite: Suite): Boolean = {
     val runQueryIds = queries.select(suite)
@@ -53,7 +54,7 @@ case class Queries(
       }
     }.toList
 
-    val passedCount = results.count(l => l.testPassed)
+    val passedCount = results.count(l => l.queryResult.succeeded())
     val count = results.count(_ => true)
 
     // RAM stats
@@ -71,8 +72,9 @@ case class Queries(
     println("")
     printf("Summary: %d out of %d queries passed. \n", passedCount, count)
     println("")
-    val succeed = results.filter(_.testPassed)
-    Queries.printResults(succeed)
+    val succeeded = results.filter(_.queryResult.succeeded())
+    val all = succeeded.map(_.queryResult).asSuccesses().agg("all").map(s => TestResultLine(s))
+    Queries.printResults(succeeded ++ all)
     println("")
 
     if (passedCount == count) {
@@ -81,20 +83,9 @@ case class Queries(
     } else {
       println("Failed queries: ")
       println("")
-      Queries.printResults(results.filter(!_.testPassed))
+      Queries.printResults(results.filter(!_.queryResult.succeeded()))
       println("")
     }
-
-    var all = Queries.aggregate(results, "all")
-
-    if (passedCount != count) {
-      all = Queries.aggregate(succeed, "succeeded") ::: all
-    }
-
-    println("Overall: ")
-    println("")
-    Queries.printResults(all)
-    println("")
 
     if (passedCount != count) {
       return false
@@ -104,28 +95,29 @@ case class Queries(
 }
 
 object Queries {
-  case class TestResultLine(
-      queryId: String,
-      testPassed: Boolean,
-      rowCount: Option[Long],
-      planningTimeMillis: Option[Long],
-      executionTimeMillis: Option[Long],
-      errorMessage: Option[String])
+  case class TestResultLine(queryResult: QueryResult)
 
   object TestResultLine {
     implicit object Parser extends TableRender.RowParser[TestResultLine] {
       override def parse(rowAppender: RowAppender, line: TestResultLine): Unit = {
         val inc = rowAppender.incremental()
-        inc.next().write(line.queryId)
-        inc.next().write(line.testPassed)
-        inc.next().write(line.rowCount)
-        inc.next().write(line.planningTimeMillis)
-        inc.next().write(line.executionTimeMillis)
+        inc.next().write(line.queryResult.caseId())
+        inc.next().write(line.queryResult.succeeded())
+        line.queryResult match {
+          case QueryRunner.Success(_, runResult) =>
+            inc.next().write(runResult.rows.size)
+            inc.next().write(runResult.planningTimeMillis)
+            inc.next().write(runResult.executionTimeMillis)
+          case QueryRunner.Failure(_, error) =>
+            inc.next().write(None)
+            inc.next().write(None)
+            inc.next().write(None)
+        }
       }
     }
   }
 
-  private def printResults(results: List[TestResultLine]): Unit = {
+  private def printResults(results: Seq[TestResultLine]): Unit = {
     val render = TableRender.plain[TestResultLine](
       "Query ID",
       "Was Passed",
@@ -140,27 +132,6 @@ object Queries {
     render.print(System.out)
   }
 
-  private def aggregate(succeed: List[TestResultLine], name: String): List[TestResultLine] = {
-    if (succeed.isEmpty) {
-      return Nil
-    }
-    List(
-      succeed.reduce((r1, r2) =>
-        TestResultLine(
-          name,
-          testPassed = true,
-          if (r1.rowCount.nonEmpty && r2.rowCount.nonEmpty)
-            Some(r1.rowCount.get + r2.rowCount.get)
-          else None,
-          if (r1.planningTimeMillis.nonEmpty && r2.planningTimeMillis.nonEmpty)
-            Some(r1.planningTimeMillis.get + r2.planningTimeMillis.get)
-          else None,
-          if (r1.executionTimeMillis.nonEmpty && r2.executionTimeMillis.nonEmpty)
-            Some(r1.executionTimeMillis.get + r2.executionTimeMillis.get)
-          else None,
-          None)))
-  }
-
   private def runQuery(
       runner: QueryRunner,
       creator: TableCreator,
@@ -170,32 +141,9 @@ object Queries {
       explain: Boolean,
       randomKillTasks: Boolean): TestResultLine = {
     println(s"Running query: $id...")
-    try {
-      val testDesc = "Gluten Spark %s %s".format(desc, id)
-      val result = runner.runQuery(
-        session,
-        testDesc,
-        id,
-        explain = explain,
-        randomKillTasks = randomKillTasks)
-      val resultRows = result.rows
-      println(
-        s"Successfully ran query $id. " +
-          s"Returned row count: ${resultRows.length}")
-      TestResultLine(
-        id,
-        testPassed = true,
-        Some(resultRows.length),
-        Some(result.planningTimeMillis),
-        Some(result.executionTimeMillis),
-        None)
-    } catch {
-      case e: Exception =>
-        val error = Some(s"FATAL: ${ExceptionUtils.getStackTrace(e)}")
-        println(
-          s"Error running query $id. " +
-            s" Error: ${error.get}")
-        TestResultLine(id, testPassed = false, None, None, None, error)
-    }
+    val testDesc = "Query %s [%s]".format(desc, id)
+    val result =
+      runner.runQuery(session, testDesc, id, explain = explain, randomKillTasks = randomKillTasks)
+    TestResultLine(result)
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
@@ -45,12 +45,18 @@ case class QueriesCompare(
     val baselineResults = (0 until iterations).flatMap { iteration =>
       runQueryIds.map { queryId =>
         println(s"Running baseline query $queryId (iteration $iteration)...")
-        QueriesCompare.runBaselineQuery(
-          runner,
-          sessionSwitcher.spark(),
-          suite.desc(),
-          queryId,
-          explain)
+        try {
+          QueriesCompare.runBaselineQuery(
+            runner,
+            sessionSwitcher.spark(),
+            suite.desc(),
+            queryId,
+            explain)
+        } finally {
+          if (noSessionReuse) {
+            sessionSwitcher.renewSession()
+          }
+        }
       }
     }.toList
 
@@ -68,7 +74,7 @@ case class QueriesCompare(
             explain)
         } finally {
           if (noSessionReuse) {
-            sessionSwitcher.close()
+            sessionSwitcher.renewSession()
           }
         }
       }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
@@ -55,6 +55,7 @@ case class QueriesCompare(
         } finally {
           if (noSessionReuse) {
             sessionSwitcher.renewSession()
+            runner.createTables(suite.tableCreator(), sessionSwitcher.spark())
           }
         }
       }
@@ -75,6 +76,7 @@ case class QueriesCompare(
         } finally {
           if (noSessionReuse) {
             sessionSwitcher.renewSession()
+            runner.createTables(suite.tableCreator(), sessionSwitcher.spark())
           }
         }
       }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/SparkShell.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/SparkShell.scala
@@ -21,7 +21,7 @@ import org.apache.spark.repl.Main
 
 case class SparkShell(scale: Double, genPartitionedData: Boolean) extends Action {
   override def execute(suite: Suite): Boolean = {
-    suite.sessionSwitcher.useSession("test", "Gluten Spark CLI")
+    suite.sessionSwitcher.useSession("test", "Spark CLI")
     val runner: QueryRunner =
       new QueryRunner(suite.queryResource(), suite.dataWritePath(scale, genPartitionedData))
     runner.createTables(suite.tableCreator(), suite.sessionSwitcher.spark())

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchDataGen.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchDataGen.scala
@@ -31,7 +31,10 @@ class ClickBenchDataGen(val spark: SparkSession, dir: String) extends DataGen {
     // Directly download from official URL.
     val target = new File(dir + File.separator + FILE_NAME)
     FileUtils.forceMkdirParent(target)
-    val code = Process(s"wget -P $dir $DATA_URL") !;
+    val cmd =
+      s"wget --no-verbose --show-progress --progress=bar:force:noscroll -O $target $DATA_URL"
+    println(s"Executing command: $cmd")
+    val code = Process(cmd) !;
     if (code != 0) {
       throw new RuntimeException("Download failed")
     }

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
@@ -65,6 +65,15 @@ class SparkSessionSwitcher(val masterUrl: String, val logLevel: String) extends 
     useSession(SessionDesc(SessionToken(token), appName))
   }
 
+  def renewSession(): Unit = synchronized {
+    if (!hasActiveSession()) {
+      return
+    }
+    val sd = _activeSessionDesc
+    stopActiveSession()
+    useSession(sd)
+  }
+
   private def useSession(desc: SessionDesc): Unit = synchronized {
     if (desc == _activeSessionDesc) {
       return

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/SparkSessionSwitcher.scala
@@ -70,6 +70,7 @@ class SparkSessionSwitcher(val masterUrl: String, val logLevel: String) extends 
       return
     }
     val sd = _activeSessionDesc
+    println(s"Renewing $sd session... ")
     stopActiveSession()
     useSession(sd)
   }


### PR DESCRIPTION
Reuse sessions with same configuration for better support of large scale / long run integration testing.

Reusing the session would avoid reloading the libraries if Gluten is enabled, and would avoid recreating table catalogs again and again.

Add `--no-session-reuse` which is enabled in `random kill task` CI job. Otherwise the job would fail by `no space on disk` since too many temporary files are created in the same session.