### PR TITLE
[VL] Remove suspend section when spilling Velox task

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -209,29 +209,6 @@ std::shared_ptr<ColumnarBatch> WholeStageResultIterator::next() {
   return std::make_shared<VeloxColumnarBatch>(vector);
 }
 
-namespace {
-class SuspendedSection {
- public:
-  SuspendedSection() {
-    reclaimer_->enterArbitration();
-  }
-
-  virtual ~SuspendedSection() {
-    reclaimer_->leaveArbitration();
-  }
-
-  // singleton
-  SuspendedSection(const SuspendedSection&) = delete;
-  SuspendedSection(SuspendedSection&&) = delete;
-  SuspendedSection& operator=(const SuspendedSection&) = delete;
-  SuspendedSection& operator=(SuspendedSection&&) = delete;
-
- private:
-  // We only use suspension APIs in exec::MemoryReclaimer.
-  std::unique_ptr<velox::memory::MemoryReclaimer> reclaimer_{velox::exec::MemoryReclaimer::create()};
-};
-} // namespace
-
 int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   auto pool = memoryManager_->getAggregateMemoryPool();
   std::string poolName{pool->root()->name() + "/" + pool->name()};
@@ -241,9 +218,6 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   if (spillStrategy_ == "auto") {
     int64_t remaining = size - shrunken;
     LOG(INFO) << logPrefix << "Trying to request spilling for " << remaining << " bytes...";
-    // suspend the driver when we are on it
-    SuspendedSection suspender;
-    velox::exec::MemoryReclaimer::Stats status;
     auto* mm = memoryManager_->getMemoryManager();
     uint64_t spilledOut = mm->arbitrator()->shrinkCapacity(remaining); // this conducts spilling
     LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -239,15 +239,6 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   int64_t shrunken = memoryManager_->shrink(size);
   // todo return the actual spilled size?
   if (spillStrategy_ == "auto") {
-    exec::DriverThreadContext* driverThreadCtx = exec::driverThreadContext();
-    if (driverThreadCtx != nullptr) {
-      if (driverThreadCtx->driverCtx.task->taskId() != task_->taskId()) {
-        // Disallow one task from spilling another. This is by Velox's restriction. See
-        // https://github.com/facebookincubator/velox/blob/9523840ac329be4f7318338fb92cb92bcb0a8c07/velox/exec/Operator.cpp#L566-L575.
-        VLOG(2) << logPrefix << "One Velox task is trying to spill another, ignoring.";
-        return shrunken;
-      }
-    }
     int64_t remaining = size - shrunken;
     LOG(INFO) << logPrefix << "Trying to request spilling for " << remaining << " bytes...";
     // suspend the driver when we are on it


### PR DESCRIPTION
Suspension is not needed during Velox updates. Remove it to minimize code.