### PR TITLE
[VL] Fix out-of-date centos 7 image in velox_docker_cache.yml

### DIFF
--- a/.github/workflows/velox_docker_cache.yml
+++ b/.github/workflows/velox_docker_cache.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   cache-native-lib-centos-7:
     runs-on: ubuntu-20.04
-    container: apache/gluten:gluten-vcpkg-builder_2024_07_11 # centos7 with dependencies installed
+    container: apache/gluten:gluten-vcpkg-builder_2024_08_05 # centos7 with dependencies installed
     steps:
       - uses: actions/checkout@v2
       - name: Generate cache key


### PR DESCRIPTION
Following changes in https://github.com/apache/incubator-gluten/pull/6616, update the image for caching.