### PR TITLE
[GLUTEN-6180][VL] Fix NPE if spilling is requested during task creation

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
@@ -63,6 +63,6 @@ public final class MemoryTargets {
       factory = TreeMemoryConsumers.shared();
     }
 
-    return dynamicOffHeapSizingIfEnabled(factory.newConsumer(tmm, name, spillers, virtualChildren));
+    return factory.newConsumer(tmm, name, spillers, virtualChildren);
   }
 }

--- a/gluten-data/src/main/java/org/apache/gluten/memory/arrow/alloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/org/apache/gluten/memory/arrow/alloc/ArrowBufferAllocators.java
@@ -60,11 +60,12 @@ public class ArrowBufferAllocators {
       listener =
           new ManagedAllocationListener(
               MemoryTargets.throwOnOom(
-                  MemoryTargets.newConsumer(
-                      tmm,
-                      "ArrowContextInstance",
-                      Collections.emptyList(),
-                      Collections.emptyMap())),
+                  MemoryTargets.dynamicOffHeapSizingIfEnabled(
+                      MemoryTargets.newConsumer(
+                          tmm,
+                          "ArrowContextInstance",
+                          Collections.emptyList(),
+                          Collections.emptyMap()))),
               TaskResources.getSharedUsage());
     }
 

--- a/gluten-data/src/main/java/org/apache/gluten/memory/nmm/NativeMemoryManagers.java
+++ b/gluten-data/src/main/java/org/apache/gluten/memory/nmm/NativeMemoryManagers.java
@@ -70,87 +70,92 @@ public final class NativeMemoryManagers {
     final MemoryTarget target =
         MemoryTargets.throwOnOom(
             MemoryTargets.overAcquire(
-                MemoryTargets.newConsumer(
-                    tmm,
-                    name,
-                    // call memory manager's shrink API, if no good then call the spiller
-                    Stream.concat(
-                            Stream.of(
-                                new Spiller() {
-                                  @Override
-                                  public long spill(MemoryTarget self, long size) {
-                                    return Optional.ofNullable(out.get())
-                                        .map(nmm -> nmm.shrink(size))
-                                        .orElseGet(
-                                            () -> {
-                                              LOG.warn(
-                                                  "Shrink is requested before native "
-                                                      + "memory manager is created. Try moving "
-                                                      + "any actions about memory allocation out "
-                                                      + "from the memory manager constructor.");
-                                              return 0L;
-                                            });
-                                  }
+                MemoryTargets.dynamicOffHeapSizingIfEnabled(
+                    MemoryTargets.newConsumer(
+                        tmm,
+                        name,
+                        // call memory manager's shrink API, if no good then call the spiller
+                        Stream.concat(
+                                Stream.of(
+                                    new Spiller() {
+                                      @Override
+                                      public long spill(MemoryTarget self, long size) {
+                                        return Optional.ofNullable(out.get())
+                                            .map(nmm -> nmm.shrink(size))
+                                            .orElseGet(
+                                                () -> {
+                                                  LOG.warn(
+                                                      "Shrink is requested before native "
+                                                          + "memory manager is created. Try moving "
+                                                          + "any actions about memory allocation"
+                                                          + " out from the memory manager"
+                                                          + " constructor.");
+                                                  return 0L;
+                                                });
+                                      }
 
-                                  @Override
-                                  public Set<Phase> applicablePhases() {
-                                    return Spillers.PHASE_SET_SHRINK_ONLY;
-                                  }
-                                }),
-                            spillers.stream())
-                        .map(spiller -> Spillers.withMinSpillSize(spiller, reservationBlockSize))
-                        .collect(Collectors.toList()),
-                    Collections.singletonMap(
-                        "single",
-                        new MemoryUsageRecorder() {
-                          @Override
-                          public void inc(long bytes) {
-                            // no-op
-                          }
+                                      @Override
+                                      public Set<Phase> applicablePhases() {
+                                        return Spillers.PHASE_SET_SHRINK_ONLY;
+                                      }
+                                    }),
+                                spillers.stream())
+                            .map(
+                                spiller -> Spillers.withMinSpillSize(spiller, reservationBlockSize))
+                            .collect(Collectors.toList()),
+                        Collections.singletonMap(
+                            "single",
+                            new MemoryUsageRecorder() {
+                              @Override
+                              public void inc(long bytes) {
+                                // no-op
+                              }
 
-                          @Override
-                          public long peak() {
-                            throw new UnsupportedOperationException("Not implemented");
-                          }
+                              @Override
+                              public long peak() {
+                                throw new UnsupportedOperationException("Not implemented");
+                              }
 
-                          @Override
-                          public long current() {
-                            throw new UnsupportedOperationException("Not implemented");
-                          }
+                              @Override
+                              public long current() {
+                                throw new UnsupportedOperationException("Not implemented");
+                              }
 
-                          @Override
-                          public MemoryUsageStats toStats() {
-                            return getNativeMemoryManager().collectMemoryUsage();
-                          }
+                              @Override
+                              public MemoryUsageStats toStats() {
+                                return getNativeMemoryManager().collectMemoryUsage();
+                              }
 
-                          private NativeMemoryManager getNativeMemoryManager() {
-                            return Optional.ofNullable(out.get())
-                                .orElseThrow(
-                                    () ->
-                                        new IllegalStateException(
-                                            ""
-                                                + "Memory usage stats are requested before native "
-                                                + "memory manager is created. Try moving any "
-                                                + "actions about memory allocation out from the "
-                                                + "memory manager constructor."));
-                          }
-                        })),
-                MemoryTargets.newConsumer(
-                    tmm,
-                    "OverAcquire.DummyTarget",
-                    Collections.singletonList(
-                        new Spiller() {
-                          @Override
-                          public long spill(MemoryTarget self, long size) {
-                            return self.repay(size);
-                          }
+                              private NativeMemoryManager getNativeMemoryManager() {
+                                return Optional.ofNullable(out.get())
+                                    .orElseThrow(
+                                        () ->
+                                            new IllegalStateException(
+                                                ""
+                                                    + "Memory usage stats are requested before"
+                                                    + " native memory manager is created. Try"
+                                                    + " moving any actions about memory"
+                                                    + " allocation out from the memory manager"
+                                                    + " constructor."));
+                              }
+                            }))),
+                MemoryTargets.dynamicOffHeapSizingIfEnabled(
+                    MemoryTargets.newConsumer(
+                        tmm,
+                        "OverAcquire.DummyTarget",
+                        Collections.singletonList(
+                            new Spiller() {
+                              @Override
+                              public long spill(MemoryTarget self, long size) {
+                                return self.repay(size);
+                              }
 
-                          @Override
-                          public Set<Phase> applicablePhases() {
-                            return Spillers.PHASE_SET_ALL;
-                          }
-                        }),
-                    Collections.emptyMap()),
+                              @Override
+                              public Set<Phase> applicablePhases() {
+                                return Spillers.PHASE_SET_ALL;
+                              }
+                            }),
+                        Collections.emptyMap())),
                 overAcquiredRatio));
     // listener
     ManagedReservationListener rl =

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -71,7 +71,7 @@ public class NativePlanEvaluator {
               @Override
               public long spill(MemoryTarget self, long size) {
                 ColumnarBatchOutIterator instance =
-                    Optional.of(outIterator.get())
+                    Optional.ofNullable(outIterator.get())
                         .orElseThrow(
                             () ->
                                 new IllegalStateException(


### PR DESCRIPTION
An initial reservation for Velox task memory pool was introduced in https://github.com/apache/incubator-gluten/pull/5815. However that reservation doesn't work correctly with spilling facilities so may lead to NPE.

The patch fixes the issue with some minor refactors.

Tested with existing integration tests to avoid regression.