### PR TITLE
[CELEBORN] CelebornShuffleManager#stop should stop non-null _vanillaCelebornShuffleManager

### DIFF
--- a/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -93,7 +93,7 @@ public class CelebornShuffleManager implements ShuffleManager {
   private final Object shuffleIdTracker;
 
   // for Celeborn 0.4.0
-  private boolean throwsFetchFailure;
+  private final boolean throwsFetchFailure;
 
   public CelebornShuffleManager(SparkConf conf) {
     if (conf.getBoolean(LOCAL_SHUFFLE_READER_KEY, true)) {
@@ -244,9 +244,13 @@ public class CelebornShuffleManager implements ShuffleManager {
       lifecycleManager.stop();
       lifecycleManager = null;
     }
-    if (columnarShuffleManager() != null) {
-      columnarShuffleManager().stop();
+    if (_columnarShuffleManager != null) {
+      _columnarShuffleManager.stop();
       _columnarShuffleManager = null;
+    }
+    if (_vanillaCelebornShuffleManager != null) {
+      _vanillaCelebornShuffleManager.stop();
+      _vanillaCelebornShuffleManager = null;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CelebornShuffleManager#stop` should stop non-null `_vanillaCelebornShuffleManager`. Meanwhile, stopping `_columnarShuffleManager` should check whether `_columnarShuffleManager` is null instead of `columnarShuffleManager()` which could not return null.

## How was this patch tested?

CI.