### PR TITLE
change velox branch to branch-1.2 for gluten v1.2.0 release

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -18,7 +18,7 @@ set -exu
 
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_07_05
+VELOX_BRANCH=branch-1.2
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
## What changes were proposed in this pull request?

change oap's velox version to branch-1.2 for gluten v1.2.0 release

## How was this patch tested?

tested in local
