### PR TITLE
[VL] Fix input_file_name results in empty string

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
@@ -34,8 +34,9 @@ object MiscColumnarRules {
   object TransformPreOverrides {
     def apply(): TransformPreOverrides = {
       TransformPreOverrides(
-        List(OffloadProject(), OffloadFilter()),
+        List(OffloadFilter()),
         List(
+          OffloadProject(),
           OffloadOthers(),
           OffloadAggregate(),
           OffloadExchange(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Spark implementation of input_file_name uses a thread local to stash the file name and retrieve it from the function. 

If there is a transformer node between project input_file_name and scan, the result of input_file_name is an empty string.
For example, read delta lake table need union checkpoint parquet file and json file, then order by `input_file_name`  to get parquet data files, it will get wrong parquet file list.
So we should push down input_file_name to transformer scan or add fallback project before fallback scan

## How was this patch tested?

UT

