### PR TITLE
[GLUTEN-6437][BUILD] Fix vcpkg setup-build-dependens.sh for centos

### DIFF
--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -20,7 +20,7 @@ install_maven_from_source() {
         cd /tmp
         wget https://archive.apache.org/dist/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz
         tar -xvf apache-maven-$maven_version-bin.tar.gz
-        rm apache-maven-$maven_version-bin.tar.gz
+        rm -f apache-maven-$maven_version-bin.tar.gz
         mv apache-maven-$maven_version "${maven_install_dir}"
         ln -s "${maven_install_dir}/bin/mvn" /usr/local/bin/mvn
     fi
@@ -52,13 +52,30 @@ install_gcc9_from_source() {
 install_centos_7() {
     export PATH=/usr/local/bin:$PATH
 
+    sed -i \
+        -e 's/^mirrorlist/#mirrorlist/' \
+        -e 's/^# *baseurl/baseurl/' \
+        -e 's/mirror\.centos\.org/vault.centos.org/' \
+        /etc/yum.repos.d/*.repo
+
     yum -y install epel-release centos-release-scl
+    sed -i \
+        -e 's/^mirrorlist/#mirrorlist/' \
+        -e 's/^# *baseurl/baseurl/' \
+        -e 's/mirror\.centos\.org/vault.centos.org/' \
+        /etc/yum.repos.d/*.repo
+
     yum -y install \
-        wget curl tar zip unzip which \
-        cmake3 ninja-build perl-IPC-Cmd autoconf autoconf-archive automake libtool \
-        devtoolset-9 \
+        wget curl tar zip unzip which patch sudo \
+        ninja-build perl-IPC-Cmd autoconf autoconf-archive automake libtool \
+        devtoolset-9 python3 pip dnf \
         bison \
         java-1.8.0-openjdk java-1.8.0-openjdk-devel
+
+    pip3 install --upgrade pip
+
+    # Requires cmake >= 3.28.3
+    pip3 install cmake==3.28.3
 
     # Requires git >= 2.7.4
     if [[ "$(git --version)" != "git version 2."* ]]; then

--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -54,14 +54,14 @@ install_centos_7() {
 
     sed -i \
         -e 's/^mirrorlist/#mirrorlist/' \
-        -e 's/^# *baseurl/baseurl/' \
+        -e 's/^# *baseurl *=/baseurl=/' \
         -e 's/mirror\.centos\.org/vault.centos.org/' \
         /etc/yum.repos.d/*.repo
 
     yum -y install epel-release centos-release-scl
     sed -i \
         -e 's/^mirrorlist/#mirrorlist/' \
-        -e 's/^# *baseurl/baseurl/' \
+        -e 's/^# *baseurl *=/baseurl=/' \
         -e 's/mirror\.centos\.org/vault.centos.org/' \
         /etc/yum.repos.d/*.repo
 
@@ -117,12 +117,20 @@ install_centos_7() {
 }
 
 install_centos_8() {
+    sed -i \
+        -e 's/^mirrorlist/#mirrorlist/' \
+        -e 's/^# *baseurl *=/baseurl=/' \
+        -e 's/mirror\.centos\.org/vault.centos.org/' \
+        /etc/yum.repos.d/*.repo
+
     yum -y install \
-        wget curl tar zip unzip git which \
-        cmake ninja-build perl-IPC-Cmd autoconf autoconf-archive automake libtool \
+        wget curl tar zip unzip git which sudo patch \
+        cmake perl-IPC-Cmd autoconf automake libtool \
         gcc-toolset-9-gcc gcc-toolset-9-gcc-c++ \
         flex bison python3 \
         java-1.8.0-openjdk java-1.8.0-openjdk-devel
+
+    dnf -y --enablerepo=powertools install autoconf-archive ninja-build
 
     install_maven_from_source
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace the mirrorlist repository of centos with vault.

(Fixes: \#6437)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Test the vcpkd setup scripty on the centos7/8 container:
```bash
# run container
podman run --name wechar_gluten --cap-add=SYS_PTRACE --cap-add=AUDIT_WRITE --pids-limit 0 -it --rm  -w /root/workspace --network host --entrypoint bash centos:7

# download gluten source code and run setup script
gluten/dev/vcpkg/setup-build-depends.sh
```


