### PR TITLE
[GLUTEN-6960][VL] Limit Velox untracked global memory manager's usage 

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -48,7 +48,6 @@ abstract class VeloxTPCHTableSupport extends VeloxWholeStageTransformerSuite {
       .set("spark.memory.offHeap.size", "2g")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
-      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
     // TODO Should enable this after fix the issue of native plan detail occasional disappearance
     // .set("spark.gluten.sql.injectNativePlanStringToExplain", "true")
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -48,6 +48,7 @@ abstract class VeloxTPCHTableSupport extends VeloxWholeStageTransformerSuite {
       .set("spark.memory.offHeap.size", "2g")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
     // TODO Should enable this after fix the issue of native plan detail occasional disappearance
     // .set("spark.gluten.sql.injectNativePlanStringToExplain", "true")
   }

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -38,6 +38,8 @@ const std::string kIgnoreMissingFiles = "spark.sql.files.ignoreMissingFiles";
 
 const std::string kDefaultSessionTimezone = "spark.gluten.sql.session.timeZone.default";
 
+const std::string kSparkOverheadMemory = "spark.gluten.memoryOverhead.size.in.bytes";
+
 const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
 
 const std::string kSparkTaskOffHeapMemory = "spark.gluten.memory.task.offHeap.size.in.bytes";

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/ThrowOnOomMemoryTarget.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/ThrowOnOomMemoryTarget.java
@@ -89,8 +89,8 @@ public class ThrowOnOomMemoryTarget implements MemoryTarget {
         .append(
             String.format(
                 "\t%s=%s",
-                GlutenConfig$.MODULE$.GLUTEN_OFFHEAP_ENABLED(),
-                SQLConf.get().getConfString(GlutenConfig$.MODULE$.GLUTEN_OFFHEAP_ENABLED())))
+                GlutenConfig$.MODULE$.SPARK_OFFHEAP_ENABLED(),
+                SQLConf.get().getConfString(GlutenConfig$.MODULE$.SPARK_OFFHEAP_ENABLED())))
         .append(System.lineSeparator())
         .append(
             String.format(

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -184,6 +184,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)
     conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, overheadSize.toString)
 
+    // FIXME: The following is a workaround. Remove once the causes are fixed.
     conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, Long.MaxValue.toString)
     logWarning(
       "Setting overhead memory that Gluten can use to UNLIMITED. This is currently a" +

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -184,6 +184,12 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)
     conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, overheadSize.toString)
 
+    conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, Long.MaxValue.toString)
+    logWarning(
+      "Setting overhead memory that Gluten can use to UNLIMITED. This is currently a" +
+        " temporary solution to avoid OOM by Velox's global memory pools." +
+        " See GLUTEN-6960 for more information.")
+
     // If dynamic off-heap sizing is enabled, the off-heap size is calculated based on the on-heap
     // size. Otherwise, the off-heap size is set to the value specified by the user (if any).
     // Note that this means that we will IGNORE the off-heap size specified by the user if the

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -181,7 +181,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
         1024 * 1024 * 1024
       }
 
