### PR TITLE
[GLUTEN-6067][CH] [Part 2] Support CH backend with Spark3.5 - Prepare for supporting sink transform

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -50,7 +50,6 @@ import org.apache.spark.sql.delta.files.TahoeFileIndex
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
-import org.apache.spark.sql.execution.datasources.GlutenWriterColumnarRules.NativeWritePostRule
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.source.DeltaMergeTreeFileFormat
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
@@ -582,14 +581,6 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
    */
   override def genExtendedColumnarTransformRules(): List[SparkSession => Rule[SparkPlan]] =
     List()
-
-  /**
-   * Generate extended columnar post-rules.
-   *
-   * @return
-   */
-  override def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] =
-    List(spark => NativeWritePostRule(spark))
 
   override def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]] = {
     List()

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashJoinExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.clickhouse.CHIteratorApi
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.utils.{BroadcastHashJoinStrategy, CHJoinValidateUtil, ShuffleHashJoinStrategy}
 
@@ -75,7 +74,7 @@ case class CHBroadcastBuildSideRDD(
 
   override def genBroadcastBuildSideIterator(): Iterator[ColumnarBatch] = {
     CHBroadcastBuildSideCache.getOrBuildBroadcastHashTable(broadcasted, broadcastContext)
-    CHIteratorApi.genCloseableColumnBatchIterator(Iterator.empty)
+    Iterator.empty
   }
 }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -46,7 +46,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
       .set("spark.io.compression.codec", "LZ4")
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
-      .set("spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level", "DEBUG")
+      // .set("spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level", "DEBUG")
       .set(
         "spark.gluten.sql.columnar.backend.ch.runtime_settings.input_format_parquet_max_block_size",
         s"$parquetMaxBlockSize")

--- a/backends-clickhouse/src/test/scala/org/apache/spark/gluten/NativeWriteChecker.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/gluten/NativeWriteChecker.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.gluten
+
+import org.apache.gluten.execution.GlutenClickHouseWholeStageTransformerSuite
+
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.datasources.FakeRowAdaptor
+import org.apache.spark.sql.util.QueryExecutionListener
+
+trait NativeWriteChecker extends GlutenClickHouseWholeStageTransformerSuite {
+
+  def checkNativeWrite(sqlStr: String, checkNative: Boolean): Unit = {
+    var nativeUsed = false
+
+    val queryListener = new QueryExecutionListener {
+      override def onFailure(f: String, qe: QueryExecution, e: Exception): Unit = {}
+      override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
+        if (!nativeUsed) {
+          nativeUsed = if (isSparkVersionGE("3.4")) {
+            false
+          } else {
+            qe.executedPlan.find(_.isInstanceOf[FakeRowAdaptor]).isDefined
+          }
+        }
+      }
+    }
+
+    try {
+      spark.listenerManager.register(queryListener)
+      spark.sql(sqlStr)
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+      assertResult(checkNative)(nativeUsed)
+    } finally {
+      spark.listenerManager.unregister(queryListener)
+    }
+  }
+}

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -827,15 +827,6 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     buf.result
   }
 
-  /**
-   * Generate extended columnar post-rules.
-   *
-   * @return
-   */
-  override def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = {
-    SparkShimLoader.getSparkShims.getExtendedColumnarPostRules() ::: List()
-  }
-
   override def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]] = {
     List(ArrowConvertorRule)
   }

--- a/cpp-ch/local-engine/Common/CHUtil.h
+++ b/cpp-ch/local-engine/Common/CHUtil.h
@@ -137,9 +137,8 @@ public:
     /// Initialize two kinds of resources
     /// 1. global level resources like global_context/shared_context, notice that they can only be initialized once in process lifetime
     /// 2. session level resources like settings/configs, they can be initialized multiple times following the lifetime of executor/driver
-    static void init(std::string * plan);
-    static void init_json(std::string * plan_json);
-    static void updateConfig(const DB::ContextMutablePtr &, std::string *);
+    static void init(const std::string & plan);
+    static void updateConfig(const DB::ContextMutablePtr &, const std::string &);
 
 
     // use excel text parser
@@ -196,7 +195,7 @@ private:
     static void updateNewSettings(const DB::ContextMutablePtr &, const DB::Settings &);
 
 
-    static std::map<std::string, std::string> getBackendConfMap(std::string * plan);
+    static std::map<std::string, std::string> getBackendConfMap(const std::string & plan);
 
     inline static std::once_flag init_flag;
     inline static Poco::Logger * logger;
@@ -283,10 +282,7 @@ public:
         return deq.empty();
     }
 
-    std::deque<T> unsafeGet()
-    {
-        return deq;
-    }
+    std::deque<T> unsafeGet() { return deq; }
 
 private:
     std::deque<T> deq;

--- a/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -453,7 +453,7 @@ std::unique_ptr<SparkRowInfo> CHColumnToSparkRow::convertCHColumnToSparkRow(cons
     if (!block.columns())
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "A block with empty columns");
     std::unique_ptr<SparkRowInfo> spark_row_info = std::make_unique<SparkRowInfo>(block, masks);
