### PR TITLE
[GLUTEN-7078][CORE] The fallback check for Scan should not be skipped when DPP is present

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
@@ -272,21 +272,15 @@ case class AddFallbackTagRule() extends Rule[SparkPlan] {
     try {
       plan match {
         case plan: BatchScanExec =>
-          // If filter expressions aren't empty, we need to transform the inner operators.
-          if (plan.runtimeFilters.isEmpty) {
-            val transformer =
-              ScanTransformerFactory
-                .createBatchScanTransformer(plan, validation = true)
-                .asInstanceOf[BasicScanExecTransformer]
-            transformer.doValidate().tagOnFallback(plan)
-          }
+          val transformer =
+            ScanTransformerFactory
+              .createBatchScanTransformer(plan, validation = true)
+              .asInstanceOf[BasicScanExecTransformer]
+          transformer.doValidate().tagOnFallback(plan)
         case plan: FileSourceScanExec =>
-          // If filter expressions aren't empty, we need to transform the inner operators.
-          if (plan.partitionFilters.isEmpty) {
-            val transformer =
-              ScanTransformerFactory.createFileSourceScanTransformer(plan)
-            transformer.doValidate().tagOnFallback(plan)
-          }
+          val transformer =
+            ScanTransformerFactory.createFileSourceScanTransformer(plan)
+          transformer.doValidate().tagOnFallback(plan)
         case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
           HiveTableScanExecTransformer.validate(plan).tagOnFallback(plan)
         case plan: ProjectExec =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
(Fixes: \#7078)
performing fallback detection for Scan in advance is good and does not introduce any side effects.

## How was this patch tested?
manual tests

