### PR TITLE
[VL] CI: Q97 OOM test passed, stop ignoring its return code in CI

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -389,7 +389,7 @@ jobs:
             -d=FLUSH_MODE:DISABLED,spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false,spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct=100,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows=0 \
             -d=FLUSH_MODE:ABANDONED,spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct=0,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows=0 \
             -d=FLUSH_MODE:FLUSHED,spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio=0.05,spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio=0.1,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct=100,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows=0
-      - name: TPC-DS SF30.0 Parquet local spark3.2 Q97 low memory, IO threads off
+      - name: TPC-DS SF30.0 Parquet local spark3.2 Q97 low memory
         run: |
           cd tools/gluten-it \
           && GLUTEN_IT_JVM_ARGS=-Xmx3G sbin/gluten-it.sh parameterized \

--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -389,8 +389,7 @@ jobs:
             -d=FLUSH_MODE:DISABLED,spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false,spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct=100,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows=0 \
             -d=FLUSH_MODE:ABANDONED,spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio=1.0,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct=0,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows=0 \
             -d=FLUSH_MODE:FLUSHED,spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio=0.05,spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio=0.1,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct=100,spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows=0
-      - name: (To be fixed) TPC-DS SF30.0 Parquet local spark3.2 Q97 low memory, IO threads off
-        continue-on-error: true # OOM
+      - name: TPC-DS SF30.0 Parquet local spark3.2 Q97 low memory, IO threads off
         run: |
           cd tools/gluten-it \
           && GLUTEN_IT_JVM_ARGS=-Xmx3G sbin/gluten-it.sh parameterized \
@@ -400,20 +399,9 @@ jobs:
             -d=ISOLATION:OFF,spark.gluten.memory.isolation=false \
             -d=ISOLATION:ON,spark.gluten.memory.isolation=true,spark.memory.storageFraction=0.1 \
             -d=OFFHEAP_SIZE:2g,spark.memory.offHeap.size=2g \
-            -d=OFFHEAP_SIZE:1g,spark.memory.offHeap.size=1g
-      - name: (To be fixed) TPC-DS SF30.0 Parquet local spark3.2 Q97 low memory, IO threads on
-        continue-on-error: true # Timeout
-        timeout-minutes: 15 # https://github.com/apache/incubator-gluten/issues/7161
-        run: |
-          cd tools/gluten-it \
-          && GLUTEN_IT_JVM_ARGS=-Xmx3G sbin/gluten-it.sh parameterized \
-            --local --preset=velox --benchmark-type=ds --error-on-memleak --queries=q97 -s=30.0 --threads=12 --shuffle-partitions=72 --iterations=1 \
-            --data-gen=skip -m=OffHeapExecutionMemory \
-            --extra-conf=spark.gluten.sql.columnar.backend.velox.IOThreads=12 \
-            -d=ISOLATION:OFF,spark.gluten.memory.isolation=false \
-            -d=ISOLATION:ON,spark.gluten.memory.isolation=true,spark.memory.storageFraction=0.1 \
-            -d=OFFHEAP_SIZE:2g,spark.memory.offHeap.size=2g \
-            -d=OFFHEAP_SIZE:1g,spark.memory.offHeap.size=1g
+            -d=OFFHEAP_SIZE:1g,spark.memory.offHeap.size=1g \
+            -d=IO_THREADS:12,spark.gluten.sql.columnar.backend.velox.IOThreads=12 \
+            -d=IO_THREADS:0,spark.gluten.sql.columnar.backend.velox.IOThreads=0
 
   run-tpc-test-ubuntu-randomkill:
     needs: build-native-lib-centos-7


### PR DESCRIPTION
The case started to pass due to the merge of:

1. Fix https://github.com/apache/incubator-gluten/pull/7244
2. Rebase https://github.com/apache/incubator-gluten/pull/7259 (investigating)

