### PR TITLE
[GLUTEN-6253] Use internal udf config to avoid modify the original one

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -65,6 +65,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
   val GLUTEN_VELOX_UDF_LIB_PATHS = getBackendConfigPrefix() + ".udfLibraryPaths"
   val GLUTEN_VELOX_DRIVER_UDF_LIB_PATHS = getBackendConfigPrefix() + ".driver.udfLibraryPaths"
+  val GLUTEN_VELOX_INTERNAL_UDF_LIB_PATHS = getBackendConfigPrefix() + ".internal.udfLibraryPaths"
 
   val MAXIMUM_BATCH_SIZE: Int = 32768
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -231,8 +231,9 @@ object UDFResolver extends Logging {
 
     udfLibPaths match {
       case Some(paths) =>
+        // Set resolved paths to the internal config to parse on native side.
         sparkConf.set(
-          VeloxBackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS,
+          VeloxBackendSettings.GLUTEN_VELOX_INTERNAL_UDF_LIB_PATHS,
           getAllLibraries(sparkConf, isDriver, paths))
       case None =>
     }

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -99,7 +99,7 @@ const std::string kVeloxAsyncTimeoutOnTaskStopping =
 const int32_t kVeloxAsyncTimeoutOnTaskStoppingDefault = 30000; // 30s
 
 // udf
-const std::string kVeloxUdfLibraryPaths = "spark.gluten.sql.columnar.backend.velox.udfLibraryPaths";
+const std::string kVeloxUdfLibraryPaths = "spark.gluten.sql.columnar.backend.velox.internal.udfLibraryPaths";
 
 // backtrace allocation
 const std::string kBacktraceAllocation = "spark.gluten.backtrace.allocation";


### PR DESCRIPTION
The current implementation sets `spark.gluten.sql.columnar.backend.velox.udfLibraryPaths` on driver side after resolving the library paths. This approach can overwrite the original settings with a local file path on the driver node before sending the SparkConf to all executors, and the executors on different nodes will fail while accessing that path.

This PR sets the resolved library paths to an internal config to avoid the conflicts.

Manually verified on a multi-node cluster.