### PR TITLE
[GLUTEN-6656][CELEBORN] Fix CelebornColumnarShuffleWriter assertion failed

### DIFF
--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriter.scala
@@ -71,7 +71,12 @@ class CHCelebornColumnarShuffleWriter[K, V](
       }
     }
 
-    assert(nativeShuffleWriter != -1L)
+    // If all of the ColumnarBatch have empty rows, the nativeShuffleWriter still equals -1
+    if (nativeShuffleWriter == -1L) {
+      handleEmptyIterator()
+      return
+    }
+
     splitResult = jniWrapper.stop(nativeShuffleWriter)
 
     dep.metrics("splitTime").add(splitResult.getSplitTime)

--- a/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornColumnarShuffleWriter.scala
@@ -111,9 +111,7 @@ abstract class CelebornColumnarShuffleWriter[K, V](
   @throws[IOException]
   final override def write(records: Iterator[Product2[K, V]]): Unit = {
     if (!records.hasNext) {
-      partitionLengths = new Array[Long](dep.partitioner.numPartitions)
-      client.mapperEnd(shuffleId, mapId, context.attemptNumber, numMappers)
-      mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
+      handleEmptyIterator()
       return
     }
     internalWrite(records)
@@ -160,5 +158,11 @@ abstract class CelebornColumnarShuffleWriter[K, V](
     client.pushMergedData(shuffleId, mapId, context.attemptNumber)
     client.mapperEnd(shuffleId, mapId, context.attemptNumber, numMappers)
     writeMetrics.incWriteTime(System.nanoTime - pushMergedDataTime)
+  }
+
+  def handleEmptyIterator(): Unit = {
+    partitionLengths = new Array[Long](dep.partitioner.numPartitions)
+    client.mapperEnd(shuffleId, mapId, context.attemptNumber, numMappers)
+    mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
   }
 }

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -82,7 +82,12 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
       }
     }
 
-    assert(nativeShuffleWriter != -1L)
+    // If all of the ColumnarBatch have empty rows, the nativeShuffleWriter still equals -1
+    if (nativeShuffleWriter == -1L) {
+      handleEmptyIterator()
+      return
+    }
+
     val startTime = System.nanoTime()
     splitResult = jniWrapper.stop(nativeShuffleWriter)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After https://github.com/apache/incubator-gluten/pull/6432, if all of the ColumnarBatch have empty rows in `CHCelebornColumnarShuffleWriter`, the `nativeShuffleWriter` won't be initialized and causes `assertion failed`. The `VeloxCelebornColumnarShuffleWriter ` also has the same issue even without https://github.com/apache/incubator-gluten/pull/6432.

(Fixes: \#6656)

## How was this patch tested?

PASS CI

