### PR TITLE
[GLUTEN-6368] Redact sensitive configs when calling `gluten::printConfig`

### DIFF
--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -16,12 +16,11 @@
  */
 
 #include <jni.h>
-
+#include <optional>
+#include <regex>
 #include "compute/ProtobufUtils.h"
 #include "config.pb.h"
 #include "jni/JniError.h"
-#include <regex>
-#include <optional>
 
 namespace gluten {
 
@@ -29,35 +28,36 @@ const std::string REDACTED_VALUE = "*********(redacted)";
 const std::string REGEX_REDACT_KEY = "spark.gluten.redaction.regex";
 
 std::unordered_map<std::string, std::string>
-  parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength) {
-    std::unordered_map<std::string, std::string> sparkConfs;
-    ConfigMap pConfigMap;
-    gluten::parseProtobuf(planData, planDataLength, &pConfigMap);
-    for (const auto& pair : pConfigMap.configs()) {
-      sparkConfs.emplace(pair.first, pair.second);
+parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength) {
+  std::unordered_map<std::string, std::string> sparkConfs;
+  ConfigMap pConfigMap;
+  gluten::parseProtobuf(planData, planDataLength, &pConfigMap);
+  for (const auto& pair : pConfigMap.configs()) {
+    sparkConfs.emplace(pair.first, pair.second);
   }
+
   return sparkConfs;
 }
 
 std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string, std::string>& conf) {
-    auto it = conf.find(REGEX_REDACT_KEY);
-    if (it != conf.end()) {
-        return std::regex(it->second);
-    }
-    return std::nullopt;
+  auto it = conf.find(REGEX_REDACT_KEY);
+  if (it != conf.end()) {
+    return std::regex(it->second);
+  }
+  return std::nullopt;
 }
 
 std::string printConfig(const std::unordered_map<std::string, std::string>& conf) {
   std::ostringstream oss;
   oss << std::endl;
 
-    auto redactionRegex = getRedactionRegex(conf);
+  auto redactionRegex = getRedactionRegex(conf);
 
   for (const auto& [k, v] : conf) {
     if (redactionRegex && std::regex_match(k, *redactionRegex)) {
-        oss << " [" << k << ", " << REDACTED_VALUE << "]\n";
+      oss << " [" << k << ", " << REDACTED_VALUE << "]\n";
     } else {
-        oss << " [" << k << ", " << v << "]\n";
+      oss << " [" << k << ", " << v << "]\n";
     }
   }
   return oss.str();

--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -22,10 +22,21 @@
 #include "config.pb.h"
 #include "jni/JniError.h"
 
+namespace {
+
+const std::string REGEX_REDACT_KEY = "spark.gluten.redaction.regex";
+std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string, std::string>& conf) {
+  auto it = conf.find(REGEX_REDACT_KEY);
+  if (it != conf.end()) {
+    return std::regex(it->second);
+  }
+  return std::nullopt;
+}
+} // namespace anonymous
+
 namespace gluten {
 
 const std::string REDACTED_VALUE = "*********(redacted)";
-const std::string REGEX_REDACT_KEY = "spark.gluten.redaction.regex";
 
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength) {
@@ -37,14 +48,6 @@ parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength)
   }
 
   return sparkConfs;
