### PR TITLE
[GLUTEN-6768][CH] Try to reorder hash join tables based on AQE statistics

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -357,6 +357,23 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       .getLong(GLUTEN_MAX_SHUFFLE_READ_BYTES, GLUTEN_MAX_SHUFFLE_READ_BYTES_DEFAULT)
   }
 
+  // Reorder hash join tables, make sure to use the smaller table to build the hash table.
+  // Need to enable AQE
+  def enableReorderHashJoinTables(): Boolean = {
+    SparkEnv.get.conf.getBoolean(
+      "spark.gluten.sql.columnar.backend.ch.enable_reorder_hash_join_tables",
+      true
+    )
+  }
+  // The threshold to reorder hash join tables, if The result of dividing two tables' size is
+  // large then this threshold, reorder the tables. e.g. a/b > threshold or b/a > threshold
+  def reorderHashJoinTablesThreshold(): Int = {
+    SparkEnv.get.conf.getInt(
+      "spark.gluten.sql.columnar.backend.ch.reorder_hash_join_tables_thresdhold",
+      10
+    )
+  }
+
   override def enableNativeWriteFiles(): Boolean = {
     GlutenConfig.getConf.enableNativeWriter.getOrElse(false)
   }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.backendsapi.{BackendsApiManager, SparkPlanExecApi}
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution._
 import org.apache.gluten.expression._
-import org.apache.gluten.extension.{CommonSubexpressionEliminateRule, CountDistinctWithoutExpand, FallbackBroadcastHashJoin, FallbackBroadcastHashJoinPrepQueryStage, RewriteDateTimestampComparisonRule, RewriteSortMergeJoinToHashJoinRule, RewriteToDateExpresstionRule}
+import org.apache.gluten.extension.{CommonSubexpressionEliminateRule, CountDistinctWithoutExpand, FallbackBroadcastHashJoin, FallbackBroadcastHashJoinPrepQueryStage, ReorderJoinTablesRule, RewriteDateTimestampComparisonRule, RewriteSortMergeJoinToHashJoinRule, RewriteToDateExpresstionRule}
 import org.apache.gluten.extension.columnar.AddFallbackTagRule
 import org.apache.gluten.extension.columnar.MiscColumnarRules.TransformPreOverrides
 import org.apache.gluten.extension.columnar.transition.Convention
@@ -601,7 +601,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
    * @return
    */
   override def genExtendedColumnarTransformRules(): List[SparkSession => Rule[SparkPlan]] =
