### PR TITLE
[GLUTEN-7077][CH]`have_compressed` is lost in `HashJoin::reuseJoinedData`

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSuite.scala
@@ -531,5 +531,21 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
     spark.sql("drop table t1")
     spark.sql("drop table t2")
   }
+
+  test("gluten-7077 bug in cross broad cast join") {
+    spark.sql("create table cross_join_t(a bigint, b string, c string) using parquet");
+    var sql = """
+                | insert into cross_join_t
+                | select id as a, cast(id as string) as b,
+                |   concat('1231231232323232322', cast(id as string)) as c
+                | from range(0, 100000)
+                |""".stripMargin
+    spark.sql(sql)
+    sql = """
+            | select * from cross_join_t as t1 full join cross_join_t as t2 limit 10
+            |""".stripMargin
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
+    spark.sql("drop table cross_join_t")
+  }
 }
 // scalastyle:off line.size.limit

--- a/cpp-ch/clickhouse.version
+++ b/cpp-ch/clickhouse.version
@@ -1,3 +1,3 @@
 CH_ORG=Kyligence
 CH_BRANCH=rebase_ch/20240830
-CH_COMMIT=fc5f00d8cb7
+CH_COMMIT=d239aeff645


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #7077

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