-    spark_row_info->setBufferAddress(reinterpret_cast<char *>(alloc(spark_row_info->getTotalBytes(), 64)));
+    spark_row_info->setBufferAddress(static_cast<char *>(alloc(spark_row_info->getTotalBytes(), 64)));
     // spark_row_info->setBufferAddress(alignedAlloc(spark_row_info->getTotalBytes(), 64));
     memset(spark_row_info->getBufferAddress(), 0, spark_row_info->getTotalBytes());
     for (auto col_idx = 0; col_idx < spark_row_info->getNumCols(); col_idx++)

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -224,11 +224,9 @@ JNIEXPORT void JNI_OnUnload(JavaVM * vm, void * /*reserved*/)
 JNIEXPORT void Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv * env, jobject, jbyteArray conf_plan)
 {
     LOCAL_ENGINE_JNI_METHOD_START
-    jsize plan_buf_size = env->GetArrayLength(conf_plan);
+    std::string::size_type plan_buf_size = env->GetArrayLength(conf_plan);
     jbyte * plan_buf_addr = env->GetByteArrayElements(conf_plan, nullptr);
-    std::string plan_str;
-    plan_str.assign(reinterpret_cast<const char *>(plan_buf_addr), plan_buf_size);
-    local_engine::BackendInitializerUtil::init(&plan_str);
+    local_engine::BackendInitializerUtil::init({reinterpret_cast<const char *>(plan_buf_addr), plan_buf_size});
     env->ReleaseByteArrayElements(conf_plan, plan_buf_addr, JNI_ABORT);
     LOCAL_ENGINE_JNI_METHOD_END(env, )
 }
@@ -254,11 +252,9 @@ JNIEXPORT jlong Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_
     auto query_context = local_engine::getAllocator(allocator_id)->query_context;
 
     // by task update new configs ( in case of dynamic config update )
-    jsize plan_buf_size = env->GetArrayLength(conf_plan);
+    std::string::size_type plan_buf_size = env->GetArrayLength(conf_plan);
     jbyte * plan_buf_addr = env->GetByteArrayElements(conf_plan, nullptr);
-    std::string plan_str;
-    plan_str.assign(reinterpret_cast<const char *>(plan_buf_addr), plan_buf_size);
-    local_engine::BackendInitializerUtil::updateConfig(query_context, &plan_str);
+    local_engine::BackendInitializerUtil::updateConfig(query_context, {reinterpret_cast<const char *>(plan_buf_addr), plan_buf_size});
 
     local_engine::SerializedPlanParser parser(query_context);
     jsize iter_num = env->GetArrayLength(iter_arr);
@@ -277,17 +273,14 @@ JNIEXPORT jlong Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_
         parser.addSplitInfo(std::string{reinterpret_cast<const char *>(split_info_addr), split_info_size});
     }
 
-    jsize plan_size = env->GetArrayLength(plan);
+    std::string::size_type plan_size = env->GetArrayLength(plan);
     jbyte * plan_address = env->GetByteArrayElements(plan, nullptr);
-    std::string plan_string;
-    plan_string.assign(reinterpret_cast<const char *>(plan_address), plan_size);
-    auto query_plan = parser.parse(plan_string);
-    local_engine::LocalExecutor * executor = new local_engine::LocalExecutor(query_context);
+    local_engine::LocalExecutor * executor
+        = parser.createExecutor<false>({reinterpret_cast<const char *>(plan_address), plan_size}).release();
     local_engine::LocalExecutor::addExecutor(executor);
-    LOG_INFO(&Poco::Logger::get("jni"), "Construct LocalExecutor {}", reinterpret_cast<intptr_t>(executor));
+    LOG_INFO(&Poco::Logger::get("jni"), "Construct LocalExecutor {}", reinterpret_cast<uintptr_t>(executor));
     executor->setMetric(parser.getMetric());
     executor->setExtraPlanHolder(parser.extra_plan_holder);
-    executor->execute(std::move(query_plan));
     env->ReleaseByteArrayElements(plan, plan_address, JNI_ABORT);
     env->ReleaseByteArrayElements(conf_plan, plan_buf_addr, JNI_ABORT);
     return reinterpret_cast<jlong>(executor);
@@ -932,11 +925,10 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
     LOCAL_ENGINE_JNI_METHOD_START
     auto query_context = local_engine::getAllocator(allocator_id)->query_context;
     // by task update new configs ( in case of dynamic config update )
-    jsize conf_plan_buf_size = env->GetArrayLength(conf_plan);
+    std::string::size_type conf_plan_buf_size = env->GetArrayLength(conf_plan);
     jbyte * conf_plan_buf_addr = env->GetByteArrayElements(conf_plan, nullptr);
-    std::string conf_plan_str;
-    conf_plan_str.assign(reinterpret_cast<const char *>(conf_plan_buf_addr), conf_plan_buf_size);
-    local_engine::BackendInitializerUtil::updateConfig(query_context, &conf_plan_str);
+    local_engine::BackendInitializerUtil::updateConfig(
+        query_context, {reinterpret_cast<const char *>(conf_plan_buf_addr), conf_plan_buf_size});
 
     const auto uuid_str = jstring2string(env, uuid_);
     const auto task_id = jstring2string(env, task_id_);
