### PR TITLE
[GLUTEN-6378][CH] Support delta count optimizer for the MergeTree format

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
@@ -144,7 +144,15 @@ object AddFileTags {
       "dirName" -> dirName,
       "marks" -> marks.toString
     )
-    AddFile(name, partitionValues, bytesOnDisk, modificationTime, dataChange, stats, tags)
+    val mapper: ObjectMapper = new ObjectMapper()
+    val rootNode = mapper.createObjectNode()
+    rootNode.put("numRecords", rows)
+    rootNode.put("minValues", "")
+    rootNode.put("maxValues", "")
+    rootNode.put("nullCount", "")
+    // Add the `stats` into delta meta log
+    val metricsStats = mapper.writeValueAsString(rootNode)
+    AddFile(name, partitionValues, bytesOnDisk, modificationTime, dataChange, metricsStats, tags)
   }
 
   def addFileToAddMergeTreeParts(addFile: AddFile): AddMergeTreeParts = {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
@@ -739,8 +739,13 @@ class GlutenClickHouseTPCHBucketSuite
     runSql(SQL6)(
       df => {
         checkResult(df, Array(Row(600572)))
-        // there is a shuffle between two phase hash aggregates.
-        checkHashAggregateCount(df, 2)
+        if (sparkVersion.equals("3.2")) {
+          // there is a shuffle between two phase hash aggregate.
+          checkHashAggregateCount(df, 2)
+        } else {
+          // the delta will use the delta log meta to response this sql
+          checkHashAggregateCount(df, 0)
+        }
       })
 
     // test sort aggregates

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -757,8 +757,13 @@ class GlutenClickHouseTPCHParquetBucketSuite
       SQL6,
       true,
       df => {
-        // there is a shuffle between two phase hash aggregate.
-        checkHashAggregateCount(df, 2)
+        if (sparkVersion.equals("3.2")) {
+          // there is a shuffle between two phase hash aggregate.
+          checkHashAggregateCount(df, 2)
+        } else {
+          // the delta will use the delta log meta to response this sql
+          checkHashAggregateCount(df, 0)
+        }
       }
     )
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -757,13 +757,8 @@ class GlutenClickHouseTPCHParquetBucketSuite
       SQL6,
       true,
       df => {
-        if (sparkVersion.equals("3.2")) {
-          // there is a shuffle between two phase hash aggregate.
-          checkHashAggregateCount(df, 2)
-        } else {
-          // the delta will use the delta log meta to response this sql
-          checkHashAggregateCount(df, 0)
-        }
+        // there is a shuffle between two phase hash aggregate.
+        checkHashAggregateCount(df, 2)
       }
     )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
[CH] Support delta count optimizer for the MergeTree format:

In Delta, it will use the rule PrepareDeltaScan to optimize the count command, which will directly use the delta meta to response the sql select count(*) from table, now support this optimizer for the MergeTree format.

Close #6378.
(Fixes: #6378)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

