### PR TITLE
[VL] Fix arrow lib conflict on centos-9

### DIFF
--- a/dev/build_arrow.sh
+++ b/dev/build_arrow.sh
@@ -30,13 +30,6 @@ function prepare_arrow_build() {
   popd
 }
 
-function install_arrow_deps {
-  wget_and_untar https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1s.tar.gz openssl
-  pushd openssl
-  ./config no-shared && make depend && make && sudo make install
-  popd
-}
-
 function build_arrow_cpp() {
  pushd $ARROW_PREFIX/cpp
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -88,7 +88,7 @@ function process_setup_ubuntu {
   sed -i '/ccache /a\    yasm \\' scripts/setup-ubuntu.sh
   ensure_pattern_matched 'run_and_time install_conda' scripts/setup-ubuntu.sh
   sed -i '/run_and_time install_conda/d' scripts/setup-ubuntu.sh
-  # Just depends on Gluten to install arrow libs since Gluten will apply some patches to Arrow source and uses different build options.
+  # Just depends on Gluten to install arrow libs since Gluten requires some patches are applied and some different build options are used.
   ensure_pattern_matched 'run_and_time install_arrow' scripts/setup-ubuntu.sh
   sed -i '/run_and_time install_arrow/d' scripts/setup-ubuntu.sh
 }
@@ -116,6 +116,10 @@ function process_setup_centos9 {
   # Required by lib hdfs.
   ensure_pattern_matched 'dnf_install ninja-build' scripts/setup-centos9.sh
   sed -i '/^  dnf_install ninja-build/a\  dnf_install yasm\' scripts/setup-centos9.sh
+
+  # Just depends on Gluten to install arrow libs since Gluten requires some patches are applied and some different build options are used.
+  ensure_pattern_matched 'run_and_time install_arrow' scripts/setup-centos9.sh
+  sed -i '/run_and_time install_arrow/d' scripts/setup-centos9.sh
 }
 
 function process_setup_alinux3 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Gluten will install arrow libs with some patches applied and some different options used. A conflict version can be installed by Velox's setup-centos9.sh.

## How was this patch tested?

Local verification.

