### PR TITLE
[CORE] Remove the fix 1.8 Java compiler version in module gluten-ut-common

### DIFF
--- a/gluten-ut/common/pom.xml
+++ b/gluten-ut/common/pom.xml
@@ -40,10 +40,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
         <executions>
           <execution>
             <phase>compile</phase>


### PR DESCRIPTION
We now use variable `java.version` to support multiple Java versions. No need to keep the fix version options.

This is a minor change.