### PR TITLE
[VL] Minor follow-ups for #7052

### DIFF
--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -7,8 +7,7 @@ if [ -z "${BASH_SOURCE[0]}" ] || [ "$0" == "${BASH_SOURCE[0]}" ]; then
 fi
 
 SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
-init_vcpkg_env=$("${SCRIPT_ROOT}/init.sh" $@)
-eval "$init_vcpkg_env"
+${SCRIPT_ROOT}/init.sh $@
 
 export VCPKG_ROOT="$SCRIPT_ROOT/.vcpkg"
 export VCPKG="$SCRIPT_ROOT/.vcpkg/vcpkg"
@@ -16,13 +15,13 @@ export VCPKG_TRIPLET=x64-linux-avx
 export VCPKG_TRIPLET_INSTALL_DIR=${SCRIPT_ROOT}/vcpkg_installed/${VCPKG_TRIPLET}
 export EXPORT_TOOLS_PATH="${VCPKG_TRIPLET_INSTALL_DIR}/tools/protobuf"
 
-if [ "\${GLUTEN_VCPKG_ENABLED:-}" != "${VCPKG_ROOT}" ]; then
+if [ "${GLUTEN_VCPKG_ENABLED:-}" != "${VCPKG_ROOT}" ]; then
     export VCPKG_ROOT=${VCPKG_ROOT}
     export VCPKG_MANIFEST_DIR=${SCRIPT_ROOT}
     export VCPKG_TRIPLET=${VCPKG_TRIPLET}
 
     export CMAKE_TOOLCHAIN_FILE=${SCRIPT_ROOT}/toolchain.cmake
-    export PKG_CONFIG_PATH=${VCPKG_TRIPLET_INSTALL_DIR}/lib/pkgconfig:${VCPKG_TRIPLET_INSTALL_DIR}/share/pkgconfig:\${PKG_CONFIG_PATH:-}
+    export PKG_CONFIG_PATH=${VCPKG_TRIPLET_INSTALL_DIR}/lib/pkgconfig:${VCPKG_TRIPLET_INSTALL_DIR}/share/pkgconfig:${PKG_CONFIG_PATH:-}
     export PATH="${EXPORT_TOOLS_PATH}:$PATH"
 
     export GLUTEN_VCPKG_ENABLED=${VCPKG_ROOT}

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -6,12 +6,13 @@ if [ -z "${BASH_SOURCE[0]}" ] || [ "$0" == "${BASH_SOURCE[0]}" ]; then
     exit 1
 fi
 
+SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
 export VCPKG_ROOT="$SCRIPT_ROOT/.vcpkg"
 export VCPKG="$SCRIPT_ROOT/.vcpkg/vcpkg"
 export VCPKG_TRIPLET=x64-linux-avx
 export VCPKG_TRIPLET_INSTALL_DIR=${SCRIPT_ROOT}/vcpkg_installed/${VCPKG_TRIPLET}
 
-SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 ${SCRIPT_ROOT}/init.sh $@
 
 if [ "${GLUTEN_VCPKG_ENABLED:-}" != "${VCPKG_ROOT}" ]; then

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -16,7 +16,7 @@ ${SCRIPT_ROOT}/init.sh $@
 
 if [ "${GLUTEN_VCPKG_ENABLED:-}" != "${VCPKG_ROOT}" ]; then
     EXPORT_TOOLS_PATH="${VCPKG_TRIPLET_INSTALL_DIR}/tools/protobuf"
-    # This scripts depends on environment $CMAKE_TOOLCHAIN_FILE, which requires
+    # The scripts depends on environment $CMAKE_TOOLCHAIN_FILE, which requires
     # cmake >= 3.21. If system cmake < 3.25, vcpkg will download latest cmake. We
     # can use vcpkg's internal cmake if we find it.
     VCPKG_CMAKE_BIN_DIR=$(echo "${VCPKG_ROOT}"/downloads/tools/cmake-*/cmake-*/bin)

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -13,7 +13,7 @@ export VCPKG="$SCRIPT_ROOT/.vcpkg/vcpkg"
 export VCPKG_TRIPLET=x64-linux-avx
 export VCPKG_TRIPLET_INSTALL_DIR=${SCRIPT_ROOT}/vcpkg_installed/${VCPKG_TRIPLET}
 
