### PR TITLE
[VL] Malformed CI job name

### DIFF
--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -582,7 +582,7 @@ jobs:
           GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox-with-celeborn --benchmark-type=ds --error-on-memleak --off-heap-size=10g -s=1.0 --threads=8 --iterations=1
 
-  run-CPP-test-UDF-test:
+  run-cpp-test-udf-test:
     runs-on: ubuntu-20.04
     container: ghcr.io/facebookincubator/velox-dev:centos8
     steps:
@@ -605,6 +605,9 @@ jobs:
         run: |
           df -a
           bash dev/ci-velox-buildshared-centos-8.sh
+      - name: Export Maven path
+        run: |
+          echo "PATH=${PATH}:/usr/lib/maven/bin" >> $GITHUB_ENV
       - name: Run CPP unit test
         run: |
           cd ./cpp/build && ctest -V

--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -582,7 +582,7 @@ jobs:
           GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox-with-celeborn --benchmark-type=ds --error-on-memleak --off-heap-size=10g -s=1.0 --threads=8 --iterations=1
 
-  run-CPP-test-UDF-test:
+  run-cpp-test-udf-test:
     runs-on: ubuntu-20.04
     container: ghcr.io/facebookincubator/velox-dev:centos8
     steps:

--- a/.github/workflows/velox_docker.yml
+++ b/.github/workflows/velox_docker.yml
@@ -582,7 +582,7 @@ jobs:
           GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox-with-celeborn --benchmark-type=ds --error-on-memleak --off-heap-size=10g -s=1.0 --threads=8 --iterations=1
 
-  run-cpp-test-udf-test:
+  run-CPP-test-UDF-test:
     runs-on: ubuntu-20.04
     container: ghcr.io/facebookincubator/velox-dev:centos8
     steps:
@@ -605,9 +605,6 @@ jobs:
         run: |
           df -a
           bash dev/ci-velox-buildshared-centos-8.sh
-      - name: Export Maven path
-        run: |
-          echo "PATH=${PATH}:/usr/lib/maven/bin" >> $GITHUB_ENV
       - name: Run CPP unit test
         run: |
           cd ./cpp/build && ctest -V

--- a/dev/ci-velox-buildshared-centos-8.sh
+++ b/dev/ci-velox-buildshared-centos-8.sh
@@ -10,6 +10,7 @@ yum install sudo patch java-1.8.0-openjdk-devel wget -y
 wget https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz
 tar -xvf apache-maven-3.8.8-bin.tar.gz && mv apache-maven-3.8.8 /usr/lib/maven
 export PATH="${PATH}:/usr/lib/maven/bin"
+echo "PATH=${PATH}:/usr/lib/maven/bin" >> $GITHUB_ENV
 
 source /opt/rh/gcc-toolset-9/enable
 ./dev/builddeps-veloxbe.sh --run_setup_script=OFF --enable_ep_cache=OFF --build_tests=ON \

--- a/dev/ci-velox-buildshared-centos-8.sh
+++ b/dev/ci-velox-buildshared-centos-8.sh
@@ -10,7 +10,6 @@ yum install sudo patch java-1.8.0-openjdk-devel wget -y
 wget https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz
 tar -xvf apache-maven-3.8.8-bin.tar.gz && mv apache-maven-3.8.8 /usr/lib/maven
 export PATH="${PATH}:/usr/lib/maven/bin"
-echo "PATH=${PATH}:/usr/lib/maven/bin" >> $GITHUB_ENV
 
 source /opt/rh/gcc-toolset-9/enable
 ./dev/builddeps-veloxbe.sh --run_setup_script=OFF --enable_ep_cache=OFF --build_tests=ON \


### PR DESCRIPTION
1. Rename the UT job for consistency
2. ~~Fix `/__w/_temp/06ddeeec-4ccc-421b-91f8-8dad1d79e7b5.sh: line 1: mvn: command not found` in UT job when centos 8 cache is hit~~ (moving to [another thread](https://github.com/apache/incubator-gluten/issues/6957))