### PR TITLE
[CORE] Rename OASPackageBridges

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.{StructField, StructType}
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.lang.{Long => JLong}

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/BatchScanMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/BatchScanMetricsUpdater.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.metrics
 
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 class BatchScanMetricsUpdater(@transient val metrics: Map[String, SQLMetric])
   extends MetricsUpdater {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/FileSourceScanMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/FileSourceScanMetricsUpdater.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.metrics
 
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 /**
  * Note: "val metrics" is made transient to avoid sending driver-side metrics to tasks, e.g.

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/HiveTableScanMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/HiveTableScanMetricsUpdater.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.metrics
 
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 class HiveTableScanMetricsUpdater(@transient val metrics: Map[String, SQLMetric])
   extends MetricsUpdater {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ExecutorManager
 

--- a/gluten-core/src/main/scala/org/apache/gluten/backendsapi/IteratorApi.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backendsapi/IteratorApi.scala
@@ -27,7 +27,7 @@ import org.apache.spark._
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 trait IteratorApi {

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenWholeStageColumnarRDD.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenWholeStageColumnarRDD.scala
@@ -25,7 +25,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.InputFileBlockHolderProxy
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ExecutorManager
 

--- a/gluten-core/src/main/scala/org/apache/gluten/metrics/MetricsUpdater.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/metrics/MetricsUpdater.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.metrics
 
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 /**
  * A minimized controller for updating operator's metrics, which means it never persists the

--- a/gluten-core/src/main/scala/org/apache/spark/sql/utils/SparkInputMetricsUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/utils/SparkInputMetricsUtil.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.utils
 import org.apache.spark.executor.InputMetrics
 
 /** Bridge to package org.apache.spark. */
-object OASPackageBridge {
+object SparkInputMetricsUtil {
   implicit class InputMetricsWrapper(val m: InputMetrics) {
     def bridgeIncBytesRead(v: Long): Unit = {
       m.incBytesRead(v)

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/JniByteInputStreams.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/JniByteInputStreams.java
@@ -60,7 +60,7 @@ public final class JniByteInputStreams {
     InputStream unwrapped = in;
     if (unwrapped instanceof BufferReleasingInputStream) {
       final BufferReleasingInputStream brin = (BufferReleasingInputStream) unwrapped;
-      unwrapped = org.apache.spark.storage.OASPackageBridge.unwrapBufferReleasingInputStream(brin);
+      unwrapped = org.apache.spark.storage.SparkInputStreamUtil.unwrapBufferReleasingInputStream(brin);
     }
     if (unwrapped instanceof CheckedInputStream) {
       final CheckedInputStream cin = (CheckedInputStream) unwrapped;

--- a/gluten-data/src/main/java/org/apache/gluten/vectorized/JniByteInputStreams.java
+++ b/gluten-data/src/main/java/org/apache/gluten/vectorized/JniByteInputStreams.java
@@ -60,7 +60,8 @@ public final class JniByteInputStreams {
     InputStream unwrapped = in;
     if (unwrapped instanceof BufferReleasingInputStream) {
       final BufferReleasingInputStream brin = (BufferReleasingInputStream) unwrapped;
-      unwrapped = org.apache.spark.storage.SparkInputStreamUtil.unwrapBufferReleasingInputStream(brin);
+      unwrapped =
+          org.apache.spark.storage.SparkInputStreamUtil.unwrapBufferReleasingInputStream(brin);
     }
     if (unwrapped instanceof CheckedInputStream) {
       final CheckedInputStream cin = (CheckedInputStream) unwrapped;

--- a/gluten-data/src/main/scala/org/apache/gluten/metrics/BatchScanMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/metrics/BatchScanMetricsUpdater.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.metrics
 
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 class BatchScanMetricsUpdater(val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
 

--- a/gluten-data/src/main/scala/org/apache/gluten/metrics/FileSourceScanMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/metrics/FileSourceScanMetricsUpdater.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.metrics
 
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 /**
  * Note: "val metrics" is made transient to avoid sending driver-side metrics to tasks, e.g.

--- a/gluten-data/src/main/scala/org/apache/gluten/metrics/HiveTableScanMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/metrics/HiveTableScanMetricsUpdater.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.metrics
 
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+import org.apache.spark.sql.utils.SparkInputMetricsUtil.InputMetricsWrapper
 
 class HiveTableScanMetricsUpdater(@transient val metrics: Map[String, SQLMetric])
   extends MetricsUpdater {

--- a/gluten-data/src/main/scala/org/apache/spark/storage/SparkInputStreamUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/storage/SparkInputStreamUtil.scala
@@ -18,7 +18,7 @@ package org.apache.spark.storage
 
 import java.io.InputStream
 
-object OASPackageBridge {
+object SparkInputStreamUtil {
   def unwrapBufferReleasingInputStream(in: BufferReleasingInputStream): InputStream = {
     in.delegate
   }


### PR DESCRIPTION
We used to name classes that are simply a bridge to Spark package-private APIs as `OASPackageBridge`. But we haven't strictly follow that criteria for naming. Now we just rename the classes and drop this rule.