### PR TITLE
[GLUTEN-6202][VL] No extra SortExec needed before WindowExec if window type is `sort`

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
@@ -30,10 +30,7 @@ object MiscColumnarRules {
   object TransformPreOverrides {
     def apply(): TransformPreOverrides = {
       TransformPreOverrides(
-        List(
-          OffloadProject(),
-          OffloadFilter(),
-          OffloadWindow()),
+        List(OffloadProject(), OffloadFilter(), OffloadWindow()),
         List(
           OffloadOthers(),
           OffloadAggregate(),

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
@@ -30,7 +30,10 @@ object MiscColumnarRules {
   object TransformPreOverrides {
     def apply(): TransformPreOverrides = {
       TransformPreOverrides(
-        List(OffloadProject(), OffloadFilter()),
+        List(
+          OffloadProject(),
+          OffloadFilter(),
+          OffloadWindow()),
         List(
           OffloadOthers(),
           OffloadAggregate(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `spark.gluten.sql.columnar.backend.velox.window.type` is set to `sort`, there should be no extra `SortExec` before `WindowExec` in plan.

(Fixes: \#6202)

## How was this patch tested?

Mannual Test and UT

