### PR TITLE
[GLUTEN-7118][VL] Fix duckdb target issue when vcpkg is enabled

### DIFF
--- a/dev/package-vcpkg.sh
+++ b/dev/package-vcpkg.sh
@@ -13,6 +13,7 @@ if [ "$LINUX_OS" == "centos" ]; then
   if [ "$VERSION" == "8" ]; then
     source /opt/rh/gcc-toolset-9/enable
   elif [ "$VERSION" == "7" ]; then
+    export MANPATH=""
     source /opt/rh/devtoolset-9/enable
   fi
 fi
@@ -22,4 +23,5 @@ source ./dev/vcpkg/env.sh
 
 # build gluten with velox backend, prompt always respond y
 export PROMPT_ALWAYS_RESPOND=y
-./dev/buildbundle-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON "$@"
+
+./dev/buildbundle-veloxbe.sh --build_tests=ON --build_arrow=OFF --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON "$@"

--- a/dev/vcpkg/Makefile
+++ b/dev/vcpkg/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMAGE=apache/gluten:gluten-vcpkg-builder
+DOCKER_IMAGE=apache/gluten:vcpkg-centos-7
 GLUTEN_REPO=$(shell realpath -L ../..)
 
 CCACHE_DIR=$(HOME)/.ccache

--- a/dev/vcpkg/ports/duckdb/portfile.cmake
+++ b/dev/vcpkg/ports/duckdb/portfile.cmake
@@ -22,4 +22,11 @@ vcpkg_configure_cmake(
 )
 vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/DuckDB)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME DuckDB)
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/dev/vcpkg/ports/duckdb/vcpkg.json
+++ b/dev/vcpkg/ports/duckdb/vcpkg.json
@@ -2,6 +2,13 @@
   "name": "duckdb",
   "version": "0.8.1",
   "dependencies": [
-
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #7118.
duckdb target is required when `build_tests=ON`.
We need to use `vcpkg_cmake_config_fixup` for duckdb to corrects issues like absolute paths and incorrectly placed binaries.

## How was this patch tested?

Local test with docker.
