### PR TITLE
[VL] Fix weekly build job failure

### DIFF
--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -89,4 +89,5 @@ jobs:
           apt-get update && apt-get install -y sudo maven wget git
           sudo apt-get install -y openjdk-8-jdk
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+          echo "test"
           cd $GITHUB_WORKSPACE/ && ./dev/package.sh

--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -89,5 +89,4 @@ jobs:
           apt-get update && apt-get install -y sudo maven wget git
           sudo apt-get install -y openjdk-8-jdk
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-          echo "test"
           cd $GITHUB_WORKSPACE/ && ./dev/package.sh

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -607,7 +607,7 @@ TEST_F(VeloxHashShuffleWriterMemoryTest, kStop) {
     // Reclaim bytes to shrink partition buffer.
     int64_t reclaimed = 0;
     ASSERT_NOT_OK(shuffleWriter->reclaimFixedSize(2000, &reclaimed));
-    ASSERT(reclaimed >= 2000);
+    ASSERT_TRUE(reclaimed >= 2000);
 
     // Trigger spill during stop.
     ASSERT_TRUE(pool.checkEvict(pool.bytes_allocated(), [&] { ASSERT_NOT_OK(shuffleWriter->stop()); }));
@@ -630,7 +630,7 @@ TEST_F(VeloxHashShuffleWriterMemoryTest, kStopComplex) {
   // Reclaim bytes to shrink partition buffer.
   int64_t reclaimed = 0;
   ASSERT_NOT_OK(shuffleWriter->reclaimFixedSize(2000, &reclaimed));
-  ASSERT(reclaimed >= 2000);
+  ASSERT_TRUE(reclaimed >= 2000);
 
   // Reclaim from PartitionWriter to free cached bytes.
   auto payloadSize = shuffleWriter->cachedPayloadSize();

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -12,7 +12,7 @@ cd "$GLUTEN_DIR"
 
 # build gluten with velox backend, prompt always respond y
 export PROMPT_ALWAYS_RESPOND=y
-./dev/buildbundle-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON "$@"
+./dev/buildbundle-veloxbe.sh --enable_vcpkg=OFF --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON "$@"
 
 # make thirdparty package
 ./dev/build-thirdparty.sh


### PR DESCRIPTION
Fix the below error on ubuntu-20.04.
```
gluten::VeloxHashShuffleWriterMemoryTest_kStop_Test::TestBody()':
2024-09-09T04:14:59.2589597Z /__w/incubator-gluten/incubator-gluten/cpp/velox/tests/VeloxShuffleWriterTest.cc:610:5: error: 'ASSERT' was not declared in this scope; did you mean 'ASSERT_EQ'?
2024-09-09T04:14:59.2591325Z   610 |     ASSERT(reclaimed >= 2000);
2024-09-09T04:14:59.2591918Z       |     ^~~~~~
2024-09-09T04:14:59.2592344Z       |     ASSERT_EQ
2024-09-09T04:14:59.2594088Z /__w/incubator-gluten/incubator-gluten/cpp/velox/tests/VeloxShuffleWriterTest.cc:593:19: warning: unused variable 'partitioning' [-Wunused-variable]
2024-09-09T04:14:59.2596113Z   593 |   for (const auto partitioning : {Partitioning::kSingle, Partitioning::kRoundRobin}) {
2024-09-09T04:14:59.2597049Z       |                   ^~~~~~~~~~~~
2024-09-09T04:14:59.2599294Z /__w/incubator-gluten/incubator-gluten/cpp/velox/tests/VeloxShuffleWriterTest.cc: In member function 'virtual void gluten::VeloxHashShuffleWriterMemoryTest_kStopComplex_Test::TestBody()':
2024-09-09T04:14:59.2602574Z /__w/incubator-gluten/incubator-gluten/cpp/velox/tests/VeloxShuffleWriterTest.cc:633:3: error: 'ASSERT' was not declared in this scope; did you mean 'ASSERT_EQ'?
2024-09-09T04:14:59.2604745Z   633 |   ASSERT(reclaimed >= 2000);
2024-09-09T04:14:59.2605310Z       |   ^~~~~~
2024-09-09T04:14:59.2605714Z       |   ASSERT_EQ
```