### PR TITLE
[GLUTEN-6737]package delta into bundle jar when specify delta profile

### DIFF
--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -314,8 +314,7 @@ First of all, compile gluten-delta module by a `delta` profile, as follows:
 mvn clean package -Pbackends-velox -Pspark-3.3 -Pdelta -DskipTests
 ```
 
-Then, put the additional `gluten-delta-XX-SNAPSHOT.jar` to the class path (usually it's `$SPARK_HOME/jars`).
-The gluten-delta jar is in `gluten-delta/target` directory.
+Once built successfully, delta features will be included in gluten-velox-bundle-X jar.
 
 After the two steps, you can query delta table by gluten/velox without scan's fallback.
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -314,9 +314,7 @@ First of all, compile gluten-delta module by a `delta` profile, as follows:
 mvn clean package -Pbackends-velox -Pspark-3.3 -Pdelta -DskipTests
 ```
 
-Once built successfully, delta features will be included in gluten-velox-bundle-X jar.
-
-After the two steps, you can query delta table by gluten/velox without scan's fallback.
+Once built successfully, delta features will be included in gluten-velox-bundle-X jar. Then you can query delta table by gluten/velox without scan's fallback.
 
 Gluten with velox backends also support the column mapping of delta tables.
 About column mapping, see more [here](https://docs.delta.io/latest/delta-column-mapping.html).
@@ -334,8 +332,6 @@ mvn clean package -Pbackends-velox -Pspark-3.3 -Piceberg -DskipTests
 ```
 
 Once built successfully, iceberg features will be included in gluten-velox-bundle-X jar. Then you can query iceberg table by gluten/velox without scan's fallback.
-
-After the two steps, you can query iceberg table by gluten/velox without scan's fallback.
 
 # Coverage
 

--- a/gluten-delta/pom.xml
+++ b/gluten-delta/pom.xml
@@ -65,10 +65,6 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <type>test-jar</type>
     </dependency>
     <dependency>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -93,6 +93,16 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>delta</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-delta</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, gluten supports packaging iceberg into a bundle jar, and it’s best for us to maintain consistent behavior on the delta side. This brings several benefits:
1. Consistent behavior avoids increasing the learning burden;
2. Simplifies deployment;
3. Aligns better with users' expectations for manually specified configurations.

(Fixes: \#6737)

## How was this patch tested?

manual tests

