### PR TITLE
[GLUTEN-6562][VL] Decouple BUILD_BENCHMARKS and BUILD_TESTS build options

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -159,6 +159,7 @@ find_package(JNI REQUIRED)
 find_package(glog REQUIRED)
 
 if(BUILD_TESTS)
+  set(BUILD_BENCHMARKS ON)
   set(GLUTEN_GTEST_MIN_VERSION "1.13.0")
   find_package(GTest ${GLUTEN_GTEST_MIN_VERSION} CONFIG)
   if(NOT GTest_FOUND)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -159,7 +159,6 @@ find_package(JNI REQUIRED)
 find_package(glog REQUIRED)
 
 if(BUILD_TESTS)
-  set(BUILD_BENCHMARKS ON)
   set(GLUTEN_GTEST_MIN_VERSION "1.13.0")
   find_package(GTest ${GLUTEN_GTEST_MIN_VERSION} CONFIG)
   if(NOT GTest_FOUND)

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -29,8 +29,7 @@ function(add_velox_test TEST_EXEC)
   target_include_directories(
     ${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox ${CMAKE_SOURCE_DIR}/src
                          ${VELOX_BUILD_PATH}/_deps/duckdb-src/src/include)
-  target_link_libraries(${TEST_EXEC} velox_benchmark_common GTest::gtest
-                        GTest::gtest_main)
+  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main google::glog benchmark::benchmark)
   gtest_discover_tests(${TEST_EXEC} DISCOVERY_MODE PRE_TEST)
 endfunction()
 

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ function(add_velox_test TEST_EXEC)
     ${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox ${CMAKE_SOURCE_DIR}/src
                          ${VELOX_BUILD_PATH}/_deps/duckdb-src/src/include)
   target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main
-                        google::glog benchmark::benchmark)
+                        google::glog)
   gtest_discover_tests(${TEST_EXEC} DISCOVERY_MODE PRE_TEST)
 endfunction()
 

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -29,7 +29,8 @@ function(add_velox_test TEST_EXEC)
   target_include_directories(
     ${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox ${CMAKE_SOURCE_DIR}/src
                          ${VELOX_BUILD_PATH}/_deps/duckdb-src/src/include)
-  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main google::glog benchmark::benchmark)
+  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main
+                        google::glog benchmark::benchmark)
   gtest_discover_tests(${TEST_EXEC} DISCOVERY_MODE PRE_TEST)
 endfunction()
 

--- a/cpp/velox/tests/MemoryManagerTest.cc
+++ b/cpp/velox/tests/MemoryManagerTest.cc
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include "benchmarks/common/BenchmarkUtils.h"
 #include "compute/VeloxBackend.h"
 #include "config/VeloxConfig.h"
 #include "memory/VeloxMemoryManager.h"
@@ -50,7 +49,7 @@ class MemoryManagerTest : public ::testing::Test {
     std::unordered_map<std::string, std::string> conf = {
         {kMemoryReservationBlockSize, std::to_string(kMemoryReservationBlockSizeDefault)},
         {kVeloxMemInitCapacity, std::to_string(kVeloxMemInitCapacityDefault)}};
-    initVeloxBackend(conf);
+    gluten::VeloxBackend::create(conf);
   }
 
   void SetUp() override {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Building Gluten tests [depends on gluten benchmark ](https://github.com/apache/incubator-gluten/blob/main/cpp/velox/tests/CMakeLists.txt#L32), this pr decouples them.

Fixes: #6562 

## How was this patch tested?
I successfully built gluten tests with `./compile.sh --build_velox_backend=ON --build_tests=ON --build_examples=ON` that BUILD_BENCHMARKS is not enabled

