### PR TITLE
[GLUTEN-7079][VL] Fix metrics for InputIteratorTransformer of broadcast exchange

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
@@ -39,6 +39,7 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
   }
 
   override def genInputIteratorTransformerMetrics(
+      child: SparkPlan,
       sparkContext: SparkContext): Map[String, SQLMetric] = {
     Map(
       "iterReadTime" -> SQLMetrics.createTimingMetric(
@@ -53,9 +54,7 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
   }
 
   override def genInputIteratorTransformerMetricsUpdater(
-      child: SparkPlan,
       metrics: Map[String, SQLMetric]): MetricsUpdater = {
-    // todo: check the metrics for broadcast exchange
     InputIteratorMetricsUpdater(metrics)
   }
 

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
@@ -53,7 +53,9 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
   }
 
   override def genInputIteratorTransformerMetricsUpdater(
+      child: SparkPlan,
       metrics: Map[String, SQLMetric]): MetricsUpdater = {
+    // todo: check the metrics for broadcast exchange
     InputIteratorMetricsUpdater(metrics)
   }
 

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHMetricsApi.scala
@@ -23,7 +23,8 @@ import org.apache.gluten.substrait.{AggregationParams, JoinParams}
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{ColumnarInputAdapter, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.QueryStageExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
 import java.lang.{Long => JLong}
@@ -40,21 +41,39 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
 
   override def genInputIteratorTransformerMetrics(
       child: SparkPlan,
-      sparkContext: SparkContext): Map[String, SQLMetric] = {
+      sparkContext: SparkContext,
+      forBroadcast: Boolean): Map[String, SQLMetric] = {
+    def metricsPlan(plan: SparkPlan): SparkPlan = {
+      plan match {
+        case ColumnarInputAdapter(child) => metricsPlan(child)
+        case q: QueryStageExec => metricsPlan(q.plan)
+        case _ => plan
+      }
+    }
+
+    val outputMetrics = if (forBroadcast) {
+      metricsPlan(child).metrics
+        .filterKeys(key => key.equals("numOutputRows"))
+    } else {
+      Map(
+        "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows")
+      )
+    }
+
     Map(
       "iterReadTime" -> SQLMetrics.createTimingMetric(
         sparkContext,
         "time of reading from iterator"),
       "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
-      "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
       "fillingRightJoinSideTime" -> SQLMetrics.createTimingMetric(
         sparkContext,
         "filling right join side time")
-    )
+    ) ++ outputMetrics
   }
 
   override def genInputIteratorTransformerMetricsUpdater(
-      metrics: Map[String, SQLMetric]): MetricsUpdater = {
+      metrics: Map[String, SQLMetric],
+      forBroadcast: Boolean): MetricsUpdater = {
     InputIteratorMetricsUpdater(metrics)
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
@@ -15,22 +15,29 @@
  * limitations under the License.
  */
 package org.apache.gluten.metrics
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.execution.metric.SQLMetric
 
-case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+case class InputIteratorMetricsUpdater(
+    metrics: Map[String, SQLMetric],
+    forBroadcast: Boolean = false)
+  extends MetricsUpdater {
   override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
     if (opMetrics != null) {
       val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
       metrics("cpuCount") += operatorMetrics.cpuCount
       metrics("wallNanos") += operatorMetrics.wallNanos
-      if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
-        // Sometimes, velox does not update metrics for intermediate operator,
-        // here we try to use the input metrics
-        metrics("numOutputRows") += operatorMetrics.inputRows
-        metrics("outputVectors") += operatorMetrics.inputVectors
-      } else {
-        metrics("numOutputRows") += operatorMetrics.outputRows
-        metrics("outputVectors") += operatorMetrics.outputVectors
+      // For broadcast exchange, we only collect the metrics once.
+      if (!forBroadcast || TaskContext.getPartitionId() == 0) {
+        if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
+          // Sometimes, velox does not update metrics for intermediate operator,
+          // here we try to use the input metrics
+          metrics("numOutputRows") += operatorMetrics.inputRows
+          metrics("outputVectors") += operatorMetrics.inputVectors
+        } else {
+          metrics("numOutputRows") += operatorMetrics.outputRows
+          metrics("outputVectors") += operatorMetrics.outputVectors
+        }
       }
     }
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
@@ -15,29 +15,22 @@
  * limitations under the License.
  */
 package org.apache.gluten.metrics
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.execution.metric.SQLMetric
 
-case class InputIteratorMetricsUpdater(
-    metrics: Map[String, SQLMetric],
-    forBroadcast: Boolean = false)
-  extends MetricsUpdater {
+case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric]) extends MetricsUpdater {
   override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
     if (opMetrics != null) {
       val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
       metrics("cpuCount") += operatorMetrics.cpuCount
       metrics("wallNanos") += operatorMetrics.wallNanos
-      // For broadcast exchange, we only collect the metrics once.
-      if (!forBroadcast || TaskContext.getPartitionId() == 0) {
-        if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
-          // Sometimes, velox does not update metrics for intermediate operator,
-          // here we try to use the input metrics
-          metrics("numOutputRows") += operatorMetrics.inputRows
-          metrics("outputVectors") += operatorMetrics.inputVectors
-        } else {
-          metrics("numOutputRows") += operatorMetrics.outputRows
-          metrics("outputVectors") += operatorMetrics.outputVectors
-        }
+      if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
+        // Sometimes, velox does not update metrics for intermediate operator,
+        // here we try to use the input metrics
+        metrics("numOutputRowsConsumed") += operatorMetrics.inputRows
+        metrics("outputVectorsConsumed") += operatorMetrics.inputVectors
+      } else {
+        metrics("numOutputRowsConsumed") += operatorMetrics.outputRows
+        metrics("outputVectorsConsumed") += operatorMetrics.outputVectors
       }
     }
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
@@ -17,20 +17,23 @@
 package org.apache.gluten.metrics
 import org.apache.spark.sql.execution.metric.SQLMetric
 
