### PR TITLE
[GLUTEN-7090][VL] fix: Number of sorting keys must be greater than zero

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxWindowExpressionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxWindowExpressionSuite.scala
@@ -73,6 +73,20 @@ class VeloxWindowExpressionSuite extends WholeStageTransformerSuite {
     }
   }
 
+  test("test overlapping partition and sorting keys") {
+    runAndCompare(
+      """
+        |WITH t AS (
+        |SELECT
+        | l_linenumber,
+        | row_number() over (partition by l_linenumber order by l_linenumber) as rn
+        |FROM lineitem
+        |)
+        |SELECT * FROM t WHERE rn = 1
+        |""".stripMargin
+    ) {}
+  }
+
   test("collect_list / collect_set") {
     withTable("t") {
       val data = Seq(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1024,6 +1024,14 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(
     }
   }
   const std::optional<std::string> rowNumberColumnName = std::nullopt;
+
+  if (sortingKeys.empty()) {
+    // Handle if all sorting keys are also used as partition keys.
+
+    return std::make_shared<core::RowNumberNode>(
+        nextPlanNodeId(), partitionKeys, rowNumberColumnName, (int32_t)windowGroupLimitRel.limit(), childNode);
+  }
+
   return std::make_shared<core::TopNRowNumberNode>(
       nextPlanNodeId(),
       partitionKeys,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to fix `number of sorting keys must be greater than zero`.

(Fixes: \#7090)

## How was this patch tested?

Add new unit tests

