### PR TITLE
[Minor] Clean up useless code in ParquetFileFormat/OrcFileFormat

### DIFF
--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -82,14 +82,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-      GlutenOrcWriterInjects
-        .getInstance()
-        .inferSchema(sparkSession, Map.empty[String, String], files)
-    } else { // the vanilla spark case
-      OrcUtils.inferSchema(sparkSession, files, options)
-    }
+    OrcUtils.inferSchema(sparkSession, files, options)
   }
 
   override def prepareWrite(

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -83,7 +83,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable") && false) {
+    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
       GlutenOrcWriterInjects
         .getInstance()
         .inferSchema(sparkSession, Map.empty[String, String], files)

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -200,12 +200,7 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
       sparkSession: SparkSession,
       parameters: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-      GlutenParquetWriterInjects.getInstance().inferSchema(sparkSession, parameters, files)
-    } else { // the vanilla spark case
-      ParquetUtils.inferSchema(sparkSession, parameters, files)
-    }
+    ParquetUtils.inferSchema(sparkSession, parameters, files)
   }
 
   /** Returns whether the reader will return the rows as batch or not. */

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -201,7 +201,7 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
       parameters: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable") && false) {
+    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
       GlutenParquetWriterInjects.getInstance().inferSchema(sparkSession, parameters, files)
     } else { // the vanilla spark case
       ParquetUtils.inferSchema(sparkSession, parameters, files)

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -65,12 +65,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-      GlutenOrcWriterInjects.getInstance().inferSchema(sparkSession, options, files)
-    } else { // the vanilla spark case
-      OrcUtils.inferSchema(sparkSession, files, options)
-    }
+    OrcUtils.inferSchema(sparkSession, files, options)
   }
 
   override def prepareWrite(

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -66,7 +66,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable") && false) {
+    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
       GlutenOrcWriterInjects.getInstance().inferSchema(sparkSession, options, files)
     } else { // the vanilla spark case
       OrcUtils.inferSchema(sparkSession, files, options)

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -196,12 +196,7 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
       sparkSession: SparkSession,
       parameters: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-      GlutenParquetWriterInjects.getInstance().inferSchema(sparkSession, parameters, files)
-    } else { // the vanilla spark case
-      ParquetUtils.inferSchema(sparkSession, parameters, files)
-    }
+    ParquetUtils.inferSchema(sparkSession, parameters, files)
   }
 
   /** Returns whether the reader will return the rows as batch or not. */

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -197,7 +197,7 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
       parameters: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     // Why if (false)? Such code requires comments when being written.
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable") && false) {
+    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
       GlutenParquetWriterInjects.getInstance().inferSchema(sparkSession, parameters, files)
     } else { // the vanilla spark case
       ParquetUtils.inferSchema(sparkSession, parameters, files)


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a if-branch for infer schema always unreachable before, we can remove it and just use vanilla spark's infer schema. 

See https://github.com/apache/incubator-gluten/issues/6649.



