### PR TITLE
[VL] Make jni debug workspace configurable

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -161,10 +161,9 @@ class VeloxListenerApi extends ListenerApi {
   private def initialize(conf: SparkConf, isDriver: Boolean): Unit = {
     SparkDirectoryUtil.init(conf)
     UDFResolver.resolveUdfConf(conf, isDriver = isDriver)
-    val debugJni = conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_MODE, defaultValue = false) &&
-      conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE, defaultValue = false)
-    if (debugJni) {
-      JniWorkspace.enableDebug()
+    if (conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE, defaultValue = false)) {
+      val debugDir = conf.get(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE_DIR)
+      JniWorkspace.enableDebug(debugDir)
     }
     val loader = JniWorkspace.getDefault.libLoader
 

--- a/gluten-core/src/main/java/org/apache/gluten/vectorized/JniWorkspace.java
+++ b/gluten-core/src/main/java/org/apache/gluten/vectorized/JniWorkspace.java
@@ -75,14 +75,14 @@ public class JniWorkspace {
     }
   }
 
-  public static void enableDebug() {
+  public static void enableDebug(String debugDir) {
     // Preserve the JNI libraries even after process exits.
     // This is useful for debugging native code if the debug symbols were embedded in
     // the libraries.
     synchronized (DEFAULT_INSTANCE_INIT_LOCK) {
       if (DEBUG_INSTANCE == null) {
         final File tempRoot =
-            Paths.get("/tmp").resolve("gluten-jni-debug-" + UUID.randomUUID()).toFile();
+            Paths.get(debugDir).resolve("gluten-jni-debug-" + UUID.randomUUID()).toFile();
         try {
           FileUtils.forceMkdir(tempRoot);
         } catch (IOException e) {

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -391,8 +391,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
     conf.getConf(COLUMNAR_VELOX_MEMORY_USE_HUGE_PAGES)
 
   def debug: Boolean = conf.getConf(DEBUG_ENABLED)
-  def debugKeepJniWorkspace: Boolean =
-    conf.getConf(DEBUG_ENABLED) && conf.getConf(DEBUG_KEEP_JNI_WORKSPACE)
+  def debugKeepJniWorkspace: Boolean = conf.getConf(DEBUG_KEEP_JNI_WORKSPACE)
   def taskStageId: Int = conf.getConf(BENCHMARK_TASK_STAGEID)
   def taskPartitionId: Int = conf.getConf(BENCHMARK_TASK_PARTITIONID)
   def taskId: Long = conf.getConf(BENCHMARK_TASK_TASK_ID)
@@ -553,6 +552,7 @@ object GlutenConfig {
 
   val GLUTEN_DEBUG_MODE = "spark.gluten.sql.debug"
   val GLUTEN_DEBUG_KEEP_JNI_WORKSPACE = "spark.gluten.sql.debug.keepJniWorkspace"
+  val GLUTEN_DEBUG_KEEP_JNI_WORKSPACE_DIR = "spark.gluten.sql.debug.keepJniWorkspaceDir"
 
   // Added back to Spark Conf during executor initialization
   val GLUTEN_NUM_TASK_SLOTS_PER_EXECUTOR_KEY = "spark.gluten.numTaskSlotsPerExecutor"
@@ -1584,6 +1584,12 @@ object GlutenConfig {
       .internal()
       .booleanConf
       .createWithDefault(false)
+
+  val DEBUG_KEEP_JNI_WORKSPACE_DIR =
+    buildConf(GLUTEN_DEBUG_KEEP_JNI_WORKSPACE_DIR)
+      .internal()
+      .stringConf
+      .createWithDefault("/tmp")
 
   val BENCHMARK_TASK_STAGEID =
     buildConf("spark.gluten.sql.benchmark_task.stageId")

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -1580,13 +1580,13 @@ object GlutenConfig {
       .createWithDefault(false)
 
   val DEBUG_KEEP_JNI_WORKSPACE =
-    buildConf(GLUTEN_DEBUG_KEEP_JNI_WORKSPACE)
+    buildStaticConf(GLUTEN_DEBUG_KEEP_JNI_WORKSPACE)
       .internal()
       .booleanConf
       .createWithDefault(false)
 
   val DEBUG_KEEP_JNI_WORKSPACE_DIR =
-    buildConf(GLUTEN_DEBUG_KEEP_JNI_WORKSPACE_DIR)
+    buildStaticConf(GLUTEN_DEBUG_KEEP_JNI_WORKSPACE_DIR)
       .internal()
       .stringConf
       .createWithDefault("/tmp")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add new config `spark.gluten.sql.debug.keepJniWorkspaceDir` to store libraries, and decouple the functionality from `spark.gluten.sql.debug`