### PR TITLE
[GLUTEN-6600][VL] Disable date type in window range frame support

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -350,7 +350,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
                         case ByteType | ShortType | IntegerType | LongType =>
                         case _ =>
                           throw new GlutenNotSupportException(
-                            "Only integral type & date type are" +
+                            "Only integral type is" +
                               " supported for sort key when literal bound type is used!")
                       })
                 case _ =>

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -347,7 +347,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
                   orderSpec.foreach(
                     order =>
                       order.dataType match {
-                        case ByteType | ShortType | IntegerType | LongType | DateType =>
+                        case ByteType | ShortType | IntegerType | LongType =>
                         case _ =>
                           throw new GlutenNotSupportException(
                             "Only integral type & date type are" +

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -304,7 +304,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
             "select max(l_partkey) over" +
               " (partition by l_suppkey order by l_commitdate" +
               " RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) from lineitem ") {
-            checkSparkOperatorMatch[WindowExecTransformer]
+            checkSparkOperatorMatch[WindowExec]
           }
 
           runQueryAndCompare(

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -302,6 +302,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
         withSQLConf("spark.gluten.sql.columnar.backend.velox.window.type" -> windowType) {
           runQueryAndCompare(
             "select max(l_partkey) over" +
+              " (partition by l_suppkey order by l_commitdate" +
+              " RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) from lineitem ") {
+            checkSparkOperatorMatch[WindowExecTransformer]
+          }
+
+          runQueryAndCompare(
+            "select max(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey" +
               " RANGE BETWEEN 1 PRECEDING AND CURRENT ROW), " +
               "min(l_comment) over" +

--- a/gluten-core/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala
@@ -178,8 +178,8 @@ trait PullOutProjectHelper {
   protected def supportPreComputeRangeFrame(sortOrders: Seq[SortOrder]): Boolean = {
     sortOrders.forall {
       _.dataType match {
-        case ByteType | ShortType | IntegerType | LongType | DateType => true
-        // Only integral type & date type are supported for sort key with Range Frame
+        case ByteType | ShortType | IntegerType | LongType => true
+        // Only integral type are supported for sort key with Range Frame.
         case _ => false
       }
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala
@@ -22,7 +22,7 @@ import org.apache.gluten.exception.{GlutenException, GlutenNotSupportException}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction}
 import org.apache.spark.sql.execution.aggregate._
-import org.apache.spark.sql.types.{ByteType, DateType, IntegerType, LongType, ShortType}
+import org.apache.spark.sql.types.{ByteType, IntegerType, LongType, ShortType}
 
 import java.util.concurrent.atomic.AtomicInteger
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To support range frames, we need to add a [pre-project](https://github.com/apache/incubator-gluten/blob/main/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/rewrite/PullOutPreProject.scala#L197) before the window to calculate the range frame's value. If the key in the order by clause is of date type, using [Add(orderSpec.child, bound)](https://github.com/apache/incubator-gluten/blob/main/gluten-core/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala#L167) will result in the column's attribute being Unresolved, because the data types on both sides of `Add` are inconsistent. We try to use `DateAdd `for date types here to perform the calculation, and the pre-project can work. However, the post-project will throw same error because we have rewritten the [frame ](https://github.com/apache/incubator-gluten/blob/main/gluten-core/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala#L214) in the Window to be of date type, but Spark's [frame type](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala#L155) does not support DateType. 


## How was this patch tested?

Adding new unit tests.


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

