### PR TITLE
[VL] Fix build Velox script incorrectly judged as successful when run make

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -109,6 +109,9 @@ function compile {
     fi
   fi
 
+  # Maybe there is some set option in velox setup script. Run set command again.
+  set -exu  
+
   CXX_FLAGS='-Wno-missing-field-initializers'
   COMPILE_OPTION="-DCMAKE_CXX_FLAGS=\"$CXX_FLAGS\" -DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF"
   if [ $BUILD_TEST_UTILS == "ON" ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build Velox script incorrectly judged as successful when run make.

(Fixes: \#6330)

## How was this patch tested?

munally.