-case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric], forBroadcast: Boolean)
+  extends MetricsUpdater {
   override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
     if (opMetrics != null) {
       val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
       metrics("cpuCount") += operatorMetrics.cpuCount
       metrics("wallNanos") += operatorMetrics.wallNanos
-      if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
-        // Sometimes, velox does not update metrics for intermediate operator,
-        // here we try to use the input metrics
-        metrics("numOutputRowsConsumed") += operatorMetrics.inputRows
-        metrics("outputVectorsConsumed") += operatorMetrics.inputVectors
-      } else {
-        metrics("numOutputRowsConsumed") += operatorMetrics.outputRows
-        metrics("outputVectorsConsumed") += operatorMetrics.outputVectors
+      if (!forBroadcast) {
+        if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
+          // Sometimes, velox does not update metrics for intermediate operator,
+          // here we try to use the input metrics
+          metrics("numOutputRows") += operatorMetrics.inputRows
+          metrics("outputVectors") += operatorMetrics.inputVectors
+        } else {
+          metrics("numOutputRows") += operatorMetrics.outputRows
+          metrics("outputVectors") += operatorMetrics.outputVectors
+        }
       }
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxMetricsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxMetricsSuite.scala
@@ -259,7 +259,6 @@ class VeloxMetricsSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
               assert(inputIterator.isDefined)
               val metrics = inputIterator.get.metrics
               assert(metrics("numOutputRows").value == partTableRecords)
-              assert(metrics("outputVectors").value == 1)
           }
         }
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxMetricsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxMetricsSuite.scala
@@ -22,8 +22,9 @@ import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted}
 import org.apache.spark.sql.TestUtils
-import org.apache.spark.sql.execution.CommandResultExec
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.{ColumnarInputAdapter, CommandResultExec, InputIteratorTransformer}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, BroadcastQueryStageExec}
+import org.apache.spark.sql.execution.exchange.BroadcastExchangeLike
 import org.apache.spark.sql.internal.SQLConf
 
 class VeloxMetricsSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
@@ -226,5 +227,41 @@ class VeloxMetricsSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
 
     assert(inputRecords == (partTableRecords + itemTableRecords))