-    List(spark => RewriteSortMergeJoinToHashJoinRule(spark))
+    List(spark => RewriteSortMergeJoinToHashJoinRule(spark), spark => ReorderJoinTablesRule(spark))
 
   override def genInjectPostHocResolutionRules(): List[SparkSession => Rule[LogicalPlan]] = {
     List()

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ReorderJoinTablesRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ReorderJoinTablesRule.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 
 case class ReorderJoinTablesRule(session: SparkSession) extends Rule[SparkPlan] with Logging {
-  logError(s"ReorderJoinTablesRule is enabled: ${CHBackendSettings.enableReorderHashJoinTables}")
   override def apply(plan: SparkPlan): SparkPlan = {
     if (CHBackendSettings.enableReorderHashJoinTables) {
       visitPlan(plan)
@@ -59,9 +58,6 @@ case class ReorderJoinTablesRule(session: SparkSession) extends Rule[SparkPlan] 
       val threshold = CHBackendSettings.reorderHashJoinTablesThreshold
       val isLeftLarger = leftQueryStageRow.get > rightQueryStageRow.get * threshold
       val isRightLarger = leftQueryStageRow.get * threshold < rightQueryStageRow.get
-      logError(
-        s"xxx isLeftLarger:$isLeftLarger, isRightLarger:$isRightLarger, " +
-          s"buildside:${hashJoin.buildSide}, join type: ${hashJoin.joinType}")
       hashJoin.joinType match {
         case Inner =>
           if (isRightLarger && hashJoin.buildSide == BuildRight) {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ReorderJoinTablesRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ReorderJoinTablesRule.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.gluten.backendsapi.clickhouse.CHBackendSettings
+import org.apache.gluten.execution._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.optimizer._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive._
+
+case class ReorderJoinTablesRule(session: SparkSession) extends Rule[SparkPlan] with Logging {
+  logError(s"ReorderJoinTablesRule is enabled: ${CHBackendSettings.enableReorderHashJoinTables}")
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (CHBackendSettings.enableReorderHashJoinTables) {
+      visitPlan(plan)
+    } else {
+      plan
+    }
+  }
+
+  private def visitPlan(plan: SparkPlan): SparkPlan = {
+    plan match {
+      case hashShuffle: ColumnarShuffleExchangeExec =>
+        hashShuffle.withNewChildren(hashShuffle.children.map(visitPlan))
+      case hashJoin: CHShuffledHashJoinExecTransformer =>
+        val newHashJoin = reorderHashJoin(hashJoin)
+        newHashJoin.withNewChildren(newHashJoin.children.map(visitPlan))
+      case _ =>
+        plan.withNewChildren(plan.children.map(visitPlan))
+    }
+  }
+
+  private def reorderHashJoin(hashJoin: CHShuffledHashJoinExecTransformer): SparkPlan = {
+    val leftQueryStageRow = childShuffleQueryStageRows(hashJoin.left)
+    val rightQueryStageRow = childShuffleQueryStageRows(hashJoin.right)
+    if (leftQueryStageRow == None || rightQueryStageRow == None) {
+      logError(s"Cannot reorder this hash join. Its children is not ShuffleQueryStageExec")
+      hashJoin
+    } else {
+      val threshold = CHBackendSettings.reorderHashJoinTablesThreshold
+      val isLeftLarger = leftQueryStageRow.get > rightQueryStageRow.get * threshold
+      val isRightLarger = leftQueryStageRow.get * threshold < rightQueryStageRow.get
+      logError(
+        s"xxx isLeftLarger:$isLeftLarger, isRightLarger:$isRightLarger, " +
+          s"buildside:${hashJoin.buildSide}, join type: ${hashJoin.joinType}")
+      hashJoin.joinType match {
+        case Inner =>
+          if (isRightLarger && hashJoin.buildSide == BuildRight) {
+            CHShuffledHashJoinExecTransformer(
+              hashJoin.rightKeys,
+              hashJoin.leftKeys,
+              hashJoin.joinType,
+              hashJoin.buildSide,
+              hashJoin.condition,
+              hashJoin.right,
+              hashJoin.left,
+              hashJoin.isSkewJoin)
+          } else if (isLeftLarger && hashJoin.buildSide == BuildLeft) {
+            CHShuffledHashJoinExecTransformer(
+              hashJoin.leftKeys,
+              hashJoin.rightKeys,
+              hashJoin.joinType,
+              BuildRight,
+              hashJoin.condition,
+              hashJoin.left,
+              hashJoin.right,
+              hashJoin.isSkewJoin)
+          } else {
+            hashJoin
+          }
+        case LeftOuter =>
+          // left outer + build right is the common case，other cases have not been covered by tests
+          // and don't reroder them.
+          if (isRightLarger && hashJoin.buildSide == BuildRight) {
+            CHShuffledHashJoinExecTransformer(
+              hashJoin.rightKeys,
+              hashJoin.leftKeys,
+              RightOuter,
+              BuildRight,
+              hashJoin.condition,
+              hashJoin.right,
+              hashJoin.left,
+              hashJoin.isSkewJoin)
+          } else {
+            hashJoin
+          }
+        case RightOuter =>
+          // right outer + build left is the common case，other cases have not been covered by tests
+          // and don't reroder them.
+          if (isLeftLarger && hashJoin.buildSide == BuildLeft) {
+            CHShuffledHashJoinExecTransformer(
+              hashJoin.leftKeys,
+              hashJoin.rightKeys,
+              RightOuter,
+              BuildRight,
+              hashJoin.condition,
+              hashJoin.left,
+              hashJoin.right,
+              hashJoin.isSkewJoin)
+          } else if (isRightLarger && hashJoin.buildSide == BuildLeft) {
+            CHShuffledHashJoinExecTransformer(
+              hashJoin.rightKeys,
+              hashJoin.leftKeys,
+              LeftOuter,
+              BuildRight,
+              hashJoin.condition,
+              hashJoin.right,
+              hashJoin.left,
+              hashJoin.isSkewJoin)
+          } else {
+            hashJoin
+          }
+        case _ => hashJoin
+      }
+    }
+  }
+
+  private def childShuffleQueryStageRows(plan: SparkPlan): Option[BigInt] = {
+    plan match {
+      case queryStage: ShuffleQueryStageExec =>
+        queryStage.getRuntimeStatistics.rowCount
+      case _: ColumnarBroadcastExchangeExec =>
+        None
+      case _: ColumnarShuffleExchangeExec =>
+        None
+      case _ =>
+        if (plan.children.length == 1) {
+          childShuffleQueryStageRows(plan.children.head)
+        } else {
+          None
+        }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #6768

If the gap of two tables‘ sizes is too large, try to reorder the tables, make sure the smaller table is used to build the hash table.

With AQE, we could get the row number from `ShuffleQueryStageExec`

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

