### PR TITLE
[CORE] Fix incorrect precision of decimal literal

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -2086,4 +2086,12 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     val df2 = runQueryAndCompare("SELECT round(cast(0.19324999999999998 as double), 2)") { _ => }
     checkLengthAndPlan(df2, 1)
   }
+
+  test("Fix wrong rescale") {
+    withTable("t") {
+      sql("create table t (col0 decimal(10, 0), col1 decimal(10, 0)) using parquet")
+      sql("insert into t values (0, 0)")
+      runQueryAndCompare("select col0 / (col1 + 1E-8) from t") { _ => }
+    }
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/utils/DecimalArithmeticUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/utils/DecimalArithmeticUtil.scala
@@ -99,7 +99,7 @@ object DecimalArithmeticUtil {
   // For decimal * 10 case, dec will be Decimal(38, 18), then the result precision is wrong,
   // so here we will get the real precision and scale of the literal.
   private def getNewPrecisionScale(dec: Decimal): (Integer, Integer) = {
-    val input = dec.abs.toString()
+    val input = dec.abs.toJavaBigDecimal.toPlainString()
     val dotIndex = input.indexOf(".")
     if (dotIndex == -1) {
       return (input.length, 0)


### PR DESCRIPTION
For SQL as follows:
```
select (col0 / (col1 + 0.00000001)) from table;
```
In this case, col0 and col1 are 0.
The result may be NULL. The reason is that the result of `Decimal(0.00000001).toString()` is "1E-8", which will make the new precision be 4.
Therefore, we use `toPlainString` here to prevent scientific notation.
