### PR TITLE
[CORE][VL] Minor code cleanups

### DIFF
--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/BatchIterator.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/BatchIterator.java
@@ -32,12 +32,6 @@ public class BatchIterator extends ClosableIterator {
     this.handle = handle;
   }
 
-  @Override
-  public String id() {
-    // Using native handle as identifier
-    return String.valueOf(handle);
-  }
-
   private native boolean nativeHasNext(long nativeHandle);
 
   private native long nativeCHNext(long nativeHandle);

--- a/backends-velox/src/main/java/org/apache/gluten/metrics/IteratorMetricsJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/metrics/IteratorMetricsJniWrapper.java
@@ -40,7 +40,7 @@ public class IteratorMetricsJniWrapper implements RuntimeAware {
   private native Metrics nativeFetchMetrics(long itrHandle);
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 }

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchResizerJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBatchResizerJniWrapper.java
@@ -32,7 +32,7 @@ public class VeloxBatchResizerJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBloomFilterJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/utils/VeloxBloomFilterJniWrapper.java
@@ -31,7 +31,7 @@ public class VeloxBloomFilterJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxResizeBatchesExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxResizeBatchesExec.scala
@@ -43,7 +43,7 @@ case class VeloxResizeBatchesExec(
   extends GlutenPlan
   with UnaryExecNode {
 
-  override lazy val metrics: Map[String, SQLMetric] = Map(
+  override lazy val metrics: Map[String, SQLMVeloxListenetric] = Map(
     "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
     "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxResizeBatchesExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxResizeBatchesExec.scala
@@ -43,7 +43,7 @@ case class VeloxResizeBatchesExec(
   extends GlutenPlan
   with UnaryExecNode {
 
-  override lazy val metrics: Map[String, SQLMVeloxListenetric] = Map(
+  override lazy val metrics: Map[String, SQLMetric] = Map(
     "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
     "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),

--- a/cpp/core/jni/JniCommon.cc
+++ b/cpp/core/jni/JniCommon.cc
@@ -39,7 +39,7 @@ jmethodID gluten::JniCommonState::runtimeAwareCtxHandle() {
 
 void gluten::JniCommonState::initialize(JNIEnv* env) {
   runtimeAwareClass_ = createGlobalClassReference(env, "Lorg/apache/gluten/runtime/RuntimeAware;");
-  runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "handle", "()J");
+  runtimeAwareCtxHandle_ = getMethodIdOrError(env, runtimeAwareClass_, "rtHandle", "()J");
   JavaVM* vm;
   if (env->GetJavaVM(&vm) != JNI_OK) {
     throw gluten::GlutenException("Unable to get JavaVM instance");

--- a/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatchJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatchJniWrapper.java
@@ -51,7 +51,7 @@ public class ColumnarBatchJniWrapper implements RuntimeAware {
   public native void close(long batch);
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/datasource/DatasourceJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/datasource/DatasourceJniWrapper.java
@@ -38,7 +38,7 @@ public class DatasourceJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/runtime/RuntimeAware.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/runtime/RuntimeAware.java
@@ -22,8 +22,8 @@ package org.apache.gluten.runtime;
  */
 public interface RuntimeAware {
   default boolean isCompatibleWith(RuntimeAware other) {
-    return handle() == other.handle();
+    return rtHandle() == other.rtHandle();
   }
 
-  long handle();
+  long rtHandle();
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -36,14 +36,8 @@ public class ColumnarBatchOutIterator extends ClosableIterator implements Runtim
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
-  }
-
-  @Override
-  public String id() {
-    // Using native iterHandle as identifier
-    return String.valueOf(iterHandle);
   }
 
   public long itrHandle() {

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializerJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializerJniWrapper.java
@@ -31,7 +31,7 @@ public class ColumnarBatchSerializerJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativeColumnarToRowJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativeColumnarToRowJniWrapper.java
@@ -31,7 +31,7 @@ public class NativeColumnarToRowJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativeRowToColumnarJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativeRowToColumnarJniWrapper.java
@@ -31,7 +31,7 @@ public class NativeRowToColumnarJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/PlanEvaluatorJniWrapper.java
@@ -37,7 +37,7 @@ public class PlanEvaluatorJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ShuffleReaderJniWrapper.java
@@ -31,7 +31,7 @@ public class ShuffleReaderJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ShuffleWriterJniWrapper.java
@@ -33,7 +33,7 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
   }
 
   @Override
-  public long handle() {
+  public long rtHandle() {
     return runtime.getHandle();
   }
 

--- a/gluten-core/src/main/java/org/apache/gluten/iterator/ClosableIterator.java
+++ b/gluten-core/src/main/java/org/apache/gluten/iterator/ClosableIterator.java
@@ -55,8 +55,6 @@ public abstract class ClosableIterator
     }
   }
 
-  public abstract String id();
-
   protected abstract void close0();
 
   protected abstract boolean hasNext0() throws Exception;


### PR DESCRIPTION
1. (core) Remove unused method `ClosableIterator#id()`
2. (velox) Rename method `RuntimeAware#handle()` to `RuntimeAware#rtHandle()` to avoid colliding with implementations' own `handle()` methods.