### PR TITLE
[GLUTEN-6235][CH] Fix crash on ExpandTransform::work()

### DIFF
--- a/cpp-ch/local-engine/Operator/ExpandTransform.cpp
+++ b/cpp-ch/local-engine/Operator/ExpandTransform.cpp
@@ -104,7 +104,7 @@ void ExpandTransform::work()
 
         if (kind == EXPAND_FIELD_KIND_SELECTION)
         {
-            const auto & original_col = original_cols[field.get<Int32>()];
+            const auto & original_col = original_cols.at(field.get<Int32>());
             if (type->isNullable() == original_col->isNullable())
             {
                 cols.push_back(original_col);

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -110,7 +110,7 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
   }
 
   override protected def doTransform(context: SubstraitContext): TransformContext = {
-    val output = filterRedundantField(outputAttributes())
+    val output = outputAttributes()
     val typeNodes = ConverterUtils.collectAttributeTypeNodes(output)
     val nameList = ConverterUtils.collectAttributeNamesWithoutExprId(output)
     val columnTypeNodes = output.map {
@@ -155,22 +155,5 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
       context,
       context.nextOperatorId(this.nodeName))
     TransformContext(output, output, readNode)
-  }
-
-  private def filterRedundantField(outputs: Seq[Attribute]): Seq[Attribute] = {
-    var finalOutput: List[Attribute] = List()
-    val outputList = outputs.toArray
-    for (i <- outputList.indices) {
-      var dup = false
-      for (j <- 0 until i) {
-        if (outputList(i).name == outputList(j).name) {
-          dup = true
-        }
-      }
-      if (!dup) {
-        finalOutput = finalOutput :+ outputList(i)
-      }
-    }
-    finalOutput
   }
 }

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -75,7 +75,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes)
+    requestedAttributes.map(originalAttributes).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -75,7 +75,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes)
+    requestedAttributes.map(originalAttributes).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -77,7 +77,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes)
+    requestedAttributes.map(originalAttributes).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -77,7 +77,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes)
+    requestedAttributes.map(originalAttributes).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later


### PR DESCRIPTION
## What changes were proposed in this pull request?

The pr https://github.com/apache/incubator-gluten/pull/5254 would filter redundant attribute when transforming to substraint plan in order to fix `Unexpected empty column` exception when reading hive text table. This introduces a new issue, for example:
```
(1) NativeScan hive tmp.testxmy_expand
Output [11]: [a1#4, a2#5, a3#6, a4#7, a5#8, a6#9, a7#10, a8#11, a3#6, a4#7, a9#12]
Arguments: [a1#4, a2#5, a3#6, a4#7, a5#8, a6#9, a7#10, a8#11, a3#6, a4#7, a9#12], HiveTableRelation [`tmp`.`testxmy_expand`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, Data Cols: [a1#4, a2#5, a3#6, a4#7, a5#8, a6#9, a7#10, a8#11, a9#12], Partition Cols: []]

(2) ExpandExecTransformer
Input [11]: [a1#4, a2#5, a3#6, a4#7, a5#8, a6#9, a7#10, a8#11, a3#6, a4#7, a9#12]
Arguments: [[a1#4, a2#5, a3#6, a4#7, a5#8, a6#9, a7#10, a8#11, a3#6, a4#7, a9#12, 0], ....
```

After filter redundant attribute, the HiveTableScan operator output 7 distinct attributes in substrait read node but its `output` method still output 9 attributes include 2 duplicated arrtibutes, which causes column index mismatch in following process and crash.

We should keep the HiveTableScan's `output` attributes unique.


(Fixes: \#6235)

## How was this patch tested?

Add UT

