### PR TITLE
[VL] Gluten-it: Remove a IDE-generated maven module name

### DIFF
--- a/tools/gluten-it/package/pom.xml
+++ b/tools/gluten-it/package/pom.xml
@@ -8,7 +8,6 @@
     <version>1.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>gluten-it-package</artifactId>
-  <name>Archetype - assembly</name>
   <url>http://maven.apache.org</url>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
The module name is auto-generated by my IDE and not needed to be in code base. Remove it.