-    val overheadSize : Long = SparkResourceUtil.getMemoryOverheadSize(conf)
+    val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)
     conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, overheadSize.toString)
 
     // If dynamic off-heap sizing is enabled, the off-heap size is calculated based on the on-heap

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
@@ -84,12 +84,13 @@ object SparkResourceUtil extends Logging {
   }
 
   def getMemoryOverheadSize(conf: SparkConf): Long = {
-    conf.get(EXECUTOR_MEMORY_OVERHEAD).getOrElse {
+    val overheadMib = conf.get(EXECUTOR_MEMORY_OVERHEAD).getOrElse {
       val executorMemMib = conf.get(EXECUTOR_MEMORY)
       val factor =
         conf.getDouble("spark.executor.memoryOverheadFactor", 0.1D)
       val minMib = conf.getLong("spark.executor.minMemoryOverhead", 384L)
-      ByteUnit.MiB.toBytes((executorMemMib * factor).toLong max minMib)
+      (executorMemMib * factor).toLong max minMib
     }
+    ByteUnit.MiB.toBytes(overheadMib)
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
@@ -18,6 +18,8 @@ package org.apache.spark.util
 
 import org.apache.spark.{SparkConf, SparkMasterRegex}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.{EXECUTOR_MEMORY, EXECUTOR_MEMORY_OVERHEAD}
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.internal.SQLConf
 
 object SparkResourceUtil extends Logging {
@@ -79,5 +81,15 @@ object SparkResourceUtil extends Logging {
 
   def isLocalMaster(conf: SparkConf): Boolean = {
     Utils.isLocalMaster(conf)
+  }
+
+  def getMemoryOverheadSize(conf: SparkConf): Long = {
+    conf.get(EXECUTOR_MEMORY_OVERHEAD).getOrElse {
+      val executorMemMib = conf.get(EXECUTOR_MEMORY)
+      val factor =
+        conf.getDouble("spark.executor.memoryOverheadFactor", 0.1D)
+      val minMib = conf.getLong("spark.executor.minMemoryOverhead", 384L)
+      ByteUnit.MiB.toBytes((executorMemMib * factor).toLong max minMib)
+    }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
@@ -87,9 +87,9 @@ object SparkResourceUtil extends Logging {
     val overheadMib = conf.get(EXECUTOR_MEMORY_OVERHEAD).getOrElse {
       val executorMemMib = conf.get(EXECUTOR_MEMORY)
       val factor =
-        conf.getDouble("spark.executor.memoryOverheadFactor", 0.1D)
+        conf.getDouble("spark.executor.memoryOverheadFactor", 0.1d)
       val minMib = conf.getLong("spark.executor.minMemoryOverhead", 384L)
-      (executorMemMib * factor).toLong max minMib
+      (executorMemMib * factor).toLong.max(minMib)
     }
     ByteUnit.MiB.toBytes(overheadMib)
   }

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -535,9 +535,11 @@ object GlutenConfig {
   val GLUTEN_CONFIG_PREFIX = "spark.gluten.sql.columnar.backend."
 
   // Private Spark configs.
-  val GLUTEN_ONHEAP_SIZE_KEY = "spark.executor.memory"
-  val GLUTEN_OFFHEAP_SIZE_KEY = "spark.memory.offHeap.size"
-  val GLUTEN_OFFHEAP_ENABLED = "spark.memory.offHeap.enabled"
+  val SPARK_ONHEAP_SIZE_KEY = "spark.executor.memory"
+  val SPARK_OVERHEAD_SIZE_KEY = "spark.executor.memoryOverhead"
+  val SPARK_OVERHEAD_FACTOR_KEY = "spark.executor.memoryOverheadFactor"
+  val SPARK_OFFHEAP_SIZE_KEY = "spark.memory.offHeap.size"
+  val SPARK_OFFHEAP_ENABLED = "spark.memory.offHeap.enabled"
   val SPARK_REDACTION_REGEX = "spark.redaction.regex"
 
   // For Soft Affinity Scheduling
@@ -570,6 +572,7 @@ object GlutenConfig {
 
   // Added back to Spark Conf during executor initialization
   val GLUTEN_NUM_TASK_SLOTS_PER_EXECUTOR_KEY = "spark.gluten.numTaskSlotsPerExecutor"
+  val GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY = "spark.gluten.memoryOverhead.size.in.bytes"
   val GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY = "spark.gluten.memory.offHeap.size.in.bytes"
   val GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY = "spark.gluten.memory.task.offHeap.size.in.bytes"
   val GLUTEN_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES_KEY =
@@ -762,9 +765,10 @@ object GlutenConfig {
       SPARK_SQL_PARQUET_COMPRESSION_CODEC,
       // datasource config end
 
+      GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY,
       GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY,
       GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY,
-      GLUTEN_OFFHEAP_ENABLED,
+      SPARK_OFFHEAP_ENABLED,
       SESSION_LOCAL_TIMEZONE.key,
       DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key,
       SPARK_REDACTION_REGEX
@@ -1243,6 +1247,16 @@ object GlutenConfig {
           "org.apache.spark.sql.execution.SQLExecution#withSQLConfPropagated")
       .intConf
       .createWithDefaultString("-1")
+
+  val COLUMNAR_OVERHEAD_SIZE_IN_BYTES =
+    buildConf(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY)
+      .internal()
+      .doc(
+        "Must provide default value since non-execution operations " +
+          "(e.g. org.apache.spark.sql.Dataset#summary) doesn't propagate configurations using " +
+          "org.apache.spark.sql.execution.SQLExecution#withSQLConfPropagated")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("0")
 
   val COLUMNAR_OFFHEAP_SIZE_IN_BYTES =
     buildConf(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY)


### PR DESCRIPTION
Limit Velox's global memory manager's usage to 0.75 * Spark overhead memory by default. The overhead memory is calculated by same manner with vanilla Spark.

Velox's global memory manager is used for some global allocations that don't belong to a specific query or task. These allocations are not tracked by Spark task memory manager.

After the patch, `spark.memory.offHeap.size` and `spark.executor.memoryOverhead` (with `spark.executor.memoryOverheadFactor` / `spark.executor.minMemoryOverhead` for higher version Spark, probably) will co-work for Velox backend's memory management.

1. `spark.memory.offHeap.size` limits major of the memory allocations happened during Velox query execution, e.g., hash tables, sort buffers, shuffle buffers, etc.
2. `spark.executor.memoryOverhead` limits the memory allocations that are hardly tracked by Spark task memory manager, or that don't belong to a specific query. E.g., allocations happen during spilling, or possibly the global cache size (unimplemented).

Edit: As the change fails a couple of CI tests, we are setting the internal Velox global poll size limit to `Long.MaxValue` by default in the PR, to bypass the check for sometime, until the relevant bugs from Velox get fixed.

