### PR TITLE
[GLUTEN-6957][VL] Fix mvn not found in cache job

### DIFF
--- a/.github/workflows/velox_backend_cache.yml
+++ b/.github/workflows/velox_backend_cache.yml
@@ -77,14 +77,17 @@ jobs:
             ./cpp/build/velox/benchmarks/
             /root/.m2/repository/org/apache/arrow/
           key: cache-velox-build-centos-8-${{ hashFiles('./cache-key') }}
-      - name: Build Gluten native libraries
+      - name: Setup java and maven
         if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
-          df -a
           sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* || true
           sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
           yum install sudo patch java-1.8.0-openjdk-devel wget -y
           bash .github/workflows/util/setup_helper.sh install_maven
+      - name: Build Gluten native libraries
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        run: |
+          df -a
           bash dev/ci-velox-buildshared-centos-8.sh
       - name: Cache
         if: steps.check-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What changes were proposed in this pull request?

In GitHub Actions, when we set an environment variable using echo "VARNAME=value" >> $GITHUB_ENV, the variable is not immediately available in the current step. It will be available in subsequent steps.

