### PR TITLE
[GLUTEN-6067][CH][MINOR][UT] Pass backends-clickhouse ut in Spark 3.5

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDecimalSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDecimalSuite.scala
@@ -66,10 +66,10 @@ class GlutenClickHouseDecimalSuite
   private val decimalTable: String = "decimal_table"
   private val decimalTPCHTables: Seq[(DecimalType, Seq[Int])] = Seq.apply(
     (DecimalType.apply(9, 4), Seq()),
-    // 1: ch decimal avg is float
     (DecimalType.apply(18, 8), Seq()),
-    // 1: ch decimal avg is float, 3/10: all value is null and compare with limit
-    (DecimalType.apply(38, 19), Seq(3, 10))
+    // 3/10: all value is null and compare with limit
+    // 1 Spark 3.5
+    (DecimalType.apply(38, 19), if (isSparkVersionLE("3.3")) Seq(3, 10) else Seq(1, 3, 10))
   )
 
   private def createDecimalTables(dataType: DecimalType): Unit = {
@@ -343,19 +343,14 @@ class GlutenClickHouseDecimalSuite
               decimalTPCHTables.foreach {
                 dt =>
                   {
+                    val fallBack = (sql_num == 16 || sql_num == 21)
+                    val compareResult = !dt._2.contains(sql_num)
+                    val native = if (fallBack) "fallback" else "native"
+                    val compare = if (compareResult) "compare" else "noCompare"
+                    val PrecisionLoss = s"allowPrecisionLoss=$allowPrecisionLoss"
                     val decimalType = dt._1
                     test(s"""TPCH Decimal(${decimalType.precision},${decimalType.scale})
-                            | Q$sql_num[allowPrecisionLoss=$allowPrecisionLoss]""".stripMargin) {
-                      var noFallBack = true
-                      var compareResult = true
-                      if (sql_num == 16 || sql_num == 21) {
-                        noFallBack = false
-                      }
-
-                      if (dt._2.contains(sql_num)) {
-                        compareResult = false
-                      }
-
+                            | Q$sql_num[$PrecisionLoss,$native,$compare]""".stripMargin) {
                       spark.sql(s"use decimal_${decimalType.precision}_${decimalType.scale}")
                       withSQLConf(
                         (SQLConf.DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key, allowPrecisionLoss)) {
@@ -363,7 +358,7 @@ class GlutenClickHouseDecimalSuite
                           sql_num,
                           tpchQueries,
                           compareResult = compareResult,
-                          noFallBack = noFallBack) { _ => {} }
+                          noFallBack = !fallBack) { _ => {} }
                       }
                       spark.sql(s"use default")
                     }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseHiveTableSuite.scala
@@ -1051,8 +1051,12 @@ class GlutenClickHouseHiveTableSuite
     spark.sql(
       s"CREATE FUNCTION my_add as " +
         s"'org.apache.hadoop.hive.contrib.udf.example.UDFExampleAdd2' USING JAR '$jarUrl'")
-    runQueryAndCompare("select MY_ADD(id, id+1) from range(10)")(
-      checkGlutenOperatorMatch[ProjectExecTransformer])
+    if (isSparkVersionLE("3.3")) {
+      runQueryAndCompare("select MY_ADD(id, id+1) from range(10)")(
+        checkGlutenOperatorMatch[ProjectExecTransformer])
+    } else {
+      runQueryAndCompare("select MY_ADD(id, id+1) from range(10)", noFallBack = false)(_ => {})
+    }
   }
 
   test("GLUTEN-4333: fix CSE in aggregate operator") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseNativeWriteTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseNativeWriteTableSuite.scala
@@ -603,7 +603,7 @@ class GlutenClickHouseNativeWriteTableSuite
       ("timestamp_field", "timestamp")
     )
     def excludeTimeFieldForORC(format: String): Seq[String] = {
-      if (format.equals("orc") && isSparkVersionGE("3.4")) {
+      if (format.equals("orc") && isSparkVersionGE("3.5")) {
         // FIXME:https://github.com/apache/incubator-gluten/pull/6507
         fields.keys.filterNot(_.equals("timestamp_field")).toSeq
       } else {
@@ -913,7 +913,7 @@ class GlutenClickHouseNativeWriteTableSuite
           (table_name, create_sql, insert_sql)
       },
       (table_name, _) =>
-        if (isSparkVersionGE("3.4")) {
+        if (isSparkVersionGE("3.5")) {
           compareResultsAgainstVanillaSpark(
             s"select * from $table_name",
             compareResult = true,

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.benchmarks.GenTPCDSTableScripts
-import org.apache.gluten.utils.UTSystemParameters
+import org.apache.gluten.utils.{Arm, UTSystemParameters}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -46,8 +46,8 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
     rootPath + "../../../../gluten-core/src/test/resources/tpcds-queries/tpcds.queries.original"
   protected val queriesResults: String = rootPath + "tpcds-decimal-queries-output"
 
-  /** Return values: (sql num, is fall back, skip fall back assert) */
-  def tpcdsAllQueries(isAqe: Boolean): Seq[(String, Boolean, Boolean)] =
+  /** Return values: (sql num, is fall back) */
+  def tpcdsAllQueries(isAqe: Boolean): Seq[(String, Boolean)] =
     Range
       .inclusive(1, 99)
       .flatMap(
@@ -57,25 +57,24 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
           } else {
             Seq("q" + "%d".format(queryNum))
           }
-          val noFallBack = queryNum match {
-            case i if !isAqe && (i == 10 || i == 16 || i == 35 || i == 94) =>
-              // q10 smj + existence join
-              // q16 smj + left semi + not condition
-              // q35 smj + existence join
-              // Q94 BroadcastHashJoin, LeftSemi, NOT condition
-              (false, false)
-            case i if isAqe && (i == 16 || i == 94) =>
-              (false, false)
-            case other => (true, false)
-          }
-          sqlNums.map((_, noFallBack._1, noFallBack._2))
+          val native = !fallbackSets(isAqe).contains(queryNum)
+          sqlNums.map((_, native))
         })
 
-  // FIXME "q17", stddev_samp inconsistent results, CH return NaN, Spark return null
+  protected def fallbackSets(isAqe: Boolean): Set[Int] = {
+    val more = if (isSparkVersionGE("3.5")) Set(44, 67, 70) else Set.empty[Int]
+
+    // q16 smj + left semi + not condition
+    // Q94 BroadcastHashJoin, LeftSemi, NOT condition
+    if (isAqe) {
+      Set(16, 94) | more
+    } else {
+      // q10, q35 smj + existence join
+      Set(10, 16, 35, 94) | more
+    }
+  }
   protected def excludedTpcdsQueries: Set[String] = Set(
-    "q61", // inconsistent results
-    "q66", // inconsistent results
-    "q67" // inconsistent results
+    "q66" // inconsistent results
   )
 
   def executeTPCDSTest(isAqe: Boolean): Unit = {
@@ -83,11 +82,12 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
       s =>
         if (excludedTpcdsQueries.contains(s._1)) {
           ignore(s"TPCDS ${s._1.toUpperCase()}") {
-            runTPCDSQuery(s._1, noFallBack = s._2, skipFallBackAssert = s._3) { df => }
+            runTPCDSQuery(s._1, noFallBack = s._2) { df => }
           }
         } else {
-          test(s"TPCDS ${s._1.toUpperCase()}") {
-            runTPCDSQuery(s._1, noFallBack = s._2, skipFallBackAssert = s._3) { df => }
+          val tag = if (s._2) "Native" else "Fallback"
+          test(s"TPCDS[$tag] ${s._1.toUpperCase()}") {
+            runTPCDSQuery(s._1, noFallBack = s._2) { df => }
           }
         })
   }
@@ -152,7 +152,7 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
   }
 
   override protected def afterAll(): Unit = {
-    ClickhouseSnapshot.clearAllFileStatusCache
+    ClickhouseSnapshot.clearAllFileStatusCache()
     DeltaLog.clearCache()
 
     try {
@@ -183,11 +183,10 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
       tpcdsQueries: String = tpcdsQueries,
       queriesResults: String = queriesResults,
       compareResult: Boolean = true,
-      noFallBack: Boolean = true,
-      skipFallBackAssert: Boolean = false)(customCheck: DataFrame => Unit): Unit = {
+      noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit = {
 
     val sqlFile = tpcdsQueries + "/" + queryNum + ".sql"
-    val sql = Source.fromFile(new File(sqlFile), "UTF-8").mkString
+    val sql = Arm.withResource(Source.fromFile(new File(sqlFile), "UTF-8"))(_.mkString)
     val df = spark.sql(sql)
 
     if (compareResult) {
@@ -212,13 +211,13 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
       // using WARN to guarantee printed
       log.warn(s"query: $queryNum, finish comparing with saved result")
     } else {
-      val start = System.currentTimeMillis();
+      val start = System.currentTimeMillis()
       val ret = df.collect()
       // using WARN to guarantee printed
       log.warn(s"query: $queryNum skipped comparing, time cost to collect: ${System
           .currentTimeMillis() - start} ms, ret size: ${ret.length}")
     }
-    WholeStageTransformerSuite.checkFallBack(df, noFallBack, skipFallBackAssert)
+    WholeStageTransformerSuite.checkFallBack(df, noFallBack)
     customCheck(df)
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
@@ -236,8 +236,7 @@ class GlutenClickHouseTPCHBucketSuite
         }
         assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         assert(plans.head.metrics("numFiles").value === 2)
-        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValueSpark)
         assert(plans.head.metrics("numOutputRows").value === 591673)
       })
   }
@@ -292,7 +291,7 @@ class GlutenClickHouseTPCHBucketSuite
         }
 
         if (sparkVersion.equals("3.2")) {
-          assert(!(plans(11).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
+          assert(!plans(11).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         } else {
           assert(plans(11).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         }
@@ -328,14 +327,14 @@ class GlutenClickHouseTPCHBucketSuite
             .isInstanceOf[InputIteratorTransformer])
 
         if (sparkVersion.equals("3.2")) {
-          assert(!(plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
+          assert(!plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         } else {
           assert(plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         }
         assert(plans(2).metrics("numFiles").value === 2)
         assert(plans(2).metrics("numOutputRows").value === 3111)
 
-        assert(!(plans(3).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
+        assert(!plans(3).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         assert(plans(3).metrics("numFiles").value === 2)
         assert(plans(3).metrics("numOutputRows").value === 72678)
       })
@@ -367,12 +366,12 @@ class GlutenClickHouseTPCHBucketSuite
         }
         // bucket join
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
             .isInstanceOf[ProjectExecTransformer])
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
             .isInstanceOf[ProjectExecTransformer])
@@ -412,8 +411,7 @@ class GlutenClickHouseTPCHBucketSuite
         }
         assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         assert(plans.head.metrics("numFiles").value === 2)
-        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValueSpark)
         assert(plans.head.metrics("numOutputRows").value === 11618)
       })
   }
@@ -427,12 +425,12 @@ class GlutenClickHouseTPCHBucketSuite
         }
         // bucket join
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
             .isInstanceOf[FilterExecTransformerBase])
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
             .isInstanceOf[ProjectExecTransformer])
@@ -587,7 +585,7 @@ class GlutenClickHouseTPCHBucketSuite
     def checkResult(df: DataFrame, exceptedResult: Seq[Row]): Unit = {
       // check the result
       val result = df.collect()
-      assert(result.size == exceptedResult.size)
+      assert(result.length == exceptedResult.size)
       val sortedRes = result.map {
         s =>
           Row.fromSeq(s.toSeq.map {
@@ -788,7 +786,7 @@ class GlutenClickHouseTPCHBucketSuite
           |order by l_orderkey, l_returnflag, t
           |limit 10
           |""".stripMargin
-      runSql(SQL7, false)(
+      runSql(SQL7, noFallBack = false)(
         df => {
           checkResult(
             df,

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
@@ -234,10 +234,11 @@ class GlutenClickHouseTPCHBucketSuite
         val plans = collect(df.queryExecution.executedPlan) {
           case scanExec: BasicScanExecTransformer => scanExec
         }
-        assert(!(plans(0).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
-        assert(plans(0).metrics("numFiles").value === 2)
-        assert(plans(0).metrics("pruningTime").value === -1)
-        assert(plans(0).metrics("numOutputRows").value === 591673)
+        assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
+        assert(plans.head.metrics("numFiles").value === 2)
+        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("numOutputRows").value === 591673)
       })
   }
 
@@ -409,10 +410,11 @@ class GlutenClickHouseTPCHBucketSuite
         val plans = collect(df.queryExecution.executedPlan) {
           case scanExec: BasicScanExecTransformer => scanExec
         }
-        assert(!(plans(0).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
-        assert(plans(0).metrics("numFiles").value === 2)
-        assert(plans(0).metrics("pruningTime").value === -1)
-        assert(plans(0).metrics("numOutputRows").value === 11618)
+        assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
+        assert(plans.head.metrics("numFiles").value === 2)
+        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("numOutputRows").value === 11618)
       })
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseWholeStageTransformerSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseWholeStageTransformerSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf}
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseConfig
 
 import org.apache.commons.io.FileUtils
+import org.scalatest.Tag
 
 import java.io.File
 
@@ -177,13 +178,21 @@ class GlutenClickHouseWholeStageTransformerSuite extends WholeStageTransformerSu
     super.beforeAll()
   }
 
-  protected val rootPath = this.getClass.getResource("/").getPath
-  protected val basePath = rootPath + "tests-working-home"
-  protected val warehouse = basePath + "/spark-warehouse"
-  protected val metaStorePathAbsolute = basePath + "/meta"
-  protected val hiveMetaStoreDB = metaStorePathAbsolute + "/metastore_db"
+  protected val rootPath: String = this.getClass.getResource("/").getPath
+  protected val basePath: String = rootPath + "tests-working-home"
+  protected val warehouse: String = basePath + "/spark-warehouse"
+  protected val metaStorePathAbsolute: String = basePath + "/meta"
+  protected val hiveMetaStoreDB: String = metaStorePathAbsolute + "/metastore_db"
 
   final override protected val resourcePath: String = "" // ch not need this
   override protected val fileFormat: String = "parquet"
+
+  protected def testSparkVersionLE33(testName: String, testTag: Tag*)(testFun: => Any): Unit = {
+    if (isSparkVersionLE("3.3")) {
+      test(testName, testTag: _*)(testFun)
+    } else {
+      ignore(s"[$SPARK_VERSION_SHORT]-$testName", testTag: _*)(testFun)
+    }
+  }
 }
 // scalastyle:off line.size.limit

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseWholeStageTransformerSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseWholeStageTransformerSuite.scala
@@ -194,5 +194,7 @@ class GlutenClickHouseWholeStageTransformerSuite extends WholeStageTransformerSu
       ignore(s"[$SPARK_VERSION_SHORT]-$testName", testTag: _*)(testFun)
     }
   }
