### PR TITLE
[MINOR][VL] Remove duplicate mvn packages

### DIFF
--- a/dev/package-vcpkg.sh
+++ b/dev/package-vcpkg.sh
@@ -15,7 +15,3 @@ if [ "$LINUX_OS" == "centos" ]; then
 fi
 source ./dev/vcpkg/env.sh
 ./dev/buildbundle-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON
-mvn clean package -Pbackends-velox -Pceleborn -Puniffle -Pspark-3.2 -DskipTests
-mvn clean package -Pbackends-velox -Pceleborn -Puniffle -Pspark-3.3 -DskipTests
-mvn clean package -Pbackends-velox -Pceleborn -Puniffle -Pspark-3.4 -DskipTests
-mvn clean package -Pbackends-velox -Pceleborn -Puniffle -Pspark-3.5 -DskipTests


### PR DESCRIPTION
## What changes were proposed in this pull request?

The mvn package commands have been executed in `buildbundle-veloxbe.sh`, so we need to remove the duplicate mvn package commands in `package-vcpkg.sh`.

## How was this patch tested?

manual test

