### PR TITLE
[GLUTEN-7037][VL] Add dwarf dependency to folly when building with vcpkg

### DIFF
--- a/dev/vcpkg/ports/folly/vcpkg.json
+++ b/dev/vcpkg/ports/folly/vcpkg.json
@@ -25,6 +25,7 @@
     "glog",
     "libevent",
     "openssl",
+    "libdwarf",
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

fix issue : https://github.com/apache/incubator-gluten/issues/7037

Adding libdwarf dependency in folly vcpkg.json manifest to enable velox to get symbol from address when throw exception.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

![image](https://github.com/user-attachments/assets/81ead75e-3773-4519-a9fa-340a0ea3a326)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