+
+  lazy val pruningTimeValueSpark: Int = if (isSparkVersionLE("3.3")) -1 else 0
 }
 // scalastyle:off line.size.limit

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseCountDistinctSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseCountDistinctSuite.scala
@@ -105,9 +105,9 @@ class GlutenClickhouseCountDistinctSuite extends GlutenClickHouseWholeStageTrans
     val sql = s"""
       select count(distinct(a,b)) , try_add(c,b) from
       values (0, null,1), (0,null,2), (1, 1,4) as data(a,b,c) group by try_add(c,b)
-      """;
+      """
     val df = spark.sql(sql)
-    WholeStageTransformerSuite.checkFallBack(df, noFallback = isSparkVersionGE("3.4"))
+    WholeStageTransformerSuite.checkFallBack(df, noFallback = isSparkVersionGE("3.5"))
   }
 
   test("check count distinct with filter") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseCountDistinctSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseCountDistinctSuite.scala
@@ -107,7 +107,7 @@ class GlutenClickhouseCountDistinctSuite extends GlutenClickHouseWholeStageTrans
       values (0, null,1), (0,null,2), (1, 1,4) as data(a,b,c) group by try_add(c,b)
       """;
     val df = spark.sql(sql)
-    WholeStageTransformerSuite.checkFallBack(df, noFallback = false)
+    WholeStageTransformerSuite.checkFallBack(df, noFallback = isSparkVersionGE("3.4"))
   }
 
   test("check count distinct with filter") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.TaskResources
 import scala.collection.JavaConverters._
 
 class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite {
-  private val parquetMaxBlockSize = 4096;
+  private val parquetMaxBlockSize = 4096
   override protected val needCopyParquetToTablePath = true
 
   override protected val tablesPath: String = basePath + "/tpch-data"
@@ -71,8 +71,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         assert(plans.size == 3)
 
         assert(plans(2).metrics("numFiles").value === 1)
-        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-        assert(plans(2).metrics("pruningTime").value === pruningTimeValue)
+        assert(plans(2).metrics("pruningTime").value === pruningTimeValueSpark)
         assert(plans(2).metrics("filesSize").value === 19230111)
 
         assert(plans(1).metrics("numOutputRows").value === 4)
@@ -140,16 +139,15 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
           assert(plans.size == 3)
 
           assert(plans(2).metrics("numFiles").value === 1)
-          val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-          assert(plans(2).metrics("pruningTime").value === pruningTimeValue)
+          assert(plans(2).metrics("pruningTime").value === pruningTimeValueSpark)
           assert(plans(2).metrics("filesSize").value === 19230111)
 
           assert(plans(1).metrics("numOutputRows").value === 4)
           assert(plans(1).metrics("outputVectors").value === 1)
 
           // Execute Sort operator, it will read the data twice.
-          assert(plans(0).metrics("numOutputRows").value === 4)
-          assert(plans(0).metrics("outputVectors").value === 1)
+          assert(plans.head.metrics("numOutputRows").value === 4)
+          assert(plans.head.metrics("outputVectors").value === 1)
       }
     }
   }
