### PR TITLE
Enable debug implicit util to show substrait content when use spark-shell.

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/debug/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/debug/package.scala
@@ -23,14 +23,14 @@ import org.apache.spark.sql.execution.QueryExecution
 package object debug {
   implicit class queryExecutionImplicit(qe: QueryExecution) {
     def debugWholeStageTransform(): Unit = {
-      val executionPlan = qe.executedPlan
-      executionPlan.foreach {
+      val executedPlan = qe.executedPlan
+      executedPlan.foreach {
         case w: WholeStageTransformer => w.doWholeStageTransform(true)
         case _ =>
       }
 
       // scalastyle:off println
-      println(executionPlan.treeString)
+      println(executedPlan.treeString)
       // scalastyle:on println
     }
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/debug/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/debug/package.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.execution.WholeStageTransformer
 import org.apache.spark.sql.execution.QueryExecution
 
 package object debug {
-  implicit class queryExecutionImplicit(qe: QueryExecution) {
+  implicit class QueryExecutionImplicit(qe: QueryExecution) {
     def debugWholeStageTransform(): Unit = {
       val executedPlan = qe.executedPlan
       executedPlan.foreach {

--- a/gluten-core/src/main/scala/org/apache/gluten/debug/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/debug/package.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten
+
+import org.apache.gluten.execution.WholeStageTransformer
+
+import org.apache.spark.sql.execution.QueryExecution
+
+package object debug {
+  implicit class queryExecutionImplicit(qe: QueryExecution) {
+    def debugWholeStageTransform(): Unit = {
+      val executionPlan = qe.executedPlan
+      executionPlan.foreach {
+        case w: WholeStageTransformer => w.doWholeStageTransform(true)
+        case _ =>
+      }
+
+      // scalastyle:off println
+      println(executionPlan.treeString)
+      // scalastyle:on println
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -230,9 +230,9 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
     WholeStageTransformContext(planNode, substraitContext)
   }
 
-  def doWholeStageTransform(): WholeStageTransformContext = {
+  def doWholeStageTransform(forceCacheContent: Boolean = false): WholeStageTransformContext = {
     val context = generateWholeStageTransformContext()
-    if (conf.getConf(GlutenConfig.CACHE_WHOLE_STAGE_TRANSFORMER_CONTEXT)) {
+    if (forceCacheContent || conf.getConf(GlutenConfig.CACHE_WHOLE_STAGE_TRANSFORMER_CONTEXT)) {
       wholeStageTransformerContext = Some(context)
     }
     context

--- a/gluten-core/src/main/scala/org/apache/gluten/utils/DebugUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/utils/DebugUtil.scala
@@ -17,9 +17,8 @@
 package org.apache.gluten.utils
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.execution.WholeStageTransformer
+
 import org.apache.spark.TaskContext
-import org.apache.spark.sql.execution.QueryExecution
 
 object DebugUtil {
   // if specify taskId, then only do that task partition
@@ -41,22 +40,5 @@ object DebugUtil {
     }
 
     false
-  }
-
-  object debug {
-
-    implicit class queryExecutionImplicit(qe: QueryExecution) {
-      def debugWholeStageTransform(): Unit = {
-        val executionPlan = qe.executedPlan
-        executionPlan.foreach {
-          case w: WholeStageTransformer => w.doWholeStageTransform(true)
-          case _ =>
-        }
-
-        // scalastyle:off println
-        println(executionPlan.treeString)
-        // scalastyle:on println
-      }
-    }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/utils/DebugUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/utils/DebugUtil.scala
@@ -17,8 +17,9 @@
 package org.apache.gluten.utils
 
 import org.apache.gluten.GlutenConfig
-
+import org.apache.gluten.execution.WholeStageTransformer
 import org.apache.spark.TaskContext
+import org.apache.spark.sql.execution.QueryExecution
 
 object DebugUtil {
   // if specify taskId, then only do that task partition
@@ -40,5 +41,22 @@ object DebugUtil {
     }
 
     false
+  }
+
+  object debug {
+
+    implicit class queryExecutionImplicit(qe: QueryExecution) {
+      def debugWholeStageTransform(): Unit = {
+        val executionPlan = qe.executedPlan
+        executionPlan.foreach {
+          case w: WholeStageTransformer => w.doWholeStageTransform(true)
+          case _ =>
+        }
+
+        // scalastyle:off println
+        println(executionPlan.treeString)
+        // scalastyle:on println
+      }
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable debug implicit util to show substrait content when use spark-shell.

for codegen, spark have a method to show the gen code in spark-shell.

<img width="809" alt="image" src="https://github.com/apache/incubator-gluten/assets/146867566/a99c082f-8206-4007-8227-82f5e3c457c5">

This PR enable to have a method to show the whole stage transform content.

<img width="604" alt="image" src="https://github.com/apache/incubator-gluten/assets/146867566/a8fb707e-cd5b-46fd-b9c0-205fbb5086ba">



(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

