### PR TITLE
[GLUTEN-6189][CORE] Shouldn't pushdown undeterministic filter to scan node

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -1873,7 +1873,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
     }
   }
 
-  test("Shouldn't pushdown deterministic filter to scan node") {
+  test("Shouldn't pushdown undeterministic filter to scan node") {
     // there are total 60175 rows in lineitem, after rand filter,
     // there should be around 30000 rows
     val resultLength = spark
@@ -1883,5 +1883,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       .collect()
       .length
     assert(resultLength >= 25000)
+    assert(resultLength >= 40000)
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -1872,4 +1872,16 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
         }
     }
   }
+
+  test("Shouldn't pushdown deterministic filter to scan node") {
+    // there are total 60175 rows in lineitem, after rand filter,
+    // there should be around 30000 rows
+    val resultLength = spark
+      .sql("""
+             |select * from lineitem where rand() <= 0.5
+             |""".stripMargin)
+      .collect()
+      .length
+    assert(resultLength >= 25000)
+  }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -1883,6 +1883,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       .collect()
       .length
     assert(resultLength >= 25000)
-    assert(resultLength >= 40000)
+    assert(resultLength <= 40000)
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -672,9 +672,11 @@ trait SparkPlanExecApi {
     def getPushedFilter(dataFilters: Seq[Expression]): Seq[Expression] = {
       val pushedFilters =
         dataFilters ++ FilterHandler.getRemainingFilters(dataFilters, extraFilters)
-      pushedFilters.filterNot(_.references.exists {
-        attr => SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)
-      })
+      pushedFilters
+        .filterNot(_.references.exists {
+          attr => SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)
+        })
+        .filter(_.deterministic)
     }
     sparkExecNode match {
       case fileSourceScan: FileSourceScanExec =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We shouldn't pushdown undeterministic filter to scan node, for example, if we push down filter with `rand() < 0.5` to scan, the result will be around 1/4 instead of 1/2.

(Fixes: \#6189)

## How was this patch tested?

UT

