### PR TITLE
[VL] Add isStreamingAgg info to HashAggregateTransformer

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
@@ -84,9 +84,14 @@ abstract class HashAggregateExecBaseTransformer(
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
     val outputString = truncatedString(output, "[", ", ", "]", maxFields)
     if (verbose) {
-      s"HashAggregateTransformer(keys=$keyString, functions=$functionString, output=$outputString)"
+      s"HashAggregateTransformer(keys=$keyString, " +
+        s"functions=$functionString, " +
+        s"isStreamingAgg=$isCapableForStreamingAggregation, " +
+        s"output=$outputString)"
     } else {
-      s"HashAggregateTransformer(keys=$keyString, functions=$functionString)"
+      s"HashAggregateTransformer(keys=$keyString, " +
+        s"functions=$functionString, " +
+        s"isStreamingAgg=$isCapableForStreamingAggregation)"
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add isStreamingAgg info to the toString method of HashAggregateBaseTransformer, so that we can easily determine the current type of the Aggregate.

## How was this patch tested?
N/A.

