### PR TITLE
[GLUTEN-6768][CH] Clear mixed join contition to avoid uneccessary data copy

### DIFF
--- a/cpp-ch/local-engine/Parser/JoinRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/JoinRelParser.cpp
@@ -593,6 +593,7 @@ bool JoinRelParser::applyJoinFilter(
         if (!allow_mixed_condition)
             return false;
         auto mixed_join_expressions_actions = expressionsToActionsDAG({expr}, mixed_header);
+        mixed_join_expressions_actions.removeUnusedActions();
         table_join.getMixedJoinExpression()
             = std::make_shared<DB::ExpressionActions>(std::move(mixed_join_expressions_actions), ExpressionActionsSettings::fromContext(context));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #6768

The mixed join condition doesn't clear the unused input columns, this will cause uneccessary data copy during joining.

It's one of the issues which are noticed in #6768

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

