### PR TITLE
[CORE] Minor code cleanups against fallback tagging

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -172,20 +172,20 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
     format match {
       case ParquetReadFormat =>
         if (validateFilePath) {
-          ValidationResult.ok
+          ValidationResult.succeeded
         } else {
-          ValidationResult.notOk("Validate file path failed.")
+          ValidationResult.failed("Validate file path failed.")
         }
-      case OrcReadFormat => ValidationResult.ok
-      case MergeTreeReadFormat => ValidationResult.ok
+      case OrcReadFormat => ValidationResult.succeeded
+      case MergeTreeReadFormat => ValidationResult.succeeded
       case TextReadFormat =>
         if (!hasComplexType) {
-          ValidationResult.ok
+          ValidationResult.succeeded
         } else {
-          ValidationResult.notOk("Has complex type.")
+          ValidationResult.failed("Has complex type.")
         }
-      case JsonReadFormat => ValidationResult.ok
-      case _ => ValidationResult.notOk(s"Unsupported file format $format")
+      case JsonReadFormat => ValidationResult.succeeded
+      case _ => ValidationResult.failed(s"Unsupported file format $format")
     }
   }
 
@@ -291,7 +291,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       fields: Array[StructField],
       bucketSpec: Option[BucketSpec],
       options: Map[String, String]): ValidationResult =
-    ValidationResult.notOk("CH backend is unsupported.")
+    ValidationResult.failed("CH backend is unsupported.")
 
   override def enableNativeWriteFiles(): Boolean = {
     GlutenConfig.getConf.enableNativeWriter.getOrElse(false)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHBroadcastNestedLoopJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHBroadcastNestedLoopJoinExecTransformer.scala
@@ -98,12 +98,12 @@ case class CHBroadcastNestedLoopJoinExecTransformer(
       case _: InnerLike =>
       case _ =>
         if (joinType == LeftSemi || condition.isDefined) {
-          return ValidationResult.notOk(
+          return ValidationResult.failed(
             s"Broadcast Nested Loop join is not supported join type $joinType with conditions")
         }
     }
 
-    ValidationResult.ok
+    ValidationResult.succeeded
   }
 
 }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHGenerateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHGenerateExecTransformer.scala
@@ -64,7 +64,7 @@ case class CHGenerateExecTransformer(
   override protected def doGeneratorValidate(
       generator: Generator,
       outer: Boolean): ValidationResult =
-    ValidationResult.ok
+    ValidationResult.succeeded
 
   override protected def getRelNode(
       context: SubstraitContext,

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashJoinExecTransformer.scala
@@ -60,7 +60,7 @@ case class CHShuffledHashJoinExecTransformer(
         right.outputSet,
         condition)
     if (shouldFallback) {
-      return ValidationResult.notOk("ch join validate fail")
+      return ValidationResult.failed("ch join validate fail")
     }
     super.doValidateInternal()
   }
@@ -118,10 +118,10 @@ case class CHBroadcastHashJoinExecTransformer(
         condition)
 
     if (shouldFallback) {
-      return ValidationResult.notOk("ch join validate fail")
+      return ValidationResult.failed("ch join validate fail")
     }
     if (isNullAwareAntiJoin) {
-      return ValidationResult.notOk("ch does not support NAAJ")
+      return ValidationResult.failed("ch does not support NAAJ")
     }
     super.doValidateInternal()
   }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHSortMergeJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHSortMergeJoinExecTransformer.scala
@@ -50,7 +50,7 @@ case class CHSortMergeJoinExecTransformer(
         right.outputSet,
         condition)
     if (shouldFallback) {
-      return ValidationResult.notOk("ch join validate fail")
+      return ValidationResult.failed("ch join validate fail")
     }
     super.doValidateInternal()
   }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarToRowExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarToRowExec.scala
@@ -58,7 +58,7 @@ case class CHColumnarToRowExec(child: SparkPlan) extends ColumnarToRowExecBase(c
             s"${field.dataType} is not supported in ColumnarToRowExecBase.")
       }
     }
-    ValidationResult.ok
+    ValidationResult.succeeded
   }
 
   override def doExecuteInternal(): RDD[InternalRow] = {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -79,9 +79,9 @@ object VeloxBackendSettings extends BackendSettingsApi {
       // Collect unsupported types.
       val unsupportedDataTypeReason = fields.collect(validatorFunc)
       if (unsupportedDataTypeReason.isEmpty) {
-        ValidationResult.ok
+        ValidationResult.succeeded
       } else {
-        ValidationResult.notOk(
+        ValidationResult.failed(
           s"Found unsupported data type in $format: ${unsupportedDataTypeReason.mkString(", ")}.")
       }
     }
@@ -135,10 +135,10 @@ object VeloxBackendSettings extends BackendSettingsApi {
         } else {
           validateTypes(parquetTypeValidatorWithComplexTypeFallback)
         }
-      case DwrfReadFormat => ValidationResult.ok
+      case DwrfReadFormat => ValidationResult.succeeded
       case OrcReadFormat =>
         if (!GlutenConfig.getConf.veloxOrcScanEnabled) {
-          ValidationResult.notOk(s"Velox ORC scan is turned off.")
+          ValidationResult.failed(s"Velox ORC scan is turned off.")
         } else {
           val typeValidator: PartialFunction[StructField, String] = {
             case StructField(_, arrayType: ArrayType, _, _)
@@ -164,7 +164,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
             validateTypes(orcTypeValidatorWithComplexTypeFallback)
           }
         }
-      case _ => ValidationResult.notOk(s"Unsupported file format for $format.")
+      case _ => ValidationResult.failed(s"Unsupported file format for $format.")
     }
   }
 
