### PR TITLE
[GLUTEN-7055][VL] Make ssh keys of gluten-vcpkg-builder configurable

### DIFF
--- a/dev/vcpkg/docker/Dockerfile
+++ b/dev/vcpkg/docker/Dockerfile
@@ -19,6 +19,21 @@ RUN if ["$BUILDER_UID" != "0"]; then \
     fi
 USER ${BUILDER_UID}:${BUILDER_GID}
 
+ARG SSH_PRV_KEY
+ARG SSH_PUB_KEY
+RUN mkdir -p ~/.ssh && \
+    chmod 0700 ~/.ssh
+RUN if [[ -n "$SSH_PRV_KEY" ]] ; then \
+    echo "$SSH_PRV_KEY" > ~/.ssh/id_rsa && \
+    chmod 600 ~/.ssh/id_rsa && \
+    echo -e "Host *\n    StrictHostKeyChecking no" > ~/.ssh/config && \
+    chmod 600 ~/.ssh/config; \
+    fi
+RUN if [[ -n "$SSH_PUB_KEY" ]] ; then \
+    echo "$SSH_PUB_KEY" > ~/.ssh/id_rsa.pub && \
+    chmod 600 ~/.ssh/id_rsa.pub; \
+    fi
+
 ENV VCPKG_BINARY_SOURCES=default
 COPY docker/entrypoint.sh /entrypoint
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make ssh keys of gluten-vcpkg-builder configurable

Fixes: #7055

## How was this patch tested?

After this, we can configure ssh keys for `gluten-vcpkg-builder`:

```
docker build --file docker/Dockerfile \
    --build-arg BUILDER_UID=`id -u` \
    --build-arg BUILDER_GID=`id -g` \
    --build-arg SSH_PRV_KEY="$(cat ~/.ssh/id_rsa)" \
    --build-arg SSH_PUB_KEY="$(cat ~/.ssh/id_rsa.pub)" \
    --tag "apache/gluten:gluten-vcpkg-builder_2024_08_28" \
    .
```

