### PR TITLE
[GLUTEN-6705] [CORE] [Part 1] Avoid adding c2r for ColumnarWriteFilesExec, since it neither output Columnar batch data nor InternalRow

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/package.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/package.scala
@@ -21,6 +21,23 @@ import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.spark.sql.execution.{CHColumnarToRowExec, RowToCHNativeColumnarExec, SparkPlan}
 
 package object clickhouse {
+
+  /**
+   * ClickHouse batch convention.
+   *
+   * [[fromRow]] and [[toRow]] need a [[TransitionDef]] instance. The scala allows an compact way to
+   * implement trait using a lambda function.
+   *
+   * Here the detail definition is given in [[CHBatch.fromRow]].
+   * {{{
+   *       fromRow(new TransitionDef {
+   *       override def create(): Transition = new Transition {
+   *         override protected def apply0(plan: SparkPlan): SparkPlan =
+   *           RowToCHNativeColumnarExec(plan)
+   *       }
+   *     })
+   * }}}
+   */
   case object CHBatch extends Convention.BatchType {
     fromRow(
       () =>

--- a/shims/common/src/main/scala/org/apache/gluten/metrics/GlutenTimeMetric.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/metrics/GlutenTimeMetric.scala
@@ -44,4 +44,10 @@ object GlutenTimeMetric {
   }
   def withMillisTime[U](block: => U)(millisTime: Long => Unit): U =
     withNanoTime(block)(t => millisTime(TimeUnit.NANOSECONDS.toMillis(t)))
+
+  def recordMillisTime[U](block: => U): (U, Long) = {
+    var time = 0L
+    val result = withMillisTime(block)(time = _)
+    (result, time)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR avoids c2r and r2c transition by returning `Convention` which ouputs both `VanillaRow` and `BatchType` for `ColumnarWriteFilesExec`.

```scala
  /**
   * ColumnarWriteFilesExec neither output Row nor columnar data. We output both row and columnar to
   * avoid c2r and r2c transitions. Please note, [[GlutenPlan]] already implement batchType()
   */
  sealed trait ExecuteWriteCompatible extends KnownChildrenConventions with KnownRowType {
   // ...
    override def requiredChildrenConventions(): Seq[ConventionReq] = {
      List(ConventionReq.backendBatch)
    }

    override def rowType(): RowType = {
      RowType.VanillaRow
    }
  }
```
### Why need

`ColumnarWriteFilesExec` neither outputs Columnar batch data nor `InternalRow`, and hence we can't add c2r or r2c on top of it, otherwise it would be am internal error.

1. In the normal code path, `DataWritingCommandExec` is on top of `ColumnarWriteFilesExec` and `DataWritingCommandExec`'s Convention is `VanillaRow` which avoid c2r transition. 
2. In ClickHouse Backend, we are preparing to support native delta write in Spark 3.5 and delta 3.2, `WriteFile` is directly added on top of delta logical plan and hence the root `SparkPlan` is `ColumnarWriteFilesExec` which casue internal error without this change.

### Other refactor
1. Using `org.apache.spark.sql.catalyst.util.sideBySide` to ouptput changed plan, which is same as spark `RuleExecutor`.
2. Improving some readability,  `case _ if !plan.supportsColumnar`  =>  `case _ if plan.supportsColumnar`  
3. Adding comments for `CHBatch.fromRow`

(Fixes: \#6705)

## How was this patch tested?

Existed UTs

