### PR TITLE
[VL] Hash shuffle writer cache multiple inputs and split

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -953,7 +953,8 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_ShuffleWriterJniWrappe
 JNIEXPORT jobject JNICALL Java_org_apache_gluten_vectorized_ShuffleWriterJniWrapper_stop( // NOLINT
     JNIEnv* env,
     jobject wrapper,
-    jlong shuffleWriterHandle) {
+    jlong shuffleWriterHandle,
+    jlong memLimit) {
   JNI_METHOD_START
   auto ctx = gluten::getRuntime(env, wrapper);
 
@@ -963,7 +964,7 @@ JNIEXPORT jobject JNICALL Java_org_apache_gluten_vectorized_ShuffleWriterJniWrap
     throw gluten::GlutenException(errorMessage);
   }
 
-  gluten::arrowAssertOkOrThrow(shuffleWriter->stop(), "Native shuffle write: ShuffleWriter stop failed");
+  gluten::arrowAssertOkOrThrow(shuffleWriter->stop(memLimit), "Native shuffle write: ShuffleWriter stop failed");
 
   const auto& partitionLengths = shuffleWriter->partitionLengths();
   auto partitionLengthArr = env->NewLongArray(partitionLengths.size());

--- a/cpp/core/operators/serializer/ColumnarBatchSerializer.h
+++ b/cpp/core/operators/serializer/ColumnarBatchSerializer.h
@@ -25,7 +25,7 @@ namespace gluten {
 
 class ColumnarBatchSerializer {
  public:
-  ColumnarBatchSerializer(arrow::MemoryPool* arrowPool, struct ArrowSchema* cSchema) : arrowPool_(arrowPool) {}
+  ColumnarBatchSerializer(arrow::MemoryPool* arrowPool) : arrowPool_(arrowPool) {}
 
   virtual ~ColumnarBatchSerializer() = default;
 

--- a/cpp/core/shuffle/FallbackRangePartitioner.cc
+++ b/cpp/core/shuffle/FallbackRangePartitioner.cc
@@ -26,7 +26,6 @@ arrow::Status gluten::FallbackRangePartitioner::compute(
     std::vector<uint32_t>& row2Partition,
     std::vector<uint32_t>& partition2RowCount) {
   row2Partition.resize(numRows);
-  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
   for (auto i = 0; i < numRows; ++i) {
     auto pid = pidArr[i];
     if (pid >= numPartitions_) {

--- a/cpp/core/shuffle/HashPartitioner.cc
+++ b/cpp/core/shuffle/HashPartitioner.cc
@@ -43,7 +43,6 @@ arrow::Status gluten::HashPartitioner::compute(
     std::vector<uint32_t>& row2partition,
     std::vector<uint32_t>& partition2RowCount) {
   row2partition.resize(numRows);
-  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
 
   for (auto i = 0; i < numRows; ++i) {
     auto pid = computePid(pidArr, i, numPartitions_);

--- a/cpp/core/shuffle/Options.h
+++ b/cpp/core/shuffle/Options.h
@@ -26,7 +26,7 @@ namespace gluten {
 
 static constexpr int16_t kDefaultBatchSize = 4096;
 static constexpr int32_t kDefaultShuffleWriterBufferSize = 4096;
-static constexpr int64_t kDefaultSortBufferThreshold = 64 << 20;
+static constexpr int64_t kDefaultSortBufferThreshold = std::numeric_limits<int64_t>::max();
 static constexpr int64_t kDefaultPushMemoryThreshold = 4096;
 static constexpr int32_t kDefaultNumSubDirs = 64;
 static constexpr int32_t kDefaultCompressionThreshold = 100;

--- a/cpp/core/shuffle/Partitioner.cc
+++ b/cpp/core/shuffle/Partitioner.cc
@@ -21,6 +21,7 @@
 #include "shuffle/RandomPartitioner.h"
 #include "shuffle/RoundRobinPartitioner.h"
 #include "shuffle/SinglePartitioner.h"
+#include "utils/exception.h"
 
 namespace gluten {
 

--- a/cpp/core/shuffle/RandomPartitioner.cc
+++ b/cpp/core/shuffle/RandomPartitioner.cc
@@ -24,7 +24,6 @@ arrow::Status gluten::RandomPartitioner::compute(
     const int64_t numRows,
     std::vector<uint32_t>& row2Partition,
     std::vector<uint32_t>& partition2RowCount) {
-  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
   row2Partition.resize(numRows);
 
   for (int32_t i = 0; i < numRows; ++i) {

--- a/cpp/core/shuffle/RoundRobinPartitioner.cc
+++ b/cpp/core/shuffle/RoundRobinPartitioner.cc
@@ -24,7 +24,6 @@ arrow::Status gluten::RoundRobinPartitioner::compute(
     const int64_t numRows,
     std::vector<uint32_t>& row2Partition,
     std::vector<uint32_t>& partition2RowCount) {
-  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
   row2Partition.resize(numRows);
 
   for (int32_t i = 0; i < numRows; ++i) {

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -101,8 +101,7 @@ class ShuffleWriter : public Reclaimable {
         partitionBufferPool_(std::make_unique<ShuffleMemoryPool>(pool)),
         partitionWriter_(std::move(partitionWriter)) {
     GLUTEN_ASSIGN_OR_THROW(
-        partitioner_,
-        partitioner_ = Partitioner::make(options_.partitioning, numPartitions_, options_.startPartitionId));
+        partitioner_, Partitioner::make(options_.partitioning, numPartitions_, options_.startPartitionId));
   }
 
   virtual ~ShuffleWriter() = default;

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -37,6 +37,8 @@ class ShuffleWriter : public Reclaimable {
  public:
   static constexpr int64_t kMinMemLimit = 128LL * 1024 * 1024;
 
+  static constexpr int64_t kMaxMemLimit = 1024LL * 1024 * 1024;
+
   virtual arrow::Status write(std::shared_ptr<ColumnarBatch> cb, int64_t memLimit) = 0;
 
   virtual arrow::Status stop(int64_t memLimit) = 0;

--- a/cpp/core/tests/RoundRobinPartitionerTest.cc
+++ b/cpp/core/tests/RoundRobinPartitionerTest.cc
@@ -27,6 +27,7 @@ class RoundRobinPartitionerTest : public ::testing::Test {
     row2Partition_.clear();
     partition2RowCount_.clear();
     partition2RowCount_.resize(numPart);
+    std::fill(std::begin(partition2RowCount_), std::end(partition2RowCount_), 0);
   }
 
   void checkResult(const std::vector<uint32_t>& expectRow2Part, const std::vector<uint32_t>& expectPart2RowCount)

--- a/cpp/core/tests/RoundRobinPartitionerTest.cc
+++ b/cpp/core/tests/RoundRobinPartitionerTest.cc
@@ -27,7 +27,6 @@ class RoundRobinPartitionerTest : public ::testing::Test {
     row2Partition_.clear();
     partition2RowCount_.clear();
     partition2RowCount_.resize(numPart);
-    std::fill(std::begin(partition2RowCount_), std::end(partition2RowCount_), 0);
   }
 
   void checkResult(const std::vector<uint32_t>& expectRow2Part, const std::vector<uint32_t>& expectPart2RowCount)
@@ -134,6 +133,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeContinuous) {
 
   {
     int numRows = 8;
+    std::fill(std::begin(partition2RowCount_), std::end(partition2RowCount_), 0);
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 8);
     std::vector<uint32_t> row2Part(numRows);
@@ -145,6 +145,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeContinuous) {
 
   {
     int numRows = 10;
+    std::fill(std::begin(partition2RowCount_), std::end(partition2RowCount_), 0);
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 8);
     std::vector<uint32_t> row2Part(numRows);
@@ -154,6 +155,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeContinuous) {
 
   {
     int numRows = 12;
+    std::fill(std::begin(partition2RowCount_), std::end(partition2RowCount_), 0);
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 0);
     std::vector<uint32_t> row2Part(numRows);
@@ -165,6 +167,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeContinuous) {
 
   {
     int numRows = 22;
+    std::fill(std::begin(partition2RowCount_), std::end(partition2RowCount_), 0);
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 2);
     std::vector<uint32_t> row2Part(numRows);

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -190,9 +190,10 @@ void runShuffle(
   {
     gluten::ScopedTimer timer(&totalTime);
     while (resultIter->hasNext()) {
-      GLUTEN_THROW_NOT_OK(shuffleWriter->write(resultIter->next(), ShuffleWriter::kMinMemLimit));
+      GLUTEN_THROW_NOT_OK(
+          shuffleWriter->write(resultIter->next(), ShuffleWriter::kMaxMemLimit - shuffleWriter->cachedPayloadSize()));
     }
-    GLUTEN_THROW_NOT_OK(shuffleWriter->stop(ShuffleWriter::kMinMemLimit));
+    GLUTEN_THROW_NOT_OK(shuffleWriter->stop(ShuffleWriter::kMaxMemLimit - shuffleWriter->cachedPayloadSize()));
   }
 
   populateWriterMetrics(shuffleWriter, totalTime, metrics);

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -192,7 +192,7 @@ void runShuffle(
     while (resultIter->hasNext()) {
       GLUTEN_THROW_NOT_OK(shuffleWriter->write(resultIter->next(), ShuffleWriter::kMinMemLimit));
     }
-    GLUTEN_THROW_NOT_OK(shuffleWriter->stop());
+    GLUTEN_THROW_NOT_OK(shuffleWriter->stop(ShuffleWriter::kMinMemLimit));
   }
 
   populateWriterMetrics(shuffleWriter, totalTime, metrics);

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -437,8 +437,6 @@ int main(int argc, char** argv) {
     std::string errorMsg{};
     if (FLAGS_data.empty()) {
       errorMsg = "Missing '--split' or '--data' option.";
-    } else if (FLAGS_partitioning != "rr" && FLAGS_partitioning != "random") {
-      errorMsg = "--run-shuffle only support round-robin partitioning and random partitioning.";
     }
     if (errorMsg.empty()) {
       try {

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.h
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.h
@@ -32,12 +32,19 @@ class VeloxColumnarBatchSerializer final : public ColumnarBatchSerializer {
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool,
       struct ArrowSchema* cSchema);
 
+  VeloxColumnarBatchSerializer(
+      arrow::MemoryPool* arrowPool,
+      std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool,
+      facebook::velox::RowTypePtr rowType);
+
   std::shared_ptr<arrow::Buffer> serializeColumnarBatches(
       const std::vector<std::shared_ptr<ColumnarBatch>>& batches) override;
 
   std::shared_ptr<ColumnarBatch> deserialize(uint8_t* data, int32_t size) override;
 
  private:
+  void initSerde();
+
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
   facebook::velox::RowTypePtr rowType_;
   std::unique_ptr<facebook::velox::serializer::presto::PrestoVectorSerde> serde_;

--- a/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashBasedShuffleWriter.cc
@@ -919,7 +919,7 @@ uint32_t VeloxHashBasedShuffleWriter::calculatePartitionBufferSize(int64_t memLi
     bytesPerRow += binaryArrayTotalSizeBytes_[i] / totalInputNumRows_;
   }
 
-  memLimit += cachedPayloadSize();
+  memLimit = memLimit - retainedSize_ + cachedPayloadSize();
   // make sure split buffer uses 128M memory at least, let's hardcode it here for now
   if (memLimit < kMinMemLimit) {
     memLimit = kMinMemLimit;

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -402,10 +402,9 @@ std::unique_ptr<ColumnarBatchIterator> VeloxColumnarBatchDeserializerFactory::cr
         hasComplexType_,
         deserializeTime_,
         decompressTime_);
-  } else if (shuffleWriterType_ == kSortShuffle) {
-    return std::make_unique<VeloxShuffleReaderOutStreamWrapper>(
-        veloxPool_, rowType_, batchSize_, veloxCompressionType_, deserializeTime_, std::move(in));
   }
+  return std::make_unique<VeloxShuffleReaderOutStreamWrapper>(
+      veloxPool_, rowType_, batchSize_, veloxCompressionType_, deserializeTime_, std::move(in));
 }
 
 VeloxShuffleReaderOutStreamWrapper::VeloxShuffleReaderOutStreamWrapper(

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -402,9 +402,10 @@ std::unique_ptr<ColumnarBatchIterator> VeloxColumnarBatchDeserializerFactory::cr
         hasComplexType_,
         deserializeTime_,
         decompressTime_);
+  } else if (shuffleWriterType_ == kSortShuffle) {
+    return std::make_unique<VeloxShuffleReaderOutStreamWrapper>(
+        veloxPool_, rowType_, batchSize_, veloxCompressionType_, deserializeTime_, std::move(in));
   }
-  return std::make_unique<VeloxShuffleReaderOutStreamWrapper>(
-      veloxPool_, rowType_, batchSize_, veloxCompressionType_, deserializeTime_, std::move(in));
 }
 
 VeloxShuffleReaderOutStreamWrapper::VeloxShuffleReaderOutStreamWrapper(

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -41,7 +41,7 @@ class VeloxColumnarBatchDeserializer final : public ColumnarBatchIterator {
       int64_t& deserializeTime,
       int64_t& decompressTime);
 
-  std::shared_ptr<ColumnarBatch> next();
+  std::shared_ptr<ColumnarBatch> next() override;
 
  private:
   std::shared_ptr<arrow::io::InputStream> in_;

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -75,10 +75,10 @@ class VeloxShuffleWriter : public ShuffleWriter {
         rv.pool(), newRowType, facebook::velox::BufferPtr(nullptr), length, std::move(children));
   }
 
-  const int32_t* getFirstColumn(const facebook::velox::RowVector& rv) {
-    VELOX_CHECK(rv.childrenSize() > 0, "RowVector missing partition id column.");
+  facebook::velox::VectorPtr getFirstColumn(const facebook::velox::RowVectorPtr& rv) {
+    VELOX_CHECK(rv->childrenSize() > 0, "RowVector missing partition id column.");
 
-    auto& firstChild = rv.childAt(0);
+    const auto& firstChild = rv->childAt(0);
     VELOX_CHECK(firstChild->isFlatEncoding(), "Partition id (field 0) is not flat encoding.");
     VELOX_CHECK(
         firstChild->type()->isInteger(),
@@ -86,7 +86,7 @@ class VeloxShuffleWriter : public ShuffleWriter {
         firstChild->type()->toString());
 
     // first column is partition key hash value or pid
-    return firstChild->asFlatVector<int32_t>()->rawValues();
+    return firstChild;
   }
 
   // For test only.

--- a/cpp/velox/shuffle/VeloxSortBasedShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxSortBasedShuffleWriter.cc
@@ -48,10 +48,6 @@ arrow::Status VeloxSortBasedShuffleWriter::init() {
   supportAvx512_ = false;
 #endif
 
-  ARROW_ASSIGN_OR_RAISE(
-      partitioner_, Partitioner::make(options_.partitioning, numPartitions_, options_.startPartitionId));
-  DLOG(INFO) << "Create partitioning type: " << std::to_string(options_.partitioning);
-
   rowVectorIndexMap_.reserve(numPartitions_);
   bufferOutputStream_ = std::make_unique<BufferOutputStream>(veloxPool_.get());
 
@@ -85,10 +81,11 @@ arrow::Status VeloxSortBasedShuffleWriter::write(std::shared_ptr<ColumnarBatch> 
     auto batches = compositeBatch->getBatches();
     VELOX_CHECK_EQ(batches.size(), 2);
     auto pidBatch = VeloxColumnarBatch::from(veloxPool_.get(), batches[0]);
-    auto pidArr = getFirstColumn(*(pidBatch->getRowVector()));
+    auto pidArr = getFirstColumn(pidBatch->getRowVector());
     START_TIMING(cpuWallTimingList_[CpuWallTimingCompute]);
     setSortState(SortState::kSort);
-    RETURN_NOT_OK(partitioner_->compute(pidArr, pidBatch->numRows(), batches_.size(), rowVectorIndexMap_));
+    RETURN_NOT_OK(partitioner_->compute(
+        pidArr->asFlatVector<int32_t>()->rawValues(), pidBatch->numRows(), batches_.size(), rowVectorIndexMap_));
     END_TIMING();
     auto rvBatch = VeloxColumnarBatch::from(veloxPool_.get(), batches[1]);
     auto rv = rvBatch->getFlattenedRowVector();
@@ -102,10 +99,11 @@ arrow::Status VeloxSortBasedShuffleWriter::write(std::shared_ptr<ColumnarBatch> 
     rv = veloxColumnBatch->getFlattenedRowVector();
     END_TIMING();
     if (partitioner_->hasPid()) {
-      auto pidArr = getFirstColumn(*rv);
+      auto pidArr = getFirstColumn(rv);
       START_TIMING(cpuWallTimingList_[CpuWallTimingCompute]);
       setSortState(SortState::kSort);
-      RETURN_NOT_OK(partitioner_->compute(pidArr, rv->size(), batches_.size(), rowVectorIndexMap_));
+      RETURN_NOT_OK(partitioner_->compute(
+          pidArr->asFlatVector<int32_t>()->rawValues(), rv->size(), batches_.size(), rowVectorIndexMap_));
       END_TIMING();
       auto strippedRv = getStrippedRowVector(*rv);
       RETURN_NOT_OK(initFromRowVector(*strippedRv));
@@ -191,7 +189,7 @@ arrow::Status VeloxSortBasedShuffleWriter::evictRowVector(uint32_t partitionId) 
   return arrow::Status::OK();
 }
 
-arrow::Status VeloxSortBasedShuffleWriter::stop() {
+arrow::Status VeloxSortBasedShuffleWriter::stop(int64_t memLimit) {
   for (auto pid = 0; pid < numPartitions(); ++pid) {
     RETURN_NOT_OK(evictRowVector(pid));
   }
@@ -201,7 +199,6 @@ arrow::Status VeloxSortBasedShuffleWriter::stop() {
     SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingStop]);
     setSortState(SortState::kSortStop);
     RETURN_NOT_OK(partitionWriter_->stop(&metrics_));
-    partitionBuffers_.clear();
   }
 
   stat();

--- a/cpp/velox/shuffle/VeloxSortBasedShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxSortBasedShuffleWriter.h
@@ -60,7 +60,7 @@ class VeloxSortBasedShuffleWriter final : public VeloxShuffleWriter {
 
   arrow::Status write(std::shared_ptr<ColumnarBatch> cb, int64_t memLimit) override;
 
-  arrow::Status stop() override;
+  arrow::Status stop(int64_t memLimit) override;
 
   arrow::Status reclaimFixedSize(int64_t size, int64_t* actual) override;
 

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornHashBasedColumnarShuffleWriter.scala
@@ -144,7 +144,7 @@ class VeloxCelebornHashBasedColumnarShuffleWriter[K, V](
 
     val startTime = System.nanoTime()
     assert(nativeShuffleWriter != -1L)
-    splitResult = jniWrapper.stop(nativeShuffleWriter)
+    splitResult = jniWrapper.stop(nativeShuffleWriter, availableOffHeapPerTask())
 
     dep
       .metrics("splitTime")

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ShuffleWriterJniWrapper.java
@@ -199,7 +199,7 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
    * @param shuffleWriterHandle shuffle writer instance handle
    * @return GlutenSplitResult
    */
-  public native GlutenSplitResult stop(long shuffleWriterHandle) throws IOException;
+  public native GlutenSplitResult stop(long shuffleWriterHandle, long memLimit) throws IOException;
 
   /**
    * Release resources associated with designated shuffle writer instance.

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -186,7 +186,7 @@ class ColumnarShuffleWriter[K, V](
 
     val startTime = System.nanoTime()
     assert(nativeShuffleWriter != -1L)
-    splitResult = jniWrapper.stop(nativeShuffleWriter)
+    splitResult = jniWrapper.stop(nativeShuffleWriter, availableOffHeapPerTask())
     closeShuffleWriter()
 
     dep

--- a/gluten-uniffle/velox/src/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/gluten-uniffle/velox/src/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -197,7 +197,7 @@ public class VeloxUniffleColumnarShuffleWriter<K, V> extends RssShuffleWriter<K,
     if (nativeShuffleWriter == -1L) {
       throw new IllegalStateException("nativeShuffleWriter should not be -1L");
     }
-    splitResult = jniWrapper.stop(nativeShuffleWriter);
+    splitResult = jniWrapper.stop(nativeShuffleWriter, availableOffHeapPerTask());
     columnarDep
         .metrics()
         .get("splitTime")


### PR DESCRIPTION
Cache input RowVectors and split together until certain conditions are satisfied ( `VeloxHashBasedShuffleWriter::shouldSplit`).
Addressed code cleanups.