### PR TITLE
[GLUTEN-6509] enable read iceberg table with timestamptz as partitioned column.

### DIFF
--- a/gluten-core/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
@@ -97,11 +97,9 @@ abstract class GlutenQueryTest extends PlanTest {
 
   def testWithSpecifiedSparkVersion(testName: String, versions: Array[String])(
       testFun: => Any): Unit = {
-    for (version <- versions) {
-      if (shouldRun(Some(version), Some(version))) {
-        test(testName) {
-          testFun
-        }
+    if (versions.exists(v => shouldRun(Some(v), Some(v)))) {
+      test(testName) {
+        testFun
       }
     }
   }

--- a/gluten-core/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
@@ -95,6 +95,17 @@ abstract class GlutenQueryTest extends PlanTest {
     }
   }
 
+  def testWithSpecifiedSparkVersion(testName: String, versions: Array[String])(
+      testFun: => Any): Unit = {
+    for (version <- versions) {
+      if (shouldRun(Some(version), Some(version))) {
+        test(testName) {
+          testFun
+        }
+      }
+    }
+  }
+
   /** Runs the plan and makes sure the answer contains all of the keywords. */
   def checkKeywordsExist(df: DataFrame, keywords: String*): Unit = {
     val outputs = df.collect().map(_.mkString).mkString

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -20,12 +20,13 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.substrait.rel.{IcebergLocalFilesBuilder, SplitInfo}
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
-import org.apache.iceberg.spark.SparkSchemaUtil
 import org.apache.spark.softaffinity.SoftAffinity
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.types.StructType
+
 import org.apache.iceberg.{CombinedScanTask, DeleteFile, FileFormat, FileScanTask, ScanTask, Schema}
+import org.apache.iceberg.spark.SparkSchemaUtil
 
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
@@ -114,8 +115,8 @@ object GlutenIcebergSourceUtil {
                 .fields()
                 .asScala
                 .filter(f => !tableFields.contains(f.name) || readFields.contains(f.name()))
-            partitionFields.foreach { field =>
-              TypeUtil.validatePartitionColumnType(field.`type`().typeId())
+            partitionFields.foreach {
+              field => TypeUtil.validatePartitionColumnType(field.`type`().typeId())
             }
             val icebergSchema = new Schema(partitionFields.toList.asJava)
             return SparkSchemaUtil.convert(icebergSchema)

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -121,14 +121,6 @@ object GlutenIcebergSourceUtil extends Logging {
             }
 
             val icebergSchema = new Schema(partitionFields.toList.asJava)
-            logInfo(s"schema: $icebergSchema")
-
-            val result = SparkSchemaUtil.convert(icebergSchema)
-            logInfo(s"result: $result")
-
-            partitionFields.foreach {
-              field => logInfo(s"name: ${field.name()}, type: ${field.`type`()}")
-            }
             return SparkSchemaUtil.convert(icebergSchema)
           } else {
             return new StructType()

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.substrait.rel.{IcebergLocalFilesBuilder, SplitInfo}
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.softaffinity.SoftAffinity
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
@@ -34,7 +33,7 @@ import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, M
 
 import scala.collection.JavaConverters._
 
-object GlutenIcebergSourceUtil extends Logging {
+object GlutenIcebergSourceUtil {
 
   def genSplitInfo(
       inputPartition: InputPartition,

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -458,7 +458,8 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  test("iceberg partition type - timestamp") {
+  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported in Spark 3.4
+  testWithSpecifiedSparkVersion("iceberg partition type - timestamp", Array("3.2", "3.3", "3.5")) {
     withSQLConf(
       "spark.sql.iceberg.handle-timestamp-without-timezone" -> "true",
       "spark.sql.iceberg.use-timestamp-without-timezone-in-new-tables" -> "true") {
@@ -484,7 +485,10 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  test("iceberg partition type - timestamptz") {
+  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported in Spark 3.4
+  testWithSpecifiedSparkVersion(
+    "iceberg partition type - timestamptz",
+    Array("3.2", "3.3", "3.5")) {
     withSQLConf(
       "spark.sql.iceberg.handle-timestamp-without-timezone" -> "false",
       "spark.sql.iceberg.use-timestamp-without-timezone-in-new-tables" -> "false") {

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -458,7 +458,8 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported in Spark 3.4
+  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported
+  // in Spark 3.4
   testWithSpecifiedSparkVersion("iceberg partition type - timestamp", Array("3.2", "3.3", "3.5")) {
     withSQLConf(
       "spark.sql.iceberg.handle-timestamp-without-timezone" -> "true",
@@ -485,7 +486,8 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported in Spark 3.4
+  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported
+  // in Spark 3.4
   testWithSpecifiedSparkVersion(
     "iceberg partition type - timestamptz",
     Array("3.2", "3.3", "3.5")) {

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -457,4 +457,49 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
       }
     }
   }
+
+  test("non-partition table with all basis iceberg types.") {
+    withTable("table_with_basis_type") {
+      spark.sql("""
+                  |CREATE TABLE table_with_basis_type (
+                  |  int_col INT,
+                  |  long_col LONG,
+                  |  float_col FLOAT,
+                  |  double_col DOUBLE,
+                  |  boolean_col BOOLEAN,
+                  |  string_col STRING,
+                  |  binary_col BINARY,
+                  |  timestamp_col TIMESTAMP,
+                  |  date_col DATE
+                  |) USING iceberg;
+                  |""".stripMargin)
+      spark.sql("""
+                  |INSERT INTO table_with_basis_type VALUES (
+                  |  1,
+                  |  100L,
+                  |  1.0,
+                  |  2.0,
+                  |  true,
+                  |  'test',
+                  |  CAST('01 02 03' AS BINARY),
+                  |  TIMESTAMP '2022-01-01 00:01:20',
+                  |  DATE '2022-01-01'
+                  |);
+                  |""".stripMargin)
+
+      val df = spark.sql("SELECT * FROM table_with_basis_type")
+      checkAnswer(
+        df,
+        Row(
+          1,
+          100L,
+          1.0f,
+          2.0,
+          true,
+          "test",
+          Array[Byte](1, 2, 3),
+          java.sql.Timestamp.valueOf("2022-01-01 00:01:20"),
+          java.sql.Date.valueOf("2022-01-01")) :: Nil)
+    }
+  }
 }

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -461,58 +461,31 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
   // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported
   // in Spark 3.4
   testWithSpecifiedSparkVersion("iceberg partition type - timestamp", Array("3.2", "3.3", "3.5")) {
-    withSQLConf(
-      "spark.sql.iceberg.handle-timestamp-without-timezone" -> "true",
-      "spark.sql.iceberg.use-timestamp-without-timezone-in-new-tables" -> "true") {
-      withTable("part_by_timestamp") {
-        spark.sql("""
-                    |create table part_by_timestamp (
-                    |  p timestamp
-                    |) using iceberg
-                    |tblproperties (
-                    |  'format-version' = '1'
-                    |)
-                    |partitioned by (p);
-                    |""".stripMargin)
+    Seq("true", "false").foreach {
+      flag =>
+        withSQLConf(
+          "spark.sql.iceberg.handle-timestamp-without-timezone" -> flag,
+          "spark.sql.iceberg.use-timestamp-without-timezone-in-new-tables" -> flag) {
+          withTable("part_by_timestamp") {
+            spark.sql("""
+                        |create table part_by_timestamp (
+                        |  p timestamp
+                        |) using iceberg
+                        |tblproperties (
+                        |  'format-version' = '1'
+                        |)
+                        |partitioned by (p);
+                        |""".stripMargin)
 
-        // Insert some test rows.
-        spark.sql("""
-                    |insert into table part_by_timestamp
-                    |values (TIMESTAMP '2022-01-01 00:01:20');
-                    |""".stripMargin)
-        val df = spark.sql("select * from part_by_timestamp")
-        checkAnswer(df, Row(java.sql.Timestamp.valueOf("2022-01-01 00:01:20")) :: Nil)
-      }
-    }
-  }
-
-  // Spark configuration spark.sql.iceberg.handle-timestamp-without-timezone is not supported
-  // in Spark 3.4
-  testWithSpecifiedSparkVersion(
-    "iceberg partition type - timestamptz",
-    Array("3.2", "3.3", "3.5")) {
-    withSQLConf(
-      "spark.sql.iceberg.handle-timestamp-without-timezone" -> "false",
-      "spark.sql.iceberg.use-timestamp-without-timezone-in-new-tables" -> "false") {
-      withTable("part_by_timestamptz") {
-        spark.sql("""
-                    |create table part_by_timestamptz (
-                    |  p timestamp
-                    |) using iceberg
-                    |tblproperties (
-                    |  'format-version' = '1'
-                    |)
-                    |partitioned by (p);
-                    |""".stripMargin)
-
-        // Insert some test rows.
-        spark.sql("""
-                    |insert into table part_by_timestamptz
-                    |values (TIMESTAMP '2022-01-01 00:01:20');
-                    |""".stripMargin)
-        val df = spark.sql("select * from part_by_timestamptz")
-        checkAnswer(df, Row(java.sql.Timestamp.valueOf("2022-01-01 00:01:20")) :: Nil)
-      }
+            // Insert some test rows.
+            spark.sql("""
+                        |insert into table part_by_timestamp
+                        |values (TIMESTAMP '2022-01-01 00:01:20');
+                        |""".stripMargin)
+            val df = spark.sql("select * from part_by_timestamp")
+            checkAnswer(df, Row(java.sql.Timestamp.valueOf("2022-01-01 00:01:20")) :: Nil)
+          }
+        }
     }
   }
 }

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -465,7 +465,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
       withTable("part_by_timestamp") {
         spark.sql("""
                     |create table part_by_timestamp (
-                    |  p timestamp,
+                    |  p timestamp
                     |) using iceberg
                     |tblproperties (
                     |  'format-version' = '1'
@@ -491,7 +491,7 @@ class VeloxIcebergSuite extends WholeStageTransformerSuite {
       withTable("part_by_timestamptz") {
         spark.sql("""
                     |create table part_by_timestamptz (
-                    |  p timestamp,
+                    |  p timestamp
                     |) using iceberg
                     |tblproperties (
                     |  'format-version' = '1'


### PR DESCRIPTION
## What changes were proposed in this pull request?

current bug when partitioned column type contains timestamptz.

```
Caused by: org.apache.spark.sql.catalyst.parser.ParseException:
DataType timestamptz is not supported.(line 1, pos 0)

== SQL ==
timestamptz
^^^

	at org.apache.spark.sql.errors.QueryParsingErrors$.dataTypeUnsupportedError(QueryParsingErrors.scala:239)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.$anonfun$visitPrimitiveDataType$1(AstBuilder.scala:2692)
	at org.apache.spark.sql.catalyst.parser.ParserUtils$.withOrigin(ParserUtils.scala:157)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.visitPrimitiveDataType(AstBuilder.scala:2662)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.visitPrimitiveDataType(AstBuilder.scala:58)
	at org.apache.spark.sql.catalyst.parser.SqlBaseParser$PrimitiveDataTypeContext.accept(SqlBaseParser.j
```


## How was this patch tested?

UT