@@ -167,7 +165,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         )
 
       assert(nativeMetricsList.size == 1)
-      val nativeMetricsData = nativeMetricsList(0)
+      val nativeMetricsData = nativeMetricsList.head
       assert(nativeMetricsData.metricsDataList.size() == 3)
 
       assert(nativeMetricsData.metricsDataList.get(0).getName.equals("kRead"))
@@ -289,7 +287,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
             assert(joinPlan.metrics("inputBytes").value == 1920000)
         }
 
-        val wholeStageTransformer2 = allWholeStageTransformers(0)
+        val wholeStageTransformer2 = allWholeStageTransformers.head
 
         GlutenClickHouseMetricsUTUtils.executeMetricsUpdater(
           wholeStageTransformer2,
@@ -327,7 +325,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         )
 
       assert(nativeMetricsList.size == 1)
-      val nativeMetricsData = nativeMetricsList(0)
+      val nativeMetricsData = nativeMetricsList.head
       assert(nativeMetricsData.metricsDataList.size() == 5)
 
       assert(nativeMetricsData.metricsDataList.get(0).getName.equals("kRead"))
@@ -401,7 +399,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         )
 
       assert(nativeMetricsListFinal.size == 1)
-      val nativeMetricsDataFinal = nativeMetricsListFinal(0)
+      val nativeMetricsDataFinal = nativeMetricsListFinal.head
       assert(nativeMetricsDataFinal.metricsDataList.size() == 3)
 
       assert(nativeMetricsDataFinal.metricsDataList.get(0).getName.equals("kRead"))

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -71,15 +71,16 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         assert(plans.size == 3)
 
         assert(plans(2).metrics("numFiles").value === 1)
