### PR TITLE
[BUILD] Fix unbound variable

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -238,6 +238,7 @@ if [ "$VELOX_HOME" == "" ]; then
 fi
 
 OS=`uname -s`
+ARCH=`uname -m`
 source $GLUTEN_DIR/dev/build_helper_functions.sh
 if [ -z "${GLUTEN_VCPKG_ENABLED:-}" ] && [ $RUN_SETUP_SCRIPT == "ON" ]; then
   echo "Start to install dependencies"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Function setup_macos of build_helper_functions.sh need variable `ARCH`.

## How was this patch tested?

Local test.

