### PR TITLE
[VL] bug fix for S3 read

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -81,9 +81,9 @@ std::shared_ptr<SplitInfo> parseScanSplitInfo(
     splitInfo->paths.emplace_back(file.uri_file());
     splitInfo->starts.emplace_back(file.start());
     splitInfo->lengths.emplace_back(file.length());
-    if (file.has_properties()){
-        facebook::velox::FileProperties fileProps = {file.properties().filesize(), file.properties().modificationtime()};
-        splitInfo->properties.emplace_back(fileProps);
+    if (file.has_properties()) {
+      facebook::velox::FileProperties fileProps = {file.properties().filesize(), file.properties().modificationtime()};
+      splitInfo->properties.emplace_back(fileProps);
     }
     switch (file.file_format_case()) {
       case SubstraitFileFormatCase::kOrc:

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -81,10 +81,13 @@ std::shared_ptr<SplitInfo> parseScanSplitInfo(
     splitInfo->paths.emplace_back(file.uri_file());
     splitInfo->starts.emplace_back(file.start());
     splitInfo->lengths.emplace_back(file.length());
+
+    facebook::velox::FileProperties fileProps;
     if (file.has_properties()) {
-      facebook::velox::FileProperties fileProps = {file.properties().filesize(), file.properties().modificationtime()};
-      splitInfo->properties.emplace_back(fileProps);
+      fileProps.fileSize = file.properties().filesize();
+      fileProps.modificationTime = file.properties().modificationtime();
     }
+    splitInfo->properties.emplace_back(fileProps);
     switch (file.file_format_case()) {
       case SubstraitFileFormatCase::kOrc:
         splitInfo->format = dwio::common::FileFormat::ORC;

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -81,8 +81,10 @@ std::shared_ptr<SplitInfo> parseScanSplitInfo(
     splitInfo->paths.emplace_back(file.uri_file());
     splitInfo->starts.emplace_back(file.start());
     splitInfo->lengths.emplace_back(file.length());
-    facebook::velox::FileProperties fileProps = {file.properties().filesize(), file.properties().modificationtime()};
-    splitInfo->properties.emplace_back(fileProps);
+    if (file.has_properties()){
+        facebook::velox::FileProperties fileProps = {file.properties().filesize(), file.properties().modificationtime()};
+        splitInfo->properties.emplace_back(fileProps);
+    }
     switch (file.file_format_case()) {
       case SubstraitFileFormatCase::kOrc:
         splitInfo->format = dwio::common::FileFormat::ORC;


### PR DESCRIPTION
Velox s3FileSystem use -1 as default file size. Gluten wrongly passed 0 if file size isn't gotten from Spark. 

https://github.com/facebookincubator/velox/blob/f5bfd1eed38780597b3b13eff1370207f67f0838/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp#L92