### PR TITLE
[INFRA] Label gluten-hudi as DATA_LAKE

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -78,7 +78,8 @@ DATA_LAKE:
   - changed-files:
     - any-glob-to-any-file: [
       'gluten-iceberg/**/*',
-      'gluten-delta/**/*'
+      'gluten-delta/**/*',
+      'gluten-hudi/**/*'
     ]
 
 RSS:


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to label gluten-hudi as `DATA_LAKE`


