### PR TITLE
[VL] Minor class name / package name clean-ups

### DIFF
--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchResizer.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchResizer.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.utils;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.vectorized.ColumnarBatchInIterator;
 import org.apache.gluten.vectorized.ColumnarBatchOutIterator;
 

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchResizerJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchResizerJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.utils;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 import org.apache.gluten.vectorized.ColumnarBatchInIterator;
 
 public class VeloxBatchResizerJniWrapper implements RuntimeAware {

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBloomFilter.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBloomFilter.java
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.utils;
 
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtimes;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.spark.util.sketch.BloomFilter;

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBloomFilterJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBloomFilterJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.utils;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 public class VeloxBloomFilterJniWrapper implements RuntimeAware {
   private final Runtime runtime;

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.backendsapi.velox
 
 import org.apache.gluten.backendsapi.TransformerApi
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import org.apache.gluten.utils.InputPartitionsUtil

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
@@ -17,8 +17,8 @@
 package org.apache.gluten.backendsapi.velox
 
 import org.apache.gluten.backendsapi.TransformerApi
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.expression.ConverterUtils
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import org.apache.gluten.utils.InputPartitionsUtil
 import org.apache.gluten.vectorized.PlanEvaluatorJniWrapper

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.utils.iterator.Iterators

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -18,8 +18,8 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.utils.iterator.Iterators
 import org.apache.gluten.vectorized._

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
@@ -18,8 +18,8 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
 import org.apache.gluten.exception.GlutenNotSupportException
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.iterator.Iterators
 import org.apache.gluten.vectorized.NativeColumnarToRowJniWrapper
 

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
 import org.apache.gluten.exception.GlutenNotSupportException
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.utils.iterator.Iterators
 import org.apache.gluten.vectorized.NativeColumnarToRowJniWrapper

--- a/backends-velox/src/main/scala/org/apache/gluten/utils/DatasourceUtil.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/utils/DatasourceUtil.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.utils
 
 import org.apache.gluten.datasource.DatasourceJniWrapper
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 
 import org.apache.spark.sql.types.StructType

--- a/backends-velox/src/main/scala/org/apache/gluten/utils/DatasourceUtil.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/utils/DatasourceUtil.scala
@@ -17,8 +17,8 @@
 package org.apache.gluten.utils
 
 import org.apache.gluten.datasource.DatasourceJniWrapper
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkSchemaUtil

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.vectorized.{ColumnarBatchSerializeResult, ColumnarBatchSerializerJniWrapper}
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.utils.iterator.Iterators
 import org.apache.gluten.vectorized.ColumnarBatchSerializerJniWrapper

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.velox
 import org.apache.gluten.columnarbatch.{ColumnarBatches, ColumnarBatchJniWrapper}
 import org.apache.gluten.datasource.DatasourceJniWrapper
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.execution.datasource.GlutenRowSplitter
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.{ArrowAbiUtil, DatasourceUtil}

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.execution.datasources.velox
 import org.apache.gluten.columnarbatch.{ColumnarBatches, ColumnarBatchJniWrapper}
 import org.apache.gluten.datasource.DatasourceJniWrapper
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.execution.datasource.GlutenRowSplitter
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.{ArrowAbiUtil, DatasourceUtil}
 
 import org.apache.spark.sql.SparkSession

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/DynamicOffHeapSizingSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/DynamicOffHeapSizingSuite.scala
@@ -22,7 +22,7 @@ import org.apache.gluten.tags.SkipTestTags
 import org.apache.spark.SparkConf
 
 @SkipTestTags
-class DynamicOffHeapSizingTest extends VeloxWholeStageTransformerSuite {
+class DynamicOffHeapSizingSuite extends VeloxWholeStageTransformerSuite {
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FunctionsValidateSuite.scala
@@ -25,7 +25,7 @@ import java.nio.file.Files
 
 import scala.collection.JavaConverters._
 
-class FunctionsValidateTest extends WholeStageTransformerSuite {
+class FunctionsValidateSuite extends WholeStageTransformerSuite {
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"
   private var parquetPath: String = _

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -67,7 +67,7 @@ class ScalarFunctionsValidateSuiteRasOn extends ScalarFunctionsValidateSuite {
   }
 }
 
-abstract class ScalarFunctionsValidateSuite extends FunctionsValidateTest {
+abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
   disableFallbackCheck
   import testImplicits._
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/WindowFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/WindowFunctionsValidateSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-class WindowFunctionsValidateSuite extends FunctionsValidateTest {
+class WindowFunctionsValidateSuite extends FunctionsValidateSuite {
 
   test("lag/lead window function with negative input offset") {
     runQueryAndCompare(

--- a/backends-velox/src/test/scala/org/apache/gluten/fuzzer/FuzzerBase.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/fuzzer/FuzzerBase.scala
@@ -18,12 +18,12 @@ package org.apache.gluten.fuzzer
 
 import org.apache.gluten.benchmarks.RandomParquetDataGenerator
 import org.apache.gluten.execution.VeloxWholeStageTransformerSuite
-import org.apache.gluten.fuzzer.FuzzerTestResult.{Failed, OOM, Successful, TestResult}
+import org.apache.gluten.fuzzer.FuzzerResult.{Failed, OOM, Successful, TestResult}
 import org.apache.gluten.memory.memtarget.ThrowOnOomMemoryTarget
 
 import org.apache.spark.SparkConf
 
-abstract class FuzzerTestBase extends VeloxWholeStageTransformerSuite {
+abstract class FuzzerBase extends VeloxWholeStageTransformerSuite {
 
   override protected val resourcePath: String = "/tpch-data-parquet-velox"
   override protected val fileFormat: String = "parquet"

--- a/backends-velox/src/test/scala/org/apache/gluten/fuzzer/FuzzerResult.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/fuzzer/FuzzerResult.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.fuzzer
 
-object FuzzerTestResult {
+object FuzzerResult {
   trait TestResult {
     val seed: Long
 

--- a/backends-velox/src/test/scala/org/apache/gluten/fuzzer/RowToColumnarFuzzer.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/fuzzer/RowToColumnarFuzzer.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.fuzzer
 
 import org.apache.gluten.execution.RowToVeloxColumnarExec
-import org.apache.gluten.fuzzer.FuzzerTestResult.Successful
+import org.apache.gluten.fuzzer.FuzzerResult.Successful
 import org.apache.gluten.tags.{FuzzerTest, SkipTestTags}
 
 import org.apache.spark.SparkConf
@@ -25,7 +25,7 @@ import org.apache.spark.sql.DataFrame
 
 @FuzzerTest
 @SkipTestTags
-class RowToColumnarFuzzerTest extends FuzzerTestBase {
+class RowToColumnarFuzzer extends FuzzerBase {
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf

--- a/backends-velox/src/test/scala/org/apache/gluten/fuzzer/ShuffleWriterFuzzer.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/fuzzer/ShuffleWriterFuzzer.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.fuzzer
 
-import org.apache.gluten.fuzzer.FuzzerTestResult.Successful
+import org.apache.gluten.fuzzer.FuzzerResult.Successful
 import org.apache.gluten.tags.{FuzzerTest, SkipTestTags}
 
 import org.apache.spark.sql.DataFrame
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.ColumnarShuffleExchangeExec
 
 @FuzzerTest
 @SkipTestTags
-class ShuffleWriterFuzzerTest extends FuzzerTestBase {
+class ShuffleWriterFuzzer extends FuzzerBase {
   private val REPARTITION_SQL = (numPartitions: Int) =>
     s"select /*+ REPARTITION($numPartitions) */ * from tbl"
   private val AGG_REPARTITION_SQL =

--- a/cpp/core/jni/JniCommon.cc
+++ b/cpp/core/jni/JniCommon.cc
@@ -38,7 +38,7 @@ jmethodID gluten::JniCommonState::runtimeAwareCtxHandle() {
 }
 
 void gluten::JniCommonState::initialize(JNIEnv* env) {
-  runtimeAwareClass_ = createGlobalClassReference(env, "Lorg/apache/gluten/exec/RuntimeAware;");
+  runtimeAwareClass_ = createGlobalClassReference(env, "Lorg/apache/gluten/runtime/RuntimeAware;");
   runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "handle", "()J");
   JavaVM* vm;
   if (env->GetJavaVM(&vm) != JNI_OK) {

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -222,7 +222,7 @@ namespace {
 const std::string kBacktraceAllocation = "spark.gluten.memory.backtrace.allocation";
 }
 
-JNIEXPORT jlong JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_createRuntime( // NOLINT
+JNIEXPORT jlong JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_createRuntime( // NOLINT
     JNIEnv* env,
     jclass,
     jstring jbackendType,
@@ -249,7 +249,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_createRunt
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 
-JNIEXPORT jbyteArray JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_collectMemoryUsage( // NOLINT
+JNIEXPORT jbyteArray JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_collectMemoryUsage( // NOLINT
     JNIEnv* env,
     jclass,
     jlong ctxHandle) {
@@ -268,7 +268,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_colle
   JNI_METHOD_END(nullptr)
 }
 
-JNIEXPORT jlong JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_shrinkMemory( // NOLINT
+JNIEXPORT jlong JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_shrinkMemory( // NOLINT
     JNIEnv* env,
     jclass,
     jlong ctxHandle,
@@ -279,7 +279,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_shrinkMemo
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 
-JNIEXPORT void JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_holdMemory( // NOLINT
+JNIEXPORT void JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_holdMemory( // NOLINT
     JNIEnv* env,
     jclass,
     jlong ctxHandle) {
@@ -289,7 +289,7 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_holdMemory(
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL Java_org_apache_gluten_exec_RuntimeJniWrapper_releaseRuntime( // NOLINT
+JNIEXPORT void JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_releaseRuntime( // NOLINT
     JNIEnv* env,
     jclass,
     jlong ctxHandle) {

--- a/dev/build_arrow.sh
+++ b/dev/build_arrow.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -exu
+
 CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 export SUDO=sudo
 source ${CURRENT_DIR}/build_helper_functions.sh

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -18,8 +18,8 @@ package org.apache.spark.shuffle
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.GlutenConfig.{GLUTEN_RSS_SORT_SHUFFLE_WRITER, GLUTEN_SORT_SHUFFLE_WRITER}
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.vectorized._
 

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -18,7 +18,7 @@ package org.apache.spark.shuffle
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.GlutenConfig.{GLUTEN_RSS_SORT_SHUFFLE_WRITER, GLUTEN_SORT_SHUFFLE_WRITER}
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.vectorized._

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -18,8 +18,8 @@ package org.apache.spark.shuffle
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.memtarget.{MemoryTarget, Spiller, Spillers}
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.vectorized._
 
 import org.apache.spark._

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -18,7 +18,7 @@ package org.apache.spark.shuffle
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.memtarget.{MemoryTarget, Spiller, Spillers}
 import org.apache.gluten.vectorized._
 

--- a/gluten-data/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatchJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatchJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.columnarbatch;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 public class ColumnarBatchJniWrapper implements RuntimeAware {
   private final Runtime runtime;

--- a/gluten-data/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
@@ -17,8 +17,8 @@
 package org.apache.gluten.columnarbatch;
 
 import org.apache.gluten.exception.GlutenException;
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.utils.ArrowAbiUtil;
 import org.apache.gluten.utils.ArrowUtil;
 import org.apache.gluten.utils.ImplicitClass;

--- a/gluten-data/src/main/java/org/apache/gluten/columnarbatch/IndicatorVectorBase.java
+++ b/gluten-data/src/main/java/org/apache/gluten/columnarbatch/IndicatorVectorBase.java
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.columnarbatch;
 
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtimes;
 
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;

--- a/gluten-data/src/main/java/org/apache/gluten/datasource/DatasourceJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/datasource/DatasourceJniWrapper.java
@@ -16,9 +16,9 @@
  */
 package org.apache.gluten.datasource;
 
+import org.apache.gluten.init.JniUtils;
 import org.apache.gluten.runtime.Runtime;
 import org.apache.gluten.runtime.RuntimeAware;
-import org.apache.gluten.init.JniUtils;
 
 import org.apache.spark.sql.execution.datasources.BlockStripes;
 

--- a/gluten-data/src/main/java/org/apache/gluten/datasource/DatasourceJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/datasource/DatasourceJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.datasource;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 import org.apache.gluten.init.JniUtils;
 
 import org.apache.spark.sql.execution.datasources.BlockStripes;

--- a/gluten-data/src/main/java/org/apache/gluten/runtime/RuntimeAware.java
+++ b/gluten-data/src/main/java/org/apache/gluten/runtime/RuntimeAware.java
@@ -14,22 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.exec
+package org.apache.gluten.runtime;
 
-import org.apache.spark.util.{TaskResource, TaskResources}
-
-object Runtimes {
-
-  /** Get or create the runtime which bound with Spark TaskContext. */
-  def contextInstance(name: String): Runtime = {
-    if (!TaskResources.inSparkTask()) {
-      throw new IllegalStateException("This method must be called in a Spark task.")
-    }
-
-    TaskResources.addResourceIfNotRegistered(name, () => create(name))
+/**
+ * This defines the base abstraction for the contextual objects that can be transmitted to C++ side
+ * for further native processing.
+ */
+public interface RuntimeAware {
+  default boolean isCompatibleWith(RuntimeAware other) {
+    return handle() == other.handle();
   }
 
-  private def create(name: String): Runtime with TaskResource = {
-    Runtime(name)
-  }
+  long handle();
 }

--- a/gluten-data/src/main/java/org/apache/gluten/runtime/RuntimeJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/runtime/RuntimeJniWrapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.exec;
+package org.apache.gluten.runtime;
 
 import org.apache.gluten.memory.listener.ReservationListener;
 

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchInIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchInIterator.java
@@ -18,8 +18,8 @@ package org.apache.gluten.vectorized;
 
 import org.apache.gluten.columnarbatch.ColumnarBatchJniWrapper;
 import org.apache.gluten.columnarbatch.ColumnarBatches;
-import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators;
+import org.apache.gluten.runtime.Runtimes;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchInIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchInIterator.java
@@ -18,7 +18,7 @@ package org.apache.gluten.vectorized;
 
 import org.apache.gluten.columnarbatch.ColumnarBatchJniWrapper;
 import org.apache.gluten.columnarbatch.ColumnarBatches;
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -17,9 +17,9 @@
 package org.apache.gluten.vectorized;
 
 import org.apache.gluten.columnarbatch.ColumnarBatches;
+import org.apache.gluten.metrics.IMetrics;
 import org.apache.gluten.runtime.Runtime;
 import org.apache.gluten.runtime.RuntimeAware;
-import org.apache.gluten.metrics.IMetrics;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -17,8 +17,8 @@
 package org.apache.gluten.vectorized;
 
 import org.apache.gluten.columnarbatch.ColumnarBatches;
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 import org.apache.gluten.metrics.IMetrics;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializerJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializerJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.vectorized;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 public class ColumnarBatchSerializerJniWrapper implements RuntimeAware {
   private final Runtime runtime;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativeColumnarToRowJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativeColumnarToRowJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.vectorized;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 public class NativeColumnarToRowJniWrapper implements RuntimeAware {
   private final Runtime runtime;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -17,11 +17,11 @@
 package org.apache.gluten.vectorized;
 
 import org.apache.gluten.backendsapi.BackendsApiManager;
-import org.apache.gluten.runtime.Runtime;
-import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.memory.memtarget.MemoryTarget;
 import org.apache.gluten.memory.memtarget.Spiller;
 import org.apache.gluten.memory.memtarget.Spillers;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.utils.DebugUtil;
 import org.apache.gluten.validate.NativePlanValidationInfo;
 

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -17,8 +17,8 @@
 package org.apache.gluten.vectorized;
 
 import org.apache.gluten.backendsapi.BackendsApiManager;
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.memory.memtarget.MemoryTarget;
 import org.apache.gluten.memory.memtarget.Spiller;
 import org.apache.gluten.memory.memtarget.Spillers;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/NativeRowToColumnarJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/NativeRowToColumnarJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.vectorized;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 public class NativeRowToColumnarJniWrapper implements RuntimeAware {
   private final Runtime runtime;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/PlanEvaluatorJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.vectorized;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 import org.apache.gluten.validate.NativePlanValidationInfo;
 
 /**

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ShuffleReaderJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.vectorized;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 public class ShuffleReaderJniWrapper implements RuntimeAware {
   private final Runtime runtime;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/ShuffleWriterJniWrapper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.vectorized;
 
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.RuntimeAware;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.RuntimeAware;
 
 import java.io.IOException;
 

--- a/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtime.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtime.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.exec
+package org.apache.gluten.runtime
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
@@ -44,7 +44,7 @@ trait Runtime {
 }
 
 object Runtime {
-  private[exec] def apply(name: String): Runtime with TaskResource = {
+  private[runtime] def apply(name: String): Runtime with TaskResource = {
     new RuntimeImpl(name)
   }
 

--- a/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtimes.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtimes.scala
@@ -14,16 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.exec;
+package org.apache.gluten.runtime
 
-/**
- * This defines the base abstraction for the contextual objects that can be transmitted to C++ side
- * for further native processing.
- */
-public interface RuntimeAware {
-  default boolean isCompatibleWith(RuntimeAware other) {
-    return handle() == other.handle();
+import org.apache.spark.util.{TaskResource, TaskResources}
+
+object Runtimes {
+
+  /** Get or create the runtime which bound with Spark TaskContext. */
+  def contextInstance(name: String): Runtime = {
+    if (!TaskResources.inSparkTask()) {
+      throw new IllegalStateException("This method must be called in a Spark task.")
+    }
+
+    TaskResources.addResourceIfNotRegistered(name, () => create(name))
   }
 
-  long handle();
+  private def create(name: String): Runtime with TaskResource = {
+    Runtime(name)
+  }
 }

--- a/gluten-data/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.vectorized
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.ArrowAbiUtil
 

--- a/gluten-data/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
@@ -17,8 +17,8 @@
 package org.apache.gluten.vectorized
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.ArrowAbiUtil
 
 import org.apache.spark.SparkEnv

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -18,8 +18,8 @@ package org.apache.spark.shuffle
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.memtarget.{MemoryTarget, Spiller, Spillers}
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.vectorized._
 
 import org.apache.spark._

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -18,7 +18,7 @@ package org.apache.spark.shuffle
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.memtarget.{MemoryTarget, Spiller, Spillers}
 import org.apache.gluten.vectorized._
 

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -17,8 +17,8 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.gluten.utils.iterator.Iterators

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.ArrowAbiUtil

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -17,8 +17,8 @@
 package org.apache.spark.sql.execution.utils
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.iterator.Iterators
 import org.apache.gluten.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper, NativePartitioning}
 

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.utils
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.exec.Runtimes
+import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.iterator.Iterators
 import org.apache.gluten.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper, NativePartitioning}

--- a/gluten-uniffle/velox/src/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/gluten-uniffle/velox/src/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -18,8 +18,8 @@ package org.apache.spark.shuffle.writer;
 
 import org.apache.gluten.GlutenConfig;
 import org.apache.gluten.columnarbatch.ColumnarBatches;
-import org.apache.gluten.exec.Runtime;
-import org.apache.gluten.exec.Runtimes;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.memory.memtarget.MemoryTarget;
 import org.apache.gluten.memory.memtarget.Spiller;
 import org.apache.gluten.memory.memtarget.Spillers;

--- a/gluten-uniffle/velox/src/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/gluten-uniffle/velox/src/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -18,11 +18,11 @@ package org.apache.spark.shuffle.writer;
 
 import org.apache.gluten.GlutenConfig;
 import org.apache.gluten.columnarbatch.ColumnarBatches;
-import org.apache.gluten.runtime.Runtime;
-import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.memory.memtarget.MemoryTarget;
 import org.apache.gluten.memory.memtarget.Spiller;
 import org.apache.gluten.memory.memtarget.Spillers;
+import org.apache.gluten.runtime.Runtime;
+import org.apache.gluten.runtime.Runtimes;
 import org.apache.gluten.vectorized.ShuffleWriterJniWrapper;
 import org.apache.gluten.vectorized.SplitResult;
 


### PR DESCRIPTION
1. `exec.Runtime` -> `runtime.Runtime` as `exec` collides with `execution`
2. Scala test suites with name `...Test` changed to use `Suite` as suffix
3. Simplify class names `...FuzzerTest` to `...Fuzzer`