### PR TITLE
[VL] Fix process_setup_alinux3 arrow CMakeLists.txt path

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -198,7 +198,6 @@ function process_setup_alinux3 {
   sed -i 's/python39 python39-devel python39-pip //g' scripts/setup-centos8.sh
   sed -i "s/.*pip.* install/#&/" scripts/setup-centos8.sh
   sed -i 's/ADDITIONAL_FLAGS=""/ADDITIONAL_FLAGS="-Wno-stringop-overflow"/g' scripts/setup-helper-functions.sh
-  sed -i "s/\${CMAKE_INSTALL_LIBDIR}/lib64/" third_party/CMakeLists.txt
 }
 
 function process_setup_tencentos32 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox moved `third_party/CMakeLists.txt` to `CMake/resolve_dependency_modules/arrow/CMakeLists.txt`. The original `sed` command will give an error. Upon verification, it is now confirmed that there is no need to modify `${CMAKE_INSTALL_LIBDIR}`, as its value is already set to `lib64`.

## How was this patch tested?

N/A