### PR TITLE
[GLUTEN-6537][BUILD] Support more shell environments beyond Bash in build scripts

### DIFF
--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -110,12 +110,12 @@ for arg in "$@"; do
 done
 
 CURRENT_DIR=$(
-  cd "$(dirname "$BASH_SOURCE")"
+  cd "$(dirname $0)"
   pwd
 )
 
 #gluten cpp will find velox lib from VELOX_HOME
-if [ "$VELOX_HOME" == "" ]; then
+if [[ "$VELOX_HOME" == "" ]]; then
   VELOX_HOME="$CURRENT_DIR/../ep/build-velox/build/velox_ep"
 fi
 

--- a/dev/build_arrow.sh
+++ b/dev/build_arrow.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(cd "$(dirname $0)"; pwd)
 export SUDO=sudo
 source ${CURRENT_DIR}/build_helper_functions.sh
 VELOX_ARROW_BUILD_VERSION=15.0.0

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -6,7 +6,7 @@
 ####################################################################################################
 set -exu
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(cd "$(dirname $0)"; pwd)
 GLUTEN_DIR="$CURRENT_DIR/.."
 BUILD_TYPE=Release
 BUILD_TESTS=OFF

--- a/dev/package-vcpkg.sh
+++ b/dev/package-vcpkg.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(cd "$(dirname $0)"; pwd)
 GLUTEN_DIR="$CURRENT_DIR/.."
 
 cd "$GLUTEN_DIR"

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(cd "$(dirname $0)"; pwd)
 GLUTEN_DIR="$CURRENT_DIR/.."
 THIRDPARTY_LIB="$GLUTEN_DIR/package/target/thirdparty-lib"
 LINUX_OS=$(. /etc/os-release && echo ${ID})

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -7,8 +7,17 @@ else
     SCRIPT_PATH="$0"
 fi
 
-# source command does not start a new process, so the cmdline would not contains current script name.
-CMD=$(cat /proc/$$/cmdline)
+OS=$(uname -s)
+if [[ $OS == "Linux" ]]; then
+    CMD=$(cat /proc/$$/cmdline)
+elif [[ $OS == "Darwin" ]]; then
+    CMD=$(ps -p $$ -o command=)
+else
+    echo "Unsupport kernel: $OS"
+    exit 1
+fi
+
+# source command does not start a new process, so the command would not contains current script name.
 if [[ ${CMD} == *"$SCRIPT_PATH"* ]]; then
     echo "env.sh should only be sourced" >&2
     exit 1

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -1,10 +1,19 @@
-#! /bin/bash
+#!/bin/sh
 
-if [ -z "${BASH_SOURCE[0]}" ] || [ "$0" == "${BASH_SOURCE[0]}" ]; then
-    echo "env.sh should only be sourced in bash" >&2
+if [ -n "$BASH_VERSION" ]; then
+    # Replace `$0` with `BASH_SOURCE[0]` in Bash because it returns the shell when using `source`.
+    SCRIPT_PATH=${BASH_SOURCE[0]}
+else
+    SCRIPT_PATH="$0"
+fi
+
+# source command does not start a new process, so the cmdline would not contains current script name.
+CMD=$(cat /proc/$$/cmdline)
+if [[ ${CMD} == *"$SCRIPT_PATH"* ]]; then
+    echo "env.sh should only be sourced" >&2
     exit 1
 fi
 
-SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+SCRIPT_ROOT="$(realpath "$(dirname "$SCRIPT_PATH")")"
 init_vcpkg_env=$("${SCRIPT_ROOT}/init.sh")
 eval "$init_vcpkg_env"

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -201,7 +201,7 @@ function check_commit {
 }
 
 CURRENT_DIR=$(
-  cd "$(dirname "$BASH_SOURCE")"
+  cd "$(dirname $0)"
   pwd
 )
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -237,7 +237,7 @@ echo "Preparing Velox source code..."
 echo "ENABLE_HDFS=${ENABLE_HDFS}"
 
 CURRENT_DIR=$(
-  cd "$(dirname "$BASH_SOURCE")"
+  cd "$(dirname $0)"
   pwd
 )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support more shell environments for build scripts.

(Fixes: \#6537)

## How was this patch tested?
Test on zsh shell.

