### PR TITLE
[VL] Fix columns added to `outNames` twice when building Substrait plan

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -223,9 +223,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
         outputSchema,
         null)
     } else {
-      for (attr <- childCtx.outputAttributes) {
-        outNames.add(ConverterUtils.genColumnNameWithExprId(attr))
-      }
       PlanBuilder.makePlan(substraitContext, Lists.newArrayList(childCtx.root), outNames)
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?


## How was this patch tested?


