### PR TITLE
[VL] Try to find arrow libs from velox bundled path firstly

### DIFF
--- a/cpp/CMake/ConfigArrow.cmake
+++ b/cpp/CMake/ConfigArrow.cmake
@@ -36,7 +36,11 @@ function(FIND_ARROW_LIB LIB_NAME)
     find_library(
       ARROW_LIB_${LIB_NAME}
       NAMES ${ARROW_LIB_FULL_NAME}
-      PATHS ${ARROW_LIB_DIR} ${ARROW_LIB64_DIR})
+      PATHS ${ARROW_LIB_DIR} ${ARROW_LIB64_DIR}
+      NO_DEFAULT_PATH)
+    if(NOT ARROW_LIB_${LIB_NAME})
+      find_library(ARROW_LIB_${LIB_NAME} NAMES ${ARROW_LIB_FULL_NAME})
+    endif()
     if(NOT ARROW_LIB_${LIB_NAME})
       message(FATAL_ERROR "Arrow library Not Found: ${ARROW_LIB_FULL_NAME}")
     endif()


### PR DESCRIPTION
## What changes were proposed in this pull request?

We expect cmake's find_library function always finds lib from specified PATHS firstly, then system paths. But local build shows it isn't true. This pr is proposed to make sure that.
