### PR TITLE
[GLUTEN-6574][VL]Validate GenerateRel should attempt to compile the generator.

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -477,7 +477,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
   }
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
   std::vector<core::TypedExprPtr> expressions;
-  if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
+  if (generateRel.has_generator()) {
     if (!validateExpression(generateRel.generator(), rowType) {
       LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
       return false;

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -482,7 +482,12 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
       LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
       return false;
     }
-    expressions.emplace_back(exprConverter_->toVeloxExpr(generateRel.generator(), rowType));
+    auto generator = generateRel.generator().scalar_function();
+    for (const auto& argument : generator.arguments()) {
+      if (argument.has_value()) {
+        expressions.emplace_back(exprConverter_->toVeloxExpr(argument.value(), rowType));
+      }
+    }
     // Try to compile the expressions. If there is any unregistred funciton or
     // mismatched type, exception will be thrown.
     exec::ExprSet exprSet(std::move(expressions), execCtx_);

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -478,7 +478,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
   std::vector<core::TypedExprPtr> expressions;
   if (generateRel.has_generator()) {
-    if (!validateExpression(generateRel.generator(), rowType) {
+    if (!validateExpression(generateRel.generator(), rowType)) {
       LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
       return false;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validate GenerateRel should attempt to compile the generator to avoid job failure when the generator is not supported and cannot fallback. For example, version 1.1.0 has the following error:
sql:
```
SELECT explode(slice(a, 2, 2)) from t
```

```
Job aborted due to stage failure: Task 1 in stage 26.0 failed 4 times, most recent failure: Lost task 1.3 in stage 26.0 (TID 360) (xx executor 11): io.glutenproject.exception.GlutenException: java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Scalar function slice not registered with arguments: (ARRAY<VARCHAR>, INTEGER, INTEGER). Found function registered with the following signatures:
((array(T),bigint,bigint) -> array(T))
Retriable: False
Function: compileRewrittenExpression
File: /root/package/gluten/ep/build-velox/build/velox_ep/velox/expression/ExprCompiler.cpp
Line: 468
```

(Fixes: \#ISSUE-6574)

## How was this patch tested?

through exist uts

