### PR TITLE
[CELEBORN] Avoid CelebornShuffleManager#getWriter adding shuffle id repeatedly to columnarShuffleIds

### DIFF
--- a/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -215,12 +215,8 @@ public class CelebornShuffleManager implements ShuffleManager {
 
   @Override
   public boolean unregisterShuffle(int shuffleId) {
-    if (columnarShuffleIds.contains(shuffleId)) {
-      if (columnarShuffleManager().unregisterShuffle(shuffleId)) {
-        return columnarShuffleIds.remove(shuffleId);
-      } else {
-        return false;
-      }
+    if (columnarShuffleIds.remove(shuffleId)) {
+      return columnarShuffleManager().unregisterShuffle(shuffleId);
     }
     return CelebornUtils.unregisterShuffle(
         lifecycleManager,
@@ -311,7 +307,6 @@ public class CelebornShuffleManager implements ShuffleManager {
           return vanillaCelebornShuffleManager().getWriter(handle, mapId, context, metrics);
         }
       } else {
-        columnarShuffleIds.add(handle.shuffleId());
         return columnarShuffleManager().getWriter(handle, mapId, context, metrics);
       }
     } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CelebornShuffleManager#getWriter` should avoid adding shuffle id repeatedly to `columnarShuffleIds`. `CelebornShuffleManager#registerShuffle` adds shuffle id to `columnarShuffleIds` which should not add shuffle id to `columnarShuffleIds` repeatedly in `CelebornShuffleManager#getWriter`.

Backport https://github.com/apache/celeborn/pull/2503.

## How was this patch tested?

CI.