### PR TITLE
[VL] Reduce spill in sort-based shuffle

### DIFF
--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -490,10 +490,9 @@ arrow::Status LocalPartitionWriter::stop(ShuffleWriterMetrics* metrics) {
       ARROW_ASSIGN_OR_RAISE(endInFinalFile, dataFileOs_->Tell());
       partitionLengths_[pid] = endInFinalFile - startInFinalFile;
     }
-    // Close Final file. Clear buffered resources.
-    RETURN_NOT_OK(clearResource());
   }
-
+  // Close Final file. Clear buffered resources.
+  RETURN_NOT_OK(clearResource());
   // Check all spills are merged.
   auto s = 0;
   for (const auto& spill : spills_) {

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -77,8 +77,6 @@ class LocalPartitionWriter::LocalSpiller {
     if (close) {
       RETURN_NOT_OK(os_->Close());
     }
-    //    std::cout << "Finish spill. spillTime_: " << spillTime_ << ", compressTime_: " << compressTime_
-    //              << ", spillFile: " << spillFile_ << std::endl;
     diskSpill_->setSpillFile(spillFile_);
     diskSpill_->setSpillTime(spillTime_);
     diskSpill_->setCompressTime(compressTime_);
@@ -453,8 +451,6 @@ arrow::Status LocalPartitionWriter::stop(ShuffleWriterMetrics* metrics) {
         RETURN_NOT_OK(mergeSpills(pid));
         partitionLengths_[pid] = totalBytesEvicted_ - bytesEvicted;
       }
-      //      std::cout << "Stop and merge spills from " << lastEvictPid_ + 1 << " to " << numPartitions_ - 1
-      //                << ", num spills: " << spills_.size() << std::endl;
     }
 
     for (auto pid = 0; pid < numPartitions_; ++pid) {
@@ -577,8 +573,6 @@ arrow::Status LocalPartitionWriter::evict(
           RETURN_NOT_OK(mergeSpills(pid));
           partitionLengths_[pid] = totalBytesEvicted_ - bytesEvicted;
         }
-        //        std::cout << "Merge spills from " << lastEvictPid_ + 1 << " to " << partitionId
-        //                  << ", num spills: " << spills_.size() << std::endl;
       }
       RETURN_NOT_OK(spiller_->spill(partitionId, std::move(payload)));
     }

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -83,7 +83,7 @@ class LocalPartitionWriter : public PartitionWriter {
 
   arrow::Status requestSpill(bool isFinal);
 
-  arrow::Status finishSpill();
+  arrow::Status finishSpill(bool close);
 
   std::string nextSpilledFileDir();
 
@@ -94,8 +94,6 @@ class LocalPartitionWriter : public PartitionWriter {
   arrow::Status clearResource();
 
   arrow::Status populateMetrics(ShuffleWriterMetrics* metrics);
-
-  bool useSpillFileAsDataFile();
 
   std::string dataFile_;
   std::vector<std::string> localDirs_;
@@ -113,10 +111,9 @@ class LocalPartitionWriter : public PartitionWriter {
   std::shared_ptr<arrow::io::OutputStream> dataFileOs_;
 
   int64_t totalBytesEvicted_{0};
-  int64_t totalBytesWritten_{0};
   std::vector<int64_t> partitionLengths_;
   std::vector<int64_t> rawPartitionLengths_;
 
-  uint32_t lastEvictPid_{0};
+  int32_t lastEvictPid_{-1};
 };
 } // namespace gluten

--- a/cpp/core/shuffle/Spill.cc
+++ b/cpp/core/shuffle/Spill.cc
@@ -86,7 +86,23 @@ void Spill::setSpillFile(const std::string& spillFile) {
   spillFile_ = spillFile;
 }
 
+void Spill::setSpillTime(int64_t spillTime) {
+  spillTime_ = spillTime;
+}
+
+void Spill::setCompressTime(int64_t compressTime) {
+  compressTime_ = compressTime;
+}
+
 std::string Spill::spillFile() const {
   return spillFile_;
+}
+
+int64_t Spill::spillTime() const {
+  return spillTime_;
+}
+
+int64_t Spill::compressTime() const {
+  return compressTime_;
 }
 } // namespace gluten

--- a/cpp/core/shuffle/Spill.h
+++ b/cpp/core/shuffle/Spill.h
@@ -52,7 +52,15 @@ class Spill final {
 
   void setSpillFile(const std::string& spillFile);
 
+  void setSpillTime(int64_t spillTime);
+
+  void setCompressTime(int64_t compressTime);
+
   std::string spillFile() const;
+
+  int64_t spillTime() const;
+
+  int64_t compressTime() const;
 
  private:
   struct PartitionPayload {
@@ -65,6 +73,8 @@ class Spill final {
   std::list<PartitionPayload> partitionPayloads_{};
   std::shared_ptr<arrow::io::MemoryMappedFile> inputStream_{};
   std::string spillFile_;
+  int64_t spillTime_;
+  int64_t compressTime_;
 
   arrow::io::InputStream* rawIs_;
 

--- a/cpp/velox/shuffle/VeloxSortShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxSortShuffleWriter.h
@@ -71,7 +71,7 @@ class VeloxSortShuffleWriter final : public VeloxShuffleWriter {
 
   void insertRows(facebook::velox::row::CompactRow& row, uint32_t offset, uint32_t rows);
 
-  arrow::Status maybeSpill(int32_t nextRows);
+  arrow::Status maybeSpill(uint32_t nextRows);
 
   arrow::Status evictAllPartitions();
 


### PR DESCRIPTION
TPCH SF3T 40000 shuffle partitions: 1794s -> 1612s (vs hash 2023s)

Before:

![image](https://github.com/user-attachments/assets/04cc34cf-9e34-400c-97c7-b591f4ff8205)

After:
![image](https://github.com/user-attachments/assets/f59d688b-a769-46cb-95eb-045983a1c7c2)
