### PR TITLE
[CELEBORN] Add compression for row-based shuffle

### DIFF
--- a/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/common/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -352,7 +352,7 @@ public class CelebornShuffleManager implements ShuffleManager {
       @SuppressWarnings("unchecked")
       CelebornShuffleHandle<K, ?, C> h = (CelebornShuffleHandle<K, ?, C>) handle;
       CelebornConf readerConf = celebornConf;
-      if (_vanillaCelebornShuffleManager != null) {
+      if (!(h.dependency() instanceof ColumnarShuffleDependency)) {
         readerConf = rowBasedCelebornConf;
       }
       return CelebornUtils.getCelebornShuffleReader(


### PR DESCRIPTION
## What changes were proposed in this pull request?
When using ```CelebornShuffleManager```, columnar shuffle data is typically compressed on the Gluten side and sent directly to Celeborn, so compression is not needed on the Celeborn side. Therefore, ```spark.celeborn.client.shuffle.compression.codec``` is set to none. However, when row-based shuffle occurs, this configuration causes Celeborn to skip compression, leading to data bloat.

## How was this patch tested?

CI
