### PR TITLE
[VL] Make conf option `s.g.s.c.shuffledHashJoin.optimizeBuildSide` work correctly with option `s.g.s.c.forceShuffledHashJoin`

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
@@ -104,9 +104,9 @@ object FallbackTags {
 
   /**
    * If true, it implies the plan maybe transformable during validation phase but not guaranteed,
-   * since another validation rule could turn it to "non-transformable" before implementing the
-   * plan within Gluten transformers. If false, the plan node will be guaranteed fallback to
-   * Vanilla plan node while being implemented.
+   * since another validation rule could turn it to "non-transformable" before implementing the plan
+   * within Gluten transformers. If false, the plan node will be guaranteed fallback to Vanilla plan
+   * node while being implemented.
    */
   def maybeOffloadable(plan: SparkPlan): Boolean = !nonEmpty(plan)
 
@@ -395,7 +395,8 @@ case class AddFallbackTagRule() extends Rule[SparkPlan] {
             windowGroupLimitPlan.rankLikeFunction,
             windowGroupLimitPlan.limit,
             windowGroupLimitPlan.mode,
-            windowGroupLimitPlan.child)
+            windowGroupLimitPlan.child
+          )
           transformer.doValidate().tagOnFallback(plan)
         case plan: CoalesceExec =>
           ColumnarCoalesceExec(plan.numPartitions, plan.child)
