### PR TITLE
[GLUTEN-3806][VL] Add Arm64 libhdfs3 support for velox build

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -96,6 +96,8 @@ function process_setup_ubuntu {
   sed -i '/libgmock-dev/d' scripts/setup-ubuntu.sh # resolved by ep/build-velox/build/velox_ep/CMake/resolve_dependency_modules/gtest.cmake
   sed -i 's/github_checkout boostorg\/boost \"\${BOOST_VERSION}\" --recursive/wget_and_untar https:\/\/github.com\/boostorg\/boost\/releases\/download\/boost-1.84.0\/boost-1.84.0.tar.gz boost \&\& cd boost/g' scripts/setup-ubuntu.sh
   if [ $ENABLE_HDFS == "ON" ]; then
+    # TODO: The 'modify_libhdfs3.patch' will be removed once the following PR is merged into the oap-project/libhdfs.
+    # Track: https://github.com/oap-project/libhdfs3/pull/2
     sed -i '/^function install_folly.*/i function install_libhdfs3 {\n  github_checkout oap-project/libhdfs3 master \n git apply ../../../src/modify_libhdfs3.patch\n cmake_install\n}\n' scripts/setup-ubuntu.sh
     sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
     sed -i '/ccache /a\  yasm \\' scripts/setup-ubuntu.sh
@@ -137,7 +139,9 @@ function process_setup_centos8 {
   sed -i '/^  run_and_time install_fbthrift/a \  run_and_time install_openssl' scripts/setup-centos8.sh
 
   if [ $ENABLE_HDFS == "ON" ]; then
-    sed -i '/^function install_gflags.*/i function install_libhdfs3 {\n cd "\${DEPENDENCY_DIR}"\n github_checkout oap-project/libhdfs3 master\n git apply ../../../src/modify_libhdfs3.patch\n cd ..\n cmake_install\n}\n' scripts/setup-centos8.sh
+    # TODO: The 'modify_libhdfs3.patch' will be removed once the following PR is merged into the oap-project/libhdfs.
+    # Track: https://github.com/oap-project/libhdfs3/pull/2
+    sed -i '/^function install_gflags.*/i function install_libhdfs3 {\n github_checkout oap-project/libhdfs3 master\n git apply ../../../src/modify_libhdfs3.patch\n cmake_install\n}\n' scripts/setup-centos8.sh
     sed -i '/^  run_and_time install_fbthrift/a \  run_and_time install_libhdfs3' scripts/setup-centos8.sh
     sed -i '/^  dnf_install ninja-build/a\  dnf_install yasm\' scripts/setup-centos8.sh
   fi
@@ -173,7 +177,9 @@ function process_setup_centos7 {
   sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_gtest' scripts/setup-centos7.sh
 
   if [ $ENABLE_HDFS = "ON" ]; then
-    sed -i '/^function install_protobuf.*/i function install_libhdfs3 {\n cd "\${DEPENDENCY_DIR}"\n github_checkout oap-project/libhdfs3 master \n git apply ../../../src/modify_libhdfs3.patch\n cd ..\n cmake_install\n}\n' scripts/setup-centos7.sh
+    # TODO: The 'modify_libhdfs3.patch' will be removed once the following PR is merged into the oap-project/libhdfs.
+    # Track: https://github.com/oap-project/libhdfs3/pull/2
+    sed -i '/^function install_protobuf.*/i function install_libhdfs3 {\n github_checkout oap-project/libhdfs3 master \n git apply ../../../src/modify_libhdfs3.patch\n cmake_install\n}\n' scripts/setup-centos7.sh
     sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_libhdfs3' scripts/setup-centos7.sh
     sed -i '/^dnf_install ccache/a\ \ yasm \\' scripts/setup-centos7.sh
   fi

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -96,7 +96,7 @@ function process_setup_ubuntu {
   sed -i '/libgmock-dev/d' scripts/setup-ubuntu.sh # resolved by ep/build-velox/build/velox_ep/CMake/resolve_dependency_modules/gtest.cmake
   sed -i 's/github_checkout boostorg\/boost \"\${BOOST_VERSION}\" --recursive/wget_and_untar https:\/\/github.com\/boostorg\/boost\/releases\/download\/boost-1.84.0\/boost-1.84.0.tar.gz boost \&\& cd boost/g' scripts/setup-ubuntu.sh
   if [ $ENABLE_HDFS == "ON" ]; then
-    sed -i '/^function install_folly.*/i function install_libhdfs3 {\n  github_checkout oap-project/libhdfs3 master \n cmake_install\n}\n' scripts/setup-ubuntu.sh
+    sed -i '/^function install_folly.*/i function install_libhdfs3 {\n  github_checkout oap-project/libhdfs3 master \n git apply ../../../src/modify_libhdfs3.patch\n cmake_install\n}\n' scripts/setup-ubuntu.sh
     sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
     sed -i '/ccache /a\  yasm \\' scripts/setup-ubuntu.sh
   fi
@@ -137,7 +137,7 @@ function process_setup_centos8 {
   sed -i '/^  run_and_time install_fbthrift/a \  run_and_time install_openssl' scripts/setup-centos8.sh
 
   if [ $ENABLE_HDFS == "ON" ]; then
-    sed -i '/^function install_gflags.*/i function install_libhdfs3 {\n cd "\${DEPENDENCY_DIR}"\n github_checkout oap-project/libhdfs3 master\n cmake_install\n}\n' scripts/setup-centos8.sh
+    sed -i '/^function install_gflags.*/i function install_libhdfs3 {\n cd "\${DEPENDENCY_DIR}"\n github_checkout oap-project/libhdfs3 master\n git apply ../../../src/modify_libhdfs3.patch\n cd ..\n cmake_install\n}\n' scripts/setup-centos8.sh
     sed -i '/^  run_and_time install_fbthrift/a \  run_and_time install_libhdfs3' scripts/setup-centos8.sh
     sed -i '/^  dnf_install ninja-build/a\  dnf_install yasm\' scripts/setup-centos8.sh
   fi
@@ -173,7 +173,7 @@ function process_setup_centos7 {
   sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_gtest' scripts/setup-centos7.sh
 
   if [ $ENABLE_HDFS = "ON" ]; then
-    sed -i '/^function install_protobuf.*/i function install_libhdfs3 {\n cd "\${DEPENDENCY_DIR}"\n github_checkout oap-project/libhdfs3 master \n cmake_install\n}\n' scripts/setup-centos7.sh
+    sed -i '/^function install_protobuf.*/i function install_libhdfs3 {\n cd "\${DEPENDENCY_DIR}"\n github_checkout oap-project/libhdfs3 master \n git apply ../../../src/modify_libhdfs3.patch\n cd ..\n cmake_install\n}\n' scripts/setup-centos7.sh
     sed -i '/^  run_and_time install_folly/a \ \ run_and_time install_libhdfs3' scripts/setup-centos7.sh
     sed -i '/^dnf_install ccache/a\ \ yasm \\' scripts/setup-centos7.sh
   fi

--- a/ep/build-velox/src/modify_libhdfs3.patch
+++ b/ep/build-velox/src/modify_libhdfs3.patch
@@ -1,0 +1,35 @@
+diff --git a/CMake/Options.cmake b/CMake/Options.cmake
+index 14762eb..161190d 100644
+--- a/CMake/Options.cmake
++++ b/CMake/Options.cmake
+@@ -1,6 +1,18 @@
+ OPTION(ENABLE_COVERAGE "enable code coverage" OFF)
+ OPTION(ENABLE_DEBUG "enable debug build" OFF)
+-OPTION(ENABLE_SSE "enable SSE4.2 buildin function" ON)
++
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
++  OPTION(ENABLE_SSE "enable SSE4.2 buildin function" ON)
++else()
++  OPTION(ENABLE_SSE "enable SSE4.2 buildin function" OFF)
++endif()
++
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(AARCH64)|(ARM64)|(arm64)")
++       OPTION(ENABLE_NEON "enable NEON buildin function" ON)
++else()
++       OPTION(ENABLE_NEON "enable NEON buildin function" OFF)
++endif()
++
+ OPTION(ENABLE_FRAME_POINTER "enable frame pointer on 64bit system with flag -fno-omit-frame-pointer, on 32bit system, it is always enabled" ON)
+ OPTION(ENABLE_LIBCPP "using libc++ instead of libstdc++, only valid for clang compiler" OFF)
+ OPTION(ENABLE_BOOST "using boost instead of native compiler c++0x support" OFF)
+@@ -34,6 +46,10 @@ IF(ENABLE_SSE STREQUAL ON)
+     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+ ENDIF(ENABLE_SSE STREQUAL ON)
+
++IF(ENABLE_NEON STREQUAL ON)
++    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
++ENDIF(ENABLE_NEON STREQUAL ON)
++
+ IF(NOT TEST_HDFS_PREFIX)
+ SET(TEST_HDFS_PREFIX "./" CACHE STRING "default directory prefix used for test." FORCE)
+ ENDIF(NOT TEST_HDFS_PREFIX)


### PR DESCRIPTION
## What changes were proposed in this pull request?
`SSE4.2` is always enabled in Project oap-project/libhdfs3 [Options.cmake](https://github.com/oap-project/libhdfs3/blob/master/CMake/Options.cmake#L3).
When building Gluten-Velox with enabling HDFS(`--enable_hdfs=ON`) on Arm64 Ubuntu, build issues occurred:

```
c++: error: unrecognized command-line option ‘-msse4.2’
ninja: build stopped: subcommand failed.
```

## How was this patch tested?
Build Gluten-Velox with --enable_hdfs=ON
./dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_hdfs=ON

libhdfs.so could be properly installed.


