### PR TITLE
[CH] REVERT CHCelebornColumnarShuffleWriter supports celeborn.client.spark.shuffle.writer to use memory sort shuffle in ClickHouse backend"

### DIFF
--- a/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornColumnarShuffleWriter.scala
@@ -23,7 +23,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.SHUFFLE_COMPRESS
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
-import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.BlockManager
 
 import org.apache.celeborn.client.ShuffleClient
@@ -53,22 +52,11 @@ abstract class CelebornColumnarShuffleWriter[K, V](
 
   protected val mapId: Int = context.partitionId()
 
-  protected lazy val nativeBufferSize: Int = {
-    val bufferSize = GlutenConfig.getConf.shuffleWriterBufferSize
-    val maxBatchSize = GlutenConfig.getConf.maxBatchSize
-    if (bufferSize > maxBatchSize) {
-      logInfo(
-        s"${GlutenConfig.SHUFFLE_WRITER_BUFFER_SIZE.key} ($bufferSize) exceeds max " +
-          s" batch size. Limited to ${GlutenConfig.COLUMNAR_MAX_BATCH_SIZE.key} ($maxBatchSize).")
-      maxBatchSize
-    } else {
-      bufferSize
-    }
-  }
-
   protected val clientPushBufferMaxSize: Int = celebornConf.clientPushBufferMaxSize
 
   protected val clientPushSortMemoryThreshold: Long = celebornConf.clientPushSortMemoryThreshold
+
+  protected val clientSortMemoryMaxSize: Long = celebornConf.clientPushSortMemoryThreshold
 
   protected val shuffleWriterType: String =
     celebornConf.shuffleWriterMode.name.toLowerCase(Locale.ROOT)
@@ -108,12 +96,6 @@ abstract class CelebornColumnarShuffleWriter[K, V](
 
   @throws[IOException]
   final override def write(records: Iterator[Product2[K, V]]): Unit = {
-    if (!records.hasNext) {
-      partitionLengths = new Array[Long](dep.partitioner.numPartitions)
-      client.mapperEnd(shuffleId, mapId, context.attemptNumber, numMappers)
-      mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
-      return
-    }
     internalWrite(records)
   }
 
@@ -140,17 +122,9 @@ abstract class CelebornColumnarShuffleWriter[K, V](
     }
   }
 
-  def createShuffleWriter(columnarBatch: ColumnarBatch): Unit = {}
-
   def closeShuffleWriter(): Unit = {}
 
   def getPartitionLengths: Array[Long] = partitionLengths
-
-  def initShuffleWriter(columnarBatch: ColumnarBatch): Unit = {
-    if (nativeShuffleWriter == -1L) {
-      createShuffleWriter(columnarBatch)
-    }
-  }
 
   def pushMergedDataToCeleborn(): Unit = {
     val pushMergedDataTime = System.nanoTime
@@ -158,5 +132,11 @@ abstract class CelebornColumnarShuffleWriter[K, V](
     client.pushMergedData(shuffleId, mapId, context.attemptNumber)
     client.mapperEnd(shuffleId, mapId, context.attemptNumber, numMappers)
     writeMetrics.incWriteTime(System.nanoTime - pushMergedDataTime)
+  }
+
+  def handleEmptyIterator(): Unit = {
+    partitionLengths = new Array[Long](dep.partitioner.numPartitions)
+    client.mapperEnd(shuffleId, mapId, context.attemptNumber, numMappers)
+    mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
   }
 }

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -55,6 +55,25 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
 
   private var splitResult: SplitResult = _
 
+  private lazy val nativeBufferSize = {
+    val bufferSize = GlutenConfig.getConf.shuffleWriterBufferSize
+    val maxBatchSize = GlutenConfig.getConf.maxBatchSize
+    if (bufferSize > maxBatchSize) {
+      logInfo(
+        s"${GlutenConfig.SHUFFLE_WRITER_BUFFER_SIZE.key} ($bufferSize) exceeds max " +
+          s" batch size. Limited to ${GlutenConfig.COLUMNAR_MAX_BATCH_SIZE.key} ($maxBatchSize).")
+      maxBatchSize
+    } else {
+      bufferSize
+    }
+  }
+
+  private val memoryLimit: Long = if ("sort".equals(shuffleWriterType)) {
+    Math.min(clientSortMemoryMaxSize, clientPushBufferMaxSize * numPartitions)
+  } else {
+    availableOffHeapPerTask()
+  }
+
   private def availableOffHeapPerTask(): Long = {
     val perTask =
       SparkMemoryUtil.getCurrentAvailableOffHeapMemory / SparkResourceUtil.getTaskSlots(conf)
@@ -63,13 +82,49 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
 
   @throws[IOException]
   override def internalWrite(records: Iterator[Product2[K, V]]): Unit = {
+    if (!records.hasNext) {
+      handleEmptyIterator()
+      return
+    }
+
     while (records.hasNext) {
       val cb = records.next()._2.asInstanceOf[ColumnarBatch]
       if (cb.numRows == 0 || cb.numCols == 0) {
         logInfo(s"Skip ColumnarBatch of ${cb.numRows} rows, ${cb.numCols} cols")
       } else {
-        initShuffleWriter(cb)
         val handle = ColumnarBatches.getNativeHandle(cb)
+        if (nativeShuffleWriter == -1L) {
+          nativeShuffleWriter = jniWrapper.makeForRSS(
+            dep.nativePartitioning,
+            nativeBufferSize,
+            customizedCompressionCodec,
+            compressionLevel,
+            bufferCompressThreshold,
+            GlutenConfig.getConf.columnarShuffleCompressionMode,
+            clientPushBufferMaxSize,
+            clientPushSortMemoryThreshold,
+            celebornPartitionPusher,
+            handle,
+            context.taskAttemptId(),
+            GlutenShuffleUtils.getStartPartitionId(dep.nativePartitioning, context.partitionId),
+            "celeborn",
+            shuffleWriterType,
+            GlutenConfig.getConf.columnarShuffleReallocThreshold
+          )
+          runtime.addSpiller(new Spiller() {
+            override def spill(self: MemoryTarget, phase: Spiller.Phase, size: Long): Long = {
+              if (!Spillers.PHASE_SET_SPILL_ONLY.contains(phase)) {
+                return 0L
+              }
+              logInfo(s"Gluten shuffle writer: Trying to push $size bytes of data")
+              // fixme pass true when being called by self
+              val pushed =
+                jniWrapper.nativeEvict(nativeShuffleWriter, size, false)
+              logInfo(s"Gluten shuffle writer: Pushed $pushed / $size bytes of data")
+              pushed
+            }
+          })
+        }
         val startTime = System.nanoTime()
         jniWrapper.write(nativeShuffleWriter, cb.numRows, handle, availableOffHeapPerTask())
         dep.metrics("splitTime").add(System.nanoTime() - startTime)
@@ -80,8 +135,8 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
       }
     }
 
-    assert(nativeShuffleWriter != -1L)
     val startTime = System.nanoTime()
+    assert(nativeShuffleWriter != -1L)
     splitResult = jniWrapper.stop(nativeShuffleWriter)
 
     dep
@@ -98,38 +153,6 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
 
     pushMergedDataToCeleborn()
     mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
-  }
-
-  override def createShuffleWriter(columnarBatch: ColumnarBatch): Unit = {
-    nativeShuffleWriter = jniWrapper.makeForRSS(
-      dep.nativePartitioning,
-      nativeBufferSize,
-      customizedCompressionCodec,
-      compressionLevel,
-      bufferCompressThreshold,
-      GlutenConfig.getConf.columnarShuffleCompressionMode,
-      clientPushBufferMaxSize,
-      clientPushSortMemoryThreshold,
-      celebornPartitionPusher,
-      ColumnarBatches.getNativeHandle(columnarBatch),
-      context.taskAttemptId(),
-      GlutenShuffleUtils.getStartPartitionId(dep.nativePartitioning, context.partitionId),
-      "celeborn",
-      shuffleWriterType,
-      GlutenConfig.getConf.columnarShuffleReallocThreshold
-    )
-    runtime.addSpiller(new Spiller() {
-      override def spill(self: MemoryTarget, phase: Spiller.Phase, size: Long): Long = {
-        if (!Spillers.PHASE_SET_SPILL_ONLY.contains(phase)) {
-          return 0L
-        }
-        logInfo(s"Gluten shuffle writer: Trying to push $size bytes of data")
-        // fixme pass true when being called by self
-        val pushed = jniWrapper.nativeEvict(nativeShuffleWriter, size, false)
-        logInfo(s"Gluten shuffle writer: Pushed $pushed / $size bytes of data")
-        pushed
-      }
-    })
   }
 
   override def closeShuffleWriter(): Unit = {


### PR DESCRIPTION
Reverts apache/incubator-gluten#6432