### PR TITLE
[VL] RAS: Avoid adding R2C whose schema contains complex data types

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxRoughCostModelSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxRoughCostModelSuite.scala
@@ -53,7 +53,7 @@ class VeloxRoughCostModelSuite extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  test("fallback r2c whose schema contains complex data types") {
+  test("avoid adding r2c whose schema contains complex data types") {
     withSQLConf(GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key -> "false") {
       runQueryAndCompare("select array_contains(c3, 0) as list from tmp1") {
         checkSparkOperatorMatch[ProjectExec]

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
@@ -22,6 +22,10 @@ import org.apache.gluten.utils.PlanUtil
 
 import org.apache.spark.sql.execution.{ColumnarToRowExec, RowToColumnarExec, SparkPlan}
 
+/**
+ * A cost model that is supposed to drive RAS planner create the same query plan with legacy
+ * planner.
+ */
 class LegacyCostModel extends LongCostModel {
 
   // A very rough estimation as of now. The cost model basically considers any

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -36,7 +36,7 @@ class RoughCostModel extends LongCostModel {
         // Make trivial ProjectExec has the same cost as ProjectExecTransform to reduce unnecessary
         // c2r and r2c.
         10L
-      case r2c: RowToColumnarExecBase if hasComplexType(r2c.schema) =>
+      case r2c: RowToColumnarExecBase if hasComplexTypes(r2c.schema) =>
         // Avoid moving computation back to native when transition has complex types in schema.
         // such transitions are observed to be extreme expensive as of now.
         Long.MaxValue
@@ -57,7 +57,7 @@ class RoughCostModel extends LongCostModel {
     case _ => false
   }
 
-  private def hasComplexType(schema: StructType): Boolean = {
+  private def hasComplexTypes(schema: StructType): Boolean = {
     schema.exists(_.dataType match {
       case _: StructType => true
       case _: ArrayType => true

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -25,6 +25,9 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpress
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 
+/**
+ * A rough cost model with some empirical heuristics.
+ */
 class RoughCostModel extends LongCostModel {
 
   override def selfLongCostOf(node: SparkPlan): Long = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -38,7 +38,7 @@ class RoughCostModel extends LongCostModel {
         10L
       case r2c: RowToColumnarExecBase if hasComplexTypes(r2c.schema) =>
         // Avoid moving computation back to native when transition has complex types in schema.
-        // such transitions are observed to be extreme expensive as of now.
+        // Such transitions are observed to be extreme expensive as of now.
         Long.MaxValue
       case ColumnarToRowExec(_) => 10L
       case RowToColumnarExec(_) => 10L

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -39,7 +39,7 @@ class RoughCostModel extends LongCostModel {
         10L
       case r2c: RowToColumnarExecBase if hasComplexTypes(r2c.schema) =>
         // Avoid moving computation back to native when transition has complex types in schema.
-        // Such transitions are observed to be extreme expensive as of now.
+        // Such transitions are observed to be extremely expensive as of now.
         Long.MaxValue
       case ColumnarToRowExec(_) => 10L
       case RowToColumnarExec(_) => 10L

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -25,9 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpress
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 
-/**
- * A rough cost model with some empirical heuristics.
- */
+/** A rough cost model with some empirical heuristics. */
 class RoughCostModel extends LongCostModel {
 
   override def selfLongCostOf(node: SparkPlan): Long = {


### PR DESCRIPTION
It's observed Velox R2C becomes expensive when containing complex data types as input. Add a coster in rough cost model to address the issue.

To enable rough cost model:

```
spark.gluten.ras.enabled=true
spark.gluten.ras.costModel=rough
```