### PR TITLE
[GLUTEN-6309][VL]cast timestamp to date

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -1787,6 +1787,18 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
     }
   }
 
+  test("Cast timestamp to date") {
+    withTable("ts") {
+      sql("create table ts (c1 timestamp) using parquet")
+      sql("insert into ts values (timestamp'2016-01-01 10:11:12.123456')")
+      sql("insert into ts values (timestamp'1965-01-01 10:11:12.123456')")
+
+      runQueryAndCompare("select cast(c1 as date) from ts") {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+    }
+  }
+
   test("cast date to timestamp with timezone") {
     sql("SET spark.sql.session.timeZone = America/Los_Angeles")
     val dfInLA = sql("SELECT cast(date'2023-01-02 01:01:01' as timestamp) as ts")

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -256,7 +256,7 @@ bool SubstraitToVeloxPlanValidator::validateCast(
   core::TypedExprPtr input = exprConverter_->toVeloxExpr(castExpr.input(), inputType);
 
   // Support for cast from timestamp to date
-  if (input->type()->kind() == TypeKind::TIMESTAMP &&  toType->isDate()) {
+  if (input->type()->kind() == TypeKind::TIMESTAMP && toType->isDate()) {
     return true;
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -255,6 +255,11 @@ bool SubstraitToVeloxPlanValidator::validateCast(
   const auto& toType = SubstraitParser::parseType(castExpr.type());
   core::TypedExprPtr input = exprConverter_->toVeloxExpr(castExpr.input(), inputType);
 
+  // Support for cast from timestamp to date
+  if (input->type()->kind() == TypeKind::TIMESTAMP &&  toType->isDate()) {
+    return true;
+  }
+
   // Only support cast from date to timestamp
   if (toType->kind() == TypeKind::TIMESTAMP && !input->type()->isDate()) {
     LOG_VALIDATION_MSG(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Observed fallbacks in Velox when casting timestamp to date. This PR addresses this by adding support for `cast(timestamp as date)`.
Before:
![image](https://github.com/apache/incubator-gluten/assets/16638792/fd65a9bf-42d9-435c-a6e2-83d607109ae4)

After:
![image](https://github.com/apache/incubator-gluten/assets/16638792/a82e0ae1-1c8a-4a0c-902e-f4cc6f53214c)

(Fixes: \#6309)

## How was this patch tested?

Added UT. Added screenshots from manual testing.


