### PR TITLE
[VL] Fix bug when setting Spark memory overhead automatically

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -49,14 +49,16 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
     // Overhead memory limits.
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.SPARK_OFFHEAP_SIZE_KEY)
-    val desiredOverheadSize = (0.1 * offHeapSize).toLong.max(ByteUnit.MiB.toBytes(384))
+    val desiredOverheadSize = (0.3 * offHeapSize).toLong.max(ByteUnit.MiB.toBytes(384))
     if (!SparkResourceUtil.isMemoryOverheadSet(conf)) {
       // If memory overhead is not set by user, automatically set it according to off-heap settings.
       logInfo(
         s"Memory overhead is not set. Setting it to $desiredOverheadSize automatically." +
           " Gluten doesn't follow Spark's calculation on default value of this option because the" +
           " actual required memory overhead will depend on off-heap usage than on on-heap usage.")
-      conf.set(GlutenConfig.SPARK_OVERHEAD_SIZE_KEY, desiredOverheadSize.toString)
+      conf.set(
+        GlutenConfig.SPARK_OVERHEAD_SIZE_KEY,
+        ByteUnit.BYTE.toMiB(desiredOverheadSize).toString)
     }
     val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)
     if (overheadSize < desiredOverheadSize) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The default byte unit is MB for spark.executor.memoryOverhead, so can not set  value in byte without byte suffix

## How was this patch tested?