@@ -284,8 +284,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
       .orElse(validateDataTypes())
       .orElse(validateWriteFilesOptions())
       .orElse(validateBucketSpec()) match {
-      case Some(reason) => ValidationResult.notOk(reason)
-      case _ => ValidationResult.ok
+      case Some(reason) => ValidationResult.failed(reason)
+      case _ => ValidationResult.succeeded
     }
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -366,7 +366,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
         val projectList = Seq(Alias(hashExpr, "hash_partition_key")()) ++ child.output
         val projectTransformer = ProjectExecTransformer(projectList, child)
         val validationResult = projectTransformer.doValidate()
-        if (validationResult.isValid) {
+        if (validationResult.ok()) {
           val newChild = maybeAddAppendBatchesExec(projectTransformer)
           ColumnarShuffleExchangeExec(shuffle, newChild, newChild.output.drop(1))
         } else {
@@ -392,7 +392,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
             val projectTransformer = ProjectExecTransformer(projectList, child)
             val projectBeforeSortValidationResult = projectTransformer.doValidate()
             // Make sure we support offload hash expression
-            val projectBeforeSort = if (projectBeforeSortValidationResult.isValid) {
+            val projectBeforeSort = if (projectBeforeSortValidationResult.ok()) {
               projectTransformer
             } else {
               val project = ProjectExec(projectList, child)
@@ -405,7 +405,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
             val dropSortColumnTransformer =
               ProjectExecTransformer(projectList.drop(1), sortByHashCode)
             val validationResult = dropSortColumnTransformer.doValidate()
-            if (validationResult.isValid) {
+            if (validationResult.ok()) {
               val newChild = maybeAddAppendBatchesExec(dropSortColumnTransformer)
               ColumnarShuffleExchangeExec(shuffle, newChild, newChild.output)
             } else {
@@ -888,7 +888,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       case p @ LimitTransformer(SortExecTransformer(sortOrder, _, child, _), 0, count) =>
         val global = child.outputPartitioning.satisfies(AllTuples)
         val topN = TopNTransformer(count, sortOrder, global, child)
-        if (topN.doValidate().isValid) {
+        if (topN.doValidate().ok()) {
           topN
         } else {
           p

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
@@ -72,11 +72,11 @@ case class GenerateExecTransformer(
       generator: Generator,
       outer: Boolean): ValidationResult = {
     if (!supportsGenerate(generator, outer)) {
-      ValidationResult.notOk(
+      ValidationResult.failed(
         s"Velox backend does not support this generator: ${generator.getClass.getSimpleName}" +
           s", outer: $outer")
     } else {
-      ValidationResult.ok
+      ValidationResult.succeeded
     }
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
@@ -66,7 +66,7 @@ case class VeloxColumnarToRowExec(child: SparkPlan) extends ColumnarToRowExecBas
               s"VeloxColumnarToRowExec.")
       }
     }
-    ValidationResult.ok
+    ValidationResult.succeeded
   }
 
   override def doExecuteInternal(): RDD[InternalRow] = {

--- a/gluten-core/src/main/java/org/apache/gluten/validate/NativePlanValidationInfo.java
+++ b/gluten-core/src/main/java/org/apache/gluten/validate/NativePlanValidationInfo.java
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten.validate;
 
+import org.apache.gluten.extension.ValidationResult;
+
 import java.util.Vector;
 
 public class NativePlanValidationInfo {
@@ -30,11 +32,13 @@ public class NativePlanValidationInfo {
     }
   }
 
-  public boolean isSupported() {
-    return isSupported == 1;
-  }
-
-  public Vector<String> getFallbackInfo() {
-    return fallbackInfo;
+  public ValidationResult asResult() {
+    if (isSupported == 1) {
+      return ValidationResult.succeeded();
+    }
+    return ValidationResult.failed(
+        String.format(
+            "Native validation failed: %n%s",
+            fallbackInfo.stream().reduce((l, r) -> l + "\n" + r)));
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -35,12 +35,12 @@ trait BackendSettingsApi {
       format: ReadFileFormat,
       fields: Array[StructField],
       partTable: Boolean,
-      paths: Seq[String]): ValidationResult = ValidationResult.ok
+      paths: Seq[String]): ValidationResult = ValidationResult.succeeded
   def supportWriteFilesExec(
       format: FileFormat,
       fields: Array[StructField],
       bucketSpec: Option[BucketSpec],
-      options: Map[String, String]): ValidationResult = ValidationResult.ok
+      options: Map[String, String]): ValidationResult = ValidationResult.succeeded
   def supportNativeWrite(fields: Array[StructField]): Boolean = true
   def supportNativeMetadataColumns(): Boolean = false
   def supportNativeRowIndexColumn(): Boolean = false

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -113,7 +113,7 @@ abstract class FilterExecTransformerBase(val cond: Expression, val input: SparkP
     if (remainingCondition == null) {
       // All the filters can be pushed down and the computing of this Filter
       // is not needed.
-      return ValidationResult.ok
+      return ValidationResult.succeeded
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -88,7 +88,7 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
 
     val validationResult = BackendsApiManager.getSettings
       .supportFileFormatRead(fileFormat, fields, getPartitionSchema.nonEmpty, getInputFilePaths)
-    if (!validationResult.isValid) {
+    if (!validationResult.ok()) {
       return validationResult
     }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
@@ -133,18 +133,18 @@ abstract class BatchScanExecTransformerBase(
 
   override def doValidateInternal(): ValidationResult = {
     if (pushedAggregate.nonEmpty) {
-      return ValidationResult.notOk(s"Unsupported aggregation push down for $scan.")
+      return ValidationResult.failed(s"Unsupported aggregation push down for $scan.")
     }
 
     if (
       SparkShimLoader.getSparkShims.findRowIndexColumnIndexInSchema(schema) > 0 &&
       !BackendsApiManager.getSettings.supportNativeRowIndexColumn()
     ) {
-      return ValidationResult.notOk("Unsupported row index column scan in native.")
+      return ValidationResult.failed("Unsupported row index column scan in native.")
     }
 
     if (hasUnsupportedColumns) {
-      return ValidationResult.notOk(s"Unsupported columns scan in native.")
+      return ValidationResult.failed(s"Unsupported columns scan in native.")
     }
 
     super.doValidateInternal()

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/CartesianProductExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/CartesianProductExecTransformer.scala
@@ -112,7 +112,7 @@ case class CartesianProductExecTransformer(
 
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportCartesianProductExec()) {
-      return ValidationResult.notOk("Cartesian product is not supported in this backend")
+      return ValidationResult.failed("Cartesian product is not supported in this backend")
     }
     val substraitContext = new SubstraitContext
     val expressionNode = condition.map {

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ExpandExecTransformer.scala
@@ -95,10 +95,10 @@ case class ExpandExecTransformer(
 
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportExpandExec()) {
-      return ValidationResult.notOk("Current backend does not support expand")
+      return ValidationResult.failed("Current backend does not support expand")
     }
     if (projections.isEmpty) {
-      return ValidationResult.notOk("Current backend does not support empty projections in expand")
+      return ValidationResult.failed("Current backend does not support empty projections in expand")
     }
 
     val substraitContext = new SubstraitContext

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -130,23 +130,23 @@ abstract class FileSourceScanExecTransformerBase(
     if (
       !metadataColumns.isEmpty && !BackendsApiManager.getSettings.supportNativeMetadataColumns()
     ) {
-      return ValidationResult.notOk(s"Unsupported metadata columns scan in native.")
+      return ValidationResult.failed(s"Unsupported metadata columns scan in native.")
     }
 
     if (
       SparkShimLoader.getSparkShims.findRowIndexColumnIndexInSchema(schema) > 0 &&
       !BackendsApiManager.getSettings.supportNativeRowIndexColumn()
     ) {
-      return ValidationResult.notOk("Unsupported row index column scan in native.")
+      return ValidationResult.failed("Unsupported row index column scan in native.")
     }
 
     if (hasUnsupportedColumns) {
-      return ValidationResult.notOk(s"Unsupported columns scan in native.")
+      return ValidationResult.failed(s"Unsupported columns scan in native.")
     }
 
     if (hasFieldIds) {
       // Spark read schema expects field Ids , the case didn't support yet by native.
-      return ValidationResult.notOk(
+      return ValidationResult.failed(
         s"Unsupported matching schema column names " +
           s"by field ids in native scan.")
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
@@ -67,7 +67,7 @@ abstract class GenerateExecTransformerBase(
 
   override protected def doValidateInternal(): ValidationResult = {
     val validationResult = doGeneratorValidate(generator, outer)
-    if (!validationResult.isValid) {
+    if (!validationResult.ok()) {
       return validationResult
     }
     val context = new SubstraitContext

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
@@ -117,7 +117,7 @@ abstract class HashAggregateExecBaseTransformer(
 
     val unsupportedAggExprs = aggregateAttributes.filterNot(attr => checkType(attr.dataType))
     if (unsupportedAggExprs.nonEmpty) {
-      return ValidationResult.notOk(
+      return ValidationResult.failed(
         "Found unsupported data type in aggregation expression: " +
           unsupportedAggExprs
             .map(attr => s"${attr.name}#${attr.exprId.id}:${attr.dataType}")
@@ -125,7 +125,7 @@ abstract class HashAggregateExecBaseTransformer(
     }
     val unsupportedGroupExprs = groupingExpressions.filterNot(attr => checkType(attr.dataType))
     if (unsupportedGroupExprs.nonEmpty) {
-      return ValidationResult.notOk(
+      return ValidationResult.failed(
         "Found unsupported data type in grouping expression: " +
           unsupportedGroupExprs
             .map(attr => s"${attr.name}#${attr.exprId.id}:${attr.dataType}")

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
@@ -210,7 +210,7 @@ trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
       return ValidationResult
-        .notOk(s"Unsupported join type of $hashJoinType for substrait: $substraitJoinType")
+        .failed(s"Unsupported join type of $hashJoinType for substrait: $substraitJoinType")
     }
     val relNode = JoinUtils.createJoinRel(
       streamedKeyExprs,

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/SampleExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/SampleExecTransformer.scala
@@ -99,7 +99,7 @@ case class SampleExecTransformer(
 
   override protected def doValidateInternal(): ValidationResult = {
     if (withReplacement) {
-      return ValidationResult.notOk(
+      return ValidationResult.failed(
         "Unsupported sample exec in native with " +
           s"withReplacement parameter is $withReplacement")
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
@@ -95,11 +95,11 @@ object ScanTransformerFactory {
         transformer.setPushDownFilters(allPushDownFilters.get)
         // Validate again if allPushDownFilters is defined.
         val validationResult = transformer.doValidate()
-        if (validationResult.isValid) {
+        if (validationResult.ok()) {
           transformer
         } else {
           val newSource = batchScan.copy(runtimeFilters = transformer.runtimeFilters)
-          FallbackTags.add(newSource, validationResult.reason.get)
+          FallbackTags.add(newSource, validationResult.reason())
           newSource
         }
       } else {

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/SortExecTransformer.scala
@@ -91,7 +91,7 @@ case class SortExecTransformer(
 
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportSortExec()) {
-      return ValidationResult.notOk("Current backend does not support sort")
+      return ValidationResult.failed("Current backend does not support sort")
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/SortMergeJoinExecTransformer.scala
@@ -164,7 +164,7 @@ abstract class SortMergeJoinExecTransformerBase(
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
       return ValidationResult
-        .notOk(s"Found unsupported join type of $joinType for substrait: $substraitJoinType")
+        .failed(s"Found unsupported join type of $joinType for substrait: $substraitJoinType")
     }
     val relNode = JoinUtils.createJoinRel(
       streamedKeys,
@@ -253,7 +253,7 @@ case class SortMergeJoinExecTransformer(
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.JOIN_TYPE_OUTER) {
       return ValidationResult
-        .notOk(s"Found unsupported join type of $joinType for velox smj: $substraitJoinType")
+        .failed(s"Found unsupported join type of $joinType for velox smj: $substraitJoinType")
     }
     super.doValidateInternal()
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -67,7 +67,7 @@ case class TakeOrderedAndProjectExecTransformer(
 
   override protected def doValidateInternal(): ValidationResult = {
     if (offset != 0) {
-      return ValidationResult.notOk(s"Native TopK does not support offset: $offset")
+      return ValidationResult.failed(s"Native TopK does not support offset: $offset")
     }
 
     var tagged: ValidationResult = null
@@ -83,14 +83,14 @@ case class TakeOrderedAndProjectExecTransformer(
         ColumnarCollapseTransformStages.wrapInputIteratorTransformer(child)
       val sortPlan = SortExecTransformer(sortOrder, false, inputTransformer)
       val sortValidation = sortPlan.doValidate()
-      if (!sortValidation.isValid) {
+      if (!sortValidation.ok()) {
         return sortValidation
       }
       val limitPlan = LimitTransformer(sortPlan, offset, limit)
       tagged = limitPlan.doValidate()
     }
 
-    if (tagged.isValid) {
+    if (tagged.ok()) {
       val projectPlan = ProjectExecTransformer(projectList, child)
       tagged = projectPlan.doValidate()
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/WindowExecTransformer.scala
@@ -165,7 +165,7 @@ case class WindowExecTransformer(
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportWindowExec(windowExpression)) {
       return ValidationResult
-        .notOk(s"Found unsupported window expression: ${windowExpression.mkString(", ")}")
+        .failed(s"Found unsupported window expression: ${windowExpression.mkString(", ")}")
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/WindowGroupLimitExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/WindowGroupLimitExecTransformer.scala
@@ -145,7 +145,7 @@ case class WindowGroupLimitExecTransformer(
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportWindowGroupLimitExec(rankLikeFunction)) {
       return ValidationResult
-        .notOk(s"Found unsupported rank like function: $rankLikeFunction")
+        .failed(s"Found unsupported rank like function: $rankLikeFunction")
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
@@ -150,8 +150,8 @@ case class WriteFilesExecTransformer(
         finalChildOutput.toStructType.fields,
         bucketSpec,
         caseInsensitiveOptions)
-    if (!validationResult.isValid) {
-      return ValidationResult.notOk("Unsupported native write: " + validationResult.reason.get)
+    if (!validationResult.ok()) {
+      return ValidationResult.failed("Unsupported native write: " + validationResult.reason())
     }
 
     val substraitContext = new SubstraitContext

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
@@ -67,7 +67,8 @@ trait GlutenPlan extends SparkPlan with Convention.KnownBatchType with LogLevelU
     val schemaVaidationResult = BackendsApiManager.getValidatorApiInstance
       .doSchemaValidate(schema)
       .map {
-        reason => ValidationResult.failed(s"Found schema check failure for $schema, due to: $reason")
+        reason =>
+          ValidationResult.failed(s"Found schema check failure for $schema, due to: $reason")
       }
       .getOrElse(ValidationResult.succeeded)
     if (!schemaVaidationResult.ok()) {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/CollapseProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/CollapseProjectExecTransformer.scala
@@ -40,11 +40,11 @@ object CollapseProjectExecTransformer extends Rule[SparkPlan] {
         val collapsedProject = p2.copy(projectList =
           CollapseProjectShim.buildCleanedProjectList(p1.projectList, p2.projectList))
         val validationResult = collapsedProject.doValidate()
-        if (validationResult.isValid) {
+        if (validationResult.ok()) {
           logDebug(s"Collapse project $p1 and $p2.")
           collapsedProject
         } else {
-          logDebug(s"Failed to collapse project, due to ${validationResult.reason.getOrElse("")}")
+          logDebug(s"Failed to collapse project, due to ${validationResult.reason()}")
           p1
         }
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/ExpandFallbackPolicy.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/ExpandFallbackPolicy.scala
@@ -243,7 +243,7 @@ case class ExpandFallbackPolicy(isAdaptiveContext: Boolean, originalPlan: SparkP
         originalPlan
           .find(_.logicalLink.exists(_.fastEquals(p.logicalLink.get)))
           .filterNot(FallbackTags.nonEmpty)
-          .foreach(origin => FallbackTags.tag(origin, FallbackTags.getTag(p)))
+          .foreach(origin => FallbackTags.add(origin, FallbackTags.get(p)))
       case _ =>
     }
 
@@ -280,7 +280,7 @@ case class ExpandFallbackPolicy(isAdaptiveContext: Boolean, originalPlan: SparkP
       } else {
         FallbackTags.addRecursively(
           vanillaSparkPlan,
-          TRANSFORM_UNSUPPORTED(fallbackInfo.reason, appendReasonIfExists = false))
+          FallbackTag.Exclusive(fallbackInfo.reason.getOrElse("Unknown reason")))
         FallbackNode(vanillaSparkPlan)
       }
     } else {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
@@ -117,9 +117,9 @@ object FallbackTags {
     val tagOption = getOption(plan)
     val newTagOption = converter.from(t)
 
-    val mergedTagOption
-        : Option[FallbackTag] = // New tag comes while the plan was already tagged, merge.
+    val mergedTagOption: Option[FallbackTag] =
       (tagOption ++ newTagOption).reduceOption {
+        // New tag comes while the plan was already tagged, merge.
         case (_, exclusive: FallbackTag.Exclusive) =>
           exclusive
         case (exclusive: FallbackTag.Exclusive, _) =>

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
@@ -118,7 +118,7 @@ object FallbackTags {
     val newTagOption = converter.from(t)
 
     val mergedTagOption: Option[FallbackTag] =
-      (tagOption ++ newTagOption).reduceOption {
+      (tagOption ++ newTagOption).reduceOption[FallbackTag] {
         // New tag comes while the plan was already tagged, merge.
         case (_, exclusive: FallbackTag.Exclusive) =>
           exclusive

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
@@ -119,20 +119,13 @@ object FallbackTags {
 
     val mergedTagOption
         : Option[FallbackTag] = // New tag comes while the plan was already tagged, merge.
-      (tagOption, newTagOption) match {
-        case (None, None) => None
-        case (None, tag) => tag
-        case (tag, None) => tag
-        case (Some(tag), Some(newTag)) =>
-          val mergedTag = (tag, newTag) match {
-            case (_, exclusive: FallbackTag.Exclusive) =>
-              exclusive
-            case (exclusive: FallbackTag.Exclusive, _) =>
-              exclusive
-            case (l: FallbackTag.Appendable, r: FallbackTag.Appendable) =>
-              FallbackTag.Appendable(s"${l.reason}; ${r.reason}")
-          }
-          Some(mergedTag)
+      (tagOption ++ newTagOption).reduceOption {
+        case (_, exclusive: FallbackTag.Exclusive) =>
+          exclusive
+        case (exclusive: FallbackTag.Exclusive, _) =>
+          exclusive
+        case (l: FallbackTag.Appendable, r: FallbackTag.Appendable) =>
+          FallbackTag.Appendable(s"${l.reason}; ${r.reason}")
       }
     mergedTagOption
       .foreach(mergedTag => plan.setTagValue(TAG, mergedTag))

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -379,7 +379,7 @@ case class OffloadFilter() extends OffloadSingleNode with LogLevelUtil {
           val newScan =
             FilterHandler.pushFilterToScan(filter.condition, scan)
           newScan match {
-            case ts: TransformSupport if ts.doValidate().isValid => ts
+            case ts: TransformSupport if ts.doValidate().ok() => ts
             case _ => scan
           }
         } else scan
@@ -550,12 +550,12 @@ object OffloadOthers {
       case plan: FileSourceScanExec =>
         val transformer = ScanTransformerFactory.createFileSourceScanTransformer(plan)
         val validationResult = transformer.doValidate()
-        if (validationResult.isValid) {
+        if (validationResult.ok()) {
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           transformer
         } else {
           logDebug(s"Columnar Processing for ${plan.getClass} is currently unsupported.")
-          FallbackTags.add(plan, validationResult.reason.get)
+          FallbackTags.add(plan, validationResult.reason())
           plan
         }
       case plan: BatchScanExec =>
@@ -565,12 +565,12 @@ object OffloadOthers {
         val hiveTableScanExecTransformer =
           BackendsApiManager.getSparkPlanExecApiInstance.genHiveTableScanExecTransformer(plan)
         val validateResult = hiveTableScanExecTransformer.doValidate()
-        if (validateResult.isValid) {
+        if (validateResult.ok()) {
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           return hiveTableScanExecTransformer
         }
         logDebug(s"Columnar Processing for ${plan.getClass} is currently unsupported.")
-        FallbackTags.add(plan, validateResult.reason.get)
+        FallbackTags.add(plan, validateResult.reason())
         plan
       case other =>
         throw new GlutenNotSupportException(s"${other.getClass.toString} is not supported.")

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/RemoveNativeWriteFilesSortAndProject.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/RemoveNativeWriteFilesSortAndProject.scala
@@ -71,7 +71,7 @@ object NativeWriteFilesWithSkippingSortAndProject extends Logging {
         }
         val transformer = ProjectExecTransformer(newProjectList, p.child)
         val validationResult = transformer.doValidate()
-        if (validationResult.isValid) {
+        if (validationResult.ok()) {
           Some(transformer)
         } else {
           // If we can not transform the project, then we fallback to origin plan which means

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/PushFilterToScan.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/PushFilterToScan.scala
@@ -37,7 +37,7 @@ class PushFilterToScan(validator: Validator) extends RasRule[SparkPlan] {
           val newScan =
             FilterHandler.pushFilterToScan(filter.condition, scan)
           newScan match {
-            case ts: TransformSupport if ts.doValidate().isValid =>
+            case ts: TransformSupport if ts.doValidate().ok() =>
               List(filter.withNewChildren(List(ts)))
             case _ =>
               List.empty

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
@@ -106,7 +106,7 @@ object RasOffload {
             case Validator.Passed =>
               val offloaded = base.offload(from)
               val offloadedNodes = offloaded.collect[GlutenPlan] { case t: GlutenPlan => t }
-              if (offloadedNodes.exists(!_.doValidate().isValid)) {
+              if (offloadedNodes.exists(!_.doValidate().ok())) {
                 // 4. If native validation fails on the offloaded node, return the
                 // original one.
                 from

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteSparkPlanRulesManager.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteSparkPlanRulesManager.scala
@@ -74,7 +74,7 @@ class RewriteSparkPlanRulesManager private (rewriteRules: Seq[RewriteSingleNode]
       case p if !p.isInstanceOf[ProjectExec] && !p.isInstanceOf[RewrittenNodeWall] => p
     }
     assert(target.size == 1)
-    FallbackTags.getTagOption(target.head)
+    FallbackTags.getOption(target.head)
   }
 
   private def applyRewriteRules(origin: SparkPlan): (SparkPlan, Option[String]) = {
@@ -112,10 +112,10 @@ class RewriteSparkPlanRulesManager private (rewriteRules: Seq[RewriteSingleNode]
           origin
         } else {
           addHint.apply(rewrittenPlan)
-          val hint = getFallbackTagBack(rewrittenPlan)
-          if (hint.isDefined) {
+          val tag = getFallbackTagBack(rewrittenPlan)
+          if (tag.isDefined) {
             // If the rewritten plan is still not transformable, return the original plan.
-            FallbackTags.tag(origin, hint.get)
+            FallbackTags.add(origin, tag.get)
             origin
           } else {
             rewrittenPlan.transformUp {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.extension.columnar.validator
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.{BackendsApiManager, BackendSettingsApi}
 import org.apache.gluten.expression.ExpressionUtils
-import org.apache.gluten.extension.columnar.{FallbackTags, TRANSFORM_UNSUPPORTED}
+import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.execution._
@@ -109,8 +109,8 @@ object Validators {
   private object FallbackByHint extends Validator {
     override def validate(plan: SparkPlan): Validator.OutCome = {
       if (FallbackTags.nonEmpty(plan)) {
-        val hint = FallbackTags.getTag(plan).asInstanceOf[TRANSFORM_UNSUPPORTED]
-        return fail(hint.reason.getOrElse("Reason not recorded"))
+        val tag = FallbackTags.get(plan)
+        return fail(tag.reason())
       }
       pass()
     }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -18,8 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.GlutenPlan
-import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark._
@@ -119,10 +118,10 @@ case class ColumnarShuffleExchangeExec(
       .doColumnarShuffleExchangeExecValidate(outputPartitioning, child)
       .map {
         reason =>
-          ValidationResult.notOk(
+          ValidationResult.failed(
             s"Found schema check failure for schema ${child.schema} due to: $reason")
       }
-      .getOrElse(ValidationResult.ok)
+      .getOrElse(ValidationResult.succeeded)
   }
 
   override def nodeName: String = "ColumnarExchange"

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -18,12 +18,12 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.execution.WholeStageTransformer
 import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.utils.PlanUtil
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Expression, PlanExpression}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.execution.GlutenFallbackReporter.FALLBACK_REASON_TAG
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, AQEShuffleReadExec, QueryStageExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
@@ -59,8 +59,8 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
       p: SparkPlan,
       fallbackNodeToReason: mutable.HashMap[String, String]
   ): Unit = {
-    p.logicalLink.flatMap(_.getTagValue(FALLBACK_REASON_TAG)) match {
-      case Some(reason) => addFallbackNodeWithReason(p, reason, fallbackNodeToReason)
+    p.logicalLink.flatMap(FallbackTags.getOption) match {
+      case Some(tag) => addFallbackNodeWithReason(p, tag.reason(), fallbackNodeToReason)
       case _ =>
         // If the SparkPlan does not have fallback reason, then there are two options:
         // 1. Gluten ignore that plan and it's a kind of fallback

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -62,7 +62,7 @@ case class EvalPythonExecTransformer(
     // All udfs should be scalar python udf
     for (udf <- udfs) {
       if (!PythonUDF.isScalarPythonUDF(udf)) {
-        return ValidationResult.notOk(s"$udf is not scalar python udf")
+        return ValidationResult.failed(s"$udf is not scalar python udf")
       }
     }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -202,7 +202,7 @@ object HiveTableScanExecTransformer {
           hiveTableScan.relation,
           hiveTableScan.partitionPruningPred)(hiveTableScan.session)
         hiveTableScanTransformer.doValidate()
-      case _ => ValidationResult.notOk("Is not a Hive scan")
+      case _ => ValidationResult.failed("Is not a Hive scan")
     }
   }
 

--- a/gluten-delta/src/main/scala/org/apache/gluten/execution/DeltaScanTransformer.scala
+++ b/gluten-delta/src/main/scala/org/apache/gluten/execution/DeltaScanTransformer.scala
@@ -57,7 +57,7 @@ case class DeltaScanTransformer(
         _.name == "__delta_internal_is_row_deleted") || requiredSchema.fields.exists(
         _.name == "__delta_internal_row_index")
     ) {
-      return ValidationResult.notOk(s"Deletion vector is not supported in native.")
+      return ValidationResult.failed(s"Deletion vector is not supported in native.")
     }
 
     super.doValidateInternal()

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -35,7 +35,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan
       )
-      if (transformer.doValidate().isValid) {
+      if (transformer.doValidate().ok()) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.execution.BasicScanExecTransformer
 import org.apache.gluten.extension.GlutenPlan
-import org.apache.gluten.extension.columnar.{FallbackEmptySchemaRelation, FallbackTags, TRANSFORM_UNSUPPORTED}
+import org.apache.gluten.extension.columnar.{FallbackEmptySchemaRelation, FallbackTags}
 import org.apache.gluten.extension.columnar.heuristic.HeuristicApplier
 import org.apache.gluten.extension.columnar.transition.InsertTransitions
 import org.apache.gluten.utils.QueryPlanSelector
@@ -124,17 +124,16 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
 
   testGluten("Tag not transformable more than once") {
     val originalPlan = UnaryOp1(LeafOp(supportsColumnar = true))
-    FallbackTags.tag(originalPlan, TRANSFORM_UNSUPPORTED(Some("fake reason")))
+    FallbackTags.add(originalPlan, "fake reason")
     val rule = FallbackEmptySchemaRelation()
     val newPlan = rule.apply(originalPlan)
-    val reason = FallbackTags.getTag(newPlan).asInstanceOf[TRANSFORM_UNSUPPORTED].reason
-    assert(reason.isDefined)
+    val reason = FallbackTags.get(newPlan).reason()
     if (BackendsApiManager.getSettings.fallbackOnEmptySchema(newPlan)) {
       assert(
-        reason.get.contains("fake reason") &&
-          reason.get.contains("at least one of its children has empty output"))
+        reason.contains("fake reason") &&
+          reason.contains("at least one of its children has empty output"))
     } else {
-      assert(reason.get.contains("fake reason"))
+      assert(reason.contains("fake reason"))
     }
   }
 

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -35,7 +35,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan
       )
-      if (transformer.doValidate().isValid) {
+      if (transformer.doValidate().ok()) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.execution.BasicScanExecTransformer
 import org.apache.gluten.extension.GlutenPlan
-import org.apache.gluten.extension.columnar.{FallbackEmptySchemaRelation, FallbackTags, TRANSFORM_UNSUPPORTED}
+import org.apache.gluten.extension.columnar.{FallbackEmptySchemaRelation, FallbackTags}
 import org.apache.gluten.extension.columnar.heuristic.HeuristicApplier
 import org.apache.gluten.extension.columnar.transition.InsertTransitions
 import org.apache.gluten.utils.QueryPlanSelector
@@ -125,17 +125,16 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
 
   testGluten("Tag not transformable more than once") {
     val originalPlan = UnaryOp1(LeafOp(supportsColumnar = true))
-    FallbackTags.tag(originalPlan, TRANSFORM_UNSUPPORTED(Some("fake reason")))
+    FallbackTags.add(originalPlan, "fake reason")
     val rule = FallbackEmptySchemaRelation()
     val newPlan = rule.apply(originalPlan)
-    val reason = FallbackTags.getTag(newPlan).asInstanceOf[TRANSFORM_UNSUPPORTED].reason
-    assert(reason.isDefined)
+    val reason = FallbackTags.get(newPlan).reason()
     if (BackendsApiManager.getSettings.fallbackOnEmptySchema(newPlan)) {
       assert(
-        reason.get.contains("fake reason") &&
-          reason.get.contains("at least one of its children has empty output"))
+        reason.contains("fake reason") &&
+          reason.contains("at least one of its children has empty output"))
     } else {
-      assert(reason.get.contains("fake reason"))
+      assert(reason.contains("fake reason"))
     }
   }
 

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -35,7 +35,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan
       )
-      if (transformer.doValidate().isValid) {
+      if (transformer.doValidate().ok()) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.execution.BasicScanExecTransformer
 import org.apache.gluten.extension.GlutenPlan
-import org.apache.gluten.extension.columnar.{FallbackEmptySchemaRelation, FallbackTags, TRANSFORM_UNSUPPORTED}
+import org.apache.gluten.extension.columnar.{FallbackEmptySchemaRelation, FallbackTags}
 import org.apache.gluten.extension.columnar.heuristic.HeuristicApplier
 import org.apache.gluten.extension.columnar.transition.InsertTransitions
 import org.apache.gluten.utils.QueryPlanSelector
@@ -125,17 +125,16 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
 
   testGluten("Tag not transformable more than once") {
     val originalPlan = UnaryOp1(LeafOp(supportsColumnar = true))
-    FallbackTags.tag(originalPlan, TRANSFORM_UNSUPPORTED(Some("fake reason")))
+    FallbackTags.add(originalPlan, "fake reason")
     val rule = FallbackEmptySchemaRelation()
     val newPlan = rule.apply(originalPlan)
-    val reason = FallbackTags.getTag(newPlan).asInstanceOf[TRANSFORM_UNSUPPORTED].reason
-    assert(reason.isDefined)
+    val reason = FallbackTags.get(newPlan).reason()
     if (BackendsApiManager.getSettings.fallbackOnEmptySchema(newPlan)) {
       assert(
-        reason.get.contains("fake reason") &&
-          reason.get.contains("at least one of its children has empty output"))
+        reason.contains("fake reason") &&
+          reason.contains("at least one of its children has empty output"))
     } else {
-      assert(reason.get.contains("fake reason"))
+      assert(reason.contains("fake reason"))
     }
   }
 

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -35,7 +35,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan
       )
-      if (transformer.doValidate().isValid) {
+      if (transformer.doValidate().ok()) {
         transformer
       } else {
         plan


### PR DESCRIPTION
1. ValidationResult:
   * Rename  `ValidationResult.ok` to  `ValidationResult.succeeded`
   * Rename  `ValidationResult.notOk(reason)` to  `ValidationResult.failed(reason)`
   * Rename  `ValidationResult.isValid()` to  `ValidationResult.ok()`
2. Remove tag type `FALLBACK_REASON_TAG`, reuse `FallbackTag` instead
3. Add `FallbackTag.Converter` to convert from different inputs to `FallbackTag` instances implicitly