### PR TITLE
[VL] Use the scripts dir in the current path as SCRIPTDIR

### DIFF
--- a/ep/build-velox/src/setup-centos7.sh
+++ b/ep/build-velox/src/setup-centos7.sh
@@ -17,7 +17,7 @@
 set -efx -o pipefail
 # Some of the packages must be build with the same compiler flags
 # so that some low level types are the same size. Also, disable warnings.
-SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")/../build/velox_ep/scripts
+SCRIPTDIR=./scripts
 source $SCRIPTDIR/setup-helper-functions.sh
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-/tmp/velox-deps}
 CPU_TARGET="${CPU_TARGET:-avx}"

--- a/ep/build-velox/src/setup-centos8.sh
+++ b/ep/build-velox/src/setup-centos8.sh
@@ -29,7 +29,7 @@
 set -efx -o pipefail
 # Some of the packages must be build with the same compiler flags
 # so that some low level types are the same size. Also, disable warnings.
-SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")/../build/velox_ep/scripts
+SCRIPTDIR=./scripts
 source $SCRIPTDIR/setup-helper-functions.sh
 CPU_TARGET="${CPU_TARGET:-avx}"
 NPROC=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The user may customize `VELOX_HOME`, or they may use the default directory `ep/build-velox/build/velox_ep`. However, in the current `setup-centos7.sh` and `setup-centos8.sh`, only the default `VELOX_HOME` path will be used.

In fact, before calling `setup-centos7.sh` or `setup-centos8.sh`, `builddeps-veloxbe.sh` has already changed the directory to `VELOX_HOME`, so we can directly use the `scripts` dir in the current path.

## How was this patch tested?

N/A
