### PR TITLE
[VL] Following #6526, minor fixes and improvements

### DIFF
--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -404,16 +404,16 @@ class SparkAllocationListener final : public gluten::AllocationListener {
       checkException(env);
     }
     std::lock_guard<std::mutex> lock(mutex_);
-    bytesReserved_ += size;
-    maxBytesReserved_ = std::max(bytesReserved_, maxBytesReserved_);
+    usedBytes_ += size;
+    peakBytes_ = std::max(usedBytes_, peakBytes_);
   }
 
   int64_t currentBytes() override {
-    return bytesReserved_;
+    return usedBytes_;
   }
 
   int64_t peakBytes() override {
-    return maxBytesReserved_;
+    return peakBytes_;
   }
 
  private:
@@ -421,8 +421,8 @@ class SparkAllocationListener final : public gluten::AllocationListener {
   jobject jListenerGlobalRef_;
   const jmethodID jReserveMethod_;
   const jmethodID jUnreserveMethod_;
-  int64_t bytesReserved_{0L};
-  int64_t maxBytesReserved_{0L};
+  int64_t usedBytes_{0L};
+  int64_t peakBytes_{0L};
 
   mutable std::mutex mutex_;
 };

--- a/cpp/core/memory/AllocationListener.h
+++ b/cpp/core/memory/AllocationListener.h
@@ -73,7 +73,7 @@ class BlockAllocationListener final : public AllocationListener {
   }
 
  private:
-  int64_t reserve(int64_t diff) {
+  inline int64_t reserve(int64_t diff) {
     std::lock_guard<std::mutex> lock(mutex_);
     usedBytes_ += diff;
     int64_t newBlockCount;

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -92,8 +92,9 @@ int64_t ListenableMemoryAllocator::peakBytes() const {
 
 void ListenableMemoryAllocator::updateUsage(int64_t size) {
   listener_->allocationChanged(size);
-  usedBytes_.fetch_add(size);
-  peakBytes_.store(std::max(peakBytes_.load(), usedBytes_.load()));
+  std::lock_guard<std::mutex> lock(mutex_);
+  usedBytes_ += size;
+  peakBytes_ = std::max(peakBytes_, usedBytes_);
 }
 
 bool StdMemoryAllocator::allocate(int64_t size, void** out) {

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -92,9 +92,17 @@ int64_t ListenableMemoryAllocator::peakBytes() const {
 
 void ListenableMemoryAllocator::updateUsage(int64_t size) {
   listener_->allocationChanged(size);
-  std::lock_guard<std::mutex> lock(mutex_);
   usedBytes_ += size;
-  peakBytes_ = std::max(peakBytes_, usedBytes_);
+  while (true) {
+    int64_t savedPeakBytes = peakBytes_;
+    if (usedBytes_ <= savedPeakBytes) {
+      break;
+    }
+    // usedBytes_ > savedPeakBytes, update peak
+    if (peakBytes_.compare_exchange_weak(savedPeakBytes, usedBytes_)) {
+      break;
+    }
+  }
 }
 
 bool StdMemoryAllocator::allocate(int64_t size, void** out) {

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -72,10 +72,8 @@ class ListenableMemoryAllocator final : public MemoryAllocator {
   void updateUsage(int64_t size);
   MemoryAllocator* const delegated_;
   AllocationListener* const listener_;
-  int64_t usedBytes_{0L};
-  int64_t peakBytes_{0L};
-
-  mutable std::mutex mutex_;
+  std::atomic_int64_t usedBytes_{0L};
+  std::atomic_int64_t peakBytes_{0L};
 };
 
 class StdMemoryAllocator final : public MemoryAllocator {

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -72,8 +72,10 @@ class ListenableMemoryAllocator final : public MemoryAllocator {
   void updateUsage(int64_t size);
   MemoryAllocator* const delegated_;
   AllocationListener* const listener_;
-  std::atomic_int64_t usedBytes_{0L};
-  std::atomic_int64_t peakBytes_{0L};
+  int64_t usedBytes_{0L};
+  int64_t peakBytes_{0L};
+
+  mutable std::mutex mutex_;
 };
 
 class StdMemoryAllocator final : public MemoryAllocator {


### PR DESCRIPTION
A follow-up to #6526

1. Use the old way before https://github.com/apache/incubator-gluten/pull/5770 for block reservation because
   * It uses same algorithm for `diff < 0` and `diff > 0` so simplifies code
   * It reduces code branches
 2. Code `peakBytes_.store(std::max(peakBytes_.load(), usedBytes_.load()))` is still not atomic so needs to be locked