### PR TITLE
[VL] RAS: Make default rough cost model exhaustively offload computations

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -56,14 +56,14 @@ class ScalarFunctionsValidateSuiteRasOn extends ScalarFunctionsValidateSuite {
   // TODO: input_file_name is not yet supported in RAS
   ignore("Test input_file_name function") {
     runQueryAndCompare("""SELECT input_file_name(), l_orderkey
-                         | from lineitem limit 100""".stripMargin) {_ => }
+                         | from lineitem limit 100""".stripMargin) { _ => }
 
     runQueryAndCompare("""SELECT input_file_name(), l_orderkey
                          | from
                          | (select l_orderkey from lineitem
                          | union all
                          | select o_orderkey as l_orderkey from orders)
-                         | limit 100""".stripMargin) {_ => }
+                         | limit 100""".stripMargin) { _ => }
   }
 }
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -52,6 +52,19 @@ class ScalarFunctionsValidateSuiteRasOn extends ScalarFunctionsValidateSuite {
     super.sparkConf
       .set("spark.gluten.ras.enabled", "true")
   }
+
+  // TODO: input_file_name is not yet supported in RAS
+  ignore("Test input_file_name function") {
+    runQueryAndCompare("""SELECT input_file_name(), l_orderkey
+                         | from lineitem limit 100""".stripMargin) {_ => }
+
+    runQueryAndCompare("""SELECT input_file_name(), l_orderkey
+                         | from
+                         | (select l_orderkey from lineitem
+                         | union all
+                         | select o_orderkey as l_orderkey from orders)
+                         | limit 100""".stripMargin) {_ => }
+  }
 }
 
 abstract class ScalarFunctionsValidateSuite extends FunctionsValidateTest {

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
@@ -70,20 +70,21 @@ object GlutenCostModel extends Logging {
         (n.children.map(longCostOf).toList :+ selfCost).reduce(safeSum)
     }
 
-    // A very rough estimation as of now.
+    // A very rough estimation as of now. The cost model basically considers any
+    // fallen back ops has extreme high cost so offloads computations as much as possible.
     private def selfLongCostOf(node: SparkPlan): Long = {
       node match {
         case _: RemoveFilter.NoopFilter =>
           // To make planner choose the tree that has applied rule PushFilterToScan.
           0L
-        case ColumnarToRowExec(child) => 3L
-        case RowToColumnarExec(child) => 3L
-        case ColumnarToRowLike(child) => 3L
-        case RowToColumnarLike(child) => 3L
-        case p if PlanUtil.isGlutenColumnarOp(p) => 2L
-        case p if PlanUtil.isVanillaColumnarOp(p) => 3L
+        case ColumnarToRowExec(child) => 0L
+        case RowToColumnarExec(child) => 0L
+        case ColumnarToRowLike(child) => 0L
+        case RowToColumnarLike(child) => 0L
+        case p if PlanUtil.isGlutenColumnarOp(p) => 0L
+        case p if PlanUtil.isVanillaColumnarOp(p) => 300L
         // Other row ops. Usually a vanilla row op.
-        case _ => 5L
+        case _ => 300L
       }
     }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/cost/GlutenCostModel.scala
@@ -77,14 +77,14 @@ object GlutenCostModel extends Logging {
         case _: RemoveFilter.NoopFilter =>
           // To make planner choose the tree that has applied rule PushFilterToScan.
           0L
-        case ColumnarToRowExec(child) => 0L
-        case RowToColumnarExec(child) => 0L
-        case ColumnarToRowLike(child) => 0L
-        case RowToColumnarLike(child) => 0L
-        case p if PlanUtil.isGlutenColumnarOp(p) => 0L
-        case p if PlanUtil.isVanillaColumnarOp(p) => 300L
+        case ColumnarToRowExec(child) => 10L
+        case RowToColumnarExec(child) => 10L
+        case ColumnarToRowLike(child) => 10L
+        case RowToColumnarLike(child) => 10L
+        case p if PlanUtil.isGlutenColumnarOp(p) => 10L
+        case p if PlanUtil.isVanillaColumnarOp(p) => 1000L
         // Other row ops. Usually a vanilla row op.
-        case _ => 300L
+        case _ => 1000L
       }
     }
 

--- a/tools/gluten-te/ubuntu/examples/buildhere-veloxbe-portable-libs/README.md
+++ b/tools/gluten-te/ubuntu/examples/buildhere-veloxbe-portable-libs/README.md
@@ -25,7 +25,7 @@ export MOUNT_MAVEN_CACHE=ON
 # Additionally, changes to HTTP_PROXY_HOST / HTTP_PROXY_PORT could invalidate the build cache
 # either. For more details, please check docker file `dockerfile-buildenv`.
 cd gluten/
-tools/gluten-te/ubuntu/examples/buildhere-veloxbe-portable-libs/run.sh
+tools/gluten-te/ubuntu/examples/buildhere-veloxbe-portable-libs/run-default.sh
 
 # 4. Check the built libs.
 ls -l cpp/build/releases/


### PR DESCRIPTION
This is to align the default cost model in RAS as much as possible with the heuristic query planner. To make RAS be able to pass more UTs with the minimal impact from default cost model.

Also do some minor code improvements.