-}
-
-std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string, std::string>& conf) {
-  auto it = conf.find(REGEX_REDACT_KEY);
-  if (it != conf.end()) {
-    return std::regex(it->second);
-  }
-  return std::nullopt;
 }
 
 std::string printConfig(const std::unordered_map<std::string, std::string>& conf) {

--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -17,17 +17,17 @@
 
 #include <jni.h>
 #include <optional>
-#include <regex>
+#include <boost/regex.hpp>
 #include "compute/ProtobufUtils.h"
 #include "config.pb.h"
 #include "jni/JniError.h"
 
 namespace {
 
-std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string, std::string>& conf) {
+std::optional<boost::regex> getRedactionRegex(const std::unordered_map<std::string, std::string>& conf) {
   auto it = conf.find(gluten::kSparkRedactionRegex);
   if (it != conf.end()) {
-    return std::regex(it->second);
+    return boost::regex(it->second);
   }
   return std::nullopt;
 }
@@ -54,7 +54,7 @@ std::string printConfig(const std::unordered_map<std::string, std::string>& conf
   auto redactionRegex = getRedactionRegex(conf);
 
   for (const auto& [k, v] : conf) {
-    if (redactionRegex && std::regex_match(k, *redactionRegex)) {
+    if (redactionRegex && boost::regex_match(k, *redactionRegex)) {
       oss << " [" << k << ", " << kSparkRedactionString << "]\n";
     } else {
       oss << " [" << k << ", " << v << "]\n";

--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -32,7 +32,7 @@ std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string
   }
   return std::nullopt;
 }
-} // namespace anonymous
+} // namespace
 
 namespace gluten {
 

--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
+#include <boost/regex.hpp>
 #include <jni.h>
 #include <optional>
-#include <boost/regex.hpp>
 #include "compute/ProtobufUtils.h"
 #include "config.pb.h"
 #include "jni/JniError.h"

--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -24,9 +24,8 @@
 
 namespace {
 
-const std::string REGEX_REDACT_KEY = "spark.gluten.redaction.regex";
 std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string, std::string>& conf) {
-  auto it = conf.find(REGEX_REDACT_KEY);
+  auto it = conf.find(gluten::kSparkRedactionRegex);
   if (it != conf.end()) {
     return std::regex(it->second);
   }
@@ -35,8 +34,6 @@ std::optional<std::regex> getRedactionRegex(const std::unordered_map<std::string
 } // namespace
 
 namespace gluten {
-
-const std::string REDACTED_VALUE = "*********(redacted)";
 
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength) {
@@ -58,7 +55,7 @@ std::string printConfig(const std::unordered_map<std::string, std::string>& conf
 
   for (const auto& [k, v] : conf) {
     if (redactionRegex && std::regex_match(k, *redactionRegex)) {
-      oss << " [" << k << ", " << REDACTED_VALUE << "]\n";
+      oss << " [" << k << ", " << kSparkRedactionString << "]\n";
     } else {
       oss << " [" << k << ", " << v << "]\n";
     }

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -64,6 +64,9 @@ const std::string kShuffleCompressionCodecBackend = "spark.gluten.sql.columnar.s
 const std::string kQatBackendName = "qat";
 const std::string kIaaBackendName = "iaa";
 
+const std::string kSparkRedactionRegex = "spark.redaction.regex";
+const std::string kSparkRedactionString = "*********(redacted)";
+
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength);
 

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -64,8 +64,6 @@ const std::string kShuffleCompressionCodecBackend = "spark.gluten.sql.columnar.s
 const std::string kQatBackendName = "qat";
 const std::string kIaaBackendName = "iaa";
 
-const std::string kRedactionRegex = "spark.gluten.redaction.regex";
-
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength);
 

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -64,6 +64,8 @@ const std::string kShuffleCompressionCodecBackend = "spark.gluten.sql.columnar.s
 const std::string kQatBackendName = "qat";
 const std::string kIaaBackendName = "iaa";
 
+const std::string kRedactionRegex = "spark.gluten.redaction.regex";
+
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength);
 

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -534,6 +534,7 @@ object GlutenConfig {
   val GLUTEN_ONHEAP_SIZE_KEY = "spark.executor.memory"
   val GLUTEN_OFFHEAP_SIZE_KEY = "spark.memory.offHeap.size"
   val GLUTEN_OFFHEAP_ENABLED = "spark.memory.offHeap.enabled"
+  val SPARK_REDACTION_REGEX = "spark.redaction.regex"
 
   // For Soft Affinity Scheduling
   // Enable Soft Affinity Scheduling, defalut value is false
@@ -622,7 +623,6 @@ object GlutenConfig {
 
   val GLUTEN_COST_EVALUATOR_ENABLED = "spark.gluten.sql.adaptive.costEvaluator.enabled"
 
-  val GLUTEN_REGEX_LOG_REDACTION = "spark.gluten.redaction.regex"
   var ins: GlutenConfig = _
 
   def getConf: GlutenConfig = {
@@ -675,7 +675,7 @@ object GlutenConfig {
       SPARK_GCS_STORAGE_ROOT_URL,
       SPARK_GCS_AUTH_TYPE,
       SPARK_GCS_AUTH_SERVICE_ACCOUNT_JSON_KEYFILE,
-      GLUTEN_REGEX_LOG_REDACTION
+      SPARK_REDACTION_REGEX
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 
@@ -760,7 +760,7 @@ object GlutenConfig {
       GLUTEN_OFFHEAP_ENABLED,
       SESSION_LOCAL_TIMEZONE.key,
       DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key,
-      GLUTEN_REGEX_LOG_REDACTION
+      SPARK_REDACTION_REGEX
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -622,6 +622,7 @@ object GlutenConfig {
 
   val GLUTEN_COST_EVALUATOR_ENABLED = "spark.gluten.sql.adaptive.costEvaluator.enabled"
 
+  val GLUTEN_REGEX_LOG_REDACTION = "spark.gluten.redaction.regex"
   var ins: GlutenConfig = _
 
   def getConf: GlutenConfig = {
@@ -673,7 +674,8 @@ object GlutenConfig {
       // gcs config
       SPARK_GCS_STORAGE_ROOT_URL,
       SPARK_GCS_AUTH_TYPE,
-      SPARK_GCS_AUTH_SERVICE_ACCOUNT_JSON_KEYFILE
+      SPARK_GCS_AUTH_SERVICE_ACCOUNT_JSON_KEYFILE,
+      GLUTEN_REGEX_LOG_REDACTION
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 
@@ -757,7 +759,8 @@ object GlutenConfig {
       GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY,
       GLUTEN_OFFHEAP_ENABLED,
       SESSION_LOCAL_TIMEZONE.key,
-      DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key
+      DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key,
+      GLUTEN_REGEX_LOG_REDACTION
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Currently Spark supports `spark.redaction.regex` which allows redacting sensitive info like passwords, tokens etc.
- However gluten does not enforce this and logs in plaintext when debug mode is enabled.
- Added support to redact in printconfig which is being used in the codebase to log the config at various places.
- User can provide a regex which will be matched and a redacted string will be visitble.

Fixes: #6368

## How was this patch tested?
 - Local Spark shell
 Before:
<img width="918" alt="image" src="https://github.com/user-attachments/assets/64f5bb38-624a-4119-a36c-5d3efcea5363">

After: (Additional regex was supplied to match `spark.gluten.ugi.tokens`)
<img width="932" alt="image" src="https://github.com/user-attachments/assets/b608ac52-aa2b-4c80-9077-c52d5d42edcc">




