### PR TITLE
[GLUTEN-6632] Bump Celeborn 0.4.2 and 0.5.1

### DIFF
--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -533,7 +533,7 @@ jobs:
       fail-fast: false
       matrix:
         spark: [ "spark-3.2" ]
-        celeborn: [ "celeborn-0.5.0", "celeborn-0.4.1", "celeborn-0.3.2-incubating" ]
+        celeborn: [ "celeborn-0.5.1", "celeborn-0.4.2", "celeborn-0.3.2-incubating" ]
     runs-on: ubuntu-20.04
     container: ubuntu:22.04
     steps:
@@ -564,9 +564,9 @@ jobs:
       - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.2 with ${{ matrix.celeborn }}
         run: |
           EXTRA_PROFILE=""
-          if [ "${{ matrix.celeborn }}" = "celeborn-0.4.1" ]; then
+          if [ "${{ matrix.celeborn }}" = "celeborn-0.4.2" ]; then
             EXTRA_PROFILE="-Pceleborn-0.4"
-          elif [ "${{ matrix.celeborn }}" = "celeborn-0.5.0" ]; then
+          elif [ "${{ matrix.celeborn }}" = "celeborn-0.5.1" ]; then
             EXTRA_PROFILE="-Pceleborn-0.5"
           fi
           echo "EXTRA_PROFILE: ${EXTRA_PROFILE}"

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -629,7 +629,7 @@ public read-only account：gluten/hN2xX3uQ4m
 
 ### Celeborn support
 
-Gluten with clickhouse backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x`, `0.4.x` and `0.5.0`.
+Gluten with clickhouse backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x`, `0.4.x` and `0.5.x`.
 
 Below introduction is used to enable this feature.
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -215,7 +215,7 @@ Currently there are several ways to asscess S3 in Spark. Please refer [Velox S3]
 
 ## Celeborn support
 
-Gluten with velox backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x`, `0.4.x` and `0.5.0`.
+Gluten with velox backend supports [Celeborn](https://github.com/apache/celeborn) as remote shuffle service. Currently, the supported Celeborn versions are `0.3.x`, `0.4.x` and `0.5.x`.
 
 Below introduction is used to enable this feature.
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <delta.package.name>delta-core</delta.package.name>
     <delta.version>2.4.0</delta.version>
     <delta.binary.version>24</delta.binary.version>
-    <celeborn.version>0.4.1</celeborn.version>
+    <celeborn.version>0.5.1</celeborn.version>
     <uniffle.version>0.8.0</uniffle.version>
     <arrow.version>15.0.0</arrow.version>
     <arrow-gluten.version>15.0.0-gluten</arrow-gluten.version>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -171,13 +171,13 @@
     <profile>
       <id>celeborn-0.4</id>
       <properties>
-        <celeborn.version>0.4.1</celeborn.version>
+        <celeborn.version>0.4.2</celeborn.version>
       </properties>
     </profile>
     <profile>
       <id>celeborn-0.5</id>
       <properties>
-        <celeborn.version>0.5.0</celeborn.version>
+        <celeborn.version>0.5.1</celeborn.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Celeborn 0.4.2 and 0.5.1 version have already been released, which release note refer to [Apache Celeborn™ 0.4.2 Release Notes](https://celeborn.apache.org/community/release_notes/release_note_0.4.2/) [Apache Celeborn™ 0.5.1 Release Notes](https://celeborn.apache.org/community/release_notes/release_note_0.5.1/) for more details. Therefore, celeborn module bumps 0.4.2 and 0.5.1 version.

Fixes: \#6632

## How was this patch tested?

CI.