@@ -1329,14 +1321,11 @@ Java_org_apache_gluten_vectorized_SimpleExpressionEval_createNativeInstance(JNIE
     local_engine::SerializedPlanParser parser(context);
     jobject iter = env->NewGlobalRef(input);
     parser.addInputIter(iter, false);
-    jsize plan_size = env->GetArrayLength(plan);
+    std::string::size_type plan_size = env->GetArrayLength(plan);
     jbyte * plan_address = env->GetByteArrayElements(plan, nullptr);
-    std::string plan_string;
-    plan_string.assign(reinterpret_cast<const char *>(plan_address), plan_size);
-    auto query_plan = parser.parse(plan_string);
-    local_engine::LocalExecutor * executor = new local_engine::LocalExecutor(context);
+    local_engine::LocalExecutor * executor
+        = parser.createExecutor<false>({reinterpret_cast<const char *>(plan_address), plan_size}).release();
     local_engine::LocalExecutor::addExecutor(executor);
-    executor->execute(std::move(query_plan));
     env->ReleaseByteArrayElements(plan, plan_address, JNI_ABORT);
     return reinterpret_cast<jlong>(executor);
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)

--- a/cpp-ch/local-engine/tests/benchmark_local_engine.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_local_engine.cpp
@@ -154,14 +154,11 @@ DB::ContextMutablePtr global_context;
                       std::move(schema))
                   .build();
         local_engine::SerializedPlanParser parser(global_context);
-        auto query_plan = parser.parse(std::move(plan));
-        local_engine::LocalExecutor local_executor;
+        auto local_executor = parser.createExecutor(*plan);
         state.ResumeTiming();
-        local_executor.execute(std::move(query_plan));
-        while (local_executor.hasNext())
-        {
-            local_engine::SparkRowInfoPtr spark_row_info = local_executor.next();
-        }
+
+        while (local_executor->hasNext())
+            local_engine::SparkRowInfoPtr spark_row_info = local_executor->next();
     }
 }
 
@@ -212,13 +209,12 @@ DB::ContextMutablePtr global_context;
                       std::move(schema))
                   .build();
         local_engine::SerializedPlanParser parser(SerializedPlanParser::global_context);
-        auto query_plan = parser.parse(std::move(plan));
-        local_engine::LocalExecutor local_executor;
+        auto local_executor = parser.createExecutor(*plan);
         state.ResumeTiming();
-        local_executor.execute(std::move(query_plan));
-        while (local_executor.hasNext())
+
+        while (local_executor->hasNext())
         {
-            Block * block = local_executor.nextColumnar();
+            Block * block = local_executor->nextColumnar();
             delete block;
         }
     }
@@ -238,15 +234,10 @@ DB::ContextMutablePtr global_context;
         std::ifstream t(path);
         std::string str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         std::cout << "the plan from: " << path << std::endl;
-
-        auto query_plan = parser.parse(str);
-        local_engine::LocalExecutor local_executor;
+        auto local_executor = parser.createExecutor<false>(str);
         state.ResumeTiming();
-        local_executor.execute(std::move(query_plan));
-        while (local_executor.hasNext())
-        {
-            [[maybe_unused]] auto * x = local_executor.nextColumnar();
-        }
+        while (local_executor->hasNext()) [[maybe_unused]]
+            auto * x = local_executor->nextColumnar();
     }
 }
 
@@ -282,14 +273,12 @@ DB::ContextMutablePtr global_context;
                       std::move(schema))
                   .build();
         local_engine::SerializedPlanParser parser(SerializedPlanParser::global_context);
-        auto query_plan = parser.parse(std::move(plan));
-        local_engine::LocalExecutor local_executor;
+
+        auto local_executor = parser.createExecutor(*plan);
         state.ResumeTiming();
-        local_executor.execute(std::move(query_plan));
-        while (local_executor.hasNext())
-        {
-            local_engine::SparkRowInfoPtr spark_row_info = local_executor.next();
-        }
+
+        while (local_executor->hasNext())
+            local_engine::SparkRowInfoPtr spark_row_info = local_executor->next();
     }
 }
 
@@ -320,16 +309,13 @@ DB::ContextMutablePtr global_context;
                   .build();
 
         local_engine::SerializedPlanParser parser(SerializedPlanParser::global_context);
-        auto query_plan = parser.parse(std::move(plan));
-        local_engine::LocalExecutor local_executor;
-
-        local_executor.execute(std::move(query_plan));
+        auto local_executor = parser.createExecutor(*plan);
         local_engine::SparkRowToCHColumn converter;
-        while (local_executor.hasNext())
+        while (local_executor->hasNext())
         {
-            local_engine::SparkRowInfoPtr spark_row_info = local_executor.next();
+            local_engine::SparkRowInfoPtr spark_row_info = local_executor->next();
             state.ResumeTiming();
-            auto block = converter.convertSparkRowInfoToCHColumn(*spark_row_info, local_executor.getHeader());
+            auto block = converter.convertSparkRowInfoToCHColumn(*spark_row_info, local_executor->getHeader());
             state.PauseTiming();
         }
         state.ResumeTiming();