@@ -423,8 +424,10 @@ case class AddFallbackTagRule() extends Rule[SparkPlan] {
         case plan: ArrowEvalPythonExec =>
           // When backend doesn't support ColumnarArrow or colunmnar arrow configuration not
           // enabled, we will try offloading through EvalPythonExecTransformer
-          if (!BackendsApiManager.getSettings.supportColumnarArrowUdf() ||
-            !GlutenConfig.getConf.enableColumnarArrowUDF) {
+          if (
+            !BackendsApiManager.getSettings.supportColumnarArrowUdf() ||
+            !GlutenConfig.getConf.enableColumnarArrowUDF
+          ) {
             // Both CH and Velox will try using backend's built-in functions for calculate
             val transformer = EvalPythonExecTransformer(plan.udfs, plan.resultAttrs, plan.child)
             transformer.doValidate().tagOnFallback(plan)
@@ -468,9 +471,9 @@ object AddFallbackTagRule {
   implicit private class ValidatorBuilderImplicits(builder: Validators.Builder) {
 
     /**
-     * Fails validation on non-scan plan nodes if Gluten is running as scan-only mode. Also,
-     * passes validation on filter for the exception that filter + scan is detected. Because
-     * filters can be pushed into scan then the filter conditions will be processed only in scan.
+     * Fails validation on non-scan plan nodes if Gluten is running as scan-only mode. Also, passes
+     * validation on filter for the exception that filter + scan is detected. Because filters can be
+     * pushed into scan then the filter conditions will be processed only in scan.
      */
     def fallbackIfScanOnlyWithFilterPushed(scanOnly: Boolean): Validators.Builder = {
       builder.add(new FallbackIfScanOnlyWithFilterPushed(scanOnly))

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -39,11 +39,11 @@ import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecSh
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 /**
- * Converts a vanilla Spark plan node into Gluten plan node. Gluten plan is supposed to be executed
- * in native, and the internals of execution is subject by backend's implementation.
+ * Converts a vanilla Spark plan node into Gluten plan node. Gluten plan is supposed to be
+ * executed in native, and the internals of execution is subject by backend's implementation.
  *
- * Note: Only the current plan node is supposed to be open to modification. Do not access or modify
- * the children node. Tree-walking is done by caller of this trait.
+ * Note: Only the current plan node is supposed to be open to modification. Do not access or
+ * modify the children node. Tree-walking is done by caller of this trait.
  */
 sealed trait OffloadSingleNode extends Logging {
   def offload(plan: SparkPlan): SparkPlan
@@ -75,10 +75,8 @@ case class OffloadAggregate() extends OffloadSingleNode with LogLevelUtil {
     val aggChild = plan.child
 
     // If child's output is empty, fallback or offload both the child and aggregation.
-    if (
-      aggChild.output.isEmpty && BackendsApiManager.getSettings
-        .fallbackAggregateWithEmptyOutputChild()
-    ) {
+    if (aggChild.output.isEmpty && BackendsApiManager.getSettings
+        .fallbackAggregateWithEmptyOutputChild()) {
       aggChild match {
         case _: TransformSupport =>
           // If the child is transformable, transform aggregation as well.
@@ -118,7 +116,6 @@ case class OffloadExchange() extends OffloadSingleNode with LogLevelUtil {
 
 // Join transformation.
 case class OffloadJoin() extends OffloadSingleNode with LogLevelUtil {
-
   override def offload(plan: SparkPlan): SparkPlan = {
     if (FallbackTags.nonEmpty(plan)) {
       logDebug(s"Columnar Processing for ${plan.getClass} is under row guard.")
@@ -134,7 +131,7 @@ case class OffloadJoin() extends OffloadSingleNode with LogLevelUtil {
             plan.leftKeys,
             plan.rightKeys,
             plan.joinType,
-            OffloadJoin.getBuildSide(plan),
+            OffloadJoin.getShjBuildSide(plan),
             plan.condition,
             left,
             right,
@@ -186,7 +183,7 @@ case class OffloadJoin() extends OffloadSingleNode with LogLevelUtil {
 }
 
 object OffloadJoin {
-  private def getBuildSide(shj: ShuffledHashJoinExec): BuildSide = {
+  def getShjBuildSide(shj: ShuffledHashJoinExec): BuildSide = {
     val leftBuildable =
       BackendsApiManager.getSettings.supportHashBuildJoinTypeOnLeft(shj.joinType)
     val rightBuildable =
@@ -379,8 +376,7 @@ object OffloadOthers {
             windowGroupLimitPlan.rankLikeFunction,
             windowGroupLimitPlan.limit,
             windowGroupLimitPlan.mode,
-            windowGroupLimitPlan.child
-          )
+            windowGroupLimitPlan.child)
         case plan: GlobalLimitExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           val child = plan.child

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.execution._
 import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.{LogLevelUtil, PlanUtil}
+
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
@@ -38,11 +39,11 @@ import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecSh
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 /**
- * Converts a vanilla Spark plan node into Gluten plan node. Gluten plan is supposed to be
- * executed in native, and the internals of execution is subject by backend's implementation.
+ * Converts a vanilla Spark plan node into Gluten plan node. Gluten plan is supposed to be executed
+ * in native, and the internals of execution is subject by backend's implementation.
  *
- * Note: Only the current plan node is supposed to be open to modification. Do not access or
- * modify the children node. Tree-walking is done by caller of this trait.
+ * Note: Only the current plan node is supposed to be open to modification. Do not access or modify
+ * the children node. Tree-walking is done by caller of this trait.
  */
 sealed trait OffloadSingleNode extends Logging {
   def offload(plan: SparkPlan): SparkPlan
@@ -74,8 +75,10 @@ case class OffloadAggregate() extends OffloadSingleNode with LogLevelUtil {
     val aggChild = plan.child
 
     // If child's output is empty, fallback or offload both the child and aggregation.
-    if (aggChild.output.isEmpty && BackendsApiManager.getSettings
-        .fallbackAggregateWithEmptyOutputChild()) {
+    if (
+      aggChild.output.isEmpty && BackendsApiManager.getSettings
+        .fallbackAggregateWithEmptyOutputChild()
+    ) {
       aggChild match {
         case _: TransformSupport =>
           // If the child is transformable, transform aggregation as well.
@@ -376,7 +379,8 @@ object OffloadOthers {
             windowGroupLimitPlan.rankLikeFunction,
             windowGroupLimitPlan.limit,
             windowGroupLimitPlan.mode,
-            windowGroupLimitPlan.child)
+            windowGroupLimitPlan.child
+          )
         case plan: GlobalLimitExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           val child = plan.child

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/OffloadSingleNode.scala
@@ -39,11 +39,11 @@ import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecSh
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 /**
- * Converts a vanilla Spark plan node into Gluten plan node. Gluten plan is supposed to be
- * executed in native, and the internals of execution is subject by backend's implementation.
+ * Converts a vanilla Spark plan node into Gluten plan node. Gluten plan is supposed to be executed
+ * in native, and the internals of execution is subject by backend's implementation.
  *
- * Note: Only the current plan node is supposed to be open to modification. Do not access or
- * modify the children node. Tree-walking is done by caller of this trait.
+ * Note: Only the current plan node is supposed to be open to modification. Do not access or modify
+ * the children node. Tree-walking is done by caller of this trait.
  */
 sealed trait OffloadSingleNode extends Logging {
   def offload(plan: SparkPlan): SparkPlan
@@ -75,8 +75,10 @@ case class OffloadAggregate() extends OffloadSingleNode with LogLevelUtil {
     val aggChild = plan.child
 
     // If child's output is empty, fallback or offload both the child and aggregation.
-    if (aggChild.output.isEmpty && BackendsApiManager.getSettings
-        .fallbackAggregateWithEmptyOutputChild()) {
+    if (
+      aggChild.output.isEmpty && BackendsApiManager.getSettings
+        .fallbackAggregateWithEmptyOutputChild()
+    ) {
       aggChild match {
         case _: TransformSupport =>
           // If the child is transformable, transform aggregation as well.
@@ -376,7 +378,8 @@ object OffloadOthers {
             windowGroupLimitPlan.rankLikeFunction,
             windowGroupLimitPlan.limit,
             windowGroupLimitPlan.mode,
-            windowGroupLimitPlan.child)
+            windowGroupLimitPlan.child
+          )
         case plan: GlobalLimitExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           val child = plan.child

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
@@ -17,9 +17,7 @@
 package org.apache.gluten.extension.columnar.rewrite
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.extension.columnar.OffloadJoin
-
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper}
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution.SparkPlan

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
@@ -19,14 +19,13 @@ package org.apache.gluten.extension.columnar.rewrite
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.extension.columnar.OffloadJoin
+
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper}
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
 
-/**
- * If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]].
- */
+/** If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]]. */
 object RewriteJoin extends RewriteSingleNode with JoinSelectionHelper {
   private def getSmjBuildSide(join: SortMergeJoinExec): Option[BuildSide] = {
     val leftBuildable =

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
@@ -25,8 +25,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
 
 /**
- * If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]]. There is
- * no need to select a smaller table as buildSide here, it will be reselected when offloading.
+ * If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]].
  */
 object RewriteJoin extends RewriteSingleNode with JoinSelectionHelper {
   private def getSmjBuildSide(join: SortMergeJoinExec): Option[BuildSide] = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
@@ -17,33 +17,41 @@
 package org.apache.gluten.extension.columnar.rewrite
 
 import org.apache.gluten.GlutenConfig
-
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.extension.columnar.OffloadJoin
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper}
-import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
 
 /**
- * If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]]. There is no
- * need to select a smaller table as buildSide here, it will be reselected when offloading.
+ * If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]]. There is
+ * no need to select a smaller table as buildSide here, it will be reselected when offloading.
  */
 object RewriteJoin extends RewriteSingleNode with JoinSelectionHelper {
-
-  private def getBuildSide(joinType: JoinType): Option[BuildSide] = {
-    val leftBuildable = canBuildShuffledHashJoinLeft(joinType)
-    val rightBuildable = canBuildShuffledHashJoinRight(joinType)
-    if (rightBuildable) {
-      Some(BuildRight)
-    } else if (leftBuildable) {
-      Some(BuildLeft)
-    } else {
-      None
+  private def getSmjBuildSide(join: SortMergeJoinExec): Option[BuildSide] = {
+    val leftBuildable =
+      BackendsApiManager.getSettings.supportHashBuildJoinTypeOnLeft(join.joinType)
+    val rightBuildable =
+      BackendsApiManager.getSettings.supportHashBuildJoinTypeOnRight(join.joinType)
+    if (!leftBuildable && !rightBuildable) {
+      return None
+    }
+    if (!leftBuildable) {
+      return Some(BuildRight)
+    }
+    if (!rightBuildable) {
+      return Some(BuildLeft)
+    }
+    join.logicalLink.flatMap {
+      case join: Join => Some(OffloadJoin.getOptimalBuildSide(join))
+      case _ => None
     }
   }
 
   override def rewrite(plan: SparkPlan): SparkPlan = plan match {
     case smj: SortMergeJoinExec if GlutenConfig.getConf.forceShuffledHashJoin =>
-      getBuildSide(smj.joinType) match {
+      getSmjBuildSide(smj) match {
         case Some(buildSide) =>
           ShuffledHashJoinExec(
             smj.leftKeys,
@@ -53,8 +61,7 @@ object RewriteJoin extends RewriteSingleNode with JoinSelectionHelper {
             smj.condition,
             smj.left,
             smj.right,
-            smj.isSkewJoin
-          )
+            smj.isSkewJoin)
         case _ => plan
       }
     case _ => plan

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.extension.columnar.rewrite
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.extension.columnar.OffloadJoin
+
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper}
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution.SparkPlan

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteJoin.scala
@@ -28,10 +28,8 @@ import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoin
 /** If force ShuffledHashJoin, convert [[SortMergeJoinExec]] to [[ShuffledHashJoinExec]]. */
 object RewriteJoin extends RewriteSingleNode with JoinSelectionHelper {
   private def getSmjBuildSide(join: SortMergeJoinExec): Option[BuildSide] = {
-    val leftBuildable =
-      BackendsApiManager.getSettings.supportHashBuildJoinTypeOnLeft(join.joinType)
-    val rightBuildable =
-      BackendsApiManager.getSettings.supportHashBuildJoinTypeOnRight(join.joinType)
+    val leftBuildable = canBuildShuffledHashJoinLeft(join.joinType)
+    val rightBuildable = canBuildShuffledHashJoinRight(join.joinType)
     if (!leftBuildable && !rightBuildable) {
       return None
     }


### PR DESCRIPTION
Currently when `s.g.s.c.shuffledHashJoin.optimizeBuildSide==false` and `s.g.s.c.forceShuffledHashJoin=true`, SMJ will be converted to SHJ with a randomly chosen build side. This PR fixes the issue by choosing a smaller one in `RewriteJoin` rule.