### PR TITLE
[MINOR] Reduce unnecessary dependencies

### DIFF
--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -119,6 +119,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-buffer</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>commons-codec</artifactId>
+          <groupId>commons-codec</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -716,6 +716,12 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${fasterxml.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
         <version>${fasterxml.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are some unnecessary dependencies in the `gluten-velox-bundle-spark3.5` jar.

`jackson-datatype-jsr310`:
![image](https://github.com/user-attachments/assets/b692d3fe-30e9-4bf3-8ecd-8c6e86d3a380)

`commons-codec`:
![image](https://github.com/user-attachments/assets/4295c824-b7a3-4f74-9c15-99ed37991b48)

## How was this patch tested?

