### PR TITLE
[BUILD] Syntax error when run `./dev/builddeps-veloxbe.sh --enable_s3=ON` on Ubuntu

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -108,6 +108,7 @@ function process_setup_ubuntu {
   if [ $ENABLE_S3 == "ON" ]; then
     sed -i '/^  run_and_time install_folly/a \ \ '${VELOX_HOME}/scripts'/setup-adapters.sh aws' scripts/setup-ubuntu.sh
     # it's used for velox CI
+    sed -i '/rpm -i minio-20220526054841.0.0.x86_64.rpm/a \ \ echo "Skip installing minio"' scripts/setup-adapters.sh
     sed -i 's/rpm -i minio-20220526054841.0.0.x86_64.rpm/#rpm -i minio-20220526054841.0.0.x86_64.rpm/g' scripts/setup-adapters.sh
   fi
   if [ $ENABLE_GCS == "ON" ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes: #6168

## How was this patch tested?

Run `./dev/builddeps-veloxbe.sh --enable_s3=ON` locally.

