### PR TITLE
[MINOR] update repository first in setup-ubuntu envs

### DIFF
--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -184,7 +184,7 @@ install_ubuntu_18.04() {
 }
 
 install_ubuntu_20.04() {
-    apt-get -y install \
+    apt-get update && apt-get -y install \
         wget curl tar zip unzip git \
         build-essential ccache cmake ninja-build pkg-config autoconf autoconf-archive libtool \
         flex bison \


### PR DESCRIPTION
## What changes were proposed in this pull request?
When starting a brand new ubuntu 22.04 container and run `setup-build-depends.sh` directly, it can not locate packages to be installed because the repository is not updated.


## How was this patch tested?

Test in local.


