### PR TITLE
[GLUTEN-6561][CH] Fix exception when mapFromArrays accepts its first argument with type Array(Nullable(T))

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -730,4 +730,14 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       runQueryAndCompare(aggregate_sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
     }
   }
+
+  test("test issue: https://github.com/apache/incubator-gluten/issues/6561") {
+    val sql = """
+                |select
+                | map_from_arrays(
+                |   transform(map_keys(map('t1',id,'t2',id+1)), v->v),
+                |   array('a','b')) as b from range(10)
+                |""".stripMargin
+    runQueryAndCompare(sql)(checkGlutenOperatorMatch[ProjectExecTransformer])
+  }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?
Fix exception when mapFromArrays accepts its first argument with type Array(Nullable(T))

(Fixes: \#6561)

related to ch pr:  https://github.com/ClickHouse/ClickHouse/pull/67103/files