### PR TITLE
[CORE] Use sc.listFiles instead of addedFiles.keys

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/HdfsConfGenerator.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/HdfsConfGenerator.scala
@@ -41,8 +41,8 @@ object HdfsConfGenerator extends Logging {
     addFileMethod.invoke(sc, path, Boolean.box(false), Boolean.box(true), Boolean.box(false))
     // Overwrite the spark internal config `spark.app.initial.file.urls`,
     // so that the file can be available before initializing executor plugin.
-    assert(sc.addedFiles.nonEmpty)
-    sc.conf.set("spark.app.initial.file.urls", sc.addedFiles.keys.toSeq.mkString(","))
+    assert(sc.listFiles.nonEmpty)
+    sc.conf.set("spark.app.initial.file.urls", sc.listFiles().mkString(","))
   }
 
   private def ignoreKey(key: String): Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The first level of `sc.addedFiles` changed to session, so this pr changes to use ` sc.listFiles` to be compatible  with Spark3.5 and later.

## How was this patch tested?

To be compatible with Spark3.5 and later