-        assert(plans(2).metrics("pruningTime").value === -1)
+        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+        assert(plans(2).metrics("pruningTime").value === pruningTimeValue)
         assert(plans(2).metrics("filesSize").value === 19230111)
 
         assert(plans(1).metrics("numOutputRows").value === 4)
         assert(plans(1).metrics("outputVectors").value === 1)
 
         // Execute Sort operator, it will read the data twice.
-        assert(plans(0).metrics("numOutputRows").value === 4)
-        assert(plans(0).metrics("outputVectors").value === 1)
+        assert(plans.head.metrics("numOutputRows").value === 4)
+        assert(plans.head.metrics("outputVectors").value === 1)
     }
   }
 
@@ -139,7 +140,8 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
           assert(plans.size == 3)
 
           assert(plans(2).metrics("numFiles").value === 1)
-          assert(plans(2).metrics("pruningTime").value === -1)
+          val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+          assert(plans(2).metrics("pruningTime").value === pruningTimeValue)
           assert(plans(2).metrics("filesSize").value === 19230111)
 
           assert(plans(1).metrics("numOutputRows").value === 4)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetAQESuite.scala
@@ -14,23 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpcds
+
+import org.apache.gluten.execution._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
-import org.apache.spark.sql.execution.{ColumnarSubqueryBroadcastExec, ReusedSubqueryExec}
+import org.apache.spark.sql.execution.ReusedSubqueryExec
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 
-class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
+class GlutenClickHouseTPCDSParquetAQESuite
   extends GlutenClickHouseTPCDSAbstractSuite
   with AdaptiveSparkPlanHelper {
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
-      .set("spark.io.compression.codec", "LZ4")
+      .set("spark.shuffle.manager", "sort")
+      .set("spark.io.compression.codec", "snappy")
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       // Currently, it can not support to read multiple partitioned file in one task.
@@ -42,13 +44,20 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
 
   executeTPCDSTest(true)
 
+  test("test 'select count(*)'") {
+    val result = runSql("""
+                          |select count(c_customer_sk) from customer
+                          |""".stripMargin) { _ => }
+    assertResult(100000L)(result.head.getLong(0))
+  }
+
   test("test reading from partitioned table") {
     val result = runSql("""
                           |select count(*)
                           |  from store_sales
                           |  where ss_quantity between 1 and 20
                           |""".stripMargin) { _ => }
-    assert(result(0).getLong(0) == 550458L)
+    assertResult(550458L)(result.head.getLong(0))
   }
 
   test("test reading from partitioned table with partition column filter") {
@@ -59,7 +68,7 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
         |  where ss_quantity between 1 and 20
         |  and ss_sold_date_sk = 2452635
         |""".stripMargin,
-      true,
+      compareResult = true,
       _ => {}
     )
   }
@@ -69,8 +78,8 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
                           |select avg(cs_item_sk), avg(cs_order_number)
                           |  from catalog_sales
                           |""".stripMargin) { _ => }
-    assert(result(0).getDouble(0) == 8998.463336886734)
-    assert(result(0).getDouble(1) == 80037.12727449503)
+    assertResult(8998.463336886734)(result.head.getDouble(0))
+    assertResult(80037.12727449503)(result.head.getDouble(1))
   }
 
   test("Gluten-1235: Fix missing reading from the broadcasted value when executing DPP") {
@@ -89,7 +98,7 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       testSql,
-      true,
+      compareResult = true,
       df => {
         val foundDynamicPruningExpr = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -100,11 +109,11 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
             .asInstanceOf[FileSourceScanExecTransformer]
             .partitionFilters
             .exists(_.isInstanceOf[DynamicPruningExpression]))
-        assert(
+        assertResult(1823)(
           foundDynamicPruningExpr(1)
             .asInstanceOf[FileSourceScanExecTransformer]
             .selectedPartitions
-            .size == 1823)
+            .length)
       }
     )
   }
