### PR TITLE
[CELEBORN] Support celeborn 0.5.0

### DIFF
--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -532,7 +532,7 @@ jobs:
       fail-fast: false
       matrix:
         spark: [ "spark-3.2" ]
-        celeborn: [ "celeborn-0.4.1", "celeborn-0.3.2-incubating" ]
+        celeborn: [ "celeborn-0.5.0", "celeborn-0.4.1", "celeborn-0.3.2-incubating" ]
     runs-on: ubuntu-20.04
     container: ubuntu:22.04
     steps:
@@ -563,8 +563,10 @@ jobs:
       - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.2 with ${{ matrix.celeborn }}
         run: |
           EXTRA_PROFILE=""
-          if [ "${{ matrix.celeborn }}" = "celeborn-0.4.0" ]; then
+          if [ "${{ matrix.celeborn }}" = "celeborn-0.4.1" ]; then
             EXTRA_PROFILE="-Pceleborn-0.4"
+          elif [ "${{ matrix.celeborn }}" = "celeborn-0.5.0" ]; then
+            EXTRA_PROFILE="-Pceleborn-0.5"
           fi
           echo "EXTRA_PROFILE: ${EXTRA_PROFILE}"
           cd /opt && mkdir -p celeborn && \

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -629,7 +629,7 @@ public read-only account：gluten/hN2xX3uQ4m
 
 ### Celeborn support
 
-Gluten with clickhouse backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x` and `0.4.0`.
+Gluten with clickhouse backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x`, `0.4.x` and `0.5.0`.
 
 Below introduction is used to enable this feature.
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -222,7 +222,7 @@ Currently there are several ways to asscess S3 in Spark. Please refer [Velox S3]
 
 ## Celeborn support
 
-Gluten with velox backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x` and `0.4.0`.
+Gluten with velox backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x`, `0.4.x` and `0.5.0`.
 
 Below introduction is used to enable this feature.
 

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -170,5 +170,11 @@
         <celeborn.version>0.4.1</celeborn.version>
       </properties>
     </profile>
+    <profile>
+      <id>celeborn-0.5</id>
+      <properties>
+        <celeborn.version>0.5.0</celeborn.version>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache celeborn was released on June 24th, you can see also [release notes](https://celeborn.apache.org/community/release_notes/release_note_0.5.0/#improvement) for more details. This PR amins to support celeborn 0.5.0.

## How was this patch tested?
GA it tests

