### PR TITLE
[GLUTEN-6705] [CORE] Refactor: Introduce GlutenCommitProtocol

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/ClickhouseBackendWrite.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/ClickhouseBackendWrite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.execution.datasources._
@@ -24,11 +24,13 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.collection.mutable
 
-case class ClickhouseBackendWrite(description: WriteJobDescription)
-  extends BackendWrite
-  with Logging {
+class ClickhouseBackendWrite(
+    description: WriteJobDescription,
+    committer: FileCommitProtocol,
+    jobTrackerID: String)
+  extends SparkHadoopMapReduceCommitProtocol(description, committer, jobTrackerID) {
 
-  override def collectNativeWriteFilesMetrics(cb: ColumnarBatch): Option[WriteTaskResult] = {
+  override def doCollectNativeResult(cb: ColumnarBatch): Option[WriteTaskResult] = {
     val numFiles = cb.numRows()
     // Write an empty iterator
     if (numFiles == 0) {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -32,6 +32,7 @@ import org.apache.gluten.vectorized.{ColumnarBatchSerializer, ColumnarBatchSeria
 
 import org.apache.spark.{ShuffleDependency, SparkException}
 import org.apache.spark.api.python.{ColumnarArrowEvalPythonExec, PullOutArrowEvalPythonPreProjectHelper}
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
@@ -556,9 +557,11 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     ShuffleUtil.genColumnarShuffleWriter(parameters)
   }
 
-  override def createBackendWrite(description: WriteJobDescription): BackendWrite = {
-    VeloxBackendWrite(description)
-  }
+  def createCommitter(
+      description: WriteJobDescription,
+      committer: FileCommitProtocol,
+      jobTrackerID: String): GlutenCommitProtocol =
+    new VeloxBackendWrite(description, committer, jobTrackerID)
 
   override def createColumnarArrowEvalPythonExec(
       udfs: Seq[PythonUDF],

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -24,6 +24,7 @@ import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
 
 import org.apache.spark.ShuffleDependency
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
@@ -40,7 +41,7 @@ import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{BackendWrite, ColumnarWriteFilesExec, FileSourceScanExec, GenerateExec, LeafExecNode, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarWriteFilesExec, FileSourceScanExec, GenerateExec, GlutenCommitProtocol, LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{FileFormat, WriteJobDescription}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -399,8 +400,11 @@ trait SparkPlanExecApi {
       staticPartitions)
   }
 
-  /** Create BackendWrite */
-  def createBackendWrite(description: WriteJobDescription): BackendWrite
+  /** Create GlutenCommitProtocol for different Backend */
+  def createCommitter(
+      description: WriteJobDescription,
+      committer: FileCommitProtocol,
+      jobTrackerID: String): GlutenCommitProtocol
 
   /** Create ColumnarArrowEvalPythonExec, for velox backend */
   def createColumnarArrowEvalPythonExec(

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -308,7 +308,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
           wsCtx.substraitContext.registeredAggregationParams
         )
       )
-      (0 until allScanPartitions.head.size).foreach(
+      allScanPartitions.head.indices.foreach(
         i => {
           val currentPartitions = allScanPartitions.map(_(i))
           currentPartitions.indices.foreach(


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#6705)

In ClickHouse Backend, we are preparing to support native delta write in Spark 3.5 and delta 3.2. This PR refactor codes to support `DelayedCommitProtocol` in `ColumnarWriteFilesRDD`. The Basic idea is introducing `GlutenCommitProtocol`,

```scala
trait GlutenCommitProtocol {
  def setupTask(): Unit
  def commitTask(batch: ColumnarBatch): Option[WriteTaskResult]
  def abortTask(): Unit
  def jobId: String
  def taskAttemptContext: TaskAttemptContext
}
```

The main difference between `DelayedCommitProtocol` and `HadoopMapReduceCommitProtocol` are how to setup and commit task. and hence `SparkWriteFilesCommitProtocol` is the direct implentation of  `GlutenCommitProtocol`  for `jobId` and `taskAttemptContext`.

Here are class hierarchy:

```
GlutenCommitProtocol
  |_ SparkWriteFilesCommitProtocol
     |_ SparkHadoopMapReduceCommitProtocol
     |  |_ VeloxBackendWrite
     |  |_ ClickhouseBackendWrite
     |__ DeltaXXX
```

1.  `SparkHadoopMapReduceCommitProtocol`  is response for implmenting setup up task
2. `VeloxBackendWrite` and `ClickhouseBackendWrite` is response for  convert `ColumnBatch` to `WriteTaskResult`

## How was this patch tested?

Using Existed UTs
