### PR TITLE
[VL] Remove redundant hash function in substrait function validation

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -68,7 +68,8 @@ static const std::unordered_set<std::string> kBlackList = {
     "trunc",
     "sequence",
     "approx_percentile",
-    "get_array_struct_fields"};
+    "get_array_struct_fields",
+    "map_from_arrays"};
 
 } // namespace
 
@@ -189,22 +190,11 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
     return validateRound(scalarFunction, inputType);
   } else if (name == "extract") {
     return validateExtractExpr(params);
-  } else if (name == "map_from_arrays") {
-    LOG_VALIDATION_MSG("map_from_arrays is not supported.");
-    return false;
   } else if (name == "concat") {
     for (const auto& type : types) {
       if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos ||
           type.find("list") != std::string::npos) {
         LOG_VALIDATION_MSG(type + " is not supported in concat.");
-        return false;
-      }
-    }
-  } else if (name == "murmur3hash") {
-    for (const auto& type : types) {
-      if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos ||
-          type.find("list") != std::string::npos) {
-        LOG_VALIDATION_MSG(type + " is not supported in murmur3hash.");
         return false;
       }
     }


### PR DESCRIPTION
Here we check the corresbonding Velox function name, which is `hash_with_seed` now, and support the complex data type
