### PR TITLE
[VL] Fix std::min params type mismatch in Apple clang 15

### DIFF
--- a/cpp/velox/shuffle/VeloxSortShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxSortShuffleWriter.cc
@@ -161,7 +161,7 @@ arrow::Status VeloxSortShuffleWriter::insert(const facebook::velox::RowVectorPtr
     auto rows = maxRowsToInsert(rowOffset, remainingRows);
     if (rows == 0) {
       auto minSizeRequired = fixedRowSize_ ? fixedRowSize_.value() : rowSizes_[rowOffset + 1] - rowSizes_[rowOffset];
-      acquireNewBuffer(memLimit, minSizeRequired);
+      acquireNewBuffer((uint64_t)memLimit, minSizeRequired);
       rows = maxRowsToInsert(rowOffset, remainingRows);
       ARROW_RETURN_IF(
           rows == 0, arrow::Status::Invalid("Failed to insert rows. Remaining rows: " + std::to_string(remainingRows)));
@@ -277,7 +277,7 @@ uint32_t VeloxSortShuffleWriter::maxRowsToInsert(uint32_t offset, uint32_t rows)
   return iter - beginIter;
 }
 
-void VeloxSortShuffleWriter::acquireNewBuffer(int64_t memLimit, uint64_t minSizeRequired) {
+void VeloxSortShuffleWriter::acquireNewBuffer(uint64_t memLimit, uint64_t minSizeRequired) {
   auto size = std::max(std::min<uint64_t>(memLimit >> 2, 64UL * 1024 * 1024), minSizeRequired);
   // Allocating new buffer can trigger spill.
   auto newBuffer = facebook::velox::AlignedBuffer::allocate<char>(size, veloxPool_.get(), 0);

--- a/cpp/velox/shuffle/VeloxSortShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxSortShuffleWriter.cc
@@ -278,7 +278,7 @@ uint32_t VeloxSortShuffleWriter::maxRowsToInsert(uint32_t offset, uint32_t rows)
 }
 
 void VeloxSortShuffleWriter::acquireNewBuffer(int64_t memLimit, uint64_t minSizeRequired) {
-  auto size = std::max(std::min((uint64_t)memLimit >> 2, 64UL * 1024 * 1024), minSizeRequired);
+  auto size = std::max(std::min<uint64_t>(memLimit >> 2, 64UL * 1024 * 1024), minSizeRequired);
   // Allocating new buffer can trigger spill.
   auto newBuffer = facebook::velox::AlignedBuffer::allocate<char>(size, veloxPool_.get(), 0);
   pages_.emplace_back(std::move(newBuffer));

--- a/cpp/velox/shuffle/VeloxSortShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxSortShuffleWriter.h
@@ -76,7 +76,7 @@ class VeloxSortShuffleWriter final : public VeloxShuffleWriter {
 
   uint32_t maxRowsToInsert(uint32_t offset, uint32_t rows);
 
-  void acquireNewBuffer(int64_t memLimit, uint64_t minSizeRequired);
+  void acquireNewBuffer(uint64_t memLimit, uint64_t minSizeRequired);
 
   void growArrayIfNecessary(uint32_t rows);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bug fix
```
/Users/zml/Desktop/git_hub/incubator-gluten/cpp/velox/shuffle/VeloxSortShuffleWriter.cc:281:24: error: no matching function for call to 'min'
  auto size = std::max(std::min((uint64_t)memLimit >> 2, 64UL * 1024 * 1024), minSizeRequired);
```

## How was this patch tested?
Local test.