@@ -119,18 +128,7 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
         }
         // On Spark 3.2, there are 15 AdaptiveSparkPlanExec,
         // and on Spark 3.3, there are 5 AdaptiveSparkPlanExec and 10 ReusedSubqueryExec
-        assert(subqueryAdaptiveSparkPlan.filter(_ == true).size == 15)
-    }
-  }
-
-  test("GLUTEN-1848: Fix execute subquery repeatedly issue with ReusedSubquery") {
-    runTPCDSQuery("q5") {
-      df =>
-        val subqueriesId = collectWithSubqueries(df.queryExecution.executedPlan) {
-          case s: ColumnarSubqueryBroadcastExec => s.id
-          case r: ReusedSubqueryExec => r.child.id
-        }
-        assert(subqueriesId.distinct.size == 1)
+        assertResult(15)(subqueryAdaptiveSparkPlan.count(_ == true))
     }
   }
 
@@ -145,12 +143,12 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
               } =>
             f
         }
-        assert(foundDynamicPruningExpr.nonEmpty == true)
+        assert(foundDynamicPruningExpr.nonEmpty)
 
         val reusedExchangeExec = collectWithSubqueries(df.queryExecution.executedPlan) {
           case r: ReusedExchangeExec => r
         }
-        assert(reusedExchangeExec.nonEmpty == true)
+        assert(reusedExchangeExec.nonEmpty)
     }
   }
 
@@ -168,7 +166,7 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
                 } =>
               f
           }