@@ -368,16 +354,13 @@ DB::ContextMutablePtr global_context;
                       std::move(schema))
                   .build();
         local_engine::SerializedPlanParser parser(SerializedPlanParser::global_context);
-        auto query_plan = parser.parse(std::move(plan));
-        local_engine::LocalExecutor local_executor;
-
-        local_executor.execute(std::move(query_plan));
+        auto local_executor = parser.createExecutor(*plan);
         local_engine::SparkRowToCHColumn converter;
-        while (local_executor.hasNext())
+        while (local_executor->hasNext())
         {
-            local_engine::SparkRowInfoPtr spark_row_info = local_executor.next();
+            local_engine::SparkRowInfoPtr spark_row_info = local_executor->next();
             state.ResumeTiming();
-            auto block = converter.convertSparkRowInfoToCHColumn(*spark_row_info, local_executor.getHeader());
+            auto block = converter.convertSparkRowInfoToCHColumn(*spark_row_info, local_executor->getHeader());
             state.PauseTiming();
         }
         state.ResumeTiming();
@@ -485,12 +468,8 @@ DB::ContextMutablePtr global_context;
     y.reserve(cnt);
 
     for (auto _ : state)
-    {
         for (i = 0; i < cnt; i++)
-        {
             y[i] = add(x[i], i);
-        }
-    }
 }
 
 [[maybe_unused]] static void BM_TestSumInline(benchmark::State & state)
@@ -504,12 +483,8 @@ DB::ContextMutablePtr global_context;
     y.reserve(cnt);
 
     for (auto _ : state)
-    {
         for (i = 0; i < cnt; i++)
-        {
             y[i] = x[i] + i;
-        }
-    }
 }
 
 [[maybe_unused]] static void BM_TestPlus(benchmark::State & state)
@@ -545,9 +520,7 @@ DB::ContextMutablePtr global_context;
     block.insert(y);
     auto executable_function = function->prepare(arguments);
     for (auto _ : state)
-    {
         auto result = executable_function->execute(block.getColumnsWithTypeAndName(), type, rows, false);
-    }
 }
 
 [[maybe_unused]] static void BM_TestPlusEmbedded(benchmark::State & state)
