### PR TITLE
[CH] Support use dynamic disk path

### DIFF
--- a/cpp-ch/local-engine/Common/CHUtil.h
+++ b/cpp-ch/local-engine/Common/CHUtil.h
@@ -196,6 +196,7 @@ private:
     static void registerAllFactories();
     static void applyGlobalConfigAndSettings(DB::Context::ConfigurationPtr, DB::Settings &);
     static void updateNewSettings(const DB::ContextMutablePtr &, const DB::Settings &);
+    static std::vector<String> wrapDiskPathConfig(const String & path_prefix, const String & path_suffix, Poco::Util::AbstractConfiguration & config);
 
 
     static std::map<std::string, std::string> getBackendConfMap(const std::string & plan);
@@ -212,6 +213,9 @@ public:
 
     /// Release session level resources like StorageJoinBuilder. Invoked every time executor/driver shutdown.
     static void finalizeSessionally();
+
+    static std::vector<String> paths_need_to_clean;
+    static std::mutex paths_mutex;
 };
 
 // Ignore memory track, memory should free before IgnoreMemoryTracker deconstruction


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support use dynamic disk path
spark.gluten.sql.columnar.backend.ch.runtime_config.use_current_directory_as_tmp=true
disk.metadata_path and cache.path are automatically mapped to the current directory
spark.gluten.sql.columnar.backend.ch.runtime_config.reuse_disk_cache=false
Add the current pid number to disk.metadata_path and cache.path

## How was this patch tested?

unit tests
