### PR TITLE
[CH] Refactor: Move SerializedPlanParser::global_context to QueryContext

### DIFF
--- a/cpp-ch/local-engine/Common/CHUtil.h
+++ b/cpp-ch/local-engine/Common/CHUtil.h
@@ -213,7 +213,7 @@ private:
     static void initContexts(DB::Context::ConfigurationPtr config);
     static void initCompiledExpressionCache(DB::Context::ConfigurationPtr config);
     static void registerAllFactories();
-    static void applyGlobalConfigAndSettings(DB::Context::ConfigurationPtr, DB::Settings &);
+    static void applyGlobalConfigAndSettings(const DB::Context::ConfigurationPtr & config, const DB::Settings & settings);
     static void updateNewSettings(const DB::ContextMutablePtr &, const DB::Settings &);
     static std::vector<String>
     wrapDiskPathConfig(const String & path_prefix, const String & path_suffix, Poco::Util::AbstractConfiguration & config);

--- a/cpp-ch/local-engine/Common/QueryContext.cpp
+++ b/cpp-ch/local-engine/Common/QueryContext.cpp
@@ -19,7 +19,6 @@
 #include <iomanip>
 #include <sstream>
 #include <Interpreters/Context.h>
-#include <Parser/SerializedPlanParser.h>
 #include <base/unit.h>
 #include <Common/CHUtil.h>
 #include <Common/ConcurrentMap.h>
@@ -35,21 +34,59 @@ extern const int LOGICAL_ERROR;
 }
 }
 
-namespace local_engine
-{
 using namespace DB;
 
-struct QueryContext
+namespace local_engine
+{
+
+struct QueryContext::Data
 {
     std::shared_ptr<ThreadStatus> thread_status;
     std::shared_ptr<ThreadGroup> thread_group;
     ContextMutablePtr query_context;
+
+    static DB::ContextMutablePtr global_context;
+    static SharedContextHolder shared_context;
 };
 
-int64_t QueryContextManager::initializeQuery()
+ContextMutablePtr QueryContext::Data::global_context{};
+SharedContextHolder QueryContext::Data::shared_context{};
+
+DB::ContextMutablePtr QueryContext::globalMutableContext()
 {
-    std::shared_ptr<QueryContext> query_context = std::make_shared<QueryContext>();
-    query_context->query_context = Context::createCopy(SerializedPlanParser::global_context);
+    return Data::global_context;
+}
+void QueryContext::resetGlobal()
+{
+    if (Data::global_context)
+    {
+        Data::global_context->shutdown();
+        Data::global_context.reset();
+    }
+    Data::shared_context.reset();
+}
+
+DB::ContextMutablePtr QueryContext::createGlobal()
+{
+    assert(Data::shared_context.get() == nullptr);
+
+    if (!Data::shared_context.get())
+        Data::shared_context = SharedContextHolder(Context::createShared());
+
+    assert(Data::global_context == nullptr);
+    Data::global_context = Context::createGlobal(Data::shared_context.get());
+    return globalMutableContext();
+}
+
+DB::ContextPtr QueryContext::globalContext()
+{
+    return Data::global_context;
+}
+
+int64_t QueryContext::initializeQuery()
+{
+    std::shared_ptr<Data> query_context = std::make_shared<Data>();
+    query_context->query_context = Context::createCopy(globalContext());
     query_context->query_context->makeQueryContext();
 
     // empty input will trigger random query id to be set
@@ -72,14 +109,14 @@ int64_t QueryContextManager::initializeQuery()
     return id;
 }
 
-DB::ContextMutablePtr QueryContextManager::currentQueryContext()
+DB::ContextMutablePtr QueryContext::currentQueryContext()
 {
     auto thread_group = currentThreadGroup();
     const int64_t id = reinterpret_cast<int64_t>(CurrentThread::getGroup().get());
     return query_map_.get(id)->query_context;
 }
 
-std::shared_ptr<DB::ThreadGroup> QueryContextManager::currentThreadGroup()
+std::shared_ptr<DB::ThreadGroup> QueryContext::currentThreadGroup()
 {
     if (auto thread_group = CurrentThread::getGroup())
         return thread_group;
@@ -87,12 +124,10 @@ std::shared_ptr<DB::ThreadGroup> QueryContextManager::currentThreadGroup()
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Thread group not found.");
 }
 
-void QueryContextManager::logCurrentPerformanceCounters(ProfileEvents::Counters & counters) const
+void QueryContext::logCurrentPerformanceCounters(ProfileEvents::Counters & counters) const
 {
     if (!CurrentThread::getGroup())
-    {
         return;
-    }
     if (logger_->information())
     {
         std::ostringstream msg;
@@ -104,44 +139,37 @@ void QueryContextManager::logCurrentPerformanceCounters(ProfileEvents::Counters 
             auto & count = counters[event];
             if (count == 0)
                 continue;
-            msg << std::setw(50) << std::setfill(' ') << std::left << name << "|"
-                << std::setw(20) << std::setfill(' ') << std::left << count.load()
-                << " | (" << doc << ")\n";
+            msg << std::setw(50) << std::setfill(' ') << std::left << name << "|" << std::setw(20) << std::setfill(' ') << std::left
+                << count.load() << " | (" << doc << ")\n";
         }
         LOG_INFO(logger_, "{}", msg.str());
     }
 }
 
-size_t QueryContextManager::currentPeakMemory(int64_t id)
+size_t QueryContext::currentPeakMemory(int64_t id)
 {
     if (!query_map_.contains(id))
         throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "context released {}", id);
     return query_map_.get(id)->thread_group->memory_tracker.getPeak();
 }
 
-void QueryContextManager::finalizeQuery(int64_t id)
+void QueryContext::finalizeQuery(int64_t id)
 {
     if (!CurrentThread::getGroup())
-    {
         throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Thread group not found.");
-    }
-    std::shared_ptr<QueryContext> context;
+    std::shared_ptr<Data> context;
     {
         context = query_map_.get(id);
     }
     auto query_context = context->thread_status->getQueryContext();
     if (!query_context)
-    {
         throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "query context not found");
-    }
     context->thread_status->flushUntrackedMemory();
     context->thread_status->finalizePerformanceCounters();
     LOG_INFO(logger_, "Task finished, peak memory usage: {} bytes", currentPeakMemory(id));
 
     if (currentThreadGroupMemoryUsage() > 1_MiB)
-    {
         LOG_WARNING(logger_, "{} bytes memory didn't release, There may be a memory leak!", currentThreadGroupMemoryUsage());
-    }
     logCurrentPerformanceCounters(context->thread_group->performance_counters);
     context->thread_status->detachFromGroup();
     context->thread_group.reset();
@@ -155,18 +183,14 @@ void QueryContextManager::finalizeQuery(int64_t id)
 size_t currentThreadGroupMemoryUsage()
 {
     if (!CurrentThread::getGroup())
-    {
         throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Thread group not found, please call initializeQuery first.");
-    }
     return CurrentThread::getGroup()->memory_tracker.get();
 }
 
 double currentThreadGroupMemoryUsageRatio()
 {
     if (!CurrentThread::getGroup())
-    {
         throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Thread group not found, please call initializeQuery first.");
-    }
     return static_cast<double>(CurrentThread::getGroup()->memory_tracker.get()) / CurrentThread::getGroup()->memory_tracker.getSoftLimit();
 }
 }

--- a/cpp-ch/local-engine/Common/QueryContext.h
+++ b/cpp-ch/local-engine/Common/QueryContext.h
@@ -19,16 +19,25 @@
 #include <Common/ConcurrentMap.h>
 #include <Common/ThreadStatus.h>
 
