### PR TITLE
[VL] Print exception early when raised from ManagedReservationListener#unreserve

### DIFF
--- a/gluten-data/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
+++ b/gluten-data/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
@@ -23,7 +23,9 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Reserve Spark managed memory. */
+/**
+ * Reserve Spark managed memory.
+ */
 public class ManagedReservationListener implements ReservationListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(ManagedReservationListener.class);
@@ -53,10 +55,15 @@ public class ManagedReservationListener implements ReservationListener {
   @Override
   public long unreserve(long size) {
     synchronized (this) {
-      long freed = target.repay(size);
-      sharedUsage.inc(-freed);
-      Preconditions.checkState(freed == size);
-      return freed;
+      try {
+        long freed = target.repay(size);
+        sharedUsage.inc(-freed);
+        Preconditions.checkState(freed == size);
+        return freed;
+      } catch (Exception e) {
+        LOG.error("Error unreserving memory from target", e);
+        throw e;
+      }
     }
   }
 

--- a/gluten-data/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
+++ b/gluten-data/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
@@ -23,9 +23,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Reserve Spark managed memory.
- */
+/** Reserve Spark managed memory. */
 public class ManagedReservationListener implements ReservationListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(ManagedReservationListener.class);


### PR DESCRIPTION
Print the error early to log to avoid further error handling/reporting issues.