@@ -847,9 +820,7 @@ QueryPlanPtr joinPlan(QueryPlanPtr left, QueryPlanPtr right, String left_key, St
     ASTPtr rkey = std::make_shared<ASTIdentifier>(right_key);
     join->addOnKeys(lkey, rkey, true);
     for (const auto & column : join->columnsFromJoinedTable())
-    {
         join->addJoinedColumn(column);
-    }
 
     auto left_keys = left->getCurrentDataStream().header.getNamesAndTypesList();
     join->addJoinedColumnsAndCorrectTypes(left_keys, true);
@@ -920,7 +891,8 @@ BENCHMARK(BM_ParquetRead)->Unit(benchmark::kMillisecond)->Iterations(10);
 
 int main(int argc, char ** argv)
 {
-    BackendInitializerUtil::init(nullptr);
+    std::string empty;
+    BackendInitializerUtil::init(empty);
     SCOPE_EXIT({ BackendFinalizerUtil::finalizeGlobally(); });
 
     ::benchmark::Initialize(&argc, argv);

--- a/cpp-ch/local-engine/tests/gluten_test_util.h
+++ b/cpp-ch/local-engine/tests/gluten_test_util.h
@@ -24,6 +24,7 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/ActionsDAG.h>
+#include <google/protobuf/util/json_util.h>
 #include <parquet/schema.h>
 
 using BlockRowType = DB::ColumnsWithTypeAndName;
@@ -60,6 +61,23 @@ AnotherRowType readParquetSchema(const std::string & file);
 
 DB::ActionsDAGPtr parseFilter(const std::string & filter, const AnotherRowType & name_and_types);
 
+namespace pb_util
+{
+template <typename Message>
+std::string JsonStringToBinary(const std::string_view & json)
+{
+    Message message;
+    std::string binary;
+    auto s = google::protobuf::util::JsonStringToMessage(json, &message);
+    if (!s.ok())
+    {
+        const std::string err_msg{s.message()};
+        throw std::runtime_error(err_msg);
+    }
+    message.SerializeToString(&binary);
+    return binary;
+}
+}
 }
 
 inline DB::DataTypePtr BIGINT()

--- a/cpp-ch/local-engine/tests/gtest_parser.cpp
+++ b/cpp-ch/local-engine/tests/gtest_parser.cpp
@@ -14,307 +14,140 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <gluten_test_util.h>
+#include <incbin.h>
 #include <Parser/SerializedPlanParser.h>
-#include <google/protobuf/util/json_util.h>
 #include <gtest/gtest.h>
+
 
 using namespace local_engine;
 using namespace DB;
 
-std::string splitBinaryFromJson(const std::string & json)
-{
-    std::string binary;
-    substrait::ReadRel::LocalFiles local_files;
-    auto s = google::protobuf::util::JsonStringToMessage(absl::string_view(json), &local_files);
-    local_files.SerializeToString(&binary);
-    return binary;
-}
-
-std::string JsonPlanFor65234()
-{
-    // Plan for https://github.com/ClickHouse/ClickHouse/pull/65234
-    return R"(
-{
-  "extensions": [{
-    "extensionFunction": {
-      "functionAnchor": 1,
-      "name": "is_not_null:str"
-    }
-  }, {
-    "extensionFunction": {
-      "functionAnchor": 2,
-      "name": "equal:str_str"
-    }
-  }, {
-    "extensionFunction": {
-      "functionAnchor": 3,
-      "name": "is_not_null:i64"
-    }
-  }, {
-    "extensionFunction": {
-      "name": "and:bool_bool"
-    }
-  }],
-  "relations": [{
-    "root": {
-      "input": {
-        "project": {
-          "common": {
-            "emit": {
-              "outputMapping": [2]
-            }
-          },
-          "input": {
-            "filter": {
-              "common": {
-                "direct": {
-                }
-              },
-              "input": {
-                "read": {
-                  "common": {
-                    "direct": {
-                    }
-                  },
-                  "baseSchema": {
-                    "names": ["r_regionkey", "r_name"],
-                    "struct": {
-                      "types": [{
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      }, {
-                        "string": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      }]
-                    },
-                    "columnTypes": ["NORMAL_COL", "NORMAL_COL"]
-                  },
-                  "filter": {
-                    "scalarFunction": {
-                      "outputType": {
-                        "bool": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      "arguments": [{
-                        "value": {
-                          "scalarFunction": {
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [{
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 1,
-                                  "outputType": {
-                                    "bool": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  "arguments": [{
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 1
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }]
-                                }
-                              }
-                            }, {
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 2,
-                                  "outputType": {
-                                    "bool": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [{
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 1
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }, {
-                                    "value": {
-                                      "literal": {
-                                        "string": "EUROPE"
-                                      }
-                                    }
-                                  }]
-                                }
-                              }
-                            }]
-                          }
-                        }
-                      }, {
-                        "value": {
-                          "scalarFunction": {
-                            "functionReference": 3,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "arguments": [{
-                              "value": {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                    }
-                                  }
-                                }
-                              }
-                            }]
-                          }
-                        }
-                      }]
-                    }
-                  },
-                  "advancedExtension": {
-                    "optimization": {
-                      "@type": "type.googleapis.com/google.protobuf.StringValue",
-                      "value": "isMergeTree\u003d0\n"
-                    }
-                  }
-                }
-              },
-              "condition": {
-                "scalarFunction": {
-                  "outputType": {
-                    "bool": {
-                      "nullability": "NULLABILITY_NULLABLE"
-                    }
-                  },
-                  "arguments": [{
-                    "value": {
-                      "scalarFunction": {
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [{
-                          "value": {
-                            "scalarFunction": {
-                              "functionReference": 1,
-                              "outputType": {
-                                "bool": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              "arguments": [{
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 1
-                                      }
-                                    }
-                                  }
-                                }
-                              }]
-                            }
-                          }
-                        }, {
-                          "value": {
-                            "scalarFunction": {
-                              "functionReference": 2,
-                              "outputType": {
-                                "bool": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [{
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 1
-                                      }
-                                    }
-                                  }
-                                }
-                              }, {
-                                "value": {
-                                  "literal": {
-                                    "string": "EUROPE"
-                                  }
-                                }
-                              }]
-                            }
-                          }
-                        }]
-                      }
-                    }
-                  }, {
-                    "value": {
-                      "scalarFunction": {
-                        "functionReference": 3,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_REQUIRED"
-                          }
-                        },
-                        "arguments": [{
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                }
-                              }
-                            }
-                          }
-                        }]
-                      }
-                    }
-                  }]
-                }
-              }
-            }
-          },
-          "expressions": [{
-            "selection": {
-              "directReference": {
-                "structField": {
-                }
-              }
-            }
-          }]
-        }
-      },
-      "names": ["r_regionkey#72"],
-      "outputSchema": {
-        "types": [{
-          "i64": {
-            "nullability": "NULLABILITY_NULLABLE"
-          }
-        }],
-        "nullability": "NULLABILITY_REQUIRED"
-      }
-    }
-  }]
-}
-)";
-}
+// Plan for https://github.com/ClickHouse/ClickHouse/pull/65234
+INCBIN(resource_embedded_pr_65234_json, SOURCE_DIR "/utils/extern-local-engine/tests/json/clickhouse_pr_65234.json");
 
 TEST(SerializedPlanParser, PR65234)
 {
     const std::string split
-        = R"({"items":[{"uriFile":"file:///part-00000-16caa751-9774-470c-bd37-5c84c53373c8-c000.snappy.parquet","length":"84633","parquet":{},"schema":{},"metadataColumns":[{}]}]}")";
+        = R"({"items":[{"uriFile":"file:///home/chang/SourceCode/rebase_gluten/backends-clickhouse/target/scala-2.12/test-classes/tests-working-home/tpch-data/supplier/part-00000-16caa751-9774-470c-bd37-5c84c53373c8-c000.snappy.parquet","length":"84633","parquet":{},"schema":{},"metadataColumns":[{}]}]})";
     SerializedPlanParser parser(SerializedPlanParser::global_context);
-    parser.addSplitInfo(splitBinaryFromJson(split));
-    parser.parseJson(JsonPlanFor65234());
+    parser.addSplitInfo(test::pb_util::JsonStringToBinary<substrait::ReadRel::LocalFiles>(split));
+    auto query_plan
+        = parser.parseJson({reinterpret_cast<const char *>(gresource_embedded_pr_65234_jsonData), gresource_embedded_pr_65234_jsonSize});
+}
+
+#include <Disks/ObjectStorages/HDFS/HDFSObjectStorage.h>
+#include <Parsers/ParserCreateQuery.h>
+#include <Parsers/parseQuery.h>
+#include <Storages/ObjectStorage/HDFS/Configuration.h>
+#include <Storages/ObjectStorage/StorageObjectStorageSink.h>
+
+Chunk testChunk()
+{
+    auto nameCol = STRING()->createColumn();
+    nameCol->insert("one");
+    nameCol->insert("two");
+    nameCol->insert("three");
+
+    auto valueCol = UINT()->createColumn();
+    valueCol->insert(1);
+    valueCol->insert(2);
+    valueCol->insert(3);
+    MutableColumns x;
+    x.push_back(std::move(nameCol));
+    x.push_back(std::move(valueCol));
+    return {std::move(x), 3};
+}
+
+TEST(LocalExecutor, StorageObjectStorageSink)
+{
+    /// 0. Create ObjectStorage for HDFS
+    auto settings = SerializedPlanParser::global_context->getSettingsRef();
+    const std::string query
+        = R"(CREATE TABLE hdfs_engine_xxxx (name String, value UInt32) ENGINE=HDFS('hdfs://localhost:8020/clickhouse/test2', 'Parquet'))";
+    DB::ParserCreateQuery parser;
+    std::string error_message;
+    const char * pos = query.data();
+    auto ast = DB::tryParseQuery(
+        parser,
+        pos,
+        pos + query.size(),
+        error_message,
+        /* hilite = */ false,
+        "QUERY TEST",
+        /* allow_multi_statements = */ false,
+        0,
+        settings.max_parser_depth,
+        settings.max_parser_backtracks,
+        true);
+    auto & create = ast->as<ASTCreateQuery &>();
+    auto arg = create.storage->children[0];
+    const auto * func = arg->as<const ASTFunction>();
+    EXPECT_TRUE(func && func->name == "HDFS");
+
+    DB::StorageHDFSConfiguration config;
+    StorageObjectStorage::Configuration::initialize(config, arg->children[0]->children, SerializedPlanParser::global_context, false);
+
+    const std::shared_ptr<DB::HDFSObjectStorage> object_storage
+        = std::dynamic_pointer_cast<DB::HDFSObjectStorage>(config.createObjectStorage(SerializedPlanParser::global_context, false));
+    EXPECT_TRUE(object_storage != nullptr);
+
+    RelativePathsWithMetadata files_with_metadata;
+    object_storage->listObjects("/clickhouse", files_with_metadata, 0);
+
+    /// 1. Create ObjectStorageSink
+    DB::StorageObjectStorageSink sink{
+        object_storage, config.clone(), {}, {{STRING(), "name"}, {UINT(), "value"}}, SerializedPlanParser::global_context, ""};
+
+    /// 2. Create Chunk
+    /// 3. comsume
+    sink.consume(testChunk());
+    sink.onFinish();
+}
+
+namespace DB
+{
+SinkToStoragePtr createFilelinkSink(
+    const StorageMetadataPtr & metadata_snapshot,
+    const String & table_name_for_log,
+    const String & path,
+    CompressionMethod compression_method,
+    const std::optional<FormatSettings> & format_settings,
+    const String & format_name,
+    const ContextPtr & context,
+    int flags);
+}
+
+INCBIN(resource_embedded_readcsv_json, SOURCE_DIR "/utils/extern-local-engine/tests/json/read_student_option_schema.csv.json");
+TEST(LocalExecutor, StorageFileSink)
+{
+    const std::string split
+        = R"({"items":[{"uriFile":"file:///home/chang/SourceCode/rebase_gluten/backends-velox/src/test/resources/datasource/csv/student_option_schema.csv","length":"56","text":{"fieldDelimiter":",","maxBlockSize":"8192","header":"1"},"schema":{"names":["id","name","language"],"struct":{"types":[{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}}]}},"metadataColumns":[{}]}]})";
+    SerializedPlanParser parser(SerializedPlanParser::global_context);
+    parser.addSplitInfo(test::pb_util::JsonStringToBinary<substrait::ReadRel::LocalFiles>(split));
+    auto local_executor = parser.createExecutor<true>(
+        {reinterpret_cast<const char *>(gresource_embedded_readcsv_jsonData), gresource_embedded_readcsv_jsonSize});
+
+    while (local_executor->hasNext())
+    {
+        const Block & x = *local_executor->nextColumnar();
+        EXPECT_EQ(4, x.rows());
+    }
+
+    StorageInMemoryMetadata metadata;
+    metadata.setColumns(ColumnsDescription::fromNamesAndTypes({{"name", STRING()}, {"value", UINT()}}));
+    StorageMetadataPtr metadata_ptr = std::make_shared<StorageInMemoryMetadata>(metadata);
+
+    auto sink = createFilelinkSink(
+        metadata_ptr,
+        "test_table",
+        "/tmp/test_table.parquet",
+        CompressionMethod::None,
+        {},
+        "Parquet",
+        SerializedPlanParser::global_context,
+        0);
+
+    sink->consume(testChunk());
+    sink->onFinish();
 }

