### PR TITLE
[CELEBORN] Rename CelebornHashBasedColumnarShuffleWriter to CelebornColumnarShuffleWriter

### DIFF
--- a/gluten-celeborn/clickhouse/src/main/resources/META-INF/services/org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
+++ b/gluten-celeborn/clickhouse/src/main/resources/META-INF/services/org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
@@ -1,1 +1,1 @@
-org.apache.spark.shuffle.CHCelebornHashBasedColumnarShuffleWriterFactory
+org.apache.spark.shuffle.CHCelebornColumnarShuffleWriterFactory

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriter.scala
@@ -33,14 +33,14 @@ import org.apache.celeborn.common.CelebornConf
 import java.io.IOException
 import java.util.Locale
 
-class CHCelebornHashBasedColumnarShuffleWriter[K, V](
+class CHCelebornColumnarShuffleWriter[K, V](
     shuffleId: Int,
     handle: CelebornShuffleHandle[K, V, V],
     context: TaskContext,
     celebornConf: CelebornConf,
     client: ShuffleClient,
     writeMetrics: ShuffleWriteMetricsReporter)
-  extends CelebornHashBasedColumnarShuffleWriter[K, V](
+  extends CelebornColumnarShuffleWriter[K, V](
     shuffleId: Int,
     handle,
     context,

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriterFactory.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriterFactory.scala
@@ -25,7 +25,7 @@ import org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 
-class CHCelebornHashBasedColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
+class CHCelebornColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
   override def backendName(): String = CHBackend.BACKEND_NAME
 
   override def createShuffleWriterInstance[K, V](
@@ -35,7 +35,7 @@ class CHCelebornHashBasedColumnarShuffleWriterFactory extends CelebornShuffleWri
       celebornConf: CelebornConf,
       client: ShuffleClient,
       writeMetrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
-    new CHCelebornHashBasedColumnarShuffleWriter[K, V](
+    new CHCelebornColumnarShuffleWriter[K, V](
       shuffleId,
       handle,
       context,

--- a/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornColumnarShuffleWriter.scala
@@ -31,7 +31,7 @@ import org.apache.celeborn.common.CelebornConf
 import java.io.IOException
 import java.util.Locale
 
-abstract class CelebornHashBasedColumnarShuffleWriter[K, V](
+abstract class CelebornColumnarShuffleWriter[K, V](
     shuffleId: Int,
     handle: CelebornShuffleHandle[K, V, V],
     context: TaskContext,

--- a/gluten-celeborn/velox/src/main/resources/META-INF/services/org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
+++ b/gluten-celeborn/velox/src/main/resources/META-INF/services/org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
@@ -1,1 +1,1 @@
-org.apache.spark.shuffle.VeloxCelebornHashBasedColumnarShuffleWriterFactory
+org.apache.spark.shuffle.VeloxCelebornColumnarShuffleWriterFactory

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -34,14 +34,14 @@ import org.apache.celeborn.common.CelebornConf
 
 import java.io.IOException
 
-class VeloxCelebornHashBasedColumnarShuffleWriter[K, V](
+class VeloxCelebornColumnarShuffleWriter[K, V](
     shuffleId: Int,
     handle: CelebornShuffleHandle[K, V, V],
     context: TaskContext,
     celebornConf: CelebornConf,
     client: ShuffleClient,
     writeMetrics: ShuffleWriteMetricsReporter)
-  extends CelebornHashBasedColumnarShuffleWriter[K, V](
+  extends CelebornColumnarShuffleWriter[K, V](
     shuffleId,
     handle,
     context,

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriterFactory.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriterFactory.scala
@@ -25,7 +25,7 @@ import org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 
-class VeloxCelebornHashBasedColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
+class VeloxCelebornColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
   override def backendName(): String = VeloxBackend.BACKEND_NAME
 
   override def createShuffleWriterInstance[K, V](
@@ -35,7 +35,7 @@ class VeloxCelebornHashBasedColumnarShuffleWriterFactory extends CelebornShuffle
       celebornConf: CelebornConf,
       client: ShuffleClient,
       writeMetrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
-    new VeloxCelebornHashBasedColumnarShuffleWriter[K, V](
+    new VeloxCelebornColumnarShuffleWriter[K, V](
       shuffleId,
       handle,
       context,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename CelebornHashBasedColumnarShuffleWriter to CelebornColumnarShuffleWriter

## How was this patch tested?

CI

