### PR TITLE
[VL] Fix arrow dataset csv scan IncompatibleClassChangeError

### DIFF
--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -87,13 +87,13 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>${arrow-memory.artifact}</artifactId>
-      <version>${arrow.version}</version>
+      <version>${arrow-gluten.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
-      <version>${arrow.version}</version>
+      <version>${arrow-gluten.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
-      <version>${arrow.version}</version>
+      <version>${arrow-gluten.version}</version>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>

--- a/gluten-ut/spark32/pom.xml
+++ b/gluten-ut/spark32/pom.xml
@@ -57,45 +57,6 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-vector</artifactId>
-          <version>${arrow.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-netty</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-core</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
       <properties>
         <clickhouse.lib.path></clickhouse.lib.path>
       </properties>

--- a/gluten-ut/spark33/pom.xml
+++ b/gluten-ut/spark33/pom.xml
@@ -64,44 +64,6 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-vector</artifactId>
-          <version>${arrow.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-netty</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-core</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
       </dependencies>
       <properties>
         <clickhouse.lib.path></clickhouse.lib.path>

--- a/gluten-ut/spark34/pom.xml
+++ b/gluten-ut/spark34/pom.xml
@@ -64,44 +64,6 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-vector</artifactId>
-          <version>${arrow.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-netty</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-core</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
         <!-- log4j -->
         <dependency>
           <groupId>org.slf4j</groupId>

--- a/gluten-ut/spark35/pom.xml
+++ b/gluten-ut/spark35/pom.xml
@@ -98,44 +98,6 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-vector</artifactId>
-          <version>${arrow.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-netty</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-core</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
         <!-- log4j -->
         <dependency>
           <groupId>org.slf4j</groupId>

--- a/gluten-ut/test/pom.xml
+++ b/gluten-ut/test/pom.xml
@@ -70,45 +70,7 @@
           <artifactId>backends-velox</artifactId>
           <version>${project.version}</version>
           <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-vector</artifactId>
-          <version>${arrow.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-netty</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.arrow</groupId>
-          <artifactId>arrow-memory-core</artifactId>
-          <version>${arrow.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-common</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-buffer</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
+        </dependency>       
       </dependencies>
       <properties>
         <clickhouse.lib.path></clickhouse.lib.path>


### PR DESCRIPTION
```
- SPARK-37326: Roundtrip in reading and writing TIMESTAMP_NTZ values with custom schema
07:13:20.662 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: WriteFiles[QueryId=1370], due to: Unsupported native write: Only ParquetFileFormat and HiveFileFormat are supported..
07:13:20.662 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Execute InsertIntoHadoopFsRelationCommand[QueryId=1370], due to: at least one of its children has empty output; at least one of its children has empty output.
07:13:20.725 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan text [QueryId=1371], due to: Unsupported file format for UnknownFormat..
E20240812 07:13:20.742442 58221 Exceptions.h:67] Line: /__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/velox/exec/Task.cpp:1864, Function:terminate, Expression:  Cancelled, Source: RUNTIME, ErrorCode: INVALID_STATE
07:13:20.747 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan text , due to: Unsupported file format for UnknownFormat..
07:13:20.808 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan csv , due to: Found schema check failure for StructType(StructField(col0,TimestampNTZType,true)), due to: Schema / data type not supported: TimestampNTZType.
07:13:20.812 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan csv , due to: Found schema check failure for StructType(StructField(col0,TimestampNTZType,true)), due to: Schema / data type not supported: TimestampNTZType.
07:13:20.885 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan text [QueryId=1374], due to: Unsupported file format for UnknownFormat..
E20240812 07:13:20.902714 57821 Exceptions.h:67] Line: /__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/velox/exec/Task.cpp:1864, Function:terminate, Expression:  Cancelled, Source: RUNTIME, ErrorCode: INVALID_STATE
07:13:20.907 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan text , due to: Unsupported file format for UnknownFormat..
07:13:20.937 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan text [QueryId=1375], due to: Unsupported file format for UnknownFormat..
E20240812 07:13:20.953720 57821 Exceptions.h:67] Line: /__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/velox/exec/Task.cpp:1864, Function:terminate, Expression:  Cancelled, Source: RUNTIME, ErrorCode: INVALID_STATE
07:13:20.957 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan text , due to: Unsupported file format for UnknownFormat..
/__w/incubator-gluten/incubator-gluten/ep/_ep/arrow_ep/java/dataset/src/main/cpp/jni_util.cc:79: Failed to update reservation while freeing bytes: Java Exception: java.lang.IncompatibleClassChangeError

/tmp/jnilib-5403273613459830800.tmp(+0x12195e8)[0x7f49e71935e8]
/tmp/jnilib-5403273613459830800.tmp(_ZN5arrow4util8ArrowLogD1Ev+0xed)[0x7f49e719376d]
/tmp/jnilib-5403273613459830800.tmp(_ZN5arrow7dataset3jni31ReservationListenableMemoryPool4FreeEPhll+0x45d)[0x7f49e67884ed]
/tmp/jnilib-5403273613459830800.tmp(_ZN5arrow10PoolBufferD0Ev+0x47)[0x7f49e741faf7]
/tmp/jnilib-5403273613459830800.tmp(_ZNSt6vectorISt10shared_ptrIN5arrow6BufferEESaIS3_EED1Ev+0x6b)[0x7f49e689d11b]
07:13:20.992 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Scan csv , due to: Unsupported file format for TextReadFormat..
/tmp/jnilib-5403273613459830800.tmp(_ZNSt23_Sp_counted_ptr_inplaceIN5arrow9ArrayDataESaIS1_ELN9__gnu_cxx12_Lock_policyE2EE10_M_disposeEv+0xda)[0x7f49e69ab0aa]
/tmp/jnilib-5403273613459830800.tmp(_ZN5arrow17SimpleRecordBatchD1Ev+0x116)[0x7f49e72c95d6]
```