### PR TITLE
[VL] Remove unused config VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK

### DIFF
--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -110,9 +110,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def veloxOrcScanEnabled: Boolean =
     conf.getConf(VELOX_ORC_SCAN_ENABLED)
 
-  def forceComplexTypeScanFallbackEnabled: Boolean =
-    conf.getConf(VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK)
-
   def forceOrcCharTypeScanFallbackEnabled: Boolean =
     conf.getConf(VELOX_FORCE_ORC_CHAR_TYPE_SCAN_FALLBACK)
 
@@ -2029,13 +2026,6 @@ object GlutenConfig {
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.orc.scan.enabled")
       .internal()
       .doc("Enable velox orc scan. If disabled, vanilla spark orc scan will be used.")
-      .booleanConf
-      .createWithDefault(true)
-
-  val VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK =
-    buildConf("spark.gluten.sql.complexType.scan.fallback.enabled")
-      .internal()
-      .doc("Force fallback for complex type scan, including struct, map, array.")
       .booleanConf
       .createWithDefault(true)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove unused config VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK.
The last usage was removed at https://github.com/apache/incubator-gluten/commit/4533c725129c1c89096beadcdb540306a7c259a8

## How was this patch tested?
CI unit tests