+namespace DB
+{
+struct ContextSharedPart;
+}
 namespace local_engine
 {
-struct QueryContext;
 
-class QueryContextManager
+class QueryContext
 {
+    struct Data;
+
 public:
-    static QueryContextManager & instance()
+    static DB::ContextMutablePtr createGlobal();
+    static void resetGlobal();
+    static DB::ContextMutablePtr globalMutableContext();
+    static DB::ContextPtr globalContext();
+    static QueryContext & instance()
     {
-        static QueryContextManager instance;
+        static QueryContext instance;
         return instance;
     }
     int64_t initializeQuery();
@@ -39,9 +48,9 @@ public:
     void finalizeQuery(int64_t id);
 
 private:
-    QueryContextManager() = default;
+    QueryContext() = default;
     LoggerPtr logger_ = getLogger("QueryContextManager");
-    ConcurrentMap<int64_t, std::shared_ptr<QueryContext>> query_map_{};
+    ConcurrentMap<int64_t, std::shared_ptr<Data>> query_map_{};
 };
 
 size_t currentThreadGroupMemoryUsage();

--- a/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskHDFS.cpp
+++ b/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskHDFS.cpp
@@ -17,11 +17,10 @@
 
 #include "GlutenDiskHDFS.h"
 #include <ranges>
-
+#include <Disks/ObjectStorages/CompactObjectStorageDiskTransaction.h>
+#include <Common/QueryContext.h>
 #include <Common/Throttler.h>
-#include <Parser/SerializedPlanParser.h>
 
-#include "CompactObjectStorageDiskTransaction.h"
 #if USE_HDFS
 
 namespace local_engine
@@ -30,7 +29,7 @@ using namespace DB;
 
 DiskTransactionPtr GlutenDiskHDFS::createTransaction()
 {
-    return std::make_shared<CompactObjectStorageDiskTransaction>(*this, SerializedPlanParser::global_context->getTempDataOnDisk()->getVolume()->getDisk());
+    return std::make_shared<CompactObjectStorageDiskTransaction>(*this, QueryContext::globalContext()->getTempDataOnDisk()->getVolume()->getDisk());
 }
 
 void GlutenDiskHDFS::createDirectory(const String & path)
@@ -78,7 +77,7 @@ DiskObjectStoragePtr GlutenDiskHDFS::createDiskObjectStorage()
         object_key_prefix,
         getMetadataStorage(),
         getObjectStorage(),
-        SerializedPlanParser::global_context->getConfigRef(),
+        QueryContext::globalContext()->getConfigRef(),
         config_prefix,
         object_storage_creator);
 }

--- a/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.cpp
+++ b/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.cpp
@@ -17,11 +17,13 @@
 
 #pragma once
 
-
 #include "GlutenDiskS3.h"
+#include <Disks/ObjectStorages/CompactObjectStorageDiskTransaction.h>
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
-#include <Parser/SerializedPlanParser.h>
-#include "CompactObjectStorageDiskTransaction.h"
+#include <Interpreters/Context.h>
+#include <Common/QueryContext.h>
+
+using namespace DB;
 
 #if USE_AWS_S3
 namespace local_engine
@@ -29,10 +31,10 @@ namespace local_engine
 
     DB::DiskTransactionPtr GlutenDiskS3::createTransaction()
     {
-        return std::make_shared<CompactObjectStorageDiskTransaction>(*this, SerializedPlanParser::global_context->getTempDataOnDisk()->getVolume()->getDisk());
+        return std::make_shared<CompactObjectStorageDiskTransaction>(*this, QueryContext::globalContext()->getTempDataOnDisk()->getVolume()->getDisk());
     }
 
-    std::unique_ptr<ReadBufferFromFileBase> GlutenDiskS3::readFile(
+    std::unique_ptr<DB::ReadBufferFromFileBase> GlutenDiskS3::readFile(
         const String & path,
         const ReadSettings & settings,
         std::optional<size_t> read_hint,
@@ -52,7 +54,7 @@ namespace local_engine
             object_key_prefix,
             getMetadataStorage(),
             getObjectStorage(),
-            SerializedPlanParser::global_context->getConfigRef(),
+            QueryContext::globalContext()->getConfigRef(),
             config_prefix,
             object_storage_creator);
     }

--- a/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.h
+++ b/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.h
@@ -19,8 +19,7 @@
 
 
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
-#include <Parser/SerializedPlanParser.h>
-#include "CompactObjectStorageDiskTransaction.h"
+
 
 #if USE_AWS_S3
 namespace local_engine
@@ -41,13 +40,11 @@ public:
 
     DB::DiskTransactionPtr createTransaction() override;
 
-    std::unique_ptr<ReadBufferFromFileBase> readFile(
-        const String & path,
-        const ReadSettings & settings,
-        std::optional<size_t> read_hint,
-        std::optional<size_t> file_size) const override;
+    std::unique_ptr<DB::ReadBufferFromFileBase>
+    readFile(const String & path, const DB::ReadSettings & settings, std::optional<size_t> read_hint, std::optional<size_t> file_size)
+        const override;
 
-    DiskObjectStoragePtr createDiskObjectStorage() override;
+    DB::DiskObjectStoragePtr createDiskObjectStorage() override;
 
 private:
     std::function<DB::ObjectStoragePtr(const Poco::Util::AbstractConfiguration & conf, DB::ContextPtr context)> object_storage_creator;

--- a/cpp-ch/local-engine/Parser/CrossRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/CrossRelParser.cpp
@@ -16,45 +16,40 @@
  */
 #include "CrossRelParser.h"
 
-#include <IO/ReadBufferFromString.h>
-#include <IO/ReadHelpers.h>
 #include <Interpreters/CollectJoinOnKeysVisitor.h>
 #include <Interpreters/GraceHashJoin.h>
 #include <Interpreters/HashJoin/HashJoin.h>
 #include <Interpreters/TableJoin.h>
 #include <Join/BroadCastJoinBuilder.h>
 #include <Join/StorageJoinFromReadBuffer.h>
-#include <Parser/SerializedPlanParser.h>
 #include <Parser/AdvancedParametersParseUtil.h>
+#include <Parser/SerializedPlanParser.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/JoinStep.h>
 #include <google/protobuf/wrappers.pb.h>
 #include <Common/CHUtil.h>
+#include <Common/QueryContext.h>
 #include <Common/logger_useful.h>
-
 
 namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
-    extern const int UNKNOWN_TYPE;
-    extern const int BAD_ARGUMENTS;
+extern const int LOGICAL_ERROR;
+extern const int UNKNOWN_TYPE;
+extern const int BAD_ARGUMENTS;
 }
 }
 
 using namespace DB;
 
