### PR TITLE
[VL] remove redundant code in parquet datasource to avoid memory leakage PR6430

### DIFF
--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -53,13 +53,6 @@ void VeloxParquetDatasource::initSink(const std::unordered_map<std::string, std:
 
 void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::string>& sparkConfs) {
   initSink(sparkConfs);
-  ArrowSchema cSchema{};
-  arrow::Status status = arrow::ExportSchema(*(schema_.get()), &cSchema);
-  if (!status.ok()) {
-    throw std::runtime_error("Failed to export arrow cSchema.");
-  }
-
-  type_ = velox::importFromArrow(cSchema);
 
   if (sparkConfs.find(kParquetBlockSize) != sparkConfs.end()) {
     maxRowGroupBytes_ = static_cast<int64_t>(stoi(sparkConfs.find(kParquetBlockSize)->second));

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.h
@@ -107,7 +107,6 @@ class VeloxParquetDatasource : public Datasource {
   int64_t maxRowGroupRows_ = 100000000; // 100M
 
   std::shared_ptr<arrow::Schema> schema_;
-  std::shared_ptr<const facebook::velox::Type> type_;
   std::shared_ptr<facebook::velox::parquet::Writer> parquetWriter_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
 };


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove the redundant code in file VeloxParquetDatasource.cc to avoid  memory  leakage

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)
#6430
## How was this patch tested?
CI.
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

