### PR TITLE
[CORE] Fix schema mismatch between ReadRelNode and LocalFilesNode

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
@@ -104,7 +104,7 @@ public class LocalFilesNode implements SplitInfo {
       for (StructField field : fileSchema.fields()) {
         structBuilder.addTypes(
             ConverterUtils.getTypeNode(field.dataType(), field.nullable()).toProtobuf());
-        namedStructBuilder.addNames(field.name());
+        namedStructBuilder.addNames(ConverterUtils.normalizeColName(field.name()));
       }
       namedStructBuilder.setStruct(structBuilder.build());
     }


### PR DESCRIPTION
The field names of baseSchema in the ReadRelNode and the field names of schema in the LocalFilesNode may mismatch, which we have met. The reason is that gluten converts the field names of the baseSchema in the ReadRelNode to lower case but does not convert the field names of the schema in the LocalFilesNode.
The bug will result the reader can't deserialize the column data correctly.