The case used to fail by [error](https://github.com/apache/incubator-gluten/actions/runs/10861275683/job/30144831318):

```
org.apache.gluten.memory.memtarget.ThrowOnOomMemoryTarget$OutOfMemoryException: Not enough spark off-heap execution memory. Acquired: 8.0 MiB, granted: 5.8 MiB. Try tweaking config option spark.memory.offHeap.size to get larger space to run this application (if spark.gluten.memory.dynamic.offHeap.sizing.enabled is not enabled). 
Current config settings: 
	spark.gluten.memory.offHeap.size.in.bytes=1024.0 MiB
	spark.gluten.memory.task.offHeap.size.in.bytes=85.3 MiB
	spark.gluten.memory.conservative.task.offHeap.size.in.bytes=76.8 MiB
	spark.memory.offHeap.enabled=true
	spark.gluten.memory.dynamic.offHeap.sizing.enabled=false
Memory consumer stats: 
	Task.98:                                                Current used bytes:  71.0 MiB, peak bytes:        N/A
	\- Gluten.Tree.465:                                     Current used bytes:  71.0 MiB, peak bytes:   76.8 MiB
	   \- root.465, 76.8 MiB:                               Current used bytes:  71.0 MiB, peak bytes:   76.8 MiB
	      +- WholeStageIterator.462:                        Current used bytes:  55.0 MiB, peak bytes:   56.0 MiB
	      |  \- single:                                     Current used bytes:  55.0 MiB, peak bytes:   56.0 MiB
	      |     +- root:                                    Current used bytes:  32.7 MiB, peak bytes:   55.0 MiB
	      |     |  +- task.Gluten_Stage_29_TID_98_VTID_323: Current used bytes:  32.7 MiB, peak bytes:   55.0 MiB
	      |     |  |  +- node.4:                            Current used bytes:  28.4 MiB, peak bytes:   48.0 MiB
	      |     |  |  |  +- op.4.1.0.HashBuild:             Current used bytes:  28.3 MiB, peak bytes:   28.3 MiB
	      |     |  |  |  \- op.4.0.0.HashProbe:             Current used bytes: 137.5 KiB, peak bytes:  200.0 KiB
	      |     |  |  +- node.3:                            Current used bytes:   4.1 MiB, peak bytes:   20.0 MiB
	      |     |  |  |  \- op.3.1.0.Aggregation:           Current used bytes:   4.1 MiB, peak bytes:   16.3 MiB
	      |     |  |  +- node.1:                            Current used bytes: 208.0 KiB, peak bytes: 1024.0 KiB
	      |     |  |  |  \- op.1.0.0.Aggregation:           Current used bytes: 208.0 KiB, peak bytes:  208.0 KiB
	      |     |  |  +- node.6:                            Current used bytes:   768.0 B, peak bytes: 1024.0 KiB
	      |     |  |  |  \- op.6.0.0.FilterProject:         Current used bytes:   768.0 B, peak bytes:    768.0 B
	      |     |  |  +- node.5:                            Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |  |  \- op.5.0.0.FilterProject:         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |  +- node.0:                            Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |  |  \- op.0.0.0.ValueStream:           Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |  +- node.2:                            Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |  |  \- op.2.1.0.ValueStream:           Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |  \- node.7:                            Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  |     \- op.7.0.0.PartialAggregation:    Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  \- default_leaf:                         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     \- gluten::MemoryAllocator:                 Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- ArrowContextInstance.367:                      Current used bytes:   8.0 MiB, peak bytes:    8.0 MiB
	      +- ShuffleReader.50:                              Current used bytes:   8.0 MiB, peak bytes:   13.8 MiB
	      |  \- single:                                     Current used bytes:   8.0 MiB, peak bytes:    8.0 MiB
	      |     +- gluten::MemoryAllocator:                 Current used bytes: 109.3 KiB, peak bytes:  145.0 KiB
	      |     \- root:                                    Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |        \- default_leaf:                         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- VeloxBatchResizer.316:                         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |  \- single:                                     Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     +- gluten::MemoryAllocator:                 Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     \- root:                                    Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |        \- default_leaf:                         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- IndicatorVectorBase#init.321:                  Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |  \- single:                                     Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     +- gluten::MemoryAllocator:                 Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     \- root:                                    Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |        \- default_leaf:                         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- WholeStageIterator.462.OverAcquire.0:          Current used bytes:     0.0 B, peak bytes:   16.8 MiB
	      +- ShuffleReader.50.OverAcquire.0:                Current used bytes:     0.0 B, peak bytes:    2.4 MiB
	      +- ArrowContextInstance.370:                      Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- ShuffleWriter.319.OverAcquire.0:               Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- ShuffleWriter.319:                             Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |  \- single:                                     Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     +- root:                                    Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     |  \- default_leaf:                         Current used bytes:     0.0 B, peak bytes:      0.0 B
	      |     \- gluten::MemoryAllocator:                 Current used bytes:     0.0 B, peak bytes:      0.0 B
	      +- IndicatorVectorBase#init.321.OverAcquire.0:    Current used bytes:     0.0 B, peak bytes:      0.0 B
	      \- VeloxBatchResizer.[316](https://github.com/apache/incubator-gluten/actions/runs/10861275683/job/30144831318#step:14:317).OverAcquire.0:           Current used bytes:     0.0 B, peak bytes:      0.0 B

	at org.apache.gluten.memory.memtarget.ThrowOnOomMemoryTarget.borrow(ThrowOnOomMemoryTarget.java:105)
	at org.apache.gluten.memory.listener.ManagedReservationListener.reserve(ManagedReservationListener.java:49)
	at org.apache.gluten.vectorized.ColumnarBatchOutIterator.nativeHasNext(Native Method)
	at org.apache.gluten.vectorized.ColumnarBatchOutIterator.hasNextInternal(ColumnarBatchOutIterator.java:61)
	at org.apache.gluten.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:37)
	at scala.collection.convert.Wrappers$JIteratorWrapper.hasNext(Wrappers.scala:45)
	at org.apache.gluten.iterator.IteratorsV1$InvocationFlowProtection.hasNext(IteratorsV1.scala:159)
	at org.apache.gluten.iterator.IteratorsV1$IteratorCompleter.hasNext(IteratorsV1.scala:71)
	at org.apache.gluten.iterator.IteratorsV1$PayloadCloser.hasNext(IteratorsV1.scala:37)
	at org.apache.gluten.iterator.IteratorsV1$LifeTimeAccumulator.hasNext(IteratorsV1.scala:100)
	at org.apache.gluten.iterator.IteratorsV1$ReadTimeAccumulator.hasNext(IteratorsV1.scala:127)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at scala.collection.convert.Wrappers$IteratorWrapper.hasNext(Wrappers.scala:32)
	at org.apache.gluten.vectorized.GeneralInIterator.hasNext(GeneralInIterator.java:31)
	at org.apache.gluten.vectorized.ColumnarBatchOutIterator.nativeHasNext(Native Method)
	at org.apache.gluten.vectorized.ColumnarBatchOutIterator.hasNextInternal(ColumnarBatchOutIterator.java:61)
	at org.apache.gluten.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:37)
	at scala.collection.convert.Wrappers$JIteratorWrapper.hasNext(Wrappers.scala:45)
	at org.apache.gluten.iterator.IteratorsV1$ReadTimeAccumulator.hasNext(IteratorsV1.scala:127)
	at org.apache.gluten.iterator.IteratorsV1$PayloadCloser.hasNext(IteratorsV1.scala:37)
	at org.apache.gluten.iterator.IteratorsV1$IteratorCompleter.hasNext(IteratorsV1.scala:71)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at org.apache.spark.shuffle.ColumnarShuffleWriter.internalWrite(ColumnarShuffleWriter.scala:125)
	at org.apache.spark.shuffle.ColumnarShuffleWriter.write(ColumnarShuffleWriter.scala:243)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```