### PR TITLE
[GLUTEN-7035][VL] Use first line of `ls-remote`'s output as build's target commit

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -151,7 +151,7 @@ fi
 VELOX_SOURCE_DIR="${VELOX_HOME}"
 
 # checkout code
-TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
+TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}' | head -n 1)"
 if [ -d $VELOX_SOURCE_DIR ]; then
   echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
   cd $VELOX_SOURCE_DIR

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -151,7 +151,7 @@ fi
 VELOX_SOURCE_DIR="${VELOX_HOME}"
 
 # checkout code
-TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}' | head -n 1)"
+TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO refs/heads/$VELOX_BRANCH | awk '{print $1;}')"
 if [ -d $VELOX_SOURCE_DIR ]; then
   echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
   cd $VELOX_SOURCE_DIR

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -151,7 +151,7 @@ fi
 VELOX_SOURCE_DIR="${VELOX_HOME}"
 
 # checkout code
-TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO refs/heads/$VELOX_BRANCH | awk '{print $1;}')"
+TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}' | head -n 1)"
 if [ -d $VELOX_SOURCE_DIR ]; then
   echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
   cd $VELOX_SOURCE_DIR


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get head for target_build_commit

Fixes: #7035

## How was this patch tested?



