### PR TITLE
[GLUTEN-7276][VL] Make fallback reason for GetStructField clearer

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
@@ -69,8 +69,9 @@ case class VeloxGetStructFieldTransformer(
         val nodeType =
           node.getTypeNode.asInstanceOf[StructNode].getFieldTypes.get(ordinal)
         ExpressionBuilder.makeNullLiteral(nodeType)
-      case other =>
-        throw new GlutenNotSupportException(s"$other is not supported.")
+      case _ =>
+        throw new GlutenNotSupportException(
+          s"Unsupported child expression of GetStructField: $original.")
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make fallback reason for GetStructField clearer

Fixes: #7276

## How was this patch tested?

Reproduced SQLs

```
create table test_20240919(a array<struct<b: string>>);
insert into test_20240919 values (array(named_struct('b', '1'), named_struct('b', '2')));
select a[1].b from test_20240919;
```

Fallback reason before this:

```
org.apache.gluten.substrait.expression.ScalarFunctionNode@9693f3e is not supported.
```

after this:

```
Unsupported child expression of GetStructField: a#13[1].b.
```
