### PR TITLE
[VL] Eliminate pre local sort after offload date type range frame window

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/EliminateLocalSort.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/EliminateLocalSort.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.{ProjectExec, SortExec, SparkPlan, UnaryEx
  *   - Offload SortAggregate to native hash aggregate
  *   - Offload WindowGroupLimit to native TopNRowNumber
  *   - The columnar window type is `sort`
+ *   - Offload Window which has date type range frame
  */
 object EliminateLocalSort extends Rule[SparkPlan] {
   private def canEliminateLocalSort(p: SparkPlan): Boolean = p match {
@@ -37,6 +38,8 @@ object EliminateLocalSort extends Rule[SparkPlan] {
     case _: ShuffledHashJoinExecTransformerBase => true
     case _: WindowGroupLimitExecTransformer => true
     case _: WindowExecTransformer => true
+    case s: SortExec if s.global == false => true
+    case s: SortExecTransformer if s.global == false => true
     case _ => false
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedApplier.scala
@@ -102,8 +102,8 @@ class EnumeratedApplier(session: SparkSession)
       List(
         (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),
         (spark: SparkSession) => RewriteTransformer(spark),
-        (_: SparkSession) => EliminateLocalSort,
         (_: SparkSession) => EnsureLocalSortRequirements,
+        (_: SparkSession) => EliminateLocalSort,
         (_: SparkSession) => CollapseProjectExecTransformer
       ) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarTransformRules() :::

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
@@ -114,8 +114,8 @@ class HeuristicApplier(session: SparkSession)
       List(
         (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),
         (spark: SparkSession) => RewriteTransformer(spark),
-        (_: SparkSession) => EliminateLocalSort,
         (_: SparkSession) => EnsureLocalSortRequirements,
+        (_: SparkSession) => EliminateLocalSort,
         (_: SparkSession) => CollapseProjectExecTransformer
       ) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarTransformRules() :::


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow up #6653 .
Offload date type range frame window rewrite orderSpec, it will produce new local sort. Pre local sort is unnecessary, so remove it.

```
 sql("select max(l_partkey) over" +
      " (partition by l_suppkey order by l_commitdate" +
      " RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) from lineitem ").collect()
```
  
  before PR
```
  +- == Final Plan ==
   VeloxColumnarToRowExec (15)
   +- ^ ProjectExecTransformer (13)
      +- ^ WindowExecTransformer (12)
         +- ^ SortExecTransformer (11)
            +- ^ ProjectExecTransformer (10)
               +- ^ SortExecTransformer (9)
                  +- ^ InputIteratorTransformer (8)
                     +- ShuffleQueryStage (6), Statistics(sizeInBytes=1175.3 KiB, rowCount=6.02E+4)
                        +- ColumnarExchange (5)
                           +- VeloxAppendBatches (4)
                              +- ^ ProjectExecTransformer (2)
                                 +- ^ Scan parquet  (1)
  ```
  after pr
```
+- == Final Plan ==
   VeloxColumnarToRowExec (14)
   +- ^ ProjectExecTransformer (12)
      +- ^ WindowExecTransformer (11)
         +- ^ SortExecTransformer (10)
            +- ^ ProjectExecTransformer (9)
               +- ^ InputIteratorTransformer (8)
                  +- ShuffleQueryStage (6), Statistics(sizeInBytes=1175.3 KiB, rowCount=6.02E+4)
                     +- ColumnarExchange (5)
                        +- VeloxAppendBatches (4)
                           +- ^ ProjectExecTransformer (2)
                              +- ^ Scan parquet  (1)
```
## How was this patch tested?

UT

