### PR TITLE
[VL] RAS: Renew validator instance for each rule applier call

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
@@ -25,6 +25,7 @@ import org.apache.gluten.planner.property.Conv
 import org.apache.gluten.ras.property.PropertySet
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.LogLevelUtil
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -40,7 +41,7 @@ import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
   extends Rule[SparkPlan]
   with LogLevelUtil {
-  
+
   private val validator: Validator = Validators
     .builder()
     .fallbackByHint()
@@ -50,7 +51,7 @@ case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
     .fallbackByUserOptions()
     .fallbackByTestInjects()
     .build()
-  
+
   private val rules = List(
     new PushFilterToScan(validator),
     RemoveSort,
@@ -71,8 +72,7 @@ case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
       RasOffload
         .from(
           (node: SparkPlan) => HiveTableScanExecTransformer.isHiveTableScan(node),
-          OffloadOthers())
-        ,
+          OffloadOthers()),
       RasOffload.from[CoalesceExec](OffloadOthers()),
       RasOffload.from[SortAggregateExec](OffloadOthers()),
       RasOffload.from[ObjectHashAggregateExec](OffloadOthers()),
@@ -85,8 +85,7 @@ case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
       RasOffload
         .from(
           (node: SparkPlan) => SparkShimLoader.getSparkShims.isWindowGroupLimitExec(node),
-          OffloadOthers())
-        ,
+          OffloadOthers()),
       RasOffload.from[LimitExec](OffloadOthers()),
       RasOffload.from[GenerateExec](OffloadOthers()),
       RasOffload.from[EvalPythonExec](OffloadOthers())

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
@@ -18,13 +18,13 @@ package org.apache.gluten.extension.columnar.enumerated
 
 import org.apache.gluten.extension.columnar.{OffloadExchange, OffloadJoin, OffloadOthers}
 import org.apache.gluten.extension.columnar.transition.ConventionReq
+import org.apache.gluten.extension.columnar.validator.{Validator, Validators}
 import org.apache.gluten.planner.GlutenOptimization
 import org.apache.gluten.planner.cost.GlutenCostModel
 import org.apache.gluten.planner.property.Conv
 import org.apache.gluten.ras.property.PropertySet
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.LogLevelUtil
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -40,46 +40,57 @@ import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
   extends Rule[SparkPlan]
   with LogLevelUtil {
-
+  
+  private val validator: Validator = Validators
+    .builder()
+    .fallbackByHint()
+    .fallbackIfScanOnly()
+    .fallbackComplexExpressions()
+    .fallbackByBackendSettings()
+    .fallbackByUserOptions()
+    .fallbackByTestInjects()
+    .build()
+  
   private val rules = List(
-    new PushFilterToScan(RasOffload.validator),
+    new PushFilterToScan(validator),
     RemoveSort,
     RemoveFilter
   )
 
   // TODO: Should obey ReplaceSingleNode#applyScanNotTransformable to select
   //  (vanilla) scan with cheaper sub-query plan through cost model.
-  private val offloadRules = List(
-    RasOffload.from[Exchange](OffloadExchange()).toRule,
-    RasOffload.from[BaseJoinExec](OffloadJoin()).toRule,
-    RasOffloadHashAggregate.toRule,
-    RasOffloadFilter.toRule,
-    RasOffloadProject.toRule,
-    RasOffload.from[DataSourceV2ScanExecBase](OffloadOthers()).toRule,
-    RasOffload.from[DataSourceScanExec](OffloadOthers()).toRule,
-    RasOffload
-      .from(
-        (node: SparkPlan) => HiveTableScanExecTransformer.isHiveTableScan(node),
-        OffloadOthers())
-      .toRule,
-    RasOffload.from[CoalesceExec](OffloadOthers()).toRule,
-    RasOffload.from[SortAggregateExec](OffloadOthers()).toRule,
-    RasOffload.from[ObjectHashAggregateExec](OffloadOthers()).toRule,
-    RasOffload.from[UnionExec](OffloadOthers()).toRule,
-    RasOffload.from[ExpandExec](OffloadOthers()).toRule,
-    RasOffload.from[WriteFilesExec](OffloadOthers()).toRule,
-    RasOffload.from[SortExec](OffloadOthers()).toRule,
-    RasOffload.from[TakeOrderedAndProjectExec](OffloadOthers()).toRule,
-    RasOffload.from[WindowExec](OffloadOthers()).toRule,
-    RasOffload
-      .from(
-        (node: SparkPlan) => SparkShimLoader.getSparkShims.isWindowGroupLimitExec(node),
-        OffloadOthers())
-      .toRule,
-    RasOffload.from[LimitExec](OffloadOthers()).toRule,
-    RasOffload.from[GenerateExec](OffloadOthers()).toRule,
-    RasOffload.from[EvalPythonExec](OffloadOthers()).toRule
-  )
+  private val offloadRules =
+    Seq(
+      RasOffload.from[Exchange](OffloadExchange()),
+      RasOffload.from[BaseJoinExec](OffloadJoin()),
+      RasOffloadHashAggregate,
+      RasOffloadFilter,
+      RasOffloadProject,
+      RasOffload.from[DataSourceV2ScanExecBase](OffloadOthers()),
+      RasOffload.from[DataSourceScanExec](OffloadOthers()),
+      RasOffload
+        .from(
+          (node: SparkPlan) => HiveTableScanExecTransformer.isHiveTableScan(node),
+          OffloadOthers())
+        ,
+      RasOffload.from[CoalesceExec](OffloadOthers()),
+      RasOffload.from[SortAggregateExec](OffloadOthers()),
+      RasOffload.from[ObjectHashAggregateExec](OffloadOthers()),
+      RasOffload.from[UnionExec](OffloadOthers()),
+      RasOffload.from[ExpandExec](OffloadOthers()),
+      RasOffload.from[WriteFilesExec](OffloadOthers()),
+      RasOffload.from[SortExec](OffloadOthers()),
+      RasOffload.from[TakeOrderedAndProjectExec](OffloadOthers()),
+      RasOffload.from[WindowExec](OffloadOthers()),
+      RasOffload
+        .from(
+          (node: SparkPlan) => SparkShimLoader.getSparkShims.isWindowGroupLimitExec(node),
+          OffloadOthers())
+        ,
+      RasOffload.from[LimitExec](OffloadOthers()),
+      RasOffload.from[GenerateExec](OffloadOthers()),
+      RasOffload.from[EvalPythonExec](OffloadOthers())
+    ).map(RasOffload.Rule(_, validator))
 
   private val optimization = {
     GlutenOptimization


### PR DESCRIPTION
`RasOffload.validators` is now initialized only once in the same process when the first time it's accessed. This causes bug that RAS planner never respond to validation-related session configuration changes.

Issue is found in PR https://github.com/apache/incubator-gluten/pull/6756
