### PR TITLE
[VL][Minor] Fix udf jni signature mismatch

### DIFF
--- a/backends-velox/src/main/java/org/apache/gluten/udf/UdfJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/udf/UdfJniWrapper.java
@@ -18,7 +18,5 @@ package org.apache.gluten.udf;
 
 public class UdfJniWrapper {
 
-  public UdfJniWrapper() {}
-
-  public native void getFunctionSignatures();
+  public static native void getFunctionSignatures();
 }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -278,6 +278,7 @@ object UDFResolver extends Logging {
       .split(",")
       .map {
         f =>
+          val file = new File(f)
           // Relative paths should be uploaded via --files or --archives
           if (isRelativePath(f)) {
             logInfo(s"resolve relative path: $f")
@@ -285,18 +286,13 @@ object UDFResolver extends Logging {
               throw new IllegalArgumentException(
                 "On yarn-client mode, driver only accepts absolute paths, but got " + f)
             }
-            if (isDriver && isYarnCluster) {
-              // Yarn AM container only gets the filename in the working directory.
-              new File(System.getProperty("user.dir"), f)
-            } else if (isYarnCluster || isYarnClient) {
-              // In other cases the yarn containers get the full path in the working directory.
-              new File(f)
+            if (isYarnCluster || isYarnClient) {
+              file
             } else {
               new File(SparkFiles.get(f))
             }
           } else {
             logInfo(s"resolve absolute URI path: $f")
-            val file = new File(f)
             // Download or copy absolute paths to JniWorkspace.
             val uri = Utils.resolveURI(f)
             val name = file.getName

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -330,7 +330,7 @@ object UDFResolver extends Logging {
       case None =>
         Seq.empty
       case Some(_) =>
-        new UdfJniWrapper().getFunctionSignatures()
+        UdfJniWrapper.getFunctionSignatures()
 
         UDFNames.map {
           name =>

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -278,7 +278,6 @@ object UDFResolver extends Logging {
       .split(",")
       .map {
         f =>
-          val file = new File(f)
           // Relative paths should be uploaded via --files or --archives
           if (isRelativePath(f)) {
             logInfo(s"resolve relative path: $f")
@@ -286,13 +285,18 @@ object UDFResolver extends Logging {
               throw new IllegalArgumentException(
                 "On yarn-client mode, driver only accepts absolute paths, but got " + f)
             }
-            if (isYarnCluster || isYarnClient) {
-              file
+            if (isDriver && isYarnCluster) {
+              // Yarn AM container only gets the filename in the working directory.
+              new File(System.getProperty("user.dir"), f)
+            } else if (isYarnCluster || isYarnClient) {
+              // In other cases the yarn containers get the full path in the working directory.
+              new File(f)
             } else {
               new File(SparkFiles.get(f))
             }
           } else {
             logInfo(s"resolve absolute URI path: $f")
+            val file = new File(f)
             // Download or copy absolute paths to JniWorkspace.
             val uri = Utils.resolveURI(f)
             val name = file.getName


### PR DESCRIPTION
In the previous implementation, Yarn AM container only gets the relative filename. e.g. "libmyudf.so", not a full path. The full path should be constructed using the current working directory.