### PR TITLE
[GLUTEN-6695][CH] Introduce shuffleWallTime in CHMetricsApi to calculate the overall shuffle write time

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
@@ -222,6 +222,7 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
       "spillTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "time to spill"),
       "compressTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "time to compress"),
       "prepareTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "time to prepare"),
+      "shuffleWallTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "shuffle wall time"),
       "avgReadBatchNumRows" -> SQLMetrics
         .createAverageMetric(sparkContext, "avg read batch num rows"),
       "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

`VeloxCelebornColumnarShuffleWriter` supports `shuffleWallTime` metric of `VeloxMetricsApi` to calculate the overall shuffle write time for columnar shuffle exchange metrics in #6579. Therefore, `CHCelebornColumnarShuffleWriter` should also support `shuffleWallTime` to calculate the overall shuffle write time.

(Fixes: \#6695)

## How was this patch tested?

CI.