### PR TITLE
[VL] Daily Update Velox Version (2024_06_18)

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_06_17
+VELOX_BRANCH=2024_06_18
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -1104,8 +1104,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
     // exclude as original metric not correct when task offloaded to velox
     .exclude("SPARK-37585: test input metrics for DSV2 with output limits")
-    // Unknown. Need to investigate.
-    .exclude("SPARK-30362: test input metrics for DSV2")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
     .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -1104,8 +1104,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
     // exclude as original metric not correct when task offloaded to velox
     .exclude("SPARK-37585: test input metrics for DSV2 with output limits")
-    // TODO(yuan): fix the input bytes on ORC code path
-    .exclude("SPARK-30362: test input metrics for DSV2")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
     .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -1120,8 +1120,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-31116: Select nested schema with case insensitive mode")
     // exclude as original metric not correct when task offloaded to velox
     .exclude("SPARK-37585: test input metrics for DSV2 with output limits")
-    // TODO(yuan): fix the input bytes on ORC code path
-    .exclude("SPARK-30362: test input metrics for DSV2")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
     .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upstream Velox's New Commits:
```
e29f59803 by Deepak Majeti, Fix LZO decompression (#10123)
b37ceb456 by Kevin Wilfong, Run preliminary checks in Docker container built for them (#10234)
718c8e907 by Jimmy Lu, Implement bucket conversion in HiveDataSource (#10228)
c84aa68b4 by wypb, Fix incorrect type conversion for ORC short_decimal. (#10212)
6b32339c9 by Jia Ke, Correctly record the RawBytesRead and scan time metric in DirectBufferedInput (#9801)
2b94eaa9e by Pedro Pedreira, Add list of components and maintainers (#10180)
32c7f6e60 by Jimmy Lu, Fix flaky test TableScanTest.statsBasedSkippingNulls (#10233)
92b31efb6 by Jimmy Lu, Enhance DWRF reader string column size estimation (#10227)
44a86baba by xiaoxmeng, Add metrics to track shuffle data and transfer times (#10226)
2cfd17459 by mwish, Fix typo in documentation of PartitionedOutputNode operator (#10137)
0b5bf0f4d by Bikramjeet Vig, Fix NaN handling for histogram, map_agg and map_union aggregates (#10071)
e452936f5 by Kevin Wilfong, Fix UBSan error triggered by StringFunctionsTest.normalize (#10205)
9558dcb77 by Christian Zentgraf, Update fbos deps to v2024.05.20.00 (#9968)
955c07159 by Kevin Wilfong, Update clang-format lint rules (#10181)
57685703e by Jialiang Tan, Reclaim unused reserved memory in dwrf writer (#10120)
fe20e490c by Krishna Pai, Rename and simplify casting policies. (#9919)
5842ce87b by Bikramjeet Vig, Fix NaN handling for map_union_sum (#10073)
41ca6f292 by Kevin Wilfong, Fix autodeps for xsimd (#10198)
8845ca23d by Masha Basmanova, Add support for DECIMAL inputs to truncate Presto function (#10217)
57dc7fef8 by Zac Wen, Fix read ssd corruption error reporting (#10199)
3652d3d31 by yanngyoung, Add row number plan for memory arbitration fuzzer (#10160)
```