-          assert(foundDynamicPruningExpr.nonEmpty == true)
+          assert(foundDynamicPruningExpr.nonEmpty)
 
           val reusedExchangeExec = collectWithSubqueries(df.queryExecution.executedPlan) {
             case r: ReusedExchangeExec => r
@@ -198,45 +196,6 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleAQESuite
         |ORDER BY channel
         | LIMIT 100 ;
         |""".stripMargin
-    compareResultsAgainstVanillaSpark(testSql, true, df => {})
-  }
-
-  test("GLUTEN-1620: fix 'attribute binding failed.' when executing hash agg with aqe") {
-    val sql =
-      """
-        |select
-        |cs_ship_mode_sk,
-        |   count(distinct cs_order_number) as `order count`
-        |  ,avg(cs_ext_ship_cost) as `avg shipping cost`
-        |  ,sum(cs_ext_ship_cost) as `total shipping cost`
-        |  ,sum(cs_net_profit) as `total net profit`
-        |from
-        |   catalog_sales cs1
-        |  ,date_dim
-        |  ,customer_address
-        |  ,call_center
-        |where
-        |    d_date between '1999-5-01' and
-        |           (cast('1999-5-01' as date) + interval '60' day)
-        |and cs1.cs_ship_date_sk = d_date_sk
-        |and cs1.cs_ship_addr_sk = ca_address_sk
-        |and ca_state = 'OH'
-        |and cs1.cs_call_center_sk = cc_call_center_sk
-        |and cc_county in ('Ziebach County','Williamson County','Walker County','Williamson County',
-        |                  'Ziebach County'
-        |)
-        |and exists (select *
-        |            from catalog_sales cs2
-        |            where cs1.cs_order_number = cs2.cs_order_number
-        |              and cs1.cs_warehouse_sk <> cs2.cs_warehouse_sk)
-        |and not exists(select *
-        |               from catalog_returns cr1
-        |               where cs1.cs_order_number = cr1.cr_order_number)
-        |group by cs_ship_mode_sk
-        |order by cs_ship_mode_sk, count(distinct cs_order_number)
-        | LIMIT 100 ;
-        |""".stripMargin
-    // There are some BroadcastHashJoin with NOT condition
-    compareResultsAgainstVanillaSpark(sql, true, { df => }, false)
+    compareResultsAgainstVanillaSpark(testSql, compareResult = true, df => {})
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetGraceHashJoinSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetGraceHashJoinSuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpcds
+
+import org.apache.gluten.execution._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
@@ -34,7 +36,7 @@ class GlutenClickHouseTPCDSParquetGraceHashJoinSuite extends GlutenClickHouseTPC
       .set("spark.gluten.sql.columnar.backend.ch.runtime_settings.max_bytes_in_join", "314572800")
   }
 
-  executeTPCDSTest(false);
+  executeTPCDSTest(false)
 
   test("Gluten-1235: Fix missing reading from the broadcasted value when executing DPP") {
     val testSql =
@@ -52,7 +54,7 @@ class GlutenClickHouseTPCDSParquetGraceHashJoinSuite extends GlutenClickHouseTPC
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       testSql,
-      true,
+      compareResult = true,
       df => {
         val foundDynamicPruningExpr = df.queryExecution.executedPlan.collect {
           case f: FileSourceScanExecTransformer => f
@@ -63,11 +65,11 @@ class GlutenClickHouseTPCDSParquetGraceHashJoinSuite extends GlutenClickHouseTPC
             .asInstanceOf[FileSourceScanExecTransformer]
             .partitionFilters
             .exists(_.isInstanceOf[DynamicPruningExpression]))
-        assert(
+        assertResult(1823)(
           foundDynamicPruningExpr(1)
             .asInstanceOf[FileSourceScanExecTransformer]
             .selectedPartitions
-            .size == 1823)
+            .length)
       }
     )
   }
@@ -86,7 +88,7 @@ class GlutenClickHouseTPCDSParquetGraceHashJoinSuite extends GlutenClickHouseTPC
               }
             case _ => false
           }
-          assert(foundDynamicPruningExpr.nonEmpty == true)
+          assert(foundDynamicPruningExpr.nonEmpty)
 
           val reuseExchange = df.queryExecution.executedPlan.find {
             case r: ReusedExchangeExec => true

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetRFSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetRFSuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpcds
+
+import org.apache.gluten.execution.GlutenClickHouseTPCDSAbstractSuite
 
 import org.apache.spark.SparkConf
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetSortMergeJoinSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetSortMergeJoinSuite.scala
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpcds
 
+import org.apache.gluten.execution.{CHSortMergeJoinExecTransformer, GlutenClickHouseTPCDSAbstractSuite}
 import org.apache.gluten.test.FallbackUtil
 
 import org.apache.spark.SparkConf
@@ -64,7 +65,7 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
           |i.i_current_price > 1.0 """.stripMargin
       compareResultsAgainstVanillaSpark(
         testSql,
-        true,
+        compareResult = true,
         df => {
           val smjTransformers = df.queryExecution.executedPlan.collect {
             case f: CHSortMergeJoinExecTransformer => f
@@ -83,7 +84,7 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
         """.stripMargin
       compareResultsAgainstVanillaSpark(
         testSql,
-        true,
+        compareResult = true,
         df => {
           val smjTransformers = df.queryExecution.executedPlan.collect {
             case f: CHSortMergeJoinExecTransformer => f
@@ -102,7 +103,7 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
         """.stripMargin
       compareResultsAgainstVanillaSpark(
         testSql,
-        true,
+        compareResult = true,
         df => {
           val smjTransformers = df.queryExecution.executedPlan.collect {
             case f: CHSortMergeJoinExecTransformer => f
@@ -124,7 +125,7 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
       val smjTransformers = df.queryExecution.executedPlan.collect {
         case f: CHSortMergeJoinExecTransformer => f
       }
-      assert(smjTransformers.size == 0)
+      assert(smjTransformers.isEmpty)
       assert(FallbackUtil.hasFallback(df.queryExecution.executedPlan))
     }
   }
@@ -140,18 +141,18 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
       val smjTransformers = df.queryExecution.executedPlan.collect {
         case f: CHSortMergeJoinExecTransformer => f
       }
-      assert(smjTransformers.size == 0)
+      assert(smjTransformers.isEmpty)
       assert(FallbackUtil.hasFallback(df.queryExecution.executedPlan))
     }
   }
 
-  val createItem =
+  val createItem: String =
     """CREATE TABLE myitem (
       |  i_current_price DECIMAL(7,2),
       |  i_category STRING)
       |USING parquet""".stripMargin
 
-  val insertItem =
+  val insertItem: String =
     """insert into myitem values
       |(null,null),
       |(null,null),
@@ -174,7 +175,7 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
           """.stripMargin
         compareResultsAgainstVanillaSpark(
           testSql,
-          true,
+          compareResult = true,
           df => {
             val smjTransformers = df.queryExecution.executedPlan.collect {
               case f: CHSortMergeJoinExecTransformer => f
@@ -206,7 +207,7 @@ class GlutenClickHouseTPCDSParquetSortMergeJoinSuite extends GlutenClickHouseTPC
         spark.sql(testSql).show()
         compareResultsAgainstVanillaSpark(
           testSql,
-          true,
+          compareResult = true,
           df => {
             val smjTransformers = df.queryExecution.executedPlan.collect {
               case f: CHSortMergeJoinExecTransformer => f

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseDatetimeExpressionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseDatetimeExpressionSuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpch
+
+import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -66,8 +66,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         assert(plans.size == 5)
 
         assert(plans(4).metrics("numFiles").value === 1)
-        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-        assert(plans(4).metrics("pruningTime").value === pruningTimeValue)
+        assert(plans(4).metrics("pruningTime").value === pruningTimeValueSpark)
         assert(plans(4).metrics("filesSize").value === 19230111)
         assert(plans(4).metrics("numOutputRows").value === 600572)
 
@@ -99,8 +98,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           assert(plans.size == 3)
 
           assert(plans(2).metrics("numFiles").value === 1)
-          val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-          assert(plans(2).metrics("pruningTime").value === pruningTimeValue)
+          assert(plans(2).metrics("pruningTime").value === pruningTimeValueSpark)
           assert(plans(2).metrics("filesSize").value === 19230111)
 
           assert(plans(1).metrics("numInputRows").value === 591673)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpch
 
 import org.apache.gluten.GlutenConfig
+import org.apache.gluten.execution._
 import org.apache.gluten.extension.GlutenPlan
 
 import org.apache.spark.SparkConf
@@ -65,7 +66,8 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         assert(plans.size == 5)
 
         assert(plans(4).metrics("numFiles").value === 1)
-        assert(plans(4).metrics("pruningTime").value === -1)
+        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+        assert(plans(4).metrics("pruningTime").value === pruningTimeValue)
         assert(plans(4).metrics("filesSize").value === 19230111)
         assert(plans(4).metrics("numOutputRows").value === 600572)
 
@@ -80,8 +82,8 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         assert(plans(1).metrics("numOutputRows").value === 8)
         assert(plans(1).metrics("outputVectors").value === 2)
 
-        assert(plans(0).metrics("numInputRows").value === 4)
-        assert(plans(0).metrics("numOutputRows").value === 4)
+        assert(plans.head.metrics("numInputRows").value === 4)
+        assert(plans.head.metrics("numOutputRows").value === 4)
     }
   }
 
@@ -97,7 +99,8 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           assert(plans.size == 3)
 
           assert(plans(2).metrics("numFiles").value === 1)
-          assert(plans(2).metrics("pruningTime").value === -1)
+          val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+          assert(plans(2).metrics("pruningTime").value === pruningTimeValue)
           assert(plans(2).metrics("filesSize").value === 19230111)
 
           assert(plans(1).metrics("numInputRows").value === 591673)
@@ -105,8 +108,8 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           assert(plans(1).metrics("outputVectors").value === 1)
 
           // Execute Sort operator, it will read the data twice.
-          assert(plans(0).metrics("numOutputRows").value === 8)
-          assert(plans(0).metrics("outputVectors").value === 2)
+          assert(plans.head.metrics("numOutputRows").value === 8)
+          assert(plans.head.metrics("outputVectors").value === 2)
       }
     }
   }
@@ -147,8 +150,8 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           assert(inputIteratorTransformers(1).metrics("numInputRows").value === 3111)
           assert(inputIteratorTransformers(1).metrics("numOutputRows").value === 3111)
 
-          assert(inputIteratorTransformers(0).metrics("numInputRows").value === 15224)
-          assert(inputIteratorTransformers(0).metrics("numOutputRows").value === 15224)
+          assert(inputIteratorTransformers.head.metrics("numInputRows").value === 15224)
+          assert(inputIteratorTransformers.head.metrics("numOutputRows").value === 15224)
       }
     }
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQEConcurrentSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQEConcurrentSuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpch
+
+import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQESuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpch
+
+import org.apache.gluten.execution._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
@@ -345,9 +347,7 @@ class GlutenClickHouseTPCHParquetAQESuite
            |order by t1.l_orderkey, t2.o_orderkey, t2.o_year, t1.l_cnt, t2.o_cnt
            |limit 100
            |
-           |""".stripMargin,
-        true,
-        true
+           |""".stripMargin
       )(df => {})
 
       runQueryAndCompare(
@@ -366,10 +366,7 @@ class GlutenClickHouseTPCHParquetAQESuite
            |order by t1.l_orderkey, t2.o_orderkey, t2.o_year
            |limit 100
            |
-           |""".stripMargin,
-        true,
-        true
-      )(df => {})
+           |""".stripMargin)(df => {})
     }
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -263,8 +263,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         }
         assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         assert(plans.head.metrics("numFiles").value === 4)
