### PR TITLE
[GLUTEN-6650] Remove bloomfilter from partition filter

### DIFF
--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
+import org.apache.spark.sql.internal.SQLConf
 
 class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
 
@@ -135,4 +136,41 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       purge = false)
   }
 
+  testGluten("test bloom filter join on partition column") {
+    val tables = Seq("test_tbl1", "test_tbl2")
+    tables.foreach {
+      t =>
+        sql(s"DROP TABLE IF EXISTS $t")
+        sql(
+          s"CREATE TABLE $t (a int) partitioned by (date STRING) " +
+            s"stored as parquet")
+    }
+
+    withSQLConf(
+      SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
+      SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1"
+    ) {
+      sql(
+        "INSERT OVERWRITE TABLE test_tbl1 partition (date='20240101') " +
+          "select id from range(10)");
+      sql(
+        "INSERT OVERWRITE TABLE test_tbl2 partition (date='20240101') " +
+          "select id from range(5, 10)");
+
+      val df = spark.sql(
+        "select count(1) from test_tbl1 join test_tbl2 " +
+          "on test_tbl1.date = test_tbl2.date where test_tbl2.a > 7")
+      checkAnswer(df, Seq(Row(20)))
+    }
+
+    tables.foreach {
+      t =>
+        spark.sessionState.catalog.dropTable(
+          TableIdentifier(t),
+          ignoreIfNotExists = true,
+          purge = false)
+    }
+  }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -20,6 +20,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
+import org.apache.spark.sql.internal.SQLConf
 
 class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
 
@@ -48,4 +49,41 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       purge = false)
   }
 
+  testGluten("test bloom filter join on partition column") {
+    val tables = Seq("test_tbl1", "test_tbl2")
+    tables.foreach {
+      t =>
+        sql(s"DROP TABLE IF EXISTS $t")
+        sql(
+          s"CREATE TABLE $t (a int) partitioned by (date STRING) " +
+            s"stored as parquet")
+    }
+
+    withSQLConf(
+      SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
+      SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1"
+    ) {
+      sql(
+        "INSERT OVERWRITE TABLE test_tbl1 partition (date='20240101') " +
+          "select id from range(10)");
+      sql(
+        "INSERT OVERWRITE TABLE test_tbl2 partition (date='20240101') " +
+          "select id from range(5, 10)");
+
+      val df = spark.sql(
+        "select count(1) from test_tbl1 join test_tbl2 " +
+          "on test_tbl1.date = test_tbl2.date where test_tbl2.a > 7")
+      checkAnswer(df, Seq(Row(20)))
+    }
+
+    tables.foreach {
+      t =>
+        spark.sessionState.catalog.dropTable(
+          TableIdentifier(t),
+          ignoreIfNotExists = true,
+          purge = false)
+    }
+  }
 }

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, DynamicPruningExpression, Expression, FileSourceConstantMetadataAttribute, FileSourceGeneratedMetadataAttribute, FileSourceMetadataAttribute, PlanExpression, Predicate}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BloomFilterMightContain, BoundReference, DynamicPruningExpression, Expression, FileSourceConstantMetadataAttribute, FileSourceGeneratedMetadataAttribute, FileSourceMetadataAttribute, PlanExpression, Predicate}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetUtils}
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -80,6 +80,13 @@ abstract class FileSourceScanExecShim(
   private def isDynamicPruningFilter(e: Expression): Boolean =
     e.find(_.isInstanceOf[PlanExpression[_]]).isDefined
 
+  private def isBloomFilterMightContain(e: Expression): Boolean =
+    e.find(
+      expr =>
+        expr.isInstanceOf[BloomFilterMightContain] ||
+          expr.prettyName == "velox_might_contain")
+      .isDefined
+
   protected def setFilesNumAndSizeMetric(
       partitions: Seq[PartitionDirectory],
       static: Boolean): Unit = {
@@ -99,7 +106,9 @@ abstract class FileSourceScanExecShim(
 
   @transient override lazy val dynamicallySelectedPartitions: Array[PartitionDirectory] = {
     val dynamicPartitionFilters =
-      partitionFilters.filter(isDynamicPruningFilter)
+      partitionFilters
+        .filter(isDynamicPruningFilter)
+        .filterNot(isBloomFilterMightContain)
     val selected = if (dynamicPartitionFilters.nonEmpty) {
       GlutenTimeMetric.withMillisTime {
         // call the file index for the files matching all filters except dynamic partition filters


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `BloomFilterMightContains` is pushed down to partition filter, it's executed in Spark driver using codegen. But since the bloom filter contructed by native are different with Spark, a NPE will throw in this case

(Fixes: \#6650)

## How was this patch tested?
UT


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