+  }
+
+  test("Metrics for input iterator of broadcast exchange") {
+    createTPCHNotNullTables()
+    val partTableRecords = spark.sql("select * from part").count()
+
+    // Repartition to make sure we have multiple tasks executing the join.
+    spark
+      .sql("select * from lineitem")
+      .repartition(2)
+      .createOrReplaceTempView("lineitem")
+
+    Seq("true", "false").foreach {
+      adaptiveEnabled =>
+        withSQLConf("spark.sql.adaptive.enabled" -> adaptiveEnabled) {
+          val sqlStr =
+            """
+              |select /*+ BROADCAST(part) */ * from part join lineitem
+              |on l_partkey = p_partkey
+              |""".stripMargin
+
+          runQueryAndCompare(sqlStr) {
+            df =>
+              val inputIterator = find(df.queryExecution.executedPlan) {
+                case InputIteratorTransformer(ColumnarInputAdapter(child)) =>
+                  child.isInstanceOf[BroadcastQueryStageExec] || child
+                    .isInstanceOf[BroadcastExchangeLike]
+                case _ => false
+              }
+              assert(inputIterator.isDefined)
+              val metrics = inputIterator.get.metrics
+              assert(metrics("numOutputRows").value == partTableRecords)
+              assert(metrics("outputVectors").value == 1)
+          }
+        }
+    }
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/MetricsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/MetricsApi.scala
@@ -33,11 +33,11 @@ trait MetricsApi extends Serializable {
       "pipelineTime" -> SQLMetrics
         .createTimingMetric(sparkContext, WholeStageCodegenExec.PIPELINE_DURATION_METRIC))
 
-  def genInputIteratorTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
-
-  def genInputIteratorTransformerMetricsUpdater(
+  def genInputIteratorTransformerMetrics(
       child: SparkPlan,
-      metrics: Map[String, SQLMetric]): MetricsUpdater
+      sparkContext: SparkContext): Map[String, SQLMetric]
+
+  def genInputIteratorTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
 
   def metricsUpdatingFunction(
       child: SparkPlan,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/MetricsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/MetricsApi.scala
@@ -35,9 +35,12 @@ trait MetricsApi extends Serializable {
 
   def genInputIteratorTransformerMetrics(
       child: SparkPlan,
-      sparkContext: SparkContext): Map[String, SQLMetric]
+      sparkContext: SparkContext,
+      forBroadcast: Boolean): Map[String, SQLMetric]
 
-  def genInputIteratorTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
+  def genInputIteratorTransformerMetricsUpdater(
+      metrics: Map[String, SQLMetric],
+      forBroadcast: Boolean): MetricsUpdater
 
   def metricsUpdatingFunction(
       child: SparkPlan,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/MetricsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/MetricsApi.scala
@@ -35,7 +35,9 @@ trait MetricsApi extends Serializable {
 
   def genInputIteratorTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
 
-  def genInputIteratorTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
+  def genInputIteratorTransformerMetricsUpdater(
+      child: SparkPlan,
+      metrics: Map[String, SQLMetric]): MetricsUpdater
 
   def metricsUpdatingFunction(
       child: SparkPlan,

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -56,7 +56,8 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
   }
 
   override def metricsUpdater(): MetricsUpdater =
-    BackendsApiManager.getMetricsApiInstance.genInputIteratorTransformerMetricsUpdater(metrics)
+    BackendsApiManager.getMetricsApiInstance
+      .genInputIteratorTransformerMetricsUpdater(child, metrics)
 
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = child.outputPartitioning

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -49,7 +49,7 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
 
   @transient
   override lazy val metrics: Map[String, SQLMetric] =
-    BackendsApiManager.getMetricsApiInstance.genInputIteratorTransformerMetrics(sparkContext)
+    BackendsApiManager.getMetricsApiInstance.genInputIteratorTransformerMetrics(child, sparkContext)
 
   override def simpleString(maxFields: Int): String = {
     s"$nodeName${truncatedString(output, "[", ", ", "]", maxFields)}"
@@ -57,7 +57,7 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
 
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance
-      .genInputIteratorTransformerMetricsUpdater(child, metrics)
+      .genInputIteratorTransformerMetricsUpdater(metrics)
 
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = child.outputPartitioning


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix issue https://github.com/apache/incubator-gluten/issues/7079 collecting metrics for `InputIteratorTransformer` of broadcast exchange.

Here is an example showing the difference before and after the change:
Execute below query on tpch test dataset, the table `lineitem` has 2 partitions:
```
select /*+ BROADCAST(part) */ * from part join lineitem on l_partkey = p_partkey
```
Before the change, the metrics showing in UI is:
![image](https://github.com/user-attachments/assets/5e477230-4aa3-49e5-9a11-556deecc2b35)

After the change, the metrics showing in UI is:
![image](https://github.com/user-attachments/assets/9417ff66-18f6-4c21-83d5-02744fa34c46)


## How was this patch tested?
UT added.
