### PR TITLE
[VL] Support date type in window range frame

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/TestOperator.scala
@@ -302,6 +302,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
         withSQLConf("spark.gluten.sql.columnar.backend.velox.window.type" -> windowType) {
           runQueryAndCompare(
             "select max(l_partkey) over" +
+              " (partition by l_suppkey order by l_commitdate" +
+              " RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) from lineitem ") {
+            checkSparkOperatorMatch[WindowExecTransformer]
+          }
+
+          runQueryAndCompare(
+            "select max(l_partkey) over" +
               " (partition by l_suppkey order by l_orderkey" +
               " RANGE BETWEEN 1 PRECEDING AND CURRENT ROW), " +
               "min(l_comment) over" +

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -275,6 +275,9 @@
                     <ignoreClass>org.apache.spark.sql.execution.columnar.ByteBufferHelper$</ignoreClass>
                     <!-- The overridden class list by Gluten. Carefully add entries to this list only when you knew exactly what is going to happen -->
                     <ignoreClass>org.apache.spark.rdd.EmptyRDD</ignoreClass>
+                    <ignoreClass>org.apache.spark.sql.types.TypeCollection</ignoreClass>
+                    <ignoreClass>org.apache.spark.sql.types.TypeCollection$</ignoreClass>
+                    <ignoreClass>org.apache.spark.sql.types.AbstractDataType</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.hive.execution.HiveFileFormat</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.hive.execution.HiveFileFormat$$$$anon$1</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.hive.execution.HiveOutputWriter</ignoreClass>

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types
+
+/** A non-concrete data type, reserved for internal uses. */
+abstract private[sql] class AbstractDataType {
+
+  /** The default concrete type to use if we want to cast a null literal into this type. */
+  private[sql] def defaultConcreteType: DataType
+
+  /**
+   * Returns true if `other` is an acceptable input type for a function that expects this, possibly
+   * abstract DataType.
+   *
+   * {{{
+   *   // this should return true
+   *   DecimalType.acceptsType(DecimalType(10, 2))
+   *
+   *   // this should return true as well
+   *   NumericType.acceptsType(DecimalType(10, 2))
+   * }}}
+   */
+  private[sql] def acceptsType(other: DataType): Boolean
+
+  /** Readable string representation for the type. */
+  private[sql] def simpleString: String
+}
+
+/**
+ * A collection of types that can be used to specify type constraints. The sequence also specifies
+ * precedence: an earlier type takes precedence over a latter type.
+ *
+ * {{{
+ *   TypeCollection(StringType, BinaryType)
+ * }}}
+ *
+ * This means that we prefer StringType over BinaryType if it is possible to cast to StringType.
+ */
+private[sql] class TypeCollection(private val types: Seq[AbstractDataType])
+  extends AbstractDataType {
+
+  require(types.nonEmpty, s"TypeCollection ($types) cannot be empty")
+
+  override private[sql] def defaultConcreteType: DataType = types.head.defaultConcreteType
+
+  override private[sql] def acceptsType(other: DataType): Boolean =
+    types.exists(_.acceptsType(other))
+
+  override private[sql] def simpleString: String = {
+    types.map(_.simpleString).mkString("(", " or ", ")")
+  }
+}
+
+private[sql] object TypeCollection {
+
+  /** Types that include numeric types and ANSI interval types. */
+  val NumericAndAnsiInterval =
+    TypeCollection(NumericType, DayTimeIntervalType, YearMonthIntervalType, DateType)
+
+  /**
+   * Types that include numeric and ANSI interval types, and additionally the legacy interval type.
+   * They are only used in unary_minus, unary_positive, add and subtract operations.
+   */
+  val NumericAndInterval = new TypeCollection(NumericAndAnsiInterval.types :+ CalendarIntervalType)
+
+  def apply(types: AbstractDataType*): TypeCollection = new TypeCollection(types)
+
+  def unapply(typ: AbstractDataType): Option[Seq[AbstractDataType]] = typ match {
+    case typ: TypeCollection => Some(typ.types)
+    case _ => None
+  }
+}

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types
+
+/** A non-concrete data type, reserved for internal uses. */
+abstract private[sql] class AbstractDataType {
+
+  /** The default concrete type to use if we want to cast a null literal into this type. */
+  private[sql] def defaultConcreteType: DataType
+
+  /**
+   * Returns true if `other` is an acceptable input type for a function that expects this, possibly
+   * abstract DataType.
+   *
+   * {{{
+   *   // this should return true
+   *   DecimalType.acceptsType(DecimalType(10, 2))
+   *
+   *   // this should return true as well
+   *   NumericType.acceptsType(DecimalType(10, 2))
+   * }}}
+   */
+  private[sql] def acceptsType(other: DataType): Boolean
+
+  /** Readable string representation for the type. */
+  private[sql] def simpleString: String
+}
+
+/**
+ * A collection of types that can be used to specify type constraints. The sequence also specifies
+ * precedence: an earlier type takes precedence over a latter type.
+ *
+ * {{{
+ *   TypeCollection(StringType, BinaryType)
+ * }}}
+ *
+ * This means that we prefer StringType over BinaryType if it is possible to cast to StringType.
+ */
+private[sql] class TypeCollection(private val types: Seq[AbstractDataType])
+  extends AbstractDataType {
+
+  require(types.nonEmpty, s"TypeCollection ($types) cannot be empty")
+
+  override private[sql] def defaultConcreteType: DataType = types.head.defaultConcreteType
+
+  override private[sql] def acceptsType(other: DataType): Boolean =
+    types.exists(_.acceptsType(other))
+
+  override private[sql] def simpleString: String = {
+    types.map(_.simpleString).mkString("(", " or ", ")")
+  }
+}
+
+private[sql] object TypeCollection {
+
+  /** Types that include numeric types and ANSI interval types. */
+  val NumericAndAnsiInterval =
+    TypeCollection(NumericType, DayTimeIntervalType, YearMonthIntervalType, DateType)
+
+  /**
+   * Types that include numeric and ANSI interval types, and additionally the legacy interval type.
+   * They are only used in unary_minus, unary_positive, add and subtract operations.
+   */
+  val NumericAndInterval = new TypeCollection(NumericAndAnsiInterval.types :+ CalendarIntervalType)
+
+  def apply(types: AbstractDataType*): TypeCollection = new TypeCollection(types)
+
+  def unapply(typ: AbstractDataType): Option[Seq[AbstractDataType]] = typ match {
+    case typ: TypeCollection => Some(typ.types)
+    case _ => None
+  }
+}

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types
+
+/** A non-concrete data type, reserved for internal uses. */
+abstract private[sql] class AbstractDataType {
+
+  /** The default concrete type to use if we want to cast a null literal into this type. */
+  private[sql] def defaultConcreteType: DataType
+
+  /**
+   * Returns true if `other` is an acceptable input type for a function that expects this, possibly
+   * abstract DataType.
+   *
+   * {{{
+   *   // this should return true
+   *   DecimalType.acceptsType(DecimalType(10, 2))
+   *
+   *   // this should return true as well
+   *   NumericType.acceptsType(DecimalType(10, 2))
+   * }}}
+   */
+  private[sql] def acceptsType(other: DataType): Boolean
+
+  /** Readable string representation for the type. */
+  private[sql] def simpleString: String
+}
+
+/**
+ * A collection of types that can be used to specify type constraints. The sequence also specifies
+ * precedence: an earlier type takes precedence over a latter type.
+ *
+ * {{{
+ *   TypeCollection(StringType, BinaryType)
+ * }}}
+ *
+ * This means that we prefer StringType over BinaryType if it is possible to cast to StringType.
+ */
+private[sql] class TypeCollection(private val types: Seq[AbstractDataType])
+  extends AbstractDataType {
+
+  require(types.nonEmpty, s"TypeCollection ($types) cannot be empty")
+
+  override private[sql] def defaultConcreteType: DataType = types.head.defaultConcreteType
+
+  override private[sql] def acceptsType(other: DataType): Boolean =
+    types.exists(_.acceptsType(other))
+
+  override private[sql] def simpleString: String = {
+    types.map(_.simpleString).mkString("(", " or ", ")")
+  }
+}
+
+private[sql] object TypeCollection {
+
+  /** Types that include numeric types and ANSI interval types. */
+  val NumericAndAnsiInterval =
+    TypeCollection(NumericType, DayTimeIntervalType, YearMonthIntervalType, DateType)
+
+  /**
+   * Types that include numeric and ANSI interval types, and additionally the legacy interval type.
+   * They are only used in unary_minus, unary_positive, add and subtract operations.
+   */
+  val NumericAndInterval = new TypeCollection(NumericAndAnsiInterval.types :+ CalendarIntervalType)
+
+  def apply(types: AbstractDataType*): TypeCollection = new TypeCollection(types)
+
+  def unapply(typ: AbstractDataType): Option[Seq[AbstractDataType]] = typ match {
+    case typ: TypeCollection => Some(typ.types)
+    case _ => None
+  }
+}

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types
+
+/** A non-concrete data type, reserved for internal uses. */
+abstract private[sql] class AbstractDataType {
+
+  /** The default concrete type to use if we want to cast a null literal into this type. */
+  private[sql] def defaultConcreteType: DataType
+
+  /**
+   * Returns true if `other` is an acceptable input type for a function that expects this, possibly
+   * abstract DataType.
+   *
+   * {{{
+   *   // this should return true
+   *   DecimalType.acceptsType(DecimalType(10, 2))
+   *
+   *   // this should return true as well
+   *   NumericType.acceptsType(DecimalType(10, 2))
+   * }}}
+   */
+  private[sql] def acceptsType(other: DataType): Boolean
+
+  /** Readable string representation for the type. */
+  private[sql] def simpleString: String
+}
+
+/**
+ * A collection of types that can be used to specify type constraints. The sequence also specifies
+ * precedence: an earlier type takes precedence over a latter type.
+ *
+ * {{{
+ *   TypeCollection(StringType, BinaryType)
+ * }}}
+ *
+ * This means that we prefer StringType over BinaryType if it is possible to cast to StringType.
+ */
+private[sql] class TypeCollection(private val types: Seq[AbstractDataType])
+  extends AbstractDataType {
+
+  require(types.nonEmpty, s"TypeCollection ($types) cannot be empty")
+
+  override private[sql] def defaultConcreteType: DataType = types.head.defaultConcreteType
+
+  override private[sql] def acceptsType(other: DataType): Boolean =
+    types.exists(_.acceptsType(other))
+
+  override private[sql] def simpleString: String = {
+    types.map(_.simpleString).mkString("(", " or ", ")")
+  }
+}
+
+private[sql] object TypeCollection {
+
+  /** Types that include numeric types and ANSI interval types. */
+  val NumericAndAnsiInterval =
+    TypeCollection(NumericType, DayTimeIntervalType, YearMonthIntervalType, DateType)
+
+  /**
+   * Types that include numeric and ANSI interval types, and additionally the legacy interval type.
+   * They are only used in unary_minus, unary_positive, add and subtract operations.
+   */
+  val NumericAndInterval = new TypeCollection(NumericAndAnsiInterval.types :+ CalendarIntervalType)
+
+  def apply(types: AbstractDataType*): TypeCollection = new TypeCollection(types)
+
+  def unapply(typ: AbstractDataType): Option[Seq[AbstractDataType]] = typ match {
+    case typ: TypeCollection => Some(typ.types)
+    case _ => None
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow up https://github.com/apache/incubator-gluten/pull/6637. In order to enable support for the date type within the window range frame, it is necessary to incorporate the date type into the Spark codebase, specifically within the AbstractDataType.scala file located at [here](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala#L82). To achieve this, we have added the AbstractDataType file to the shim folder. 

## How was this patch tested?

Adding new tests.

