### PR TITLE
[GLUTEN-6127] [VL] When the regexExpr of the split function is an empty character or a non-ASCII character, fall back to Valina Spark

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
@@ -129,9 +129,9 @@ case class VeloxStringSplitTransformer(
 
     val limit = limitExpr.doTransform(args).asInstanceOf[IntLiteralNode].getValue
     val regex = regexExpr.doTransform(args).asInstanceOf[StringLiteralNode].getValue
-    if (limit > 0 || regex.length > 1) {
+    if (limit > 0 || regex.length != 1 || regex.charAt(0) > 127) {
       throw new GlutenNotSupportException(
-        s"$original supported single-length regex and negative limit, but given $limit and $regex")
+        s"$original supported single-length ASCII regex and negative limit, but given $limit and $regex")
     }
 
     super.doTransform(args)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
@@ -541,9 +541,11 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
       s"select l_orderkey, split(l_comment, '') " +
         s"from $LINEITEM_TABLE limit 5", noFallBack = false) { _ => }
 
+    // scalastyle:off nonascii
     runQueryAndCompare(
       s"select l_orderkey, split(l_comment, '，') " +
         s"from $LINEITEM_TABLE limit 5", noFallBack = false) { _ => }
+    // scalastyle:on nonascii
   }
 
   test("substr") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
@@ -536,6 +536,14 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
     runQueryAndCompare(
       s"select l_orderkey, split(l_comment, 'h') " +
         s"from $LINEITEM_TABLE limit 5") { _ => }
+
+    runQueryAndCompare(
+      s"select l_orderkey, split(l_comment, '') " +
+        s"from $LINEITEM_TABLE limit 5", noFallBack = false) { _ => }
+
+    runQueryAndCompare(
+      s"select l_orderkey, split(l_comment, '，') " +
+        s"from $LINEITEM_TABLE limit 5", noFallBack = false) { _ => }
   }
 
   test("substr") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently Velox's split function's regexExpr does not support empty characters and non-ASCII characters. We should fall back to Valina Spark first.


## How was this patch tested?
unit tests