### PR TITLE
[CORE] Propagate SQLConf to code block of TaskResources.runUnsafe

### DIFF
--- a/backends-velox/src/test/java/org/apache/gluten/test/VeloxBackendTestBase.java
+++ b/backends-velox/src/test/java/org/apache/gluten/test/VeloxBackendTestBase.java
@@ -53,7 +53,7 @@ public abstract class VeloxBackendTestBase {
       @Override
       public SparkConf conf() {
         final SparkConf conf = new SparkConf();
-        conf.set(GlutenConfig.GLUTEN_NUM_TASK_SLOTS_PER_EXECUTOR_KEY(), "0");
+        conf.set(GlutenConfig.COLUMNAR_VELOX_CONNECTOR_IO_THREADS().key(), "0");
         return conf;
       }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/planner/plan/GlutenPlanModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/planner/plan/GlutenPlanModel.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.{ColumnarToRowExec, LeafExecNode, SparkPlan}
 import org.apache.spark.util.{SparkTaskUtil, TaskResources}
 
-import java.util.Objects
+import java.util.{Objects, Properties}
 
 object GlutenPlanModel {
   def apply(): PlanModel[SparkPlan] = {
@@ -71,7 +71,7 @@ object GlutenPlanModel {
   }
 
   private object PlanModelImpl extends PlanModel[SparkPlan] {
-    private val fakeTc = SparkShimLoader.getSparkShims.createTestTaskContext()
+    private val fakeTc = SparkShimLoader.getSparkShims.createTestTaskContext(new Properties())
     private def fakeTc[T](body: => T): T = {
       assert(!TaskResources.inSparkTask())
       SparkTaskUtil.setTaskContext(fakeTc)

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkTaskUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkTaskUtil.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.util
 
 import org.apache.spark.TaskContext
+import org.apache.spark.memory.TaskMemoryManager
 
 object SparkTaskUtil {
   def setTaskContext(taskContext: TaskContext): Unit = {
@@ -25,5 +26,9 @@ object SparkTaskUtil {
 
   def unsetTaskContext(): Unit = {
     TaskContext.unset()
+  }
+
+  def getTaskMemoryManager(taskContext: TaskContext): TaskMemoryManager = {
+    taskContext.taskMemoryManager()
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -61,6 +61,7 @@ object TaskResources extends TaskListener with Logging {
     SQLConf.get.getAllConfs.foreach {
       case (key, value) if key.startsWith("spark") =>
         properties.put(key, value)
+      case _ =>
     }
     properties.setIfMissing("spark.memory.offHeap.enabled", "true")
     properties.setIfMissing("spark.memory.offHeap.size", "1TB")

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -44,6 +44,14 @@ object TaskResources extends TaskListener with Logging {
     SparkShimLoader.getSparkShims.createTestTaskContext(properties)
   }
 
+  implicit private class PropertiesOps(properties: Properties) {
+    def setIfMissing(key: String, value: String): Unit = {
+      if (!properties.containsKey(key)) {
+        properties.setProperty(key, value)
+      }
+    }
+  }
+
   private def setUnsafeTaskContext(): Unit = {
     if (inSparkTask()) {
       throw new UnsupportedOperationException(
@@ -54,6 +62,8 @@ object TaskResources extends TaskListener with Logging {
       case (key, value) if key.startsWith("spark") =>
         properties.put(key, value)
     }
+    properties.setIfMissing("spark.memory.offHeap.enabled", "true")
+    properties.setIfMissing("spark.memory.offHeap.size", "1TB")
     TaskContext.setTaskContext(newUnsafeTaskContext(properties))
   }
 

--- a/gluten-data/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
@@ -100,7 +100,6 @@ public class ColumnarBatches {
         newVectors[i] = from.column(i);
       }
       FIELD_COLUMNS.set(target, newVectors);
-      System.out.println();
     } catch (IllegalAccessException e) {
       throw new GlutenException(e);
     }

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -50,7 +50,7 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.schema.MessageType
 
-import java.util.{ArrayList => JArrayList, Map => JMap}
+import java.util.{Map => JMap, Properties}
 
 import scala.reflect.ClassTag
 
@@ -156,7 +156,7 @@ trait SparkShims {
 
   def enableNativeWriteFilesByDefault(): Boolean = false
 
-  def createTestTaskContext(): TaskContext
+  def createTestTaskContext(properties: Properties): TaskContext
 
   def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
     // Since Spark 3.4, the `sc.broadcast` has been optimized to use `sc.broadcastInternal`.

--- a/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
@@ -53,7 +53,7 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.schema.MessageType
 
-import java.util.{HashMap => JHashMap, Map => JMap}
+import java.util.{HashMap => JHashMap, Map => JMap, Properties}
 
 class Spark32Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
@@ -156,8 +156,8 @@ class Spark32Shims extends SparkShims {
     List(session => GlutenParquetWriterInjects.getInstance().getExtendedColumnarPostRule(session))
   }
 
-  override def createTestTaskContext(): TaskContext = {
-    TaskContextUtils.createTestTaskContext()
+  override def createTestTaskContext(properties: Properties): TaskContext = {
+    TaskContextUtils.createTestTaskContext(properties)
   }
 
   def setJobDescriptionOrTagForBroadcastExchange(

--- a/shims/spark32/src/main/scala/org/apache/spark/TaskContextUtils.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/TaskContextUtils.scala
@@ -19,17 +19,16 @@ package org.apache.spark
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.network.util.ByteUnit
 
 import java.util.Properties
 
+import scala.collection.JavaConverters._
+
 object TaskContextUtils {
-  def createTestTaskContext(): TaskContext = {
+  def createTestTaskContext(properties: Properties): TaskContext = {
     val conf = new SparkConf()
-    conf.set("spark.memory.offHeap.enabled", "true")
-    conf.set("spark.memory.offHeap.size", "1TB")
-    val memoryManager =
-      new UnifiedMemoryManager(conf, ByteUnit.TiB.toBytes(2), ByteUnit.TiB.toBytes(1), 1)
+    conf.setAll(properties.asScala)
+    val memoryManager = UnifiedMemoryManager(conf, 1)
     new TaskContextImpl(
       -1,
       -1,
@@ -37,7 +36,7 @@ object TaskContextUtils {
       -1L,
       -1,
       new TaskMemoryManager(memoryManager, -1L),
-      new Properties,
+      properties,
       MetricsSystem.createMetricsSystem("GLUTEN_UNSAFE", conf),
       TaskMetrics.empty,
       Map.empty

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -56,7 +56,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.schema.MessageType
 
 import java.time.ZoneOffset
-import java.util.{HashMap => JHashMap, Map => JMap}
+import java.util.{HashMap => JHashMap, Map => JMap, Properties}
 
 class Spark33Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
@@ -248,8 +248,8 @@ class Spark33Shims extends SparkShims {
     List(session => GlutenParquetWriterInjects.getInstance().getExtendedColumnarPostRule(session))
   }
 
-  override def createTestTaskContext(): TaskContext = {
-    TaskContextUtils.createTestTaskContext()
+  override def createTestTaskContext(properties: Properties): TaskContext = {
+    TaskContextUtils.createTestTaskContext(properties)
   }
 
   def setJobDescriptionOrTagForBroadcastExchange(

--- a/shims/spark33/src/main/scala/org/apache/spark/TaskContextUtils.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/TaskContextUtils.scala
@@ -19,17 +19,16 @@ package org.apache.spark
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.network.util.ByteUnit
 
 import java.util.Properties
 
+import scala.collection.JavaConverters._
+
 object TaskContextUtils {
-  def createTestTaskContext(): TaskContext = {
+  def createTestTaskContext(properties: Properties): TaskContext = {
     val conf = new SparkConf()
-    conf.set("spark.memory.offHeap.enabled", "true")
-    conf.set("spark.memory.offHeap.size", "1TB")
-    val memoryManager =
-      new UnifiedMemoryManager(conf, ByteUnit.TiB.toBytes(2), ByteUnit.TiB.toBytes(1), 1)
+    conf.setAll(properties.asScala)
+    val memoryManager = UnifiedMemoryManager(conf, 1)
     new TaskContextImpl(
       -1,
       -1,
@@ -37,7 +36,7 @@ object TaskContextUtils {
       -1L,
       -1,
       new TaskMemoryManager(memoryManager, -1L),
-      new Properties,
+      properties,
       MetricsSystem.createMetricsSystem("GLUTEN_UNSAFE", conf),
       TaskMetrics.empty,
       1,

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -58,7 +58,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.schema.MessageType
 
 import java.time.ZoneOffset
-import java.util.{HashMap => JHashMap, Map => JMap}
+import java.util.{HashMap => JHashMap, Map => JMap, Properties}
 
 import scala.reflect.ClassTag
 
@@ -298,8 +298,8 @@ class Spark34Shims extends SparkShims {
 
   override def enableNativeWriteFilesByDefault(): Boolean = true
 
-  override def createTestTaskContext(): TaskContext = {
-    TaskContextUtils.createTestTaskContext()
+  override def createTestTaskContext(properties: Properties): TaskContext = {
+    TaskContextUtils.createTestTaskContext(properties)
   }
 
   override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {

--- a/shims/spark34/src/main/scala/org/apache/spark/TaskContextUtils.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/TaskContextUtils.scala
@@ -19,17 +19,16 @@ package org.apache.spark
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.network.util.ByteUnit
 
 import java.util.Properties
 
+import scala.collection.JavaConverters._
+
 object TaskContextUtils {
-  def createTestTaskContext(): TaskContext = {
+  def createTestTaskContext(properties: Properties): TaskContext = {
     val conf = new SparkConf()
-    conf.set("spark.memory.offHeap.enabled", "true")
-    conf.set("spark.memory.offHeap.size", "1TB")
-    val memoryManager =
-      new UnifiedMemoryManager(conf, ByteUnit.TiB.toBytes(2), ByteUnit.TiB.toBytes(1), 1)
+    conf.setAll(properties.asScala)
+    val memoryManager = UnifiedMemoryManager(conf, 1)
     new TaskContextImpl(
       -1,
       -1,
@@ -38,7 +37,7 @@ object TaskContextUtils {
       -1,
       -1,
       new TaskMemoryManager(memoryManager, -1L),
-      new Properties,
+      properties,
       MetricsSystem.createMetricsSystem("GLUTEN_UNSAFE", conf),
       TaskMetrics.empty,
       1,

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.sql.shims.spark35
 
 import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.{ShimDescriptor, SparkShims}
+
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -52,11 +53,13 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
+
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.schema.MessageType
 
 import java.time.ZoneOffset
-import java.util.{Properties, HashMap => JHashMap, Map => JMap}
+import java.util.{HashMap => JHashMap, Map => JMap, Properties}
+
 import scala.reflect.ClassTag
 
 class Spark35Shims extends SparkShims {

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -18,7 +18,6 @@ package org.apache.gluten.sql.shims.spark35
 
 import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.{ShimDescriptor, SparkShims}
-
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -53,13 +52,11 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
-
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.schema.MessageType
 
 import java.time.ZoneOffset
-import java.util.{HashMap => JHashMap, Map => JMap}
-
+import java.util.{Properties, HashMap => JHashMap, Map => JMap}
 import scala.reflect.ClassTag
 
 class Spark35Shims extends SparkShims {
@@ -325,8 +322,8 @@ class Spark35Shims extends SparkShims {
 
   override def enableNativeWriteFilesByDefault(): Boolean = true
 
-  override def createTestTaskContext(): TaskContext = {
-    TaskContextUtils.createTestTaskContext()
+  override def createTestTaskContext(properties: Properties): TaskContext = {
+    TaskContextUtils.createTestTaskContext(properties)
   }
 
   override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {

--- a/shims/spark35/src/main/scala/org/apache/spark/TaskContextUtils.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/TaskContextUtils.scala
@@ -19,17 +19,16 @@ package org.apache.spark
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.network.util.ByteUnit
 
 import java.util.Properties
 
+import scala.collection.JavaConverters._
+
 object TaskContextUtils {
-  def createTestTaskContext(): TaskContext = {
+  def createTestTaskContext(properties: Properties): TaskContext = {
     val conf = new SparkConf()
-    conf.set("spark.memory.offHeap.enabled", "true")
-    conf.set("spark.memory.offHeap.size", "1TB")
-    val memoryManager =
-      new UnifiedMemoryManager(conf, ByteUnit.TiB.toBytes(2), ByteUnit.TiB.toBytes(1), 1)
+    conf.setAll(properties.asScala)
+    val memoryManager = UnifiedMemoryManager(conf, 1)
     new TaskContextImpl(
       -1,
       -1,
@@ -38,7 +37,7 @@ object TaskContextUtils {
       -1,
       -1,
       new TaskMemoryManager(memoryManager, -1L),
-      new Properties,
+      properties,
       MetricsSystem.createMetricsSystem("GLUTEN_UNSAFE", conf),
       TaskMetrics.empty,
       1,

--- a/tools/gluten-it/sbin/gluten-it.sh
+++ b/tools/gluten-it/sbin/gluten-it.sh
@@ -48,7 +48,7 @@ $JAVA_HOME/bin/java $GLUTEN_IT_JVM_ARGS \
     --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
-    --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \
     --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
     --add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
     --add-opens=java.base/sun.security.action=ALL-UNNAMED \

--- a/tools/gluten-it/sbin/gluten-it.sh
+++ b/tools/gluten-it/sbin/gluten-it.sh
@@ -48,6 +48,7 @@ $JAVA_HOME/bin/java $GLUTEN_IT_JVM_ARGS \
     --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
+    --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
     --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
     --add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
     --add-opens=java.base/sun.security.action=ALL-UNNAMED \


### PR DESCRIPTION
This could fix some issues like debug configurations not taking effect in native validation or similar issues. Generally we should pass all SQL configurations to code block of `TaskResources.runUnsafe` as if it's a real Spark task but is running on Driver.