### PR TITLE
[VL] Fix offload input_file_name assert error

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -661,6 +661,15 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
                          | from lineitem limit 100""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
+
+    runQueryAndCompare("""SELECT input_file_name(), l_orderkey
+                         | from
+                         | (select l_orderkey from lineitem
+                         | union all
+                         | select o_orderkey as l_orderkey from orders)
+                         | limit 100""".stripMargin) {
+      checkGlutenOperatorMatch[ProjectExecTransformer]
+    }
   }
 
   test("Test E function") {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -315,7 +315,7 @@ case class OffloadProject() extends OffloadSingleNode with LogLevelUtil {
       // https://github.com/apache/spark/blob/e459674127e7b21e2767cc62d10ea6f1f941936c
       // /sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala#L519
       val leafScans = findScanNodes(projectExec)
-      if (leafScans.isEmpty || leafScans.forall(FallbackTags.nonEmpty)) {
+      if (leafScans.isEmpty || leafScans.exists(FallbackTags.nonEmpty)) {
         // It means
         // 1. projectExec has `input_file_name` but no scan child.
         // 2. It has scan children node but the scan node fallback.

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -299,16 +299,15 @@ case class OffloadProject() extends OffloadSingleNode with LogLevelUtil {
       // Project is still not transformable after remove `input_file_name` expressions.
       projectExec
     } else {
-      // the project with `input_file_name` expression should have at most
-      // one data source, reference:
+      // the project with `input_file_name` expression may have multiple data source
+      // by union all, reference:
       // https://github.com/apache/spark/blob/e459674127e7b21e2767cc62d10ea6f1f941936c
-      // /sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala#L506
+      // /sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala#L519
       val leafScans = findScanNodes(projectExec)
-      assert(leafScans.size <= 1)
-      if (leafScans.isEmpty || FallbackTags.nonEmpty(leafScans(0))) {
+      if (leafScans.isEmpty || leafScans.forall(FallbackTags.nonEmpty)) {
         // It means
         // 1. projectExec has `input_file_name` but no scan child.
-        // 2. It has scan child node but the scan node fallback.
+        // 2. It has scan children node but the scan node fallback.
         projectExec
       } else {
         val replacedExprs = scala.collection.mutable.Map[String, AttributeReference]()


### PR DESCRIPTION
## What changes were proposed in this pull request?

 The project with `input_file_name` expression may have multiple data source by union all, reference:
https://github.com/apache/spark/blob/e459674127e7b21e2767cc62d10ea6f1f941936c/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala#L519
For example, pulls the protocol and metadata of the delta lake table from the files
https://github.com/delta-io/delta/blob/074ce173bb070ed60f10e98d3ef7dcc04cc2a744/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala#L209

## How was this patch tested?

UT.