### PR TITLE
[VL] Daily Update Velox Version (2024_07_23)

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -18,7 +18,7 @@ set -exu
 
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_07_19
+VELOX_BRANCH=2024_07_23
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
8156d7d42 (upstream/main) Move parquet-specific options to parquet::WriterOptions (#10470)
0c00c9322 Add arbitration/grow message to memory pool oom (#10506)
b7adf8f64 Implement TPCH Query 4 in TPCHQueryBuilder (#9857)
51d9a40d8 Fix int128::max() to double conversion issue (#10440)
c89762804 Remove handling of map inputs from min and max Presto functions (#10503)
121cf011f Add instructions for setting DEPENDENCY_DIR in README.md (#10435)
a08da4239 Document Spark types (#10507)
cbe8ca4ca Fix argument check error message for HistogramAggregate (#10501)
7089078fd Iceberg row group fix new (#10505)
450b105ed Fix Parquet DELTA_BINARY_PACKED decoder move buffer ptr to the end of page (#10485)
facd967aa Support for dictionary encoded INT96 timestamp in parquet files (#4680)
524fc394d Fix .gitignore and some typos. (#10326)
0fe4fb951 Remove the duplicated linking library in pyvelox. (#10484)
```
