### PR TITLE
[GLUTEN-6981][CH]Not supported operator TakeOrderedAndProjectExecTransformer for BroadcastRelation

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -524,6 +524,8 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
             wrapChild(r2c)
           case union: ColumnarUnionExec =>
             wrapChild(union)
+          case ordered: TakeOrderedAndProjectExecTransformer =>
+            wrapChild(ordered)
           case other =>
             throw new GlutenNotSupportException(
               s"Not supported operator ${other.nodeName} for BroadcastRelation")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetSuite.scala
@@ -336,5 +336,22 @@ class GlutenClickHouseTPCDSParquetSuite extends GlutenClickHouseTPCDSAbstractSui
     compareResultsAgainstVanillaSpark(sql5, compareResult = true, _ => {})
   }
 
+  test("TakeOrderedAndProjectExecTransformer in broadcastRelation") {
+    val q =
+      """
+        | with dd as (
+        | select d_date_sk, count(*) as cn
+        | from date_dim
+        | where d_date_sk is not null
+        | group by d_date_sk
+        | order by cn desc
+        | limit 10)
+        | select count(ss.ss_sold_date_sk)
+        | from store_sales ss, dd
+        | where ss_sold_date_sk=dd.d_date_sk+1
+        |""".stripMargin
+    runQueryAndCompare(q)(checkGlutenOperatorMatch[TakeOrderedAndProjectExecTransformer])
+  }
+
 }
 // scalastyle:on line.size.limit


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some cases, the child node of broadcast is TakeOrderedAndProjectExecTransformer, which is not supported by now.
Add TakeOrderedAndProjectExecTransformer node case support for broadcast . 
please refer to #6981 for more details
Fixes: \#6981
## How was this patch tested?

by UT

