### PR TITLE
[VL] Set Spark memory overhead automatically according to off-heap size when it's not explicitly configured

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -27,6 +27,7 @@ import org.apache.gluten.vectorized.{JniLibLoader, JniWorkspace}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.api.plugin.PluginContext
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.execution.datasources.velox.{VeloxOrcWriterInjects, VeloxParquetWriterInjects, VeloxRowSplitter}
 import org.apache.spark.sql.expression.UDFResolver
 import org.apache.spark.sql.internal.{GlutenConfigUtil, StaticSQLConf}
@@ -44,7 +45,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
     // Overhead memory limits.
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.SPARK_OFFHEAP_SIZE_KEY)
-    val desiredOverheadSize = (0.1 * offHeapSize).toLong
+    val desiredOverheadSize = (0.1 * offHeapSize).toLong.max(ByteUnit.MiB.toBytes(384))
     if (!SparkResourceUtil.isMemoryOverheadSet(conf)) {
       // If memory overhead is not set by user, automatically set it according to off-heap settings.
       logInfo(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -49,7 +49,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
     if (!SparkResourceUtil.isMemoryOverheadSet(conf)) {
       // If memory overhead is not set by user, automatically set it according to off-heap settings.
       logInfo(
-        "Memory overhead is not set. Setting it to 0.1 * off-heap memory size automatically." +
+        s"Memory overhead is not set. Setting it to $desiredOverheadSize automatically." +
           " Gluten doesn't follow Spark's calculation on default value of this option because the" +
           " actual required memory overhead will depend on off-heap usage than on on-heap usage.")
       conf.set(GlutenConfig.SPARK_OVERHEAD_SIZE_KEY, desiredOverheadSize.toString)

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -49,8 +49,8 @@ class VeloxListenerApi extends ListenerApi with Logging {
       // If memory overhead is not set by user, automatically set it according to off-heap settings.
       logInfo(
         "Memory overhead is not set. Setting it to 0.1 * off-heap memory size automatically." +
-          " Gluten doesn't follow Spark's calculation on this because the actual overhead will" +
-          " depend on off-heap usage than on on-heap usage.")
+          " Gluten doesn't follow Spark's calculation on default value of this option because the" +
+          " actual required memory overhead will depend on off-heap usage than on on-heap usage.")
       conf.set(GlutenConfig.SPARK_OVERHEAD_SIZE_KEY, desiredOverheadSize.toString)
     }
     val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)

--- a/backends-velox/src/test/java/org/apache/gluten/test/VeloxBackendTestBase.java
+++ b/backends-velox/src/test/java/org/apache/gluten/test/VeloxBackendTestBase.java
@@ -54,6 +54,7 @@ public abstract class VeloxBackendTestBase {
       public SparkConf conf() {
         final SparkConf conf = new SparkConf();
         conf.set(GlutenConfig.COLUMNAR_VELOX_CONNECTOR_IO_THREADS().key(), "0");
+        conf.set(GlutenConfig.SPARK_OFFHEAP_SIZE_KEY(), "1g");
         return conf;
       }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -159,7 +159,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     // value (detected for the platform) is used, consistent with spark.
     conf.set(GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY, SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
 
-    // task slots
+    // Task slotss
     val taskSlots = SparkResourceUtil.getTaskSlots(conf)
     conf.set(GlutenConfig.GLUTEN_NUM_TASK_SLOTS_PER_EXECUTOR_KEY, taskSlots.toString)
 
@@ -170,9 +170,6 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
         // 1GB default
         1024 * 1024 * 1024
       }
-
-    val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)
-    conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, overheadSize.toString)
 
     // If dynamic off-heap sizing is enabled, the off-heap size is calculated based on the on-heap
     // size. Otherwise, the off-heap size is set to the value specified by the user (if any).

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -159,7 +159,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     // value (detected for the platform) is used, consistent with spark.
     conf.set(GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY, SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
 
-    // Task slotss
+    // Task slots.
     val taskSlots = SparkResourceUtil.getTaskSlots(conf)
     conf.set(GlutenConfig.GLUTEN_NUM_TASK_SLOTS_PER_EXECUTOR_KEY, taskSlots.toString)
 


### PR DESCRIPTION
In vanilla Spark, the option `spark.executor.memoryOverhead` is by default calculated by `max(0.1 * on-heap size, 384m)`. The patch makes it `max(0.1 * off-heap size, 384m)` to gain better compatibility with Velox's memory management system.

If user does configure the memory overhead options, Velox backend will raise a warning when it's smaller than the recommended size during initialization.