### PR TITLE
Revert "[GLUTEN-6930][VL] Print memory statistics during task ending when leak is found"

### DIFF
--- a/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtime.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtime.scala
@@ -117,11 +117,10 @@ object Runtime {
         LOGGER.warn(
           String.format(
             "%s Reservation listener %s still reserved non-zero bytes, which may cause memory" +
-              " leak, size: %s, dump: %s ",
+              " leak, size: %s",
             name,
             rl.toString,
-            SparkMemoryUtil.bytesToString(rl.getUsedBytes),
-            dump()
+            SparkMemoryUtil.bytesToString(rl.getUsedBytes)
           ))
       }
     }

--- a/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtime.scala
+++ b/gluten-data/src/main/scala/org/apache/gluten/runtime/Runtime.scala
@@ -117,7 +117,7 @@ object Runtime {
         LOGGER.warn(
           String.format(
             "%s Reservation listener %s still reserved non-zero bytes, which may cause memory" +
-              " leak, size: %s",
+              " leak, size: %s.",
             name,
             rl.toString,
             SparkMemoryUtil.bytesToString(rl.getUsedBytes)


### PR DESCRIPTION
This reverts https://github.com/apache/incubator-gluten/pull/6959 which could cause core dump when memory leak is found.