### PR TITLE
[GLUTEN-6834][CORE] feat: add other join types from the official Substrait

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashJoinExecTransformer.scala
@@ -67,7 +67,7 @@ object JoinTypeTransform {
         if (!buildRight) {
           throw new IllegalArgumentException("LeftAnti join should not switch children")
         }
-        JoinRel.JoinType.JOIN_TYPE_ANTI
+        JoinRel.JoinType.JOIN_TYPE_LEFT_ANTI
       case _ =>
         // TODO: Support cross join with Cross Rel
         JoinRel.JoinType.UNRECOGNIZED

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ShuffledHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ShuffledHashJoinExecTransformer.scala
@@ -69,7 +69,7 @@ case class ShuffledHashJoinExecTransformer(
         JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI
       }
     case LeftAnti =>
-      JoinRel.JoinType.JOIN_TYPE_ANTI
+      JoinRel.JoinType.JOIN_TYPE_LEFT_ANTI
     case _ =>
       JoinRel.JoinType.UNRECOGNIZED
   }
@@ -112,7 +112,7 @@ case class BroadcastHashJoinExecTransformer(
     case LeftSemi | ExistenceJoin(_) =>
       JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI
     case LeftAnti =>
-      JoinRel.JoinType.JOIN_TYPE_ANTI
+      JoinRel.JoinType.JOIN_TYPE_LEFT_ANTI
     case _ =>
       // TODO: Support cross join with Cross Rel
       JoinRel.JoinType.UNRECOGNIZED

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -1104,7 +1104,7 @@ JoinUtil::getJoinKindAndStrictness(substrait::JoinRel_JoinType join_type, bool i
                 return {DB::JoinKind::Left, DB::JoinStrictness::Any};
             return {DB::JoinKind::Left, DB::JoinStrictness::Semi};
         }
-        case substrait::JoinRel_JoinType_JOIN_TYPE_ANTI:
+        case substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI:
             return {DB::JoinKind::Left, DB::JoinStrictness::Anti};
         case substrait::JoinRel_JoinType_JOIN_TYPE_LEFT:
             return {DB::JoinKind::Left, DB::JoinStrictness::All};

--- a/cpp-ch/local-engine/Parser/JoinRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/JoinRelParser.cpp
@@ -269,7 +269,7 @@ DB::QueryPlanPtr JoinRelParser::parseJoin(const substrait::JoinRel & join, DB::Q
 
     if (storage_join)
     {
-        if (join_opt_info.is_null_aware_anti_join && join.type() == substrait::JoinRel_JoinType_JOIN_TYPE_ANTI)
+        if (join_opt_info.is_null_aware_anti_join && join.type() == substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI)
         {
             if (storage_join->has_null_key_value)
             {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -309,7 +309,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
         joinType = core::JoinType::kRightSemiFilter;
       }
       break;
-    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_ANTI: {
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI: {
       // Determine the anti join type based on extracted information.
       if (sJoin.has_advanced_extension() &&
           SubstraitParser::configSetInOptimization(sJoin.advanced_extension(), "isNullAwareAntiJoin=")) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -899,7 +899,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT:
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_SEMI:
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT_SEMI:
-      case ::substrait::JoinRel_JoinType_JOIN_TYPE_ANTI:
+      case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI:
         break;
       default:
         LOG_VALIDATION_MSG("Sort merge join type is not supported: " + std::to_string(joinRel.type()));
@@ -913,7 +913,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
     case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT:
     case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_SEMI:
     case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT_SEMI:
-    case ::substrait::JoinRel_JoinType_JOIN_TYPE_ANTI:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI:
       break;
     default:
       LOG_VALIDATION_MSG("Join type is not supported: " + std::to_string(joinRel.type()));

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -253,16 +253,6 @@ message CrossRel {
 
   JoinType type = 5;
 
-  // TODO -- Remove this unnecessary type.
-  enum JoinType {
-    JOIN_TYPE_UNSPECIFIED = 0;
-    JOIN_TYPE_INNER = 1;
-    JOIN_TYPE_OUTER = 2;
-    JOIN_TYPE_LEFT = 3;
-    JOIN_TYPE_RIGHT = 4;
-    JOIN_TYPE_LEFT_SEMI = 5;
-  }
-
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -234,11 +234,11 @@ message JoinRel {
     JOIN_TYPE_LEFT = 3;
     JOIN_TYPE_RIGHT = 4;
     JOIN_TYPE_LEFT_SEMI = 5;
-    JOIN_TYPE_RIGHT_SEMI = 6;
-    JOIN_TYPE_ANTI = 7;
-    // This join is useful for nested sub-queries where we need exactly one tuple in output (or throw exception)
-    // See Section 3.2 of https://15721.courses.cs.cmu.edu/spring2018/papers/16-optimizer2/hyperjoins-btw2017.pdf
-    JOIN_TYPE_SINGLE = 8;
+    JOIN_TYPE_LEFT_ANTI = 6;
+    JOIN_TYPE_LEFT_SINGLE = 7;
+    JOIN_TYPE_RIGHT_SEMI = 8;
+    JOIN_TYPE_RIGHT_ANTI = 9;
+    JOIN_TYPE_RIGHT_SINGLE = 10;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
@@ -253,6 +253,7 @@ message CrossRel {
 
   JoinType type = 5;
 
+  // TODO -- Remove this unnecessary type.
   enum JoinType {
     JOIN_TYPE_UNSPECIFIED = 0;
     JOIN_TYPE_INNER = 1;
@@ -649,6 +650,8 @@ message HashJoinRel {
     JOIN_TYPE_RIGHT_SEMI = 6;
     JOIN_TYPE_LEFT_ANTI = 7;
     JOIN_TYPE_RIGHT_ANTI = 8;
+    JOIN_TYPE_LEFT_SINGLE = 9;
+    JOIN_TYPE_RIGHT_SINGLE = 10;
   }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -253,6 +253,21 @@ message CrossRel {
 
   JoinType type = 5;
 
+  // TODO -- Remove this unnecessary type.
+  enum JoinType {
+    JOIN_TYPE_UNSPECIFIED = 0;
+    JOIN_TYPE_INNER = 1;
+    JOIN_TYPE_OUTER = 2;
+    JOIN_TYPE_LEFT = 3;
+    JOIN_TYPE_RIGHT = 4;
+    JOIN_TYPE_LEFT_SEMI = 5;
+    JOIN_TYPE_LEFT_ANTI = 6;
+    JOIN_TYPE_LEFT_SINGLE = 7;
+    JOIN_TYPE_RIGHT_SEMI = 8;
+    JOIN_TYPE_RIGHT_ANTI = 9;
+    JOIN_TYPE_RIGHT_SINGLE = 10;
+  }
+
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/SortMergeJoinExecTransformer.scala
@@ -152,7 +152,7 @@ abstract class SortMergeJoinExecTransformerBase(
     case LeftSemi =>
       JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI
     case LeftAnti =>
-      JoinRel.JoinType.JOIN_TYPE_ANTI
+      JoinRel.JoinType.JOIN_TYPE_LEFT_ANTI
     case _ =>
       // TODO: Support cross join with Cross Rel
       // TODO: Support existence join

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/SubstraitUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/SubstraitUtil.scala
@@ -43,7 +43,7 @@ object SubstraitUtil {
     case LeftSemi =>
       JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI
     case LeftAnti =>
-      JoinRel.JoinType.JOIN_TYPE_ANTI
+      JoinRel.JoinType.JOIN_TYPE_LEFT_ANTI
     case _ =>
       // TODO: Support existence join
       JoinRel.JoinType.UNRECOGNIZED


### PR DESCRIPTION
Adds the join types currently defined in Substrait to the Gluten copy.  This is one of a vast set of changes aimed at reducing the differences from the official version in hope that one day there would be no differences.
