### PR TITLE
[VL][MINOR] Fix typo error when convert lag() to lead()

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/WindowFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/WindowFunctionsValidateSuite.scala
@@ -20,13 +20,25 @@ class WindowFunctionsValidateSuite extends FunctionsValidateSuite {
 
   test("lag/lead window function with negative input offset") {
     runQueryAndCompare(
+      "select l_suppkey,lag(l_orderkey, -2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkGlutenOperatorMatch[WindowExecTransformer]
+    }
+
+    runQueryAndCompare(
+      "select l_suppkey, lead(l_orderkey, -2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkGlutenOperatorMatch[WindowExecTransformer]
+    }
+
+    runQueryAndCompare(
       "select lag(l_orderkey, -2) over" +
         " (partition by l_suppkey order by l_orderkey) from lineitem") {
       checkGlutenOperatorMatch[WindowExecTransformer]
     }
 
     runQueryAndCompare(
-      "select lead(l_orderkey, -2) over" +
+      "select lag(l_orderkey, 2) over" +
         " (partition by l_suppkey order by l_orderkey) from lineitem") {
       checkGlutenOperatorMatch[WindowExecTransformer]
     }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/WindowFunctionsBuilder.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/WindowFunctionsBuilder.scala
@@ -31,7 +31,7 @@ object WindowFunctionsBuilder {
     val substraitFunc = windowFunc match {
       // Handle lag with negative inputOffset, e.g., converts lag(c1, -1) to lead(c1, 1).
       // Spark uses `-inputOffset` as `offset` for Lag function.
-      case lag: Lag if lag.offset.eval(EmptyRow).asInstanceOf[Int] > 0 =>
+      case lag: Lag if lag.offset.eval(EmptyRow).asInstanceOf[Int] < 0 =>
         Some(LEAD)
       // Handle lead with negative offset, e.g., converts lead(c1, -1) to lag(c1, 1).
       case lead: Lead if lead.offset.eval(EmptyRow).asInstanceOf[Int] < 0 =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the offset is negative, convert lag() to lead().


## How was this patch tested?

Exist UT.