### PR TITLE
[GLUTEN-6523][VL] fix: Remove fix for stringop-overflow warning in alinux3

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -225,7 +225,6 @@ function process_setup_alinux3 {
   sed -i 's|^export CXX=/opt/rh/gcc-toolset-9/root/bin/g++|# &|' scripts/setup-centos8.sh
   sed -i 's/python39 python39-devel python39-pip //g' scripts/setup-centos8.sh
   sed -i "s/.*pip.* install/#&/" scripts/setup-centos8.sh
-  sed -i 's/ADDITIONAL_FLAGS=""/ADDITIONAL_FLAGS="-Wno-stringop-overflow"/g' scripts/setup-helper-functions.sh
 }
 
 function process_setup_tencentos32 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the fix for stringop-overflow warning as this has been fixed on the Velox side.
Also, ADDITIONAL_FLAGS is no longer present inside `scripts/setup-helper-functions.sh`

Resolves #6523