### PR TITLE
[GLUTEN-7213][CORE] Avoid fallback caused by CheckOverflowInTableInsert

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -481,6 +481,12 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           substraitExprName,
           replaceWithExpressionTransformer0(c.child, attributeSeq, expressionsMap),
           c)
+      case c if c.getClass.getSimpleName.equals("CheckOverflowInTableInsert") =>
+        ChildTransformer(
+          substraitExprName,
+          replaceWithExpressionTransformer0(expr.children.head, attributeSeq, expressionsMap),
+          expr
+        )
       case b: BinaryArithmetic if DecimalArithmeticUtil.isDecimalArithmetic(b) =>
         DecimalArithmeticUtil.checkAllowDecimalArithmetic()
         if (!BackendsApiManager.getSettings.transformCheckOverflow) {

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.sources
 
 import org.apache.gluten.GlutenColumnarWriteTestSupport
-import org.apache.gluten.execution.SortExecTransformer
+import org.apache.gluten.execution.{ProjectExecTransformer, SortExecTransformer}
 import org.apache.gluten.extension.GlutenPlan
 
 import org.apache.spark.SparkConf
@@ -25,7 +25,7 @@ import org.apache.spark.executor.OutputMetrics
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.execution.{CommandResultExec, GlutenImplicits, QueryExecution, SparkPlan}
+import org.apache.spark.sql.execution.{CommandResultExec, GlutenImplicits, ProjectExec, QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -593,6 +593,19 @@ class GlutenInsertSuite
             }.getMessage.contains(incompatibleDefault))
           }
       }
+    }
+  }
+
+  testGluten("GLUTEN-7213: Check no fallback with CheckOverflowInTableInsert") {
+    withTable("t1", "t2") {
+      sql("create table t1 (a float) using parquet")
+      sql("insert into t1 values(1.1)")
+      sql("create table t2 (b decimal(10,4)) using parquet")
+
+      val df = sql("insert overwrite t2 select * from t1")
+      val (_, child) = checkWriteFilesAndGetChild(df)
+      assert(find(child)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
+      assert(find(child)(_.isInstanceOf[ProjectExec]).isEmpty)
     }
   }
 }

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
@@ -97,9 +97,9 @@ class GlutenExpressionMappingSuite
 
   test("GLUTEN-7213: Check no fallback even if there is CheckOverflowInTableInsert") {
     withTable("t1", "t2") {
-      sql("create table t1 (a float) stored as parquet")
+      sql("create table t1 (a float) using parquet")
       sql("insert into t1 values(1.1)")
-      sql("create table t2 (b decimal(10,4)) stored as parquet")
+      sql("create table t2 (b decimal(10,4)) using parquet")
 
       withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "true") {
         val df = sql("insert overwrite t2 select * from t1")

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
@@ -96,14 +96,15 @@ class GlutenExpressionMappingSuite
   }
 
   test("GLUTEN-7213: Check no fallback even if there is CheckOverflowInTableInsert") {
-    withTable("t1","t2") {
+    withTable("t1", "t2") {
       sql("create table t1 (a float) stored as parquet")
       sql("insert into t1 values(1.1)")
       sql("create table t2 (b decimal(10,4)) stored as parquet")
 
       withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "true") {
         val df = sql("insert overwrite t2 select * from t1")
-        assert(find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
+        assert(
+          find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
         assert(find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExec]).isEmpty)
       }
     }

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
@@ -94,20 +94,4 @@ class GlutenExpressionMappingSuite
       }
     }
   }
-
-  test("GLUTEN-7213: Check no fallback even if there is CheckOverflowInTableInsert") {
-    withTable("t1", "t2") {
-      sql("create table t1 (a float) using parquet")
-      sql("insert into t1 values(1.1)")
-      sql("create table t2 (b decimal(10,4)) using parquet")
-
-      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "true") {
-        val df = sql("insert overwrite t2 select * from t1")
-        assert(
-          find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
-        assert(find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExec]).isEmpty)
-      }
-    }
-
-  }
 }

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -314,6 +314,7 @@ object ExpressionNames {
   final val INLINE = "inline"
   final val POSEXPLODE = "posexplode"
   final val CHECK_OVERFLOW = "check_overflow"
+  final val CHECK_OVERFLOW_IN_TABLE_INSERT = "check_overflow_in_table_insert"
   final val MAKE_DECIMAL = "make_decimal"
   final val PROMOTE_PRECISION = "promote_precision"
   final val SPARK_PARTITION_ID = "spark_partition_id"

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -82,7 +82,8 @@ class Spark34Shims extends SparkShims {
       Sig[RoundFloor](ExpressionNames.FLOOR),
       Sig[RoundCeil](ExpressionNames.CEIL),
       Sig[Mask](ExpressionNames.MASK),
-      Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT)
+      Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
+      Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT)
     )
   }
 

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -82,7 +82,8 @@ class Spark35Shims extends SparkShims {
       Sig[TimestampAdd](ExpressionNames.TIMESTAMP_ADD),
       Sig[RoundFloor](ExpressionNames.FLOOR),
       Sig[RoundCeil](ExpressionNames.CEIL),
-      Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT)
+      Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
+      Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT)
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using `ChildTransformer` to transform `CheckOverflowInTableInsert` to avoid fallback.

closes: #7213

## How was this patch tested?

added unit test
