### PR TITLE
[CORE] Fix sorting issue with dynamic partition writing when AQE enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <sparkbundle.version>3.2</sparkbundle.version>
         <sparkshim.module.name>spark32</sparkshim.module.name>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
-        <spark.version>3.2.2</spark.version>
+        <spark.version>3.2.3</spark.version>
         <iceberg.version>1.3.1</iceberg.version>
         <delta.package.name>delta-core</delta.package.name>
         <delta.version>2.0.1</delta.version>
@@ -269,7 +269,7 @@
         <sparkbundle.version>3.3</sparkbundle.version>
         <sparkshim.module.name>spark33</sparkshim.module.name>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark33</sparkshim.artifactId>
-        <spark.version>3.3.1</spark.version>
+        <spark.version>3.3.2</spark.version>
         <!-- keep using iceberg v1.3.1 for parquet compatibilty. -->
         <iceberg.version>1.3.1</iceberg.version>
         <delta.package.name>delta-core</delta.package.name>

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{ProjectExec, SortExec, SparkPlan, SQLExecution, UnsafeExternalRowSorter}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.unsafe.types.UTF8String
@@ -224,8 +225,17 @@ object FileFormatWriter extends Logging {
     // We should first sort by partition columns, then bucket id, and finally sorting columns.
     val requiredOrdering = partitionColumns.drop(numStaticPartitionCols) ++
       bucketIdExpression ++ sortColumns
+
+    // SPARK-40588: plan may contain an AdaptiveSparkPlanExec, which does not know
+    // its final plan's ordering, so we have to materialize that plan first
+    def materializeAdaptiveSparkPlan(plan: SparkPlan): SparkPlan = plan match {
+      case a: AdaptiveSparkPlanExec => a.finalPhysicalPlan
+      case p: SparkPlan => p.withNewChildren(p.children.map(materializeAdaptiveSparkPlan))
+    }
+    val materializedPlan = materializeAdaptiveSparkPlan(empty2NullPlan)
+
     // the sort order doesn't matter
-    val actualOrdering = empty2NullPlan.outputOrdering.map(_.child)
+    val actualOrdering = materializedPlan.outputOrdering.map(_.child)
     val orderingMatched = if (requiredOrdering.length > actualOrdering.length) {
       false
     } else {
@@ -267,9 +277,9 @@ object FileFormatWriter extends Logging {
     try {
       val (rdd, concurrentOutputWriterSpec) = if (orderingMatched) {
         if (!nativeEnabled || (staticPartitionWriteOnly && nativeEnabled)) {
-          (empty2NullPlan.execute(), None)
+          (materializedPlan.execute(), None)
         } else {
-          nativeWrap(empty2NullPlan)
+          nativeWrap(materializedPlan)
         }
       } else {
         // SPARK-21165: the `requiredOrdering` is based on the attributes from analyzed plan, and
@@ -277,7 +287,7 @@ object FileFormatWriter extends Logging {
         // aliases. Here we bind the expression ahead to avoid potential attribute ids mismatch.
         val orderingExpr =
           bindReferences(requiredOrdering.map(SortOrder(_, Ascending)), outputSpec.outputColumns)
-        val sortPlan = SortExec(orderingExpr, global = false, child = empty2NullPlan)
+        val sortPlan = SortExec(orderingExpr, global = false, child = materializedPlan)
 
         val maxWriters = sparkSession.sessionState.conf.maxConcurrentOutputFileWriters
         var concurrentWritersEnabled = maxWriters > 0 && sortColumns.isEmpty
@@ -291,12 +301,12 @@ object FileFormatWriter extends Logging {
 
         if (concurrentWritersEnabled) {
           (
-            empty2NullPlan.execute(),
+            materializedPlan.execute(),
             Some(ConcurrentOutputWriterSpec(maxWriters, () => sortPlan.createSorter())))
         } else {
           if (staticPartitionWriteOnly && nativeEnabled) {
             // remove the sort operator for static partition write.
-            (empty2NullPlan.execute(), None)
+            (materializedPlan.execute(), None)
           } else {
             if (!nativeEnabled) {
               (sortPlan.execute(), None)

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -242,6 +242,16 @@ object FileFormatWriter extends Logging {
       statsTrackers = statsTrackers
     )
 
+    SQLExecution.checkSQLExecutionId(sparkSession)
+
+    // propagate the description UUID into the jobs, so that committers
+    // get an ID guaranteed to be unique.
+    job.getConfiguration.set("spark.sql.sources.writeJobUUID", description.uuid)
+
+    // This call shouldn't be put into the `try` block below because it only initializes and
+    // prepares the job, any exception thrown from here shouldn't cause abortJob() to be called.
+    committer.setupJob(job)
+
     // We should first sort by partition columns, then bucket id, and finally sorting columns.
     val requiredOrdering = partitionColumns.drop(numStaticPartitionCols) ++
       writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
@@ -264,16 +274,6 @@ object FileFormatWriter extends Logging {
           requiredOrder.semanticEquals(childOutputOrder)
       }
     }
-
-    SQLExecution.checkSQLExecutionId(sparkSession)
-
-    // propagate the description UUID into the jobs, so that committers
-    // get an ID guaranteed to be unique.
-    job.getConfiguration.set("spark.sql.sources.writeJobUUID", description.uuid)
-
-    // This call shouldn't be put into the `try` block below because it only initializes and
-    // prepares the job, any exception thrown from here shouldn't cause abortJob() to be called.
-    committer.setupJob(job)
 
     def nativeWrap(plan: SparkPlan) = {
       var wrapped: SparkPlan = plan


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a known issue in Spark ([SPARK-40588](https://issues.apache.org/jira/browse/SPARK-40588)) and have bee fixed in Spark versions `3.2.3` and `3.3.2`.

I encountered this issue recently and found that it could lead to missing data when dynamically writing multiple partitions in the CH backend.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

