### PR TITLE
[MINOR][BUILD] Extract gcc version from libgluten.so

### DIFF
--- a/dev/gluten-build-info.sh
+++ b/dev/gluten-build-info.sh
@@ -39,7 +39,7 @@ echo_build_properties() {
   echo url=$(git config --get remote.origin.url)
 
   if [ "$BACKEND_TYPE" = "velox" ]; then
-      echo gcc_version=$(readelf -p .comment $GLUTEN_ROOT/cpp/build/releases/libgluten.so | grep GCC | head -n 1 | sed -n 's/.*\(GCC.*\)/\1/p')
+      echo gcc_version=$(strings $GLUTEN_ROOT/cpp/build/releases/libgluten.so | grep "GCC:" | head -n 1)
       echo velox_branch=$(git -C $BACKEND_HOME rev-parse --abbrev-ref HEAD)
       echo velox_revision=$(git -C $BACKEND_HOME rev-parse HEAD)
       echo velox_revision_time=$(git -C $BACKEND_HOME show -s --format=%ci HEAD)

--- a/dev/gluten-build-info.sh
+++ b/dev/gluten-build-info.sh
@@ -39,7 +39,7 @@ echo_build_properties() {
   echo url=$(git config --get remote.origin.url)
 
   if [ "$BACKEND_TYPE" = "velox" ]; then
-      echo gcc_version=$(gcc --version | head -n 1)
+      echo gcc_version=$(readelf -p .comment $GLUTEN_ROOT/cpp/build/releases/libgluten.so | grep GCC | head -n 1 | sed -n 's/.*\(GCC.*\)/\1/p')
       echo velox_branch=$(git -C $BACKEND_HOME rev-parse --abbrev-ref HEAD)
       echo velox_revision=$(git -C $BACKEND_HOME rev-parse HEAD)
       echo velox_revision_time=$(git -C $BACKEND_HOME show -s --format=%ci HEAD)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Read the gcc version from generated `libgluten.so` file instead of use `gcc --version` directly.

We may compile cpp codes and scala codes in different bash, if multiple versions of GCC are installed on the system and the GCC version used by C++ is not correctly sourced during Scala code compilation, the generated GCC version by `gcc --version` may be inaccurate in `gluten-build-info.properties`.

(Fixes: \#ISSUE-ID)

## How was this patch tested?
Manually test on local by comparing the generated `gluten-build-info.properties` files.