-        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValueSpark)
         assert(plans.head.metrics("numOutputRows").value === 600572)
       }
     )
@@ -458,8 +457,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         }
         assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         assert(plans.head.metrics("numFiles").value === 4)
-        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
-        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValueSpark)
         assert(plans.head.metrics("numOutputRows").value === 600572)
       }
     )

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpch
+
+import org.apache.gluten.execution._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
@@ -259,10 +261,11 @@ class GlutenClickHouseTPCHParquetBucketSuite
         val plans = collect(df.queryExecution.executedPlan) {
           case scanExec: BasicScanExecTransformer => scanExec
         }
-        assert(!(plans(0).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
-        assert(plans(0).metrics("numFiles").value === 4)
-        assert(plans(0).metrics("pruningTime").value === -1)
-        assert(plans(0).metrics("numOutputRows").value === 600572)
+        assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
+        assert(plans.head.metrics("numFiles").value === 4)
+        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("numOutputRows").value === 600572)
       }
     )
   }
@@ -319,7 +322,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         }
 
         if (sparkVersion.equals("3.2")) {
-          assert(!(plans(11).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
+          assert(!plans(11).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         } else {
           assert(plans(11).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         }
@@ -359,14 +362,14 @@ class GlutenClickHouseTPCHParquetBucketSuite
             .isInstanceOf[InputIteratorTransformer])
 
         if (sparkVersion.equals("3.2")) {
-          assert(!(plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
+          assert(!plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         } else {
           assert(plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         }
         assert(plans(2).metrics("numFiles").value === 4)
         assert(plans(2).metrics("numOutputRows").value === 15000)
 
-        assert(!(plans(3).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
+        assert(!plans(3).asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
         assert(plans(3).metrics("numFiles").value === 4)
         assert(plans(3).metrics("numOutputRows").value === 150000)
       }
@@ -404,12 +407,12 @@ class GlutenClickHouseTPCHParquetBucketSuite
         }
         // bucket join
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
             .isInstanceOf[ProjectExecTransformer])
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
             .isInstanceOf[ProjectExecTransformer])
@@ -453,10 +456,11 @@ class GlutenClickHouseTPCHParquetBucketSuite
         val plans = collect(df.queryExecution.executedPlan) {
           case scanExec: BasicScanExecTransformer => scanExec
         }
-        assert(!(plans(0).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
-        assert(plans(0).metrics("numFiles").value === 4)
-        assert(plans(0).metrics("pruningTime").value === -1)
-        assert(plans(0).metrics("numOutputRows").value === 600572)
+        assert(!plans.head.asInstanceOf[FileSourceScanExecTransformer].bucketedScan)
+        assert(plans.head.metrics("numFiles").value === 4)
+        val pruningTimeValue = if (isSparkVersionGE("3.4")) 0 else -1
+        assert(plans.head.metrics("pruningTime").value === pruningTimeValue)
+        assert(plans.head.metrics("numOutputRows").value === 600572)
       }
     )
   }
@@ -472,12 +476,12 @@ class GlutenClickHouseTPCHParquetBucketSuite
         }
         // bucket join
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
             .isInstanceOf[FilterExecTransformerBase])
         assert(
-          plans(0)
+          plans.head
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
             .isInstanceOf[ProjectExecTransformer])
@@ -654,7 +658,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL,
-      true,
+      compareResult = true,
       df => {}
     )
   }
@@ -675,7 +679,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL,
-      true,
+      compareResult = true,
       df => { checkHashAggregateCount(df, 1) }
     )
 
