### PR TITLE
[VL] Set default validation log level to WARN

### DIFF
--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -1504,7 +1504,7 @@ object GlutenConfig {
       .checkValue(
         logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
         "Valid values are 'trace', 'debug', 'info', 'warn' and 'error'.")
-      .createWithDefault("INFO")
+      .createWithDefault("WARN")
 
   val VALIDATION_PRINT_FAILURE_STACK_ =
     buildConf("spark.gluten.sql.validation.printStackOnFailure")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set default validation log level from `INFO` to `WARN`.

## How was this patch tested?

N/A

