### PR TITLE
[MINOR] exclude velox build path ep/build-velox/build/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Testing/
 cmake-build-debug/
 cmake-build-release/
 ep/_ep/
+ep/build-velox/build/
 
 # Editor temporary/working/backup files #
 .#*


### PR DESCRIPTION
velox build directory in .gitignore

## What changes were proposed in this pull request?

Add ep/build-velox/build/ to .gitignore. it's local build src files and binary

## How was this patch tested?
manual

