### PR TITLE
[VL] RAS: Incorporate query plan's logical link into metadata model

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RemoveFilter.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RemoveFilter.scala
@@ -42,6 +42,7 @@ object RemoveFilter extends RasRule[SparkPlan] {
     val filter = node.asInstanceOf[FilterExecTransformerBase]
     if (filter.isNoop()) {
       val out = NoopFilter(filter.child, filter.output)
+      out.copyTagsFrom(filter)
       return List(out)
     }
     List.empty

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/metadata/GlutenMetadata.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/metadata/GlutenMetadata.scala
@@ -18,42 +18,18 @@ package org.apache.gluten.planner.metadata
 
 import org.apache.gluten.ras.Metadata
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-
 sealed trait GlutenMetadata extends Metadata {
-  import GlutenMetadata._
   def schema(): Schema
+  def logicalLink(): LogicalLink
 }
 
 object GlutenMetadata {
-  def apply(schema: Schema): Metadata = {
-    Impl(schema)
+  def apply(schema: Schema, logicalLink: LogicalLink): Metadata = {
+    Impl(schema, logicalLink)
   }
 
-  private case class Impl(override val schema: Schema) extends GlutenMetadata
-
-  case class Schema(output: Seq[Attribute]) {
-    private val hash = output.map(_.semanticHash()).hashCode()
-
-    override def hashCode(): Int = {
-      hash
-    }
-
-    override def equals(obj: Any): Boolean = obj match {
-      case other: Schema =>
-        semanticEquals(other)
-      case _ =>
-        false
-    }
-
-    private def semanticEquals(other: Schema): Boolean = {
-      if (output.size != other.output.size) {
-        return false
-      }
-      output.zip(other.output).forall {
-        case (left, right) =>
-          left.semanticEquals(right)
-      }
-    }
+  private case class Impl(override val schema: Schema, override val logicalLink: LogicalLink)
+    extends GlutenMetadata {
+    override def toString: String = s"$schema,$logicalLink"
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/metadata/LogicalLink.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/metadata/LogicalLink.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.planner.metadata
+
+import org.apache.gluten.planner.metadata.GlutenMetadataModel.Verifier
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Statistics}
+
+case class LogicalLink(plan: LogicalPlan) {
+  override def hashCode(): Int = System.identityHashCode(plan)
+  override def equals(obj: Any): Boolean = obj match {
+    // LogicalLink's comparison is based on ref equality of the logical plans being compared.
+    case LogicalLink(otherPlan) => plan eq otherPlan
+    case _ => false
+  }
+
+  override def toString: String = s"${plan.nodeName}[${plan.stats.simpleString}]"
+}
+
+object LogicalLink {
+  private case class LogicalLinkNotFound() extends logical.LeafNode {
+    override def output: Seq[Attribute] = List.empty
+    override def canEqual(that: Any): Boolean = throw new UnsupportedOperationException()
+    override def computeStats(): Statistics = Statistics(sizeInBytes = 0)
+  }
+
+  val notFound = new LogicalLink(LogicalLinkNotFound())
+  implicit val verifier: Verifier[LogicalLink] = new Verifier[LogicalLink] with Logging {
+    override def verify(one: LogicalLink, other: LogicalLink): Unit = {
+      // LogicalLink's comparison is based on ref equality of the logical plans being compared.
+      if (one != other) {
+        logWarning(s"Warning: Logical link mismatch: one: $one, other: $other")
+      }
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/metadata/Schema.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/metadata/Schema.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.planner.metadata
+
+import org.apache.gluten.planner.metadata.GlutenMetadataModel.Verifier
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class Schema(output: Seq[Attribute]) {
+  private val hash = output.map(_.semanticHash()).hashCode()
+
+  override def hashCode(): Int = {
+    hash
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: Schema =>
+      semanticEquals(other)
+    case _ =>
+      false
+  }
+
+  private def semanticEquals(other: Schema): Boolean = {
+    if (output.size != other.output.size) {
+      return false
+    }
+    output.zip(other.output).forall {
+      case (left, right) =>
+        left.semanticEquals(right)
+    }
+  }
+
+  override def toString: String = {
+    output.toString()
+  }
+}
+
+object Schema {
+  implicit val verifier: Verifier[Schema] = new Verifier[Schema] with Logging {
+    override def verify(one: Schema, other: Schema): Unit = {
+      if (one != other) {
+        // We apply loose restriction on schema. Since Gluten still have some customized
+        // logics causing schema of an operator to change after being transformed.
+        // For example: https://github.com/apache/incubator-gluten/pull/5171
+        logWarning(s"Warning: Schema mismatch: one: $one, other: $other")
+      }
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/property/Conv.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/property/Conv.scala
@@ -99,6 +99,7 @@ case class ConvEnforcerRule(reqConv: Conv) extends RasRule[SparkPlan] {
     }
     val transition = Conv.findTransition(conv, reqConv)
     val after = transition.apply(node)
+    after.copyTagsFrom(node)
     List(after)
   }
 

--- a/gluten-ras/common/src/test/scala/org/apache/gluten/ras/OperationSuite.scala
+++ b/gluten-ras/common/src/test/scala/org/apache/gluten/ras/OperationSuite.scala
@@ -230,7 +230,7 @@ class OperationSuite extends AnyFunSuite {
               48,
               Unary3(48, Unary3(48, Unary3(48, Unary3(48, Unary3(48, Unary3(48, Leaf(30))))))))))))
     assert(costModel.costOfCount == 32) // TODO reduce this for performance
-    assert(costModel.costCompareCount == 20) // TODO reduce this for performance
+    assert(costModel.costCompareCount == 50) // TODO reduce this for performance
   }
 
   test("Cost evaluation count - max cost") {
@@ -292,7 +292,7 @@ class OperationSuite extends AnyFunSuite {
               48,
               Unary3(48, Unary3(48, Unary3(48, Unary3(48, Unary3(48, Unary3(48, Leaf(30))))))))))))
     assert(costModel.costOfCount == 32) // TODO reduce this for performance
-    assert(costModel.costCompareCount == 20) // TODO reduce this for performance
+    assert(costModel.costCompareCount == 50) // TODO reduce this for performance
   }
 }
 


### PR DESCRIPTION
This is a concept work to add logical link to RAS metadata. To:

1. Make sure plans in the same group/cluster share the same logical link thus be logically identical (if query plans in the same group/cluster differ on their logical links, planner will throw an error)
3. Prove it possible to obtain Spark statistics from cost model

And with other minor improvements.