-${SCRIPT_ROOT}/init.sh $@
+${SCRIPT_ROOT}/init.sh "$@"
 
 if [ "${GLUTEN_VCPKG_ENABLED:-}" != "${VCPKG_ROOT}" ]; then
     EXPORT_TOOLS_PATH="${VCPKG_TRIPLET_INSTALL_DIR}/tools/protobuf"

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -35,5 +35,5 @@ if [ "${GLUTEN_VCPKG_ENABLED:-}" != "${VCPKG_ROOT}" ]; then
 
     export GLUTEN_VCPKG_ENABLED=${VCPKG_ROOT}
 else
-    echo "Gluten's vcpkg environment is enabled" >&2
+    echo "Gluten's vcpkg environment is already enabled" >&2
 fi

--- a/dev/vcpkg/init.sh
+++ b/dev/vcpkg/init.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-exec 3>&1 >&2
-
 BUILD_TESTS=OFF
 ENABLE_S3=OFF
 ENABLE_GCS=OFF

--- a/dev/vcpkg/toolchain.cmake
+++ b/dev/vcpkg/toolchain.cmake
@@ -8,7 +8,10 @@ set(ENABLE_GLUTEN_VCPKG ON)
 # in script `init.sh` will be used across all CMake sub-projects.
 #
 # Reference: https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/cmake-integration
-set(VCPKG_MANIFEST_MODE OFF)
+#
+# Note: "CACHE BOOL" is required to make this successfully override the option defined in
+# vcpkg.cmake.
+set(VCPKG_MANIFEST_MODE OFF CACHE BOOL "Use manifest mode, as opposed to classic mode." FORCE)
 
 set(VCPKG_TARGET_TRIPLET $ENV{VCPKG_TRIPLET})
 set(VCPKG_HOST_TRIPLET $ENV{VCPKG_TRIPLET})

--- a/dev/vcpkg/toolchain.cmake
+++ b/dev/vcpkg/toolchain.cmake
@@ -3,11 +3,12 @@
 
 set(ENABLE_GLUTEN_VCPKG ON)
 
-# If this arg is set, `vcpkg install` will be executed according
-# to the manifest file exists in this given path, i.e., vcpkg.json,
-# which will not respect our setting for extra features through
-# `--x-feature`.
-#set(VCPKG_MANIFEST_DIR $ENV{VCPKG_MANIFEST_DIR})
+# Force the use of VCPKG classic mode to avoid reinstalling vcpkg features during
+# different CMake sub-projects. Which means, the features installed by `vcpkg install`
+# in script `init.sh` will be used across all CMake sub-projects.
+#
+# Reference: https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/cmake-integration
+set(VCPKG_MANIFEST_MODE OFF)
 
 set(VCPKG_TARGET_TRIPLET $ENV{VCPKG_TRIPLET})
 set(VCPKG_HOST_TRIPLET $ENV{VCPKG_TRIPLET})


### PR DESCRIPTION
Some fixes following PR https://github.com/apache/incubator-gluten/pull/7052

1. Fix [bug](https://github.com/apache/incubator-gluten/pull/7052#issuecomment-2367282032) when `--enable_vcpkg=ON --build_arrow=ON`
2. Restore broken logic to use CMake bin installed by vcpkg
3. Fix check on `$GLUTEN_VCPKG_ENABLED` to skip vcpkg config (do we really need this?)
4. Remove meaningless `eval "$init_vcpkg_env"`
5. Fix malformed env `PKG_CONFIG_PATH`