### PR TITLE
[VL] Add schema validation for all operators

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -17,9 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.exec.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil
@@ -47,13 +45,6 @@ import scala.collection.mutable.ListBuffer
 case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBase(child = child) {
 
   override def doExecuteColumnarInternal(): RDD[ColumnarBatch] = {
-    BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema).foreach {
-      reason =>
-        throw new GlutenException(
-          s"Input schema contains unsupported type when convert row to columnar for $schema " +
-            s"due to $reason")
-    }
-
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     val convertTime = longMetric("convertTime")

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -258,6 +258,16 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
     checkLengthAndPlan(df, 5)
   }
 
+  testWithSpecifiedSparkVersion("coalesce validation", Some("3.5")) {
+    withTempPath {
+      path =>
+        val data = "2019-09-09 01:02:03.456789"
+        val df = Seq(data).toDF("strTs").selectExpr(s"CAST(strTs AS TIMESTAMP_NTZ) AS ts")
+        df.coalesce(1).write.format("parquet").save(path.getCanonicalPath)
+        spark.read.parquet(path.getCanonicalPath).collect
+    }
+  }
+
   test("groupby") {
     val df = runQueryAndCompare(
       "select l_orderkey, sum(l_partkey) as sum from lineitem " +

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -258,7 +258,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
     checkLengthAndPlan(df, 5)
   }
 
-  testWithSpecifiedSparkVersion("coalesce validation", Some("3.5")) {
+  testWithSpecifiedSparkVersion("coalesce validation", Some("3.4")) {
     withTempPath {
       path =>
         val data = "2019-09-09 01:02:03.456789"

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -311,15 +311,6 @@ case class ColumnarUnionExec(children: Seq[SparkPlan]) extends SparkPlan with Gl
   }
 
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = columnarInputRDD
-
-  override protected def doValidateInternal(): ValidationResult = {
-    BackendsApiManager.getValidatorApiInstance
-      .doSchemaValidate(schema)
-      .map {
-        reason => ValidationResult.notOk(s"Found schema check failure for $schema, due to: $reason")
-      }
-      .getOrElse(ValidationResult.ok)
-  }
 }
 
 /**

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
+import org.apache.gluten.extension.GlutenPlan
 
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
@@ -32,16 +31,6 @@ case class ColumnarCoalesceExec(numPartitions: Int, child: SparkPlan)
   with GlutenPlan {
 
   override def supportsColumnar: Boolean = true
-
-  override protected def doValidateInternal(): ValidationResult = {
-    BackendsApiManager.getValidatorApiInstance
-      .doSchemaValidate(child.schema)
-      .map {
-        reason =>
-          ValidationResult.notOk(s"Found schema check failure for ${child.schema}, due to: $reason")
-      }
-      .getOrElse(ValidationResult.ok)
-  }
 
   override def output: Seq[Attribute] = child.output
 

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
@@ -16,7 +16,9 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.extension.ValidationResult
 
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
@@ -31,6 +33,16 @@ case class ColumnarCoalesceExec(numPartitions: Int, child: SparkPlan)
   with GlutenPlan {
 
   override def supportsColumnar: Boolean = true
+
+  override protected def doValidateInternal(): ValidationResult = {
+    BackendsApiManager.getValidatorApiInstance
+      .doSchemaValidate(child.schema)
+      .map {
+        reason =>
+          ValidationResult.notOk(s"Found schema check failure for ${child.schema}, due to: $reason")
+      }
+      .getOrElse(ValidationResult.ok)
+  }
 
   override def output: Seq[Attribute] = child.output
 

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
@@ -17,8 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.GlutenPlan
-import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
 
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
@@ -63,15 +63,19 @@ trait GlutenPlan extends SparkPlan with Convention.KnownBatchType with LogLevelU
    * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
    */
   final def doValidate(): ValidationResult = {
+    val schemaVaidationResult = BackendsApiManager.getValidatorApiInstance
+      .doSchemaValidate(schema)
+      .map {
+        reason => ValidationResult.notOk(s"Found schema check failure for $schema, due to: $reason")
+      }
+      .getOrElse(ValidationResult.ok)
+    if (!schemaVaidationResult.isValid) {
+      TestStats.addFallBackClassName(this.getClass.toString)
+      return schemaVaidationResult
+    }
     try {
       TransformerState.enterValidation
-      val res = BackendsApiManager.getValidatorApiInstance
-        .doSchemaValidate(schema)
-        .map {
-          reason =>
-            ValidationResult.notOk(s"Found schema check failure for $schema, due to: $reason")
-        }
-        .getOrElse(doValidateInternal())
+      val res = doValidateInternal()
       if (!res.isValid) {
         TestStats.addFallBackClassName(this.getClass.toString)
       }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
+import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.sql.shims.SparkShimLoader
 
@@ -131,19 +131,6 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     val canonicalized =
       BackendsApiManager.getSparkPlanExecApiInstance.doCanonicalizeForBroadcastMode(mode)
     ColumnarBroadcastExchangeExec(canonicalized, child.canonicalized)
-  }
-
-  override protected def doValidateInternal(): ValidationResult = {
-    BackendsApiManager.getValidatorApiInstance
-      .doSchemaValidate(schema)
-      .map {
-        reason =>
-          {
-            ValidationResult.notOk(
-              s"Unsupported schema in broadcast exchange: $schema, reason: $reason")
-          }
-      }
-      .getOrElse(ValidationResult.ok)
   }
 
   override def doPrepare(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixed the failure below.
```
val data = "2019-09-09 01:02:03.456789"
val df = Seq(data).toDF("strTs").selectExpr(s"CAST(strTs AS TIMESTAMP_NTZ) AS ts")
df.coalesce(1).write.format("parquet").save("/tmp/test")
```

```
 org.apache.gluten.exception.GlutenException: Input schema contains unsupported type when convert row to columnar for StructType(StructField(ts,TimestampNTZType,true)) due to Schema / data type not supported: TimestampNTZType
  at org.apache.gluten.execution.RowToVeloxColumnarExec.$anonfun$doExecuteColumnarInternal$1(RowToVeloxColumnarExec.scala:54)
  at scala.Option.foreach(Option.scala:407)
  at org.apache.gluten.execution.RowToVeloxColumnarExec.doExecuteColumnarInternal(RowToVeloxColumnarExec.scala:51)
  at org.apache.gluten.execution.RowToColumnarExecBase.doExecuteColumnar(RowToColumnarExecBase.scala:62)
  at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeColumnar$1(SparkPlan.scala:222)
  at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:246)
  at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
  at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:243)
  at org.apache.spark.sql.execution.SparkPlan.executeColumnar(SparkPlan.scala:218)
  at org.apache.gluten.execution.ColumnarCoalesceExec.doExecuteColumnar(ColumnarCoalesceExec.scala:46)
```
## How was this patch tested?

UT.

