### PR TITLE
[VL][Core] Add InputFileReplaceFallback Rule

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -591,6 +591,9 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
   override def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] =
     List(spark => NativeWritePostRule(spark))
 
+  override def genExtendedColumnarFinalRules(): List[SparkSession => Rule[SparkPlan]] =
+    List()
+
   override def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]] = {
     List()
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -833,6 +833,10 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     SparkShimLoader.getSparkShims.getExtendedColumnarPostRules() ::: List()
   }
 
+  override def genExtendedColumnarFinalRules(): List[SparkSession => Rule[SparkPlan]] = {
+    List((s: SparkSession) => InputFileNameReplaceFallbackRule(s))
+  }
+
   override def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]] = {
     List(ArrowConvertorRule)
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -821,7 +821,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
    */
   override def genExtendedColumnarTransformRules(): List[SparkSession => Rule[SparkPlan]] = {
     val buf: ListBuffer[SparkSession => Rule[SparkPlan]] = ListBuffer()
-    if (GlutenConfig.getConf.enableInputFileNameReplaceRule) {
+    if (GlutenConfig.getConf.enableVeloxFlushablePartialAggregation) {
       buf += FlushableHashAggregateRule.apply
     }
     buf.result
@@ -838,7 +838,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
 
   override def genExtendedColumnarFinalRules(): List[SparkSession => Rule[SparkPlan]] = {
     val buf: ListBuffer[SparkSession => Rule[SparkPlan]] = ListBuffer()
-    if (GlutenConfig.getConf.enableVeloxFlushablePartialAggregation) {
+    if (GlutenConfig.getConf.enableInputFileNameReplaceRule) {
       buf += InputFileNameReplaceFallbackRule.apply
     }
     buf.result

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/InputFileNameReplaceFallbackRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/InputFileNameReplaceFallbackRule.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, InputFileBlockLength, InputFileBlockStart, InputFileName, NamedExpression}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ColumnarToRowExec, FileSourceScanExec, ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+case class InputFileNameReplaceFallbackRule(spark: SparkSession) extends Rule[SparkPlan] {
+  import InputFileNameReplaceRule._
+
+  private def replacedAttrs(output: Seq[Attribute]): Seq[Attribute] = {
+    output.filter(
+      p =>
+        p.name == replacedInputFileName ||
+          p.name == replacedInputFileBlockStart ||
+          p.name == replacedInputFileBlockLength)
+  }
+
+  private def projectList(
+      output: Seq[Attribute],
+      replacedAttrs: Seq[Attribute]): Seq[NamedExpression] = {
+    output ++ replacedAttrs.map {
+      v =>
+        v.name match {
+          case `replacedInputFileName` =>
+            Alias(InputFileName(), replacedInputFileName)(v.exprId)
+          case `replacedInputFileBlockStart` =>
+            Alias(InputFileBlockStart(), replacedInputFileBlockStart)(v.exprId)
+          case `replacedInputFileBlockLength` =>
+            Alias(InputFileBlockLength(), replacedInputFileBlockLength)(v.exprId)
+        }
+    }
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    def insertProjectAfterScanIfFallback(plan: SparkPlan): SparkPlan = {
+      plan match {
+        case c: ColumnarToRowExec =>
+          c.child match {
+            case f: FileSourceScanExec =>
+              val fallbackAttrs = replacedAttrs(f.output)
+              if (fallbackAttrs.nonEmpty) {
+                val newScanOutput = f.output.filterNot(fallbackAttrs.contains)
+                val scan = f.copy(output = newScanOutput)
+                val newProjectList = projectList(scan.output, fallbackAttrs)
+                ProjectExec(newProjectList, c.copy(child = scan))
+              } else c
+            case b: BatchScanExec =>
+              val fallbackAttrs = replacedAttrs(b.output)
+              if (fallbackAttrs.nonEmpty) {
+                val newScanOutput = b.output.filterNot(fallbackAttrs.contains)
+                val scan = b.copy(output = newScanOutput)
+                val newProjectList = projectList(scan.output, fallbackAttrs)
+                ProjectExec(newProjectList, c.copy(child = scan))
+              } else c
+            case _ =>
+              val newChildren = c.children.map(insertProjectAfterScanIfFallback)
+              c.withNewChildren(newChildren)
+          }
+        case other =>
+          val newChildren = other.children.map(insertProjectAfterScanIfFallback)
+          other.withNewChildren(newChildren)
+      }
+    }
+
+    insertProjectAfterScanIfFallback(plan)
+  }
+}

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -624,9 +624,13 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
   }
 
   test("Test input_file_name function") {
-    runQueryAndCompare("""SELECT input_file_name(), l_orderkey
-                         | from lineitem limit 100""".stripMargin) {
-      checkGlutenOperatorMatch[ProjectExecTransformer]
+    withSQLConf(
+      "spark.gluten.sql.enableInputFileNameReplaceRule" -> "true"
+    ) {
+      runQueryAndCompare("""SELECT input_file_name(), l_orderkey
+                           | from lineitem limit 100""".stripMargin) {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -432,6 +432,8 @@ trait SparkPlanExecApi {
    */
   def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
 
+  def genExtendedColumnarFinalRules(): List[SparkSession => Rule[SparkPlan]]
+
   def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]]
 
   def genGetStructFieldTransformer(

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
@@ -151,7 +151,8 @@ class HeuristicApplier(session: SparkSession)
       (s: SparkSession) => RemoveGlutenTableCacheColumnarToRow(s),
       (s: SparkSession) => GlutenFallbackReporter(GlutenConfig.getConf, s),
       (_: SparkSession) => RemoveTransformHintRule()
-    )
+    ) :::
+      BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarFinalRules()
   }
 
   // Just for test use.

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
@@ -16,34 +16,40 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.functions.{expr, input_file_name}
+import org.apache.spark.sql.types._
 
 class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTestsTrait {
   testGluten("input_file_name with scan is fallback") {
-    withTempPath { dir =>
-      val rawData = Seq(
-        Row(1, "Alice", Seq(Row(Seq(1, 2, 3)))),
-        Row(2, "Bob", Seq(Row(Seq(4, 5)))),
-        Row(3, "Charlie", Seq(Row(Seq(6, 7, 8, 9))))
-      )
-      val schema = StructType(Array(
-        StructField("id", IntegerType, nullable = false),
-        StructField("name", StringType, nullable = false),
-        StructField("nested_column", ArrayType(StructType(Array(
-          StructField("array_in_struct", ArrayType(IntegerType), nullable = true)
-        ))), nullable = true)
-      ))
-      val data: DataFrame = spark.createDataFrame(
-        sparkContext.parallelize(rawData), schema)
-      data.write.parquet(dir.getCanonicalPath)
+    withTempPath {
+      dir =>
+        val rawData = Seq(
+          Row(1, "Alice", Seq(Row(Seq(1, 2, 3)))),
+          Row(2, "Bob", Seq(Row(Seq(4, 5)))),
+          Row(3, "Charlie", Seq(Row(Seq(6, 7, 8, 9))))
+        )
+        val schema = StructType(
+          Array(
+            StructField("id", IntegerType, nullable = false),
+            StructField("name", StringType, nullable = false),
+            StructField(
+              "nested_column",
+              ArrayType(
+                StructType(Array(
+                  StructField("array_in_struct", ArrayType(IntegerType), nullable = true)
+                ))),
+              nullable = true)
+          ))
+        val data: DataFrame = spark.createDataFrame(sparkContext.parallelize(rawData), schema)
+        data.write.parquet(dir.getCanonicalPath)
 
-      // Test the 3 expressions when reading from files
-      val q = spark.read.parquet(dir.getCanonicalPath).select(
-        input_file_name(), expr("nested_column"))
-      logWarning(s"gyytest q is ${q.queryExecution.executedPlan}")
-      val firstRow = q.head()
-      assert(firstRow.getString(0).contains(dir.toURI.getPath))
+        val q =
+          spark.read.parquet(dir.getCanonicalPath).select(input_file_name(), expr("nested_column"))
+        val firstRow = q.head()
+        assert(firstRow.getString(0).contains(dir.toURI.getPath))
+        val project = q.queryExecution.executedPlan.collect { case p: ProjectExec => p }
+        assert(project.size == 1)
     }
   }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
@@ -16,4 +16,34 @@
  */
 package org.apache.spark.sql
 
-class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTestsTrait {}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.{expr, input_file_name}
+
+class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTestsTrait {
+  testGluten("input_file_name with scan is fallback") {
+    withTempPath { dir =>
+      val rawData = Seq(
+        Row(1, "Alice", Seq(Row(Seq(1, 2, 3)))),
+        Row(2, "Bob", Seq(Row(Seq(4, 5)))),
+        Row(3, "Charlie", Seq(Row(Seq(6, 7, 8, 9))))
+      )
+      val schema = StructType(Array(
+        StructField("id", IntegerType, nullable = false),
+        StructField("name", StringType, nullable = false),
+        StructField("nested_column", ArrayType(StructType(Array(
+          StructField("array_in_struct", ArrayType(IntegerType), nullable = true)
+        ))), nullable = true)
+      ))
+      val data: DataFrame = spark.createDataFrame(
+        sparkContext.parallelize(rawData), schema)
+      data.write.parquet(dir.getCanonicalPath)
+
+      // Test the 3 expressions when reading from files
+      val q = spark.read.parquet(dir.getCanonicalPath).select(
+        input_file_name(), expr("nested_column"))
+      logWarning(s"gyytest q is ${q.queryExecution.executedPlan}")
+      val firstRow = q.head()
+      assert(firstRow.getString(0).contains(dir.toURI.getPath))
+    }
+  }
+}

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -752,8 +752,9 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.enableInputFileNameReplaceRule")
       .internal()
       .doc(
-        "This config apply for velox backend to specify whether to enable inputFileNameReplaceRule " +
-          "to support offload input_file_name expression to native.")
+        "This config apply for velox backend to specify whether to enable " +
+          "inputFileNameReplaceRule to support offload input_file_name " +
+          "expression to native.")
       .booleanConf
       .createWithDefault(true)
 

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -752,11 +752,11 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.enableInputFileNameReplaceRule")
       .internal()
       .doc(
-        "This config apply for velox backend to specify whether to enable " +
+        "Experimental: This config apply for velox backend to specify whether to enable " +
           "inputFileNameReplaceRule to support offload input_file_name " +
           "expression to native.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   // FIXME the option currently controls both JVM and native validation against a Substrait plan.
   val NATIVE_VALIDATION_ENABLED =

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -37,6 +37,8 @@ case class GlutenNumaBindingInfo(
 class GlutenConfig(conf: SQLConf) extends Logging {
   import GlutenConfig._
 
+  def enableInputFileNameReplaceRule: Boolean = conf.getConf(INPUT_FILE_NAME_REPLACE_RULE_ENABLED)
+
   def enableAnsiMode: Boolean = conf.ansiEnabled
 
   def enableGluten: Boolean = conf.getConf(GLUTEN_ENABLED)
@@ -745,6 +747,15 @@ object GlutenConfig {
         " Recommend to enable/disable Gluten through the setting for spark.plugins.")
       .booleanConf
       .createWithDefault(GLUTEN_ENABLE_BY_DEFAULT)
+
+  val INPUT_FILE_NAME_REPLACE_RULE_ENABLED =
+    buildConf("spark.gluten.sql.enableInputFileNameReplaceRule")
+      .internal()
+      .doc(
+        "This config apply for velox backend to specify whether to enable inputFileNameReplaceRule " +
+          "to support offload input_file_name expression to native.")
+      .booleanConf
+      .createWithDefault(true)
 
   // FIXME the option currently controls both JVM and native validation against a Substrait plan.
   val NATIVE_VALIDATION_ENABLED =


### PR DESCRIPTION
## What changes were proposed in this pull request?

The is a following up PR for `input_file_name` native support, it 
1. Add a `inputfileNameReplaceFallbackRule` to handle the case if scan fallback due to complex data type
2. Add a feature flag to control if enable the rules in case any corner issues happen we can disable the rule

(Fixes: https://github.com/facebookincubator/velox/issues/9957)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