@@ -690,7 +694,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL1,
-      true,
+      compareResult = true,
       df => { checkHashAggregateCount(df, 1) }
     )
 
@@ -702,7 +706,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL2,
-      true,
+      compareResult = true,
       df => { checkHashAggregateCount(df, 1) }
     )
 
@@ -716,7 +720,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL3,
-      true,
+      compareResult = true,
       df => { checkHashAggregateCount(df, 2) }
     )
 
@@ -731,7 +735,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL4,
-      true,
+      compareResult = true,
       df => { checkHashAggregateCount(df, 4) }
     )
 
@@ -745,7 +749,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL5,
-      true,
+      compareResult = true,
       df => { checkHashAggregateCount(df, 4) }
     )
 
@@ -755,7 +759,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL6,
-      true,
+      compareResult = true,
       df => {
         // there is a shuffle between two phase hash aggregate.
         checkHashAggregateCount(df, 2)
@@ -773,7 +777,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
         |""".stripMargin
     compareResultsAgainstVanillaSpark(
       SQL7,
-      true,
+      compareResult = true,
       df => {
         checkHashAggregateCount(df, 1)
       }
@@ -790,7 +794,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
           |""".stripMargin
       compareResultsAgainstVanillaSpark(
         SQL,
-        true,
+        compareResult = true,
         df => {
           checkHashAggregateCount(df, 0)
           val plans = collect(df.queryExecution.executedPlan) { case agg: SortAggregateExec => agg }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetRFSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetRFSuite.scala
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.gluten.execution.tpch
+
+import org.apache.gluten.execution._
 
 import org.apache.spark.SparkConf
 
@@ -60,7 +62,10 @@ class GlutenClickHouseTPCHParquetRFSuite extends GlutenClickHouseTPCHSaltNullPar
             }
             assert(filterExecs.size == 4)
             assert(
-              filterExecs(0).asInstanceOf[FilterExecTransformer].toString.contains("might_contain"))
+              filterExecs.head
+                .asInstanceOf[FilterExecTransformer]
+                .toString
+                .contains("might_contain"))
           }
         }
       )

--- a/backends-clickhouse/src/test/scala/org/apache/spark/gluten/NativeWriteChecker.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/gluten/NativeWriteChecker.scala
@@ -40,7 +40,7 @@ trait NativeWriteChecker
       override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
         if (!nativeUsed) {
           val executedPlan = stripAQEPlan(qe.executedPlan)
-          nativeUsed = if (isSparkVersionGE("3.4")) {
+          nativeUsed = if (isSparkVersionGE("3.5")) {
             executedPlan.find(_.isInstanceOf[ColumnarWriteFilesExec]).isDefined
           } else {
             executedPlan.find(_.isInstanceOf[FakeRowAdaptor]).isDefined


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move tpch/tpcds parquet test to tpch/tpcds package, so that we can run these tests in spark-3.5 ut

(Fixes: \#6067)

## How was this patch tested?

Using Existed UTs
