### PR TITLE
[VL] Support row type and fix subfield in filter push-down

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -141,11 +141,21 @@ void SubstraitParser::parseColumnTypes(
   return;
 }
 
-int32_t SubstraitParser::parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment) {
+bool SubstraitParser::parseReferenceSegment(
+    const ::substrait::Expression::ReferenceSegment& refSegment,
+    uint32_t& fieldIndex) {
   auto typeCase = refSegment.reference_type_case();
   switch (typeCase) {
     case ::substrait::Expression::ReferenceSegment::ReferenceTypeCase::kStructField: {
-      return refSegment.struct_field().field();
+      if (refSegment.struct_field().has_child()) {
+        // To parse subfield index is not supported.
+        return false;
+      }
+      fieldIndex = refSegment.struct_field().field();
+      if (fieldIndex < 0) {
+        return false;
+      }
+      return true;
     }
     default:
       VELOX_NYI("Substrait conversion not supported for ReferenceSegment '{}'", std::to_string(typeCase));

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -50,8 +50,9 @@ class SubstraitParser {
   /// Parse Substrait Type to Velox type.
   static facebook::velox::TypePtr parseType(const ::substrait::Type& substraitType, bool asLowerCase = false);
 
-  /// Parse Substrait ReferenceSegment.
-  static int32_t parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment);
+  /// Parse Substrait ReferenceSegment and extract the field index. Return false if the segment is not a valid unnested
+  /// field.
+  static bool parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment, uint32_t& fieldIndex);
 
   /// Make names in the format of {prefix}_{index}.
   static std::vector<std::string> makeNames(const std::string& prefix, int size);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Supports the push-down of IsNull and IsNotNull filter for row type.
Filter on subfield cannot be pushed-down, and we put them in the remaining filter.

## How was this patch tested?

With unit test.