--- a/cpp-ch/local-engine/tests/json/clickhouse_pr_65234.json
+++ b/cpp-ch/local-engine/tests/json/clickhouse_pr_65234.json
@@ -1,0 +1,273 @@
+{
+  "extensions": [{
+    "extensionFunction": {
+      "functionAnchor": 1,
+      "name": "is_not_null:str"
+    }
+  }, {
+    "extensionFunction": {
+      "functionAnchor": 2,
+      "name": "equal:str_str"
+    }
+  }, {
+    "extensionFunction": {
+      "functionAnchor": 3,
+      "name": "is_not_null:i64"
+    }
+  }, {
+    "extensionFunction": {
+      "name": "and:bool_bool"
+    }
+  }],
+  "relations": [{
+    "root": {
+      "input": {
+        "project": {
+          "common": {
+            "emit": {
+              "outputMapping": [2]
+            }
+          },
+          "input": {
+            "filter": {
+              "common": {
+                "direct": {
+                }
+              },
+              "input": {
+                "read": {
+                  "common": {
+                    "direct": {
+                    }
+                  },
+                  "baseSchema": {
+                    "names": ["r_regionkey", "r_name"],
+                    "struct": {
+                      "types": [{
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }, {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }]
+                    },
+                    "columnTypes": ["NORMAL_COL", "NORMAL_COL"]
+                  },
+                  "filter": {
+                    "scalarFunction": {
+                      "outputType": {
+                        "bool": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [{
+                        "value": {
+                          "scalarFunction": {
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [{
+                              "value": {
+                                "scalarFunction": {
+                                  "functionReference": 1,
+                                  "outputType": {
+                                    "bool": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  "arguments": [{
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }]
+                                }
+                              }
+                            }, {
+                              "value": {
+                                "scalarFunction": {
+                                  "functionReference": 2,
+                                  "outputType": {
+                                    "bool": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [{
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }, {
+                                    "value": {
+                                      "literal": {
+                                        "string": "EUROPE"
+                                      }
+                                    }
+                                  }]
+                                }
+                              }
+                            }]
+                          }
+                        }
+                      }, {
+                        "value": {
+                          "scalarFunction": {
+                            "functionReference": 3,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "arguments": [{
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                    }
+                                  }
+                                }
+                              }
+                            }]
+                          }
+                        }
+                      }]
+                    }
+                  },
+                  "advancedExtension": {
+                    "optimization": {
+                      "@type": "type.googleapis.com/google.protobuf.StringValue",
+                      "value": "isMergeTree\u003d0\n"
+                    }
+                  }
+                }
+              },
+              "condition": {
+                "scalarFunction": {
+                  "outputType": {
+                    "bool": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [{
+                    "value": {
+                      "scalarFunction": {
+                        "outputType": {
+                          "bool": {
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        },
+                        "arguments": [{
+                          "value": {
+                            "scalarFunction": {
+                              "functionReference": 1,
+                              "outputType": {
+                                "bool": {
+                                  "nullability": "NULLABILITY_REQUIRED"
+                                }
+                              },
+                              "arguments": [{
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 1
+                                      }
+                                    }
+                                  }
+                                }
+                              }]
+                            }
+                          }
+                        }, {
+                          "value": {
+                            "scalarFunction": {
+                              "functionReference": 2,
+                              "outputType": {
+                                "bool": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [{
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 1
+                                      }
+                                    }
+                                  }
+                                }
+                              }, {
+                                "value": {
+                                  "literal": {
+                                    "string": "EUROPE"
+                                  }
+                                }
+                              }]
+                            }
+                          }
+                        }]
+                      }
+                    }
+                  }, {
+                    "value": {
+                      "scalarFunction": {
+                        "functionReference": 3,
+                        "outputType": {
+                          "bool": {
+                            "nullability": "NULLABILITY_REQUIRED"
+                          }
+                        },
+                        "arguments": [{
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                }
+                              }
+                            }
+                          }
+                        }]
+                      }
+                    }
+                  }]
+                }
+              }
+            }
+          },
+          "expressions": [{
+            "selection": {
+              "directReference": {
+                "structField": {
+                }
+              }
+            }
+          }]
+        }
+      },
+      "names": ["r_regionkey#72"],
+      "outputSchema": {
+        "types": [{
+          "i64": {
+            "nullability": "NULLABILITY_NULLABLE"
+          }
+        }],
+        "nullability": "NULLABILITY_REQUIRED"
+      }
+    }
+  }]
+}