-
-
-
 namespace local_engine
 {
 std::shared_ptr<DB::TableJoin> createCrossTableJoin(substrait::CrossRel_JoinType join_type)
 {
-    auto & global_context = SerializedPlanParser::global_context;
+    auto global_context = QueryContext::globalContext();
     auto table_join = std::make_shared<TableJoin>(
         global_context->getSettingsRef(), global_context->getGlobalTemporaryVolume(), global_context->getTempDataOnDisk());
 

--- a/cpp-ch/local-engine/Parser/ExpandRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpandRelParser.cpp
@@ -22,9 +22,7 @@
 #include <Parser/ExpandField.h>
 #include <Parser/RelParser.h>
 #include <Parser/SerializedPlanParser.h>
-#include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
-#include <Poco/Logger.h>
 #include <Common/logger_useful.h>
 
 namespace DB

--- a/cpp-ch/local-engine/Parser/ExpandRelParser.h
+++ b/cpp-ch/local-engine/Parser/ExpandRelParser.h
@@ -16,10 +16,11 @@
  */
 #pragma once
 #include <Parser/RelParser.h>
-#include <Parser/SerializedPlanParser.h>
+
 
 namespace local_engine
 {
+class SerializedPlanParser;
 class ExpandRelParser : public RelParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.cpp
@@ -60,7 +60,7 @@ DB::QueryPlanPtr MergeTreeRelParser::parseReadRel(
     MergeTreeTableInstance merge_tree_table(extension_table);
     // ignore snapshot id for query
     merge_tree_table.snapshot_id = "";
-    auto storage = merge_tree_table.restoreStorage(global_context);
+    auto storage = merge_tree_table.restoreStorage(QueryContext::globalMutableContext());
 
     DB::Block input;
     if (rel.has_base_schema() && rel.base_schema().names_size())
@@ -318,7 +318,7 @@ String MergeTreeRelParser::filterRangesOnDriver(const substrait::ReadRel & read_
     MergeTreeTableInstance merge_tree_table(read_rel.advanced_extension().enhancement());
     // ignore snapshot id for query
     merge_tree_table.snapshot_id = "";
-    auto storage = merge_tree_table.restoreStorage(global_context);
+    auto storage = merge_tree_table.restoreStorage(QueryContext::globalMutableContext());
 
     auto input = TypeParser::buildBlockFromNamedStruct(read_rel.base_schema());
     auto names_and_types_list = input.getNamesAndTypesList();

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
@@ -20,7 +20,6 @@
 #include <substrait/algebra.pb.h>
 
 #include <Parser/RelParser.h>
-#include <Parser/SerializedPlanParser.h>
 
 namespace DB
 {
@@ -37,8 +36,7 @@ using namespace DB;
 class MergeTreeRelParser : public RelParser
 {
 public:
-    explicit MergeTreeRelParser(SerializedPlanParser * plan_paser_, const ContextPtr & context_)
-        : RelParser(plan_paser_), context(context_), global_context(plan_paser_->global_context)
+    explicit MergeTreeRelParser(SerializedPlanParser * plan_paser_, const ContextPtr & context_) : RelParser(plan_paser_), context(context_)
     {
     }
 
@@ -88,8 +86,7 @@ private:
     static void collectColumns(const substrait::Expression & rel, NameSet & columns, Block & block);
     UInt64 getColumnsSize(const NameSet & columns);
 
-    const ContextPtr & context;
-    ContextMutablePtr & global_context;
+    ContextPtr context;
 };
 
 }

--- a/cpp-ch/local-engine/Parser/RelMetric.cpp
+++ b/cpp-ch/local-engine/Parser/RelMetric.cpp
@@ -49,7 +49,7 @@ namespace local_engine
 
 static void writeCacheHits(Writer<StringBuffer> & writer)
 {
-    const auto thread_group = QueryContextManager::currentThreadGroup();
+    const auto thread_group = QueryContext::currentThreadGroup();
     auto & counters = thread_group->performance_counters;
     auto read_cache_hits = counters[ProfileEvents::CachedReadBufferReadFromCacheHits].load();
     auto miss_cache_hits = counters[ProfileEvents::CachedReadBufferReadFromCacheMisses].load();
@@ -109,7 +109,7 @@ RelMetricTimes RelMetric::getTotalTime() const
             {
                 for (const auto & processor : step->getProcessors())
                 {
-                    timeMetrics.time += processor->getElapsedNs() / 1000U ;
+                    timeMetrics.time += processor->getElapsedNs() / 1000U;
                     timeMetrics.input_wait_elapsed_us += processor->getInputWaitElapsedNs() / 1000U;
                     timeMetrics.output_wait_elapsed_us += processor->getInputWaitElapsedNs() / 1000U;
                 }
@@ -209,9 +209,7 @@ std::string RelMetricSerializer::serializeRelMetric(const RelMetricPtr & rel_met
             auto metric = metrics.top();
             metrics.pop();
             for (const auto & item : metric->getInputs())
-            {
                 metrics.push(item);
-            }
             metric->serialize(writer);
         }
         writer.EndArray();

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1324,10 +1324,6 @@ SerializedPlanParser::SerializedPlanParser(const ContextPtr & context_) : contex
 {
 }
 
-ContextMutablePtr SerializedPlanParser::global_context = nullptr;
-
-Context::ConfigurationPtr SerializedPlanParser::config = nullptr;
-
 void SerializedPlanParser::collectJoinKeys(
     const substrait::Expression & condition, std::vector<std::pair<int32_t, int32_t>> & join_keys, int32_t right_key_start)
 {
@@ -1564,8 +1560,6 @@ void SerializedPlanParser::wrapNullable(
         nullable_measure_names[item] = node->result_name;
     }
 }
-
-SharedContextHolder SerializedPlanParser::shared_context;
 
 LocalExecutor::~LocalExecutor()
 {

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -131,9 +131,6 @@ public:
 
     static std::pair<DataTypePtr, Field> parseLiteral(const substrait::Expression_Literal & literal);
 
-    static ContextMutablePtr global_context;
-    static Context::ConfigurationPtr config;
-    static SharedContextHolder shared_context;
     std::vector<QueryPlanPtr> extra_plan_holder;
 
 private:
@@ -142,22 +139,19 @@ private:
     collectJoinKeys(const substrait::Expression & condition, std::vector<std::pair<int32_t, int32_t>> & join_keys, int32_t right_key_start);
 
     void parseFunctionOrExpression(
-        const substrait::Expression & rel,
-        std::string & result_name,
-        DB::ActionsDAG& actions_dag,
-        bool keep_result = false);
+        const substrait::Expression & rel, std::string & result_name, DB::ActionsDAG & actions_dag, bool keep_result = false);
     void parseJsonTuple(
         const substrait::Expression & rel,
         std::vector<String> & result_names,
-        DB::ActionsDAG& actions_dag,
+        DB::ActionsDAG & actions_dag,
         bool keep_result = false,
         bool position = false);
     const ActionsDAG::Node * parseFunctionWithDAG(
-        const substrait::Expression & rel, std::string & result_name, DB::ActionsDAG& actions_dag, bool keep_result = false);
+        const substrait::Expression & rel, std::string & result_name, DB::ActionsDAG & actions_dag, bool keep_result = false);
     ActionsDAG::NodeRawConstPtrs parseArrayJoinWithDAG(
         const substrait::Expression & rel,
         std::vector<String> & result_name,
-        DB::ActionsDAG& actions_dag,
+        DB::ActionsDAG & actions_dag,
         bool keep_result = false,
         bool position = false);
     void parseFunctionArguments(
@@ -174,14 +168,14 @@ private:
         bool & is_map);
 
 
-    const DB::ActionsDAG::Node * parseExpression(DB::ActionsDAG& actions_dag, const substrait::Expression & rel);
+    const DB::ActionsDAG::Node * parseExpression(DB::ActionsDAG & actions_dag, const substrait::Expression & rel);
     const ActionsDAG::Node *
-    toFunctionNode(ActionsDAG& actions_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args);
+    toFunctionNode(ActionsDAG & actions_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args);
     // remove nullable after isNotNull
     void removeNullableForRequiredColumns(const std::set<String> & require_columns, ActionsDAG & actions_dag) const;
     std::string getUniqueName(const std::string & name) { return name + "_" + std::to_string(name_no++); }
     void wrapNullable(
-        const std::vector<String> & columns, ActionsDAG& actions_dag, std::map<std::string, std::string> & nullable_measure_names);
+        const std::vector<String> & columns, ActionsDAG & actions_dag, std::map<std::string, std::string> & nullable_measure_names);
     static std::pair<DB::DataTypePtr, DB::Field> convertStructFieldType(const DB::DataTypePtr & type, const DB::Field & field);
 
     bool isFunction(substrait::Expression_ScalarFunction rel, String function_name);
@@ -198,7 +192,7 @@ private:
     std::vector<RelMetricPtr> metrics;
 
 public:
-    const ActionsDAG::Node * addColumn(DB::ActionsDAG& actions_dag, const DataTypePtr & type, const Field & field);
+    const ActionsDAG::Node * addColumn(DB::ActionsDAG & actions_dag, const DataTypePtr & type, const Field & field);
 };
 
 struct SparkBuffer

--- a/cpp-ch/local-engine/Parser/TypeParser.cpp
+++ b/cpp-ch/local-engine/Parser/TypeParser.cpp
@@ -19,14 +19,12 @@
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate32.h>
-#include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/DataTypeSet.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -38,6 +36,7 @@
 #include <Parser/TypeParser.h>
 #include <Poco/StringTokenizer.h>
 #include <Common/Exception.h>
+#include <Common/QueryContext.h>
 
 namespace DB
 {
@@ -274,7 +273,7 @@ DB::Block TypeParser::buildBlockFromNamedStruct(const substrait::NamedStruct & s
 
             auto args_types = tuple_type->getElements();
             AggregateFunctionProperties properties;
-            auto tmp_ctx = DB::Context::createCopy(SerializedPlanParser::global_context);
+            auto tmp_ctx = DB::Context::createCopy(QueryContext::globalContext());
             SerializedPlanParser tmp_plan_parser(tmp_ctx);
             auto function_parser = AggregateFunctionParserFactory::instance().get(name_parts[3], &tmp_plan_parser);
             /// This may remove elements from args_types, because some of them are used to determine CH function name, but not needed for the following

--- a/cpp-ch/local-engine/Parser/TypeParser.h
+++ b/cpp-ch/local-engine/Parser/TypeParser.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 #include <list>
-#include <optional>
+
 #include <unordered_map>
 #include <Core/Block.h>
 #include <DataTypes/IDataType.h>

--- a/cpp-ch/local-engine/Parser/WriteRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/WriteRelParser.cpp
@@ -30,6 +30,7 @@
 #include <Common/GlutenSettings.h>
 
 using namespace local_engine;
+using namespace DB;
 
 DB::ProcessorPtr make_sink(
     const DB::ContextPtr & context,

--- a/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_add.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_add.cpp
@@ -15,17 +15,18 @@
  * limitations under the License.
  */
 #include <iostream>
+#include <DataTypes/DataTypeNullable.h>
 #include <Parser/FunctionExecutor.h>
 #include <Parser/FunctionParser.h>
 #include <gtest/gtest.h>
-#include <DataTypes/DataTypeNullable.h>
+#include <Common/QueryContext.h>
 
 using namespace DB;
 using namespace local_engine;
 
 TEST(MyAdd, Common)
 {
-    auto context = local_engine::SerializedPlanParser::global_context;
+    auto context = local_engine::QueryContext::globalContext();
     auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>());
     FunctionExecutor executor("my_add", {type, type}, type, context);
 

--- a/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_md5.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_md5.cpp
@@ -15,17 +15,18 @@
  * limitations under the License.
  */
 #include <iostream>
+#include <DataTypes/DataTypeNullable.h>
 #include <Parser/FunctionExecutor.h>
 #include <Parser/FunctionParser.h>
 #include <gtest/gtest.h>
-#include <DataTypes/DataTypeNullable.h>
+#include <Common/QueryContext.h>
 
 using namespace DB;
 using namespace local_engine;
 
 TEST(MyMd5, Common)
 {
-    auto context = local_engine::SerializedPlanParser::global_context;
+    auto context = local_engine::QueryContext::globalContext();
     auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
     FunctionExecutor executor("my_md5", {type}, type, context);
 

--- a/cpp-ch/local-engine/Rewriter/RelRewriter.h
+++ b/cpp-ch/local-engine/Rewriter/RelRewriter.h
@@ -16,32 +16,27 @@
  */
 
 #pragma once
+#include <unordered_map>
+#include <Functions/SparkFunctionGetJsonObject.h>
+#include <Interpreters/Context_fwd.h>
 #include <Parser/SerializedPlanParser.h>
 #include <substrait/algebra.pb.h>
-#include <substrait/type.pb.h>
-#include <Interpreters/Context_fwd.h>
-#include <Interpreters/Context.h>
-#include <unordered_map>
-#include <Common/Exception.h>
-#include <set>
-#include <Functions/SparkFunctionGetJsonObject.h>
 
-#include <Poco/Logger.h>
-#include <Common/logger_useful.h>
 
 namespace local_engine
 {
 class RelRewriter
 {
 public:
-    RelRewriter(SerializedPlanParser *parser_) : parser(parser_) {}
+    RelRewriter(SerializedPlanParser * parser_) : parser(parser_) { }
     virtual ~RelRewriter() = default;
     virtual void rewrite(substrait::Rel & rel) = 0;
-protected:
-    SerializedPlanParser *parser;
 
-    inline DB::ContextPtr getContext() { return parser->context; }
-    inline std::unordered_map<std::string, std::string> & getFunctionMapping() { return parser->function_mapping; }
+protected:
+    SerializedPlanParser * parser;
+
+    inline DB::ContextPtr getContext() const { return parser->context; }
+    inline std::unordered_map<std::string, std::string> & getFunctionMapping() const { return parser->function_mapping; }
 };
 
 }

--- a/cpp-ch/local-engine/Shuffle/PartitionWriter.cpp
+++ b/cpp-ch/local-engine/Shuffle/PartitionWriter.cpp
@@ -22,18 +22,16 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteBufferFromString.h>
+#include <Interpreters/sortBlock.h>
 #include <Processors/Merges/Algorithms/MergingSortedAlgorithm.h>
+#include <Processors/Transforms/SortingTransform.h>
 #include <Shuffle/CachedShuffleWriter.h>
-#include <Storages/IO/AggregateSerializationUtils.h>
 #include <Storages/IO/CompressedWriteBuffer.h>
+#include <Storages/IO/NativeWriter.h>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <Common/CHUtil.h>
 #include <Common/Stopwatch.h>
 #include <Common/ThreadPool.h>
-#include <Common/QueryContext.h>
-
-#include <Processors/Transforms/SortingTransform.h>
-#include <Storages/IO/NativeWriter.h>
 
 
 namespace DB
@@ -324,7 +322,7 @@ PartitionWriter::PartitionWriter(CachedShuffleWriter * shuffle_writer_, LoggerPt
         partition_block_buffer[partition_id] = std::make_shared<ColumnsBuffer>(options->split_size);
         partition_buffer[partition_id] = std::make_shared<Partition>();
     }
-    settings = MemoryConfig::loadFromContext(SerializedPlanParser::global_context);
+    settings = MemoryConfig::loadFromContext(QueryContext::globalContext());
 }
 
 size_t PartitionWriter::bytes() const

--- a/cpp-ch/local-engine/Shuffle/PartitionWriter.h
+++ b/cpp-ch/local-engine/Shuffle/PartitionWriter.h
@@ -18,15 +18,14 @@
 #include <cstddef>
 #include <memory>
 #include <vector>
-#include <Common/GlutenConfig.h>
 #include <Core/Block.h>
 #include <Core/Settings.h>
 #include <Interpreters/TemporaryDataOnDisk.h>
-#include <Parser/SerializedPlanParser.h>
 #include <Shuffle/CachedShuffleWriter.h>
 #include <Shuffle/ShuffleCommon.h>
 #include <jni/CelebornClient.h>
-
+#include <Common/GlutenConfig.h>
+#include <Common/QueryContext.h>
 
 namespace DB
 {
@@ -113,7 +112,7 @@ public:
 
 protected:
     String getNextSpillFile();
-    std::vector<UInt64> mergeSpills(CachedShuffleWriter * shuffle_writer, WriteBuffer & data_file, ExtraData extra_data = {});
+    std::vector<UInt64> mergeSpills(CachedShuffleWriter * shuffle_writer, DB::WriteBuffer & data_file, ExtraData extra_data = {});
     std::vector<SpillInfo> spill_infos;
 
 private:
@@ -140,7 +139,7 @@ protected:
     {
         max_merge_block_size = options->split_size;
         max_sort_buffer_size = options->max_sort_buffer_size;
-        max_merge_block_bytes = SerializedPlanParser::global_context->getSettingsRef().prefer_external_sort_block_bytes;
+        max_merge_block_bytes = QueryContext::globalContext()->getSettingsRef().prefer_external_sort_block_bytes;
     }
 public:
     String getName() const override { return "SortBasedPartitionWriter"; }
@@ -161,10 +160,10 @@ protected:
     size_t max_merge_block_bytes = 0;
     size_t current_accumulated_bytes = 0;
     size_t current_accumulated_rows = 0;
-    Chunks accumulated_blocks;
-    Block output_header;
-    Block sort_header;
-    SortDescription sort_description;
+    DB::Chunks accumulated_blocks;
+    DB::Block output_header;
+    DB::Block sort_header;
+    DB::SortDescription sort_description;
 };
 
 class MemorySortLocalPartitionWriter : public SortBasedPartitionWriter, public Spillable

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
@@ -17,7 +17,6 @@
 #include "SelectorBuilder.h"
 #include <limits>
 #include <memory>
-#include <Columns/ColumnArray.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
 #include <DataTypes/DataTypeArray.h>
@@ -30,6 +29,7 @@
 #include <Poco/MemoryStream.h>
 #include <Common/CHUtil.h>
 #include <Common/Exception.h>
+#include <Common/QueryContext.h>
 
 namespace DB
 {
@@ -101,7 +101,7 @@ PartitionInfo HashSelectorBuilder::build(DB::Block & block)
     if (!hash_function) [[unlikely]]
     {
         auto & factory = DB::FunctionFactory::instance();
-        auto function = factory.get(hash_function_name, local_engine::SerializedPlanParser::global_context);
+        auto function = factory.get(hash_function_name, QueryContext::globalContext());
 
         hash_function = function->build(args);
     }
@@ -328,7 +328,7 @@ void RangeSelectorBuilder::initActionsDAG(const DB::Block & block)
     std::lock_guard lock(actions_dag_mutex);
     if (has_init_actions_dag)
         return;
-    SerializedPlanParser plan_parser(local_engine::SerializedPlanParser::global_context);
+    SerializedPlanParser plan_parser(QueryContext::globalContext());
     plan_parser.parseExtensions(projection_plan_pb->extensions());
 
     const auto & expressions = projection_plan_pb->relations().at(0).root().input().project().expressions();

--- a/cpp-ch/local-engine/Storages/Cache/CacheManager.cpp
+++ b/cpp-ch/local-engine/Storages/Cache/CacheManager.cpp
@@ -25,6 +25,7 @@
 #include <Interpreters/Context.h>
 #include <Processors/Executors/PipelineExecutor.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
+#include <Processors/QueryPlan/QueryPlan.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/MetaDataHelper.h>
 #include <jni/jni_common.h>
@@ -65,7 +66,7 @@ CacheManager & CacheManager::instance()
     return cache_manager;
 }
 
-void CacheManager::initialize(DB::ContextMutablePtr context_)
+void CacheManager::initialize(const DB::ContextMutablePtr & context_)
 {
     auto & manager = instance();
     manager.context = context_;

--- a/cpp-ch/local-engine/Storages/Cache/CacheManager.h
+++ b/cpp-ch/local-engine/Storages/Cache/CacheManager.h
@@ -39,7 +39,7 @@ public:
     static void initJNI(JNIEnv * env);
 
     static CacheManager & instance();
-    static void initialize(DB::ContextMutablePtr context);
+    static void initialize(const DB::ContextMutablePtr & context);
     JobId cacheParts(const MergeTreeTableInstance & table, const std::unordered_set<String> & columns);
     static jobject getCacheStatus(JNIEnv * env, const String & jobId);
 

--- a/cpp-ch/local-engine/Storages/Cache/JobScheduler.cpp
+++ b/cpp-ch/local-engine/Storages/Cache/JobScheduler.cpp
@@ -18,9 +18,9 @@
 
 #include "JobScheduler.h"
 
+#include <Interpreters/Context.h>
 #include <Common/GlutenConfig.h>
 #include <Common/ThreadPool.h>
-#include <Interpreters/Context.h>
 #include <Common/logger_useful.h>
 
 namespace DB
@@ -42,7 +42,7 @@ namespace local_engine
 {
 std::shared_ptr<JobScheduler> global_job_scheduler = nullptr;
 
-void JobScheduler::initialize(DB::ContextPtr context)
+void JobScheduler::initialize(const DB::ContextPtr & context)
 {
     auto config = GlutenJobSchedulerConfig::loadFromContext(context);
     instance().thread_pool = std::make_unique<ThreadPool>(

--- a/cpp-ch/local-engine/Storages/Cache/JobScheduler.h
+++ b/cpp-ch/local-engine/Storages/Cache/JobScheduler.h
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 #pragma once
-#include <base/types.h>
-#include <Common/ThreadPool_fwd.h>
 #include <Interpreters/Context_fwd.h>
+#include <base/types.h>
 #include <Common/Stopwatch.h>
+#include <Common/ThreadPool_fwd.h>
 
 namespace local_engine
 {
@@ -108,7 +108,7 @@ public:
         return global_job_scheduler;
     }
 
-    static void initialize(DB::ContextPtr context);
+    static void initialize(const DB::ContextPtr & context);
 
     JobId scheduleJob(Job&& job);
 

--- a/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 #include "MetaDataHelper.h"
-
 #include <filesystem>
 #include <Core/Settings.h>
 #include <Disks/ObjectStorages/MetadataStorageFromDisk.h>
 #include <Storages/MergeTree/MergeSparkMergeTreeTask.h>
 #include <Poco/StringTokenizer.h>
+#include <Common/QueryContext.h>
 
 namespace CurrentMetrics
 {
@@ -78,7 +78,7 @@ void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTa
             return;
 
         // Increase the speed of metadata recovery
-        auto max_concurrency = std::max(10UL, SerializedPlanParser::global_context->getSettingsRef().max_threads.value);
+        auto max_concurrency = std::max(10UL, QueryContext::globalContext()->getSettingsRef().max_threads.value);
         auto max_threads = std::min(max_concurrency, not_exists_part.size());
         FreeThreadPool thread_pool(
             CurrentMetrics::LocalThread,

--- a/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.cpp
@@ -83,7 +83,7 @@ StorageMergeTreeFactory::getDataPartsByNames(const StorageID & id, const String 
 {
     DataPartsVector res;
     auto table_name = getTableName(id, snapshot_id);
-    auto config = MergeTreeConfig::loadFromContext(SerializedPlanParser::global_context);
+    auto config = MergeTreeConfig::loadFromContext(QueryContext::globalContext());
     std::lock_guard lock(datapart_mutex);
     std::unordered_set<String> missing_names;
     if (!datapart_map->has(table_name)) [[unlikely]]

--- a/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.h
@@ -16,10 +16,11 @@
  */
 #pragma once
 #include <Interpreters/MergeTreeTransaction.h>
-#include <Parser/SerializedPlanParser.h>
 #include <Storages/MergeTree/SparkMergeTreeMeta.h>
+#include <Storages/MergeTree/SparkStorageMergeTree.h>
 #include <Poco/LRUCache.h>
 #include <Common/GlutenConfig.h>
+#include <Common/QueryContext.h>
 
 namespace local_engine
 {
@@ -70,7 +71,7 @@ public:
     static DataPartsVector getDataPartsByNames(const StorageID & id, const String & snapshot_id, std::unordered_set<String> part_name);
     static void init_cache_map()
     {
-        auto config = MergeTreeConfig::loadFromContext(SerializedPlanParser::global_context);
+        auto config = MergeTreeConfig::loadFromContext(QueryContext::globalContext());
         auto & storage_map_v = storage_map;
         if (!storage_map_v)
         {

--- a/cpp-ch/local-engine/Storages/Output/FileWriterWrappers.cpp
+++ b/cpp-ch/local-engine/Storages/Output/FileWriterWrappers.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "FileWriterWrappers.h"
+#include <QueryPipeline/QueryPipeline.h>
 
 namespace local_engine
 {

--- a/cpp-ch/local-engine/tests/benchmark_spark_divide_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_divide_function.cpp
@@ -21,10 +21,11 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/SparkFunctionDivide.h>
 #include <Interpreters/ActionsDAG.h>
-#include <Parser/SerializedPlanParser.h>
+#include <Interpreters/ExpressionActions.h>
 #include <Processors/Executors/PipelineExecutor.h>
 #include <Processors/Sources/BlocksSource.h>
 #include <benchmark/benchmark.h>
+#include <Common/QueryContext.h>
 
 using namespace DB;
 
@@ -63,7 +64,7 @@ static std::string join(const ActionsDAG::NodeRawConstPtrs & v, char c)
 static const ActionsDAG::Node *
 addFunction(ActionsDAG & actions_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args)
 {
-    auto function_builder = FunctionFactory::instance().get(function, local_engine::SerializedPlanParser::global_context);
+    auto function_builder = FunctionFactory::instance().get(function, local_engine::QueryContext::globalContext());
     std::string args_name = join(args, ',');
     auto result_name = function + "(" + args_name + ")";
     return &actions_dag.addFunction(function_builder, args, result_name);

--- a/cpp-ch/local-engine/tests/benchmark_spark_row.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_row.cpp
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <string>
+#include <vector>
 #include <Core/Block.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <IO/ReadBufferFromFile.h>
@@ -26,9 +28,6 @@
 #include <base/types.h>
 #include <benchmark/benchmark.h>
 #include <parquet/arrow/reader.h>
-
-#include <string>
-#include <vector>
 
 using namespace DB;
 using namespace local_engine;

--- a/cpp-ch/local-engine/tests/benchmark_unix_timestamp_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_unix_timestamp_function.cpp
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-#include <Core/Block.h>
 #include <Columns/IColumn.h>
-#include <DataTypes/IDataType.h>
+#include <Core/Block.h>
 #include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsRound.h>
-#include <Parser/SerializedPlanParser.h>
 #include <Parser/FunctionParser.h>
 #include <benchmark/benchmark.h>
+#include <Common/QueryContext.h>
 
 using namespace DB;
 
@@ -32,16 +32,10 @@ static Block createDataBlock(String type_str, size_t rows)
     auto type = DataTypeFactory::instance().get(type_str);
     auto column = type->createColumn();
     for (size_t i = 0; i < rows; ++i)
-    {
         if (type_str == "Date32")
-        {
             column->insert(i);
-        }
         else if (type_str == "Date")
-        {
             column->insert(i);
-        }
-    }
     Block block;
     block.insert(ColumnWithTypeAndName(std::move(column), type, "d"));
     return std::move(block);
@@ -51,10 +45,10 @@ static void BM_CHUnixTimestamp_For_Date32(benchmark::State & state)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("toUnixTimestamp", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("toUnixTimestamp", local_engine::QueryContext::globalContext());
     Block block = createDataBlock("Date32", 30000000);
     auto executable = function->build(block.getColumnsWithTypeAndName());
-    for (auto _ : state)[[maybe_unused]]
+    for (auto _ : state) [[maybe_unused]]
         auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
 }
 
@@ -62,10 +56,10 @@ static void BM_CHUnixTimestamp_For_Date(benchmark::State & state)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("toUnixTimestamp", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("toUnixTimestamp", local_engine::QueryContext::globalContext());
     Block block = createDataBlock("Date", 30000000);
     auto executable = function->build(block.getColumnsWithTypeAndName());
-    for (auto _ : state)[[maybe_unused]]
+    for (auto _ : state) [[maybe_unused]]
         auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
 }
 
@@ -73,22 +67,22 @@ static void BM_SparkUnixTimestamp_For_Date32(benchmark::State & state)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("sparkDateToUnixTimestamp", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("sparkDateToUnixTimestamp", local_engine::QueryContext::globalContext());
     Block block = createDataBlock("Date32", 30000000);
     auto executable = function->build(block.getColumnsWithTypeAndName());
-    for (auto _ : state)[[maybe_unused]]
-         auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
+    for (auto _ : state) [[maybe_unused]]
+        auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
 }
 
 static void BM_SparkUnixTimestamp_For_Date(benchmark::State & state)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("sparkDateToUnixTimestamp", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("sparkDateToUnixTimestamp", local_engine::QueryContext::globalContext());
     Block block = createDataBlock("Date", 30000000);
     auto executable = function->build(block.getColumnsWithTypeAndName());
-    for (auto _ : state)[[maybe_unused]]
-         auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
+    for (auto _ : state) [[maybe_unused]]
+        auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
 }
 
 BENCHMARK(BM_CHUnixTimestamp_For_Date32)->Unit(benchmark::kMillisecond)->Iterations(100);

--- a/cpp-ch/local-engine/tests/gluten_test_util.h
+++ b/cpp-ch/local-engine/tests/gluten_test_util.h
@@ -23,10 +23,13 @@
 #include <Core/NamesAndTypes.h>
 
 #include <Interpreters/ActionsDAG.h>
-#include <Parser/SerializedPlanParser.h>
 #include <boost/algorithm/string/replace.hpp>
 #include <parquet/schema.h>
 
+namespace substrait
+{
+class Plan;
+}
 namespace local_engine
 {
 class LocalExecutor;

--- a/cpp-ch/local-engine/tests/gtest_ch_functions.cpp
+++ b/cpp-ch/local-engine/tests/gtest_ch_functions.cpp
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 #include <Columns/ColumnSet.h>
+#include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeSet.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/Set.h>
-#include <Parser/SerializedPlanParser.h>
 #include <gtest/gtest.h>
 #include <Common/DebugUtils.h>
+#include <Common/QueryContext.h>
 
 TEST(TestFuntion, Hash)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("murmurHash2_64", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("murmurHash2_64", local_engine::QueryContext::globalContext());
     auto type0 = DataTypeFactory::instance().get("String");
     auto column0 = type0->createColumn();
     column0->insert("A");
@@ -56,7 +57,7 @@ TEST(TestFunction, In)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("in", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("in", local_engine::QueryContext::globalContext());
     auto type0 = DataTypeFactory::instance().get("String");
     auto type_set = std::make_shared<DataTypeSet>();
 
@@ -83,8 +84,7 @@ TEST(TestFunction, In)
     auto arg = ColumnSet::create(4, future_set);
 
     ColumnsWithTypeAndName columns
-        = {ColumnWithTypeAndName(std::move(column1), type0, "string0"),
-           ColumnWithTypeAndName(std::move(arg), type_set, "__set")};
+        = {ColumnWithTypeAndName(std::move(column1), type0, "string0"), ColumnWithTypeAndName(std::move(arg), type_set, "__set")};
     Block block(columns);
     std::cerr << "input:\n";
     debug::headBlock(block);
@@ -100,7 +100,7 @@ TEST(TestFunction, NotIn1)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("notIn", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("notIn", local_engine::QueryContext::globalContext());
     auto type0 = DataTypeFactory::instance().get("String");
     auto type_set = std::make_shared<DataTypeSet>();
 
@@ -125,7 +125,7 @@ TEST(TestFunction, NotIn1)
     auto future_set = std::make_shared<FutureSetFromStorage>(std::move(set));
 
     //TODO: WHY? after https://github.com/ClickHouse/ClickHouse/pull/63723 we need pass 4 instead of 1
-    auto arg = ColumnSet::create(4,future_set);
+    auto arg = ColumnSet::create(4, future_set);
 
     ColumnsWithTypeAndName columns
         = {ColumnWithTypeAndName(std::move(column1), type0, "string0"), ColumnWithTypeAndName(std::move(arg), type_set, "__set")};
@@ -143,7 +143,7 @@ TEST(TestFunction, NotIn2)
 {
     using namespace DB;
     auto & factory = FunctionFactory::instance();
-    auto function = factory.get("in", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("in", local_engine::QueryContext::globalContext());
     auto type0 = DataTypeFactory::instance().get("String");
     auto type_set = std::make_shared<DataTypeSet>();
 
@@ -168,7 +168,7 @@ TEST(TestFunction, NotIn2)
     auto future_set = std::make_shared<FutureSetFromStorage>(std::move(set));
 
     //TODO: WHY? after https://github.com/ClickHouse/ClickHouse/pull/63723 we need pass 4 instead of 1
-    auto arg = ColumnSet::create(4,future_set);
+    auto arg = ColumnSet::create(4, future_set);
 
     ColumnsWithTypeAndName columns
         = {ColumnWithTypeAndName(std::move(column1), type0, "string0"), ColumnWithTypeAndName(std::move(arg), type_set, "__set")};
@@ -178,7 +178,7 @@ TEST(TestFunction, NotIn2)
     auto executable = function->build(block.getColumnsWithTypeAndName());
     auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
 
-    auto function_not = factory.get("not", local_engine::SerializedPlanParser::global_context);
+    auto function_not = factory.get("not", local_engine::QueryContext::globalContext());
     auto type_bool = DataTypeFactory::instance().get("UInt8");
     ColumnsWithTypeAndName columns2 = {ColumnWithTypeAndName(result, type_bool, "string0")};
     Block block2(columns2);

--- a/cpp-ch/local-engine/tests/gtest_ch_join.cpp
+++ b/cpp-ch/local-engine/tests/gtest_ch_join.cpp
@@ -14,37 +14,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <Core/Settings.h>
+#include <DataTypes/DataTypeFactory.h>
 #include <Functions/FunctionFactory.h>
+#include <Interpreters/HashJoin/HashJoin.h>
+#include <Interpreters/TableJoin.h>
 #include <Join/StorageJoinFromReadBuffer.h>
-#include <Parser/SerializedPlanParser.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Processors/Executors/PipelineExecutor.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
+#include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-
 #include <Storages/MergeTree/SparkMergeTreeMeta.h>
 #include <Storages/SubstraitSource/SubstraitFileSource.h>
 #include <gtest/gtest.h>
 #include <Common/DebugUtils.h>
-
-#include <Core/Settings.h>
-#include <Interpreters/HashJoin/HashJoin.h>
-#include <Interpreters/TableJoin.h>
-#include <substrait/plan.pb.h>
+#include <Common/QueryContext.h>
 
 using namespace DB;
 using namespace local_engine;
 
 TEST(TestJoin, simple)
 {
-    auto global_context = SerializedPlanParser::global_context;
-    local_engine::SerializedPlanParser::global_context->setSetting("join_use_nulls", true);
+    auto global_context = local_engine::QueryContext::globalContext();
+    local_engine::QueryContext::globalMutableContext()->setSetting("join_use_nulls", true);
     auto & factory = DB::FunctionFactory::instance();
-    auto function = factory.get("murmurHash2_64", local_engine::SerializedPlanParser::global_context);
+    auto function = factory.get("murmurHash2_64", global_context);
     auto int_type = DataTypeFactory::instance().get("Int32");
     auto column0 = int_type->createColumn();
     column0->insert(1);

--- a/cpp-ch/local-engine/tests/gtest_ch_storages.cpp
+++ b/cpp-ch/local-engine/tests/gtest_ch_storages.cpp
@@ -16,7 +16,6 @@
  */
 #include <Functions/FunctionFactory.h>
 #include <Parser/MergeTreeRelParser.h>
-#include <Parser/SerializedPlanParser.h>
 #include <Processors/Executors/PipelineExecutor.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/SparkMergeTreeMeta.h>
@@ -26,6 +25,7 @@
 #include <gtest/gtest.h>
 #include <substrait/plan.pb.h>
 #include <Common/DebugUtils.h>
+#include <Common/QueryContext.h>
 
 using namespace DB;
 using namespace local_engine;
@@ -33,7 +33,7 @@ using namespace local_engine;
 TEST(TestBatchParquetFileSource, blob)
 {
     GTEST_SKIP();
-    auto config = local_engine::SerializedPlanParser::config;
+    Context::ConfigurationPtr config;
     config->setString("blob.storage_account_url", "http://127.0.0.1:10000/devstoreaccount1");
     config->setString("blob.container_name", "libch");
     config->setString("blob.container_already_exists", "true");
@@ -79,7 +79,7 @@ TEST(TestBatchParquetFileSource, blob)
         columns.emplace_back(std::move(col));
     }
     auto header = Block(std::move(columns));
-    builder->init(Pipe(std::make_shared<local_engine::SubstraitFileSource>(SerializedPlanParser::global_context, header, files)));
+    builder->init(Pipe(std::make_shared<local_engine::SubstraitFileSource>(QueryContext::globalContext(), header, files)));
 
     auto pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
     auto executor = PullingPipelineExecutor(pipeline);
@@ -101,7 +101,7 @@ TEST(TestBatchParquetFileSource, blob)
 TEST(TestBatchParquetFileSource, s3)
 {
     GTEST_SKIP();
-    auto config = local_engine::SerializedPlanParser::config;
+    Context::ConfigurationPtr config;
     config->setString("s3.endpoint", "http://localhost:9000/tpch/");
     config->setString("s3.region", "us-east-1");
     config->setString("s3.access_key_id", "admin");
@@ -143,7 +143,7 @@ TEST(TestBatchParquetFileSource, s3)
         columns.emplace_back(std::move(col));
     }
     auto header = Block(std::move(columns));
-    builder->init(Pipe(std::make_shared<SubstraitFileSource>(SerializedPlanParser::global_context, header, files)));
+    builder->init(Pipe(std::make_shared<SubstraitFileSource>(QueryContext::globalContext(), header, files)));
 
     auto pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
     auto executor = PullingPipelineExecutor(pipeline);
@@ -210,7 +210,7 @@ TEST(TestBatchParquetFileSource, local_file)
         columns.emplace_back(std::move(col));
     }
     auto header = Block(std::move(columns));
-    builder->init(Pipe(std::make_shared<SubstraitFileSource>(SerializedPlanParser::global_context, header, files)));
+    builder->init(Pipe(std::make_shared<SubstraitFileSource>(QueryContext::globalContext(), header, files)));
 
     auto pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
     auto executor = PullingPipelineExecutor(pipeline);
@@ -260,11 +260,11 @@ TEST(TestPrewhere, OptimizePrewhereCondition)
     }
     Block block(std::move(columns));
 
-    ContextPtr context = SerializedPlanParser::global_context;
+    ContextPtr context = QueryContext::globalContext();
     SerializedPlanParser * parser = new SerializedPlanParser(context);
     parser->parseExtensions(plan_ptr->extensions());
 
-    MergeTreeRelParser mergeTreeParser(parser, SerializedPlanParser::global_context);
+    MergeTreeRelParser mergeTreeParser(parser, QueryContext::globalContext());
 
     mergeTreeParser.column_sizes["l_discount"] = 0;
     mergeTreeParser.column_sizes["l_quantity"] = 1;

--- a/cpp-ch/local-engine/tests/gtest_clickhouse_pr_verify.cpp
+++ b/cpp-ch/local-engine/tests/gtest_clickhouse_pr_verify.cpp
@@ -17,11 +17,12 @@
 #include <gluten_test_util.h>
 #include <incbin.h>
 #include <Core/Settings.h>
+#include <Interpreters/Context.h>
 #include <Parser/SerializedPlanParser.h>
 #include <Parser/SubstraitParserUtils.h>
 #include <gtest/gtest.h>
 #include <Common/DebugUtils.h>
-
+#include <Common/QueryContext.h>
 
 using namespace local_engine;
 
@@ -31,7 +32,7 @@ using namespace DB;
 INCBIN(_pr_54881_, SOURCE_DIR "/utils/extern-local-engine/tests/json/clickhouse_pr_54881.json");
 TEST(Clickhouse, PR54881)
 {
-    const auto context1 = DB::Context::createCopy(SerializedPlanParser::global_context);
+    const auto context1 = DB::Context::createCopy(QueryContext::globalContext());
     // context1->setSetting("enable_named_columns_in_function_tuple", DB::Field(true));
     auto settings = context1->getSettingsRef();
     EXPECT_FALSE(settings.enable_named_columns_in_function_tuple) << "GLUTEN NEED set enable_named_columns_in_function_tuple to false";
@@ -81,7 +82,7 @@ INCBIN(_pr_65234_, SOURCE_DIR "/utils/extern-local-engine/tests/json/clickhouse_
 TEST(Clickhouse, PR65234)
 {
     const std::string split = R"({"items":[{"uriFile":"file:///foo","length":"84633","parquet":{},"schema":{},"metadataColumns":[{}]}]})";
-    SerializedPlanParser parser(SerializedPlanParser::global_context);
+    SerializedPlanParser parser(QueryContext::globalContext());
     parser.addSplitInfo(local_engine::JsonStringToBinary<substrait::ReadRel::LocalFiles>(split));
     const auto plan = local_engine::JsonStringToMessage<substrait::Plan>(EMBEDDED_PLAN(_pr_65234_));
     auto query_plan = parser.parse(plan);

--- a/cpp-ch/local-engine/tests/gtest_parquet_columnindex_bug.cpp
+++ b/cpp-ch/local-engine/tests/gtest_parquet_columnindex_bug.cpp
@@ -17,12 +17,13 @@
 #include <gluten_test_util.h>
 #include <incbin.h>
 #include <Core/Settings.h>
+#include <Interpreters/Context.h>
 #include <Parser/SerializedPlanParser.h>
 #include <Parser/SubstraitParserUtils.h>
 #include <gtest/gtest.h>
 #include <Common/DebugUtils.h>
 #include <Common/GlutenConfig.h>
-
+#include <Common/QueryContext.h>
 
 using namespace local_engine;
 
@@ -32,7 +33,7 @@ INCBIN(_pr_18_2, SOURCE_DIR "/utils/extern-local-engine/tests/decimal_filter_pus
 TEST(ColumnIndex, Decimal182)
 {
     // [precision,scale] = [18,2]
-    const auto context1 = DB::Context::createCopy(SerializedPlanParser::global_context);
+    const auto context1 = DB::Context::createCopy(QueryContext::globalMutableContext());
     const auto config = ExecutorConfig::loadFromContext(context1);
     EXPECT_TRUE(config.use_local_format) << "gtest need set use_local_format to true";
 

--- a/cpp-ch/local-engine/tests/gtest_parser.cpp
+++ b/cpp-ch/local-engine/tests/gtest_parser.cpp
@@ -18,6 +18,7 @@
 #include <incbin.h>
 #include <testConfig.h>
 #include <Core/Settings.h>
+#include <Interpreters/Context.h>
 #include <Parser/SerializedPlanParser.h>
 #include <Parser/SubstraitParserUtils.h>
 #include <Parser/TypeParser.h>
@@ -26,7 +27,7 @@
 #include <gtest/gtest.h>
 #include <Common/CHUtil.h>
 #include <Common/DebugUtils.h>
-
+#include <Common/QueryContext.h>
 
 using namespace local_engine;
 using namespace DB;
@@ -39,7 +40,7 @@ TEST(LocalExecutor, ReadCSV)
         = R"({"items":[{"uriFile":"{replace_local_files}","length":"56","text":{"fieldDelimiter":",","maxBlockSize":"8192","header":"1"},"schema":{"names":["id","name","language"],"struct":{"types":[{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}}]}},"metadataColumns":[{}]}]})";
     const std::string split = replaceLocalFilesWildcards(
         split_template, GLUTEN_SOURCE_DIR("/backends-velox/src/test/resources/datasource/csv/student_option_schema.csv"));
-    SerializedPlanParser parser(SerializedPlanParser::global_context);
+    SerializedPlanParser parser(QueryContext::globalContext());
     parser.addSplitInfo(local_engine::JsonStringToBinary<substrait::ReadRel::LocalFiles>(split));
     auto plan = local_engine::JsonStringToMessage<substrait::Plan>(EMBEDDED_PLAN(_readcsv_plan));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
After #6558, `QueryContext` is rewritten, and it's better to put  SerializedPlanParser::global_context here.

1. Rename QueryContextManager => QueryContext 
2. Move SerializedPlanParser::global_context to  QueryContext:Data 
3. Move SerializedPlanParser::shared_context to QueryContext::Data 
4. Remove SerializedPlanParser config
5. Cleanup #include <Parser/SerializedPlanParser.h>

The following 4 static functions is added to QueryContext, we should use `QueryContext::globalContext()` in most case.

```c++
class QueryContext 
    static DB::ContextMutablePtr createGlobal();
    static void resetGlobal();
    static DB::ContextMutablePtr globalMutableContext();
    static DB::ContextPtr globalContext();
```

## How was this patch tested?

Using exited UTs


