### PR TITLE
[VL][CI] Change to use push event to trigger docker build workflow

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -16,7 +16,9 @@
 name: Build and Push Docker Image
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - '.github/workflows/docker_image.yml'
   schedule:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Github secrets are not passed to workflows that are triggered by a pull request from a fork. So change to use push event.