--- a/cpp-ch/local-engine/tests/json/gtest_local_engine_config.json
+++ b/cpp-ch/local-engine/tests/json/gtest_local_engine_config.json
@@ -1,0 +1,269 @@
+{
+  "advancedExtensions": {
+    "enhancement": {
+      "@type": "type.googleapis.com/substrait.Expression",
+      "literal": {
+        "map": {
+          "keyValues": [
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level"
+              },
+              "value": {
+                "string": "test"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_settings.max_bytes_before_external_sort"
+              },
+              "value": {
+                "string": "5368709120"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.endpoint"
+              },
+              "value": {
+                "string": "localhost:9000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.velox.IOThreads"
+              },
+              "value": {
+                "string": "0"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.hdfs.input_read_timeout"
+              },
+              "value": {
+                "string": "180000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_settings.query_plan_enable_optimizations"
+              },
+              "value": {
+                "string": "false"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.worker.id"
+              },
+              "value": {
+                "string": "1"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.memory.offHeap.enabled"
+              },
+              "value": {
+                "string": "true"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.iam.role.session.name"
+              },
+              "value": {
+                "string": ""
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.hdfs.input_connect_timeout"
+              },
+              "value": {
+                "string": "180000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.shuffle.codec"
+              },
+              "value": {
+                "string": ""
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.local_engine.settings.log_processors_profiles"
+              },
+              "value": {
+                "string": "true"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.memory.offHeap.size.in.bytes"
+              },
+              "value": {
+                "string": "10737418240"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.shuffle.codecBackend"
+              },
+              "value": {
+                "string": ""
+              }
+            },
+            {
+              "key": {
+                "string": "spark.sql.orc.compression.codec"
+              },
+              "value": {
+                "string": "snappy"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_settings.max_bytes_before_external_group_by"
+              },
+              "value": {
+                "string": "5368709120"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.input.write.timeout"
+              },
+              "value": {
+                "string": "180000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.secret.key"
+              },
+              "value": {
+                "string": ""
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.access.key"
+              },
+              "value": {
+                "string": ""
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.hdfs.dfs_client_log_severity"
+              },
+              "value": {
+                "string": "INFO"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.path.style.access"
+              },
+              "value": {
+                "string": "true"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.timezone"
+              },
+              "value": {
+                "string": "Asia/Shanghai"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.input.read.timeout"
+              },
+              "value": {
+                "string": "180000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.use.instance.credentials"
+              },
+              "value": {
+                "string": "false"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_settings.output_format_orc_compression_method"
+              },
+              "value": {
+                "string": "snappy"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.iam.role"
+              },
+              "value": {
+                "string": ""
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.memory.task.offHeap.size.in.bytes"
+              },
+              "value": {
+                "string": "10737418240"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.input.connect.timeout"
+              },
+              "value": {
+                "string": "180000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.dfs.client.log.severity"
+              },
+              "value": {
+                "string": "INFO"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver"
+              },
+              "value": {
+                "string": "2"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.gluten.sql.columnar.backend.ch.runtime_config.hdfs.input_write_timeout"
+              },
+              "value": {
+                "string": "180000"
+              }
+            },
+            {
+              "key": {
+                "string": "spark.hadoop.fs.s3a.connection.ssl.enabled"
+              },
+              "value": {
+                "string": "false"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/cpp-ch/local-engine/tests/json/read_student_option_schema.csv.json
+++ b/cpp-ch/local-engine/tests/json/read_student_option_schema.csv.json
@@ -1,0 +1,77 @@
+{
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "read": {
+            "common": {
+              "direct": {}
+            },
+            "baseSchema": {
+              "names": [
+                "id",
+                "name",
+                "language"
+              ],
+              "struct": {
+                "types": [
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }
+                ]
+              },
+              "columnTypes": [
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL"
+              ]
+            },
+            "advancedExtension": {
+              "optimization": {
+                "@type": "type.googleapis.com/google.protobuf.StringValue",
+                "value": "isMergeTree=0\n"
+              }
+            }
+          }
+        },
+        "names": [
+          "id#20",
+          "name#21",
+          "language#22"
+        ],
+        "outputSchema": {
+          "types": [
+            {
+              "string": {
+                "nullability": "NULLABILITY_NULLABLE"
+              }
+            },
+            {
+              "string": {
+                "nullability": "NULLABILITY_NULLABLE"
+              }
+            },
+            {
+              "string": {
+                "nullability": "NULLABILITY_NULLABLE"
+              }
+            }
+          ],
+          "nullability": "NULLABILITY_REQUIRED"
+        }
+      }
+    }
+  ]
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -430,7 +430,9 @@ trait SparkPlanExecApi {
    *
    * @return
    */
-  def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
+  def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = {
+    SparkShimLoader.getSparkShims.getExtendedColumnarPostRules() ::: List()
+  }
 
   def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We refactor the codes for the following purpose:
1. Calling `SparkShim::genExtendedColumnarPostRules`, so we can fallback write to vanilla spark in case of spark 3.5
2. Add `NativeWriteCheck`，Make UT failed in spark 3.5
3. Refactor `LocalExecutor`, moving pipeline building to `SerializedPlanParser`, because we can not add sink transform in this class. 
4. Reducing duplcate codes, i.e. `CHIteratorApi` and  `SubstraitPlanPrinterUtil`

(Fixes: \#6067)

## How was this patch tested?

Existed UTs
