### PR TITLE
[GLUTEN-6487][VL] ColumnarBatchOutIterator should be interruptible iterator

### DIFF
--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/BatchIterator.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/BatchIterator.java
@@ -19,7 +19,7 @@ package org.apache.gluten.vectorized;
 import org.apache.gluten.metrics.IMetrics;
 import org.apache.gluten.metrics.NativeMetrics;
 
-import org.apache.spark.TaskContext
+import org.apache.spark.TaskContext;
 import org.apache.spark.sql.execution.utils.CHExecUtil;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/BatchIterator.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/BatchIterator.java
@@ -19,6 +19,7 @@ package org.apache.gluten.vectorized;
 import org.apache.gluten.metrics.IMetrics;
 import org.apache.gluten.metrics.NativeMetrics;
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.execution.utils.CHExecUtil;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -30,8 +31,8 @@ public class BatchIterator extends GeneralOutIterator {
   private final long handle;
   private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
-  public BatchIterator(long handle) {
-    super();
+  public BatchIterator(long handle, TaskContext context) {
+    super(context);
     this.handle = handle;
   }
 

--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/CHNativeExpressionEvaluator.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/CHNativeExpressionEvaluator.java
@@ -25,7 +25,7 @@ import org.apache.gluten.substrait.extensions.AdvancedExtensionNode;
 import org.apache.gluten.substrait.extensions.ExtensionBuilder;
 import org.apache.gluten.substrait.plan.PlanBuilder;
 
-import org.apache.spark.SparkConf;
+import org.apache.spark.{SparkConf, TaskContext};
 import org.apache.spark.sql.internal.SQLConf;
 
 import java.util.Arrays;
@@ -115,6 +115,6 @@ public class CHNativeExpressionEvaluator {
   }
 
   private BatchIterator createBatchIterator(long nativeHandle) {
-    return new BatchIterator(nativeHandle);
+    return new BatchIterator(nativeHandle, TaskContext.get());
   }
 }

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppender.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchAppender.java
@@ -21,6 +21,7 @@ import org.apache.gluten.exec.Runtimes;
 import org.apache.gluten.vectorized.ColumnarBatchInIterator;
 import org.apache.gluten.vectorized.ColumnarBatchOutIterator;
 
+import org.apache.spark.TaskContext;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.util.Iterator;
@@ -32,6 +33,6 @@ public final class VeloxBatchAppender {
     long outHandle =
         VeloxBatchAppenderJniWrapper.create(runtime)
             .create(minOutputBatchSize, new ColumnarBatchInIterator(in));
-    return new ColumnarBatchOutIterator(runtime, outHandle);
+    return new ColumnarBatchOutIterator(runtime, outHandle, TaskContext.get());
   }
 }

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -22,7 +22,7 @@ import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.vectorized._
 
-import org.apache.spark.SparkEnv
+import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.SHUFFLE_COMPRESS
 import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer, SerializerInstance}
@@ -121,7 +121,8 @@ private class CelebornColumnarBatchSerializerInstance(
       runtime,
       ShuffleReaderJniWrapper
         .create(runtime)
-        .readStream(shuffleReaderHandle, byteIn))
+        .readStream(shuffleReaderHandle, byteIn),
+      TaskContext.get())
 
     private var cb: ColumnarBatch = _
 

--- a/gluten-core/src/main/java/org/apache/gluten/vectorized/GeneralOutIterator.java
+++ b/gluten-core/src/main/java/org/apache/gluten/vectorized/GeneralOutIterator.java
@@ -19,6 +19,7 @@ package org.apache.gluten.vectorized;
 import org.apache.gluten.exception.GlutenException;
 import org.apache.gluten.metrics.IMetrics;
 
+import org.apache.spark.TaskContext;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.io.Serializable;
@@ -28,12 +29,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class GeneralOutIterator
     implements AutoCloseable, Serializable, Iterator<ColumnarBatch> {
   protected final AtomicBoolean closed = new AtomicBoolean(false);
+  protected final TaskContext context;
 
-  public GeneralOutIterator() {}
+  public GeneralOutIterator(TaskContext context) {
+    this.context = context;
+  }
 
   @Override
   public final boolean hasNext() {
     try {
+      context.killTaskIfInterrupted();
       return hasNextInternal();
     } catch (Exception e) {
       throw new GlutenException(e);
@@ -43,6 +48,7 @@ public abstract class GeneralOutIterator
   @Override
   public final ColumnarBatch next() {
     try {
+      context.killTaskIfInterrupted();
       return nextInternal();
     } catch (Exception e) {
       throw new GlutenException(e);

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -21,6 +21,7 @@ import org.apache.gluten.exec.Runtime;
 import org.apache.gluten.exec.RuntimeAware;
 import org.apache.gluten.metrics.IMetrics;
 
+import org.apache.spark.TaskContext;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.io.IOException;
@@ -29,8 +30,8 @@ public class ColumnarBatchOutIterator extends GeneralOutIterator implements Runt
   private final Runtime runtime;
   private final long iterHandle;
 
-  public ColumnarBatchOutIterator(Runtime runtime, long iterHandle) {
-    super();
+  public ColumnarBatchOutIterator(Runtime runtime, long iterHandle, TaskContext context) {
+    super(context);
     this.runtime = runtime;
     this.iterHandle = iterHandle;
   }

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -76,7 +76,7 @@ public class NativePlanEvaluator {
             TaskContext.get().taskAttemptId(),
             DebugUtil.saveInputToFile(),
             BackendsApiManager.getSparkPlanExecApiInstance().rewriteSpillPath(spillDirPath));
-    final ColumnarBatchOutIterator out = createOutIterator(runtime, itrHandle);
+    final ColumnarBatchOutIterator out = createOutIterator(runtime, itrHandle, TaskContext.get());
     runtime.addSpiller(
         new Spiller() {
           @Override
@@ -90,7 +90,8 @@ public class NativePlanEvaluator {
     return out;
   }
 
-  private ColumnarBatchOutIterator createOutIterator(Runtime runtime, long itrHandle) {
-    return new ColumnarBatchOutIterator(runtime, itrHandle);
+  private ColumnarBatchOutIterator createOutIterator(
+      Runtime runtime, long itrHandle, TaskContext context) {
+    return new ColumnarBatchOutIterator(runtime, itrHandle, context);
   }
 }

--- a/gluten-data/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.exec.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil
 
-import org.apache.spark.SparkEnv
+import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer, SerializerInstance}
 import org.apache.spark.shuffle.GlutenShuffleUtils
@@ -139,7 +139,8 @@ private class ColumnarBatchSerializerInstance(
       runtime,
       ShuffleReaderJniWrapper
         .create(runtime)
-        .readStream(shuffleReaderHandle, byteIn))
+        .readStream(shuffleReaderHandle, byteIn),
+      TaskContext.get())
 
     private var cb: ColumnarBatch = _
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ColumnarBatchOutIterator` should check whether the task is interrupted, so that speculation tasks can end as soon as possible. 
Since when `Thread.interrupt()` is called and it's in a JNI call, the `InterruptedException` is not thrown, then we need to check the interrupt status.

A case in our env is the speculation task run for 2 hours, but in fact, the task with attempt id = 0 has already fininshed 1.5 hours ago.
![image](https://github.com/user-attachments/assets/bbc80a7e-04f3-4407-ad98-57f9d43ec536)


(Fixes: \#6487)

## How was this patch tested?
Mannually