### PR TITLE
[VL] Validate unsupported rewrite string in Re2

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -171,7 +171,7 @@ bool SubstraitToVeloxPlanValidator::validateRegexExpr(
     rewrite = rewriteArg.literal().string();
   }
   std::string error;
-  if (!validatePattern(pattern, rewrite, error)) {
+  if (!validateRe2Function(pattern, rewrite, error)) {
     LOG_VALIDATION_MSG(name + " due to " + error);
     return false;
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -162,7 +162,7 @@ bool SubstraitToVeloxPlanValidator::validateRegexExpr(
   const auto& pattern = patternArg.literal().string();
 
   std::string rewrite;
-  if (scalarFunction.arguments().size() > 2) {
+  if (name == "regexp_replace " && scalarFunction.arguments().size() > 2) {
     const auto& rewriteArg = scalarFunction.arguments()[2].value();
     if (!rewriteArg.has_literal() || !rewriteArg.literal().has_string()) {
       LOG_VALIDATION_MSG("Rewrite is not string literal for " + name);

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -159,10 +159,19 @@ bool SubstraitToVeloxPlanValidator::validateRegexExpr(
     LOG_VALIDATION_MSG("Pattern is not string literal for " + name);
     return false;
   }
-
   const auto& pattern = patternArg.literal().string();
+
+  std::string rewrite;
+  if (scalarFunction.arguments().size() > 2) {
+    const auto& rewriteArg = scalarFunction.arguments()[2].value();
+    if (!rewriteArg.has_literal() || !rewriteArg.literal().has_string()) {
+      LOG_VALIDATION_MSG("Rewrite is not string literal for " + name);
+      return false;
+    }
+    rewrite = rewriteArg.literal().string();
+  }
   std::string error;
-  if (!validatePattern(pattern, error)) {
+  if (!validatePattern(pattern, rewrite, error)) {
     LOG_VALIDATION_MSG(name + " due to " + error);
     return false;
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -116,7 +116,7 @@ class SubstraitToVeloxPlanValidator {
 
   /// Validates regex functions.
   /// Ensures the second pattern argument is a literal string.
-  /// Check if the pattern can pass with RE2 compilation.
+  /// Check if the pattern can pass with RE2 compilation and check rewriteString of regexp_replace is validate
   bool validateRegexExpr(const std::string& name, const ::substrait::Expression::ScalarFunction& scalarFunction);
 
   /// Validate Substrait scarlar function.

--- a/cpp/velox/utils/Common.cc
+++ b/cpp/velox/utils/Common.cc
@@ -52,10 +52,15 @@ std::unique_ptr<re2::RE2> compilePattern(const std::string& pattern) {
   return std::make_unique<re2::RE2>(re2::StringPiece(pattern), RE2::Quiet);
 }
 
-bool validatePattern(const std::string& pattern, std::string& error) {
+bool validatePattern(const std::string& pattern, const std::string& rewrite, std::string& error) {
   auto re2 = compilePattern(pattern);
   if (!re2->ok()) {
     error = "Pattern " + pattern + " compilation failed in RE2. Reason: " + re2->error();
+    return false;
+  }
+  std::string err;
+  if (!rewrite.empty() && !re2->CheckRewriteString(re2::StringPiece(rewrite), &err)) {
+    error = "Rewrite " + rewrite + "check failed in RE2. Reason: " + err;
     return false;
   }
   return ensureRegexIsCompatible(pattern, error);

--- a/cpp/velox/utils/Common.cc
+++ b/cpp/velox/utils/Common.cc
@@ -52,18 +52,23 @@ std::unique_ptr<re2::RE2> compilePattern(const std::string& pattern) {
   return std::make_unique<re2::RE2>(re2::StringPiece(pattern), RE2::Quiet);
 }
 
-bool validatePattern(const std::string& pattern, const std::string& rewrite, std::string& error) {
+bool validateRe2Function(const std::string& pattern, const std::string& rewrite, std::string& error) {
   auto re2 = compilePattern(pattern);
   if (!re2->ok()) {
     error = "Pattern " + pattern + " compilation failed in RE2. Reason: " + re2->error();
     return false;
   }
+
+  if (!ensureRegexIsCompatible(pattern, error)) {
+    return false;
+  }
+
   std::string err;
   if (!rewrite.empty() && !re2->CheckRewriteString(re2::StringPiece(rewrite), &err)) {
     error = "Rewrite " + rewrite + "check failed in RE2. Reason: " + err;
     return false;
   }
-  return ensureRegexIsCompatible(pattern, error);
+  return true;
 }
 
 } // namespace gluten

--- a/cpp/velox/utils/Common.h
+++ b/cpp/velox/utils/Common.h
@@ -29,7 +29,7 @@ namespace gluten {
 // Compile the given pattern and return the RE2 object.
 inline std::unique_ptr<re2::RE2> compilePattern(const std::string& pattern);
 
-bool validatePattern(const std::string& pattern, std::string& error);
+bool validatePattern(const std::string& pattern, const std::string& rewrite, std::string& error);
 
 static inline void fastCopy(void* dst, const void* src, size_t n) {
   facebook::velox::simd::memcpy(dst, src, n);

--- a/cpp/velox/utils/Common.h
+++ b/cpp/velox/utils/Common.h
@@ -29,7 +29,7 @@ namespace gluten {
 // Compile the given pattern and return the RE2 object.
 inline std::unique_ptr<re2::RE2> compilePattern(const std::string& pattern);
 
-bool validatePattern(const std::string& pattern, const std::string& rewrite, std::string& error);
+bool validateRe2Function(const std::string& pattern, const std::string& rewrite, std::string& error);
 
 static inline void fastCopy(void* dst, const void* src, size_t n) {
   facebook::velox::simd::memcpy(dst, src, n);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now we only validate the regex pattern, but we also need to validate the rewrite string. The `regexp_function` will call `RE2::GlobalReplace()`, which will swallow the errors thrown by `RE2::Rewrite()`.

When RE2::CheckRewriteString() fails, Gluten will fallback to vanilla and print a log like:
```
24/07/02 22:21:38 INFO GlutenFallbackReporter: Validation failed for plan: Project, due to: native check failure:native validation failed for function: regexp_replace due to: Rewrite \[check failed in RE2. Reason: Rewrite schema error: '\' must be followed by a digit or '\'..
24/07/02 22:21:38 INFO GlutenFallbackReporter: appId=local-c0csj_b8MAcjJdWfT2zfiQ, containerId=null, jsonStr={"plan":"Project","reason":"native check failure:native validation failed for function: regexp_replace due to: Rewrite \\[check failed in RE2. Reason: Rewrite schema error: '\\' must be followed by a digit or '\\'."}
```

(Fixes: \#6224)

## How was this patch tested?
Exist CI.

