### PR TITLE
[GLUTEN-7311][CH] Support grace aggregate algorithm in partial aggregating stages

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
@@ -135,43 +135,32 @@ case class CHHashAggregateExecTransformer(
             nameList.addAll(ConverterUtils.collectStructFieldNames(attr.dataType))
           }
           (child.output, output)
-        } else {
+        } else if (!modes.contains(Partial)) {
+          // non-partial mode
           var resultAttrIndex = 0
           for (attr <- aggregateResultAttributes) {
-            val aggregateExpression = aggregateExpressions.find(_.resultAttribute == attr)
-            if (aggregateExpression.isEmpty) {
-              // These should be grouping keys
-              typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-              nameList.add(ConverterUtils.genColumnNameWithExprId(attr))
-              nameList.addAll(ConverterUtils.collectStructFieldNames(attr.dataType))
-            } else {
-              // It's an aggregate expression
-              // There could be multiple aggregate mode in the same step. We need to adjust
-              // the input schema according to the AggregateMode.
-              if (aggregateExpression.get.mode != Partial) {
-                val colName = getIntermediateAggregateResultColumnName(
-                  resultAttrIndex,
-                  aggregateResultAttributes,
-                  groupingExpressions,
-                  aggregateExpressions)
-                nameList.add(colName)
-                val (dataType, nullable) =
-                  getIntermediateAggregateResultType(attr, aggregateExpressions)
-                nameList.addAll(ConverterUtils.collectStructFieldNames(dataType))
-                typeList.add(ConverterUtils.getTypeNode(dataType, nullable))
-              } else {
-                typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-                nameList.add(ConverterUtils.genColumnNameWithExprId(attr))
-                nameList.addAll(ConverterUtils.collectStructFieldNames(attr.dataType))
-              }
-            }
+            val colName = getIntermediateAggregateResultColumnName(
+              resultAttrIndex,
+              aggregateResultAttributes,
+              groupingExpressions,
+              aggregateExpressions)
+            nameList.add(colName)
+            val (dataType, nullable) =
+              getIntermediateAggregateResultType(attr, aggregateExpressions)
+            nameList.addAll(ConverterUtils.collectStructFieldNames(dataType))
+            typeList.add(ConverterUtils.getTypeNode(dataType, nullable))
             resultAttrIndex += 1
           }
-          if (modes.forall(_ == Partial)) {
-            (child.output, aggregateResultAttributes)
-          } else {
-            (aggregateResultAttributes, output)
+          (aggregateResultAttributes, output)
+        } else {
+          // partial mode
+          for (attr <- child.output) {
+            typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+            nameList.add(ConverterUtils.genColumnNameWithExprId(attr))
+            nameList.addAll(ConverterUtils.collectStructFieldNames(attr.dataType))
           }
+
+          (child.output, aggregateResultAttributes)
         }
       }
 

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
@@ -30,7 +30,9 @@ import org.apache.gluten.substrait.rel.{RelBuilder, RelNode}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
+import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.types._
 
 import com.google.protobuf.{Any, StringValue}
@@ -53,6 +55,19 @@ object CHHashAggregateExecTransformer {
   def newStructFieldId(): Long = curId.getAndIncrement()
 }
 
+/**
+ * About aggregate modes. In general, all the modes of aggregate expressions in the same
+ * HashAggregateExec are the same. And the aggregation will be divided into two stages, partial
+ * aggregate and final merge aggregated. But there are some exceptions.
+ *   - f(distinct x). This will be divided into four stages (without stages merged by
+ *     `MergeTwoPhasesHashBaseAggregate`). The first two stages use `x` as a grouping key and
+ *     without aggregate functions. The last two stages aggregate without `x` as a grouping key and
+ *     with aggregate function `f`.
+ *   - f1(distinct x), f(2). This will be divided into four stages. The first two stages use `x` as
+ *     a grouping key and with partial aggregate function `f2`. The last two stages aggregate
+ *     without `x` as a grouping key and with aggregate function `f1` and `f2`. The 3rd stages hase
+ *     different modes at the same time. `f2` is partial merge but `f1` is partial.
+ */
 case class CHHashAggregateExecTransformer(
     requiredChildDistributionExpressions: Option[Seq[Expression]],
     groupingExpressions: Seq[NamedExpression],
@@ -413,13 +428,59 @@ case class CHHashAggregateExecTransformer(
     } else {
       null
     }
-    val optimizationContent = s"has_required_child_distribution_expressions=" +
-      s"${requiredChildDistributionExpressions.isDefined}\n"
+    val parametersStrBuf = new StringBuffer("AggregateParams:")
+    parametersStrBuf
+      .append(s"hasPrePartialAggregate=$hasPrePartialAggregate")
+      .append("\n")
+      .append(s"hasRequiredChildDistributionExpressions=" +
+        s"${requiredChildDistributionExpressions.isDefined}")
+      .append("\n")
     val optimization =
       BackendsApiManager.getTransformerApiInstance.packPBMessage(
-        StringValue.newBuilder.setValue(optimizationContent).build)
+        StringValue.newBuilder.setValue(parametersStrBuf.toString).build)
     ExtensionBuilder.makeAdvancedExtension(optimization, enhancement)
+  }
 
+  // Check that there is a partial aggregation ahead this HashAggregateExec.
+  // This is useful when aggregate expressions are empty.
+  private def hasPrePartialAggregate(): Boolean = {
+    def isSameAggregation(agg1: BaseAggregateExec, agg2: BaseAggregateExec): Boolean = {
+      val res = agg1.groupingExpressions.length == agg2.groupingExpressions.length &&
+        agg1.groupingExpressions.zip(agg2.groupingExpressions).forall {
+          case (e1, e2) =>
+            e1.toAttribute == e2.toAttribute
+        }
+      res
+    }
+
+    def checkChild(exec: SparkPlan): Boolean = {
+      exec match {
+        case agg: BaseAggregateExec =>
+          isSameAggregation(this, agg)
+        case shuffle: ShuffleExchangeLike =>
+          checkChild(shuffle.child)
+        case iter: InputIteratorTransformer =>
+          checkChild(iter.child)
+        case inputAdapter: ColumnarInputAdapter =>
+          checkChild(inputAdapter.child)
+        case wholeStage: WholeStageTransformer =>
+          checkChild(wholeStage.child)
+        case aqeShuffleRead: AQEShuffleReadExec =>
+          checkChild(aqeShuffleRead.child)
+        case shuffle: ShuffleQueryStageExec =>
+          checkChild(shuffle.plan)
+        case _ =>
+          false
+      }
+    }
+
+    // It's more complex when the aggregate expressions are empty. We need to iterate the plan
+    // to find whether there is a partial aggregation. `count(distinct x)` is one of these cases.
+    if (aggregateExpressions.length > 0) {
+      modes.exists(mode => mode == PartialMerge || mode == Final)
+    } else {
+      checkChild(child)
+    }
   }
 }
 

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/MergeTwoPhasesHashBaseAggregate.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/MergeTwoPhasesHashBaseAggregate.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.extension
 
 import org.apache.gluten.GlutenConfig
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -33,7 +34,9 @@ import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregat
  * Note: this rule must be applied before the `PullOutPreProject` rule, because the
  * `PullOutPreProject` rule will modify the attributes in some cases.
  */
-case class MergeTwoPhasesHashBaseAggregate(session: SparkSession) extends Rule[SparkPlan] {
+case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
+  extends Rule[SparkPlan]
+  with Logging {
 
   val columnarConf: GlutenConfig = GlutenConfig.getConf
   val scanOnly: Boolean = columnarConf.enableScanOnly
@@ -73,7 +76,6 @@ case class MergeTwoPhasesHashBaseAggregate(session: SparkSession) extends Rule[S
           // convert to complete mode aggregate expressions
           val completeAggregateExpressions = aggregateExpressions.map(_.copy(mode = Complete))
           hashAgg.copy(
-            requiredChildDistributionExpressions = None,
             groupingExpressions = child.groupingExpressions,
             aggregateExpressions = completeAggregateExpressions,
             initialInputBufferOffset = 0,

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/HashAggregateMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/metrics/HashAggregateMetricsUpdater.scala
@@ -77,10 +77,12 @@ object HashAggregateMetricsUpdater {
     "AggregatingTransform",
     "StreamingAggregatingTransform",
     "MergingAggregatedTransform",
+    "GraceAggregatingTransform",
     "GraceMergingAggregatedTransform")
   val CH_PLAN_NODE_NAME = Array(
     "AggregatingTransform",
     "StreamingAggregatingTransform",
     "MergingAggregatedTransform",
+    "GraceAggregatingTransform",
     "GraceMergingAggregatedTransform")
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseCountDistinctSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickhouseCountDistinctSuite.scala
@@ -69,6 +69,12 @@ class GlutenClickhouseCountDistinctSuite extends GlutenClickHouseWholeStageTrans
     }
   }
 
+  test("test distinct with not-distinct") {
+    val sql = "select a,  count(distinct(b)), sum(c)  from " +
+      "values (0, null,1), (0,null,1), (1, 1,1), (2, 2, 1) ,(2,2,2) as data(a,b,c) group by a"
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
+  }
+
   test("check all data types") {
     spark.createDataFrame(genTestData()).createOrReplaceTempView("all_data_types")
 

--- a/cpp-ch/clickhouse.version
+++ b/cpp-ch/clickhouse.version
@@ -1,3 +1,3 @@
 CH_ORG=Kyligence
 CH_BRANCH=rebase_ch/20241010
-CH_COMMIT=3e57eb5c17e
+CH_COMMIT=30b3ff313a9

--- a/cpp-ch/local-engine/AggregateFunctions/AggregateFunctionPartialMerge.h
+++ b/cpp-ch/local-engine/AggregateFunctions/AggregateFunctionPartialMerge.h
@@ -27,7 +27,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 }
 
@@ -50,8 +50,7 @@ private:
 
 public:
     AggregateFunctionPartialMerge(const AggregateFunctionPtr & nested_, const DataTypePtr & argument, const Array & params_)
-        : IAggregateFunctionHelper<AggregateFunctionPartialMerge>({argument}, params_, createResultType(nested_))
-        , nested_func(nested_)
+        : IAggregateFunctionHelper<AggregateFunctionPartialMerge>({argument}, params_, createResultType(nested_)), nested_func(nested_)
     {
         const DataTypeAggregateFunction * data_type = typeid_cast<const DataTypeAggregateFunction *>(argument.get());
 
@@ -115,5 +114,9 @@ public:
     bool allocatesMemoryInArena() const override { return nested_func->allocatesMemoryInArena(); }
 
     AggregateFunctionPtr getNestedFunction() const override { return nested_func; }
+    /// If the aggregate phase is `INTEMEDIATE_TO_INTERMEDIATE`, partial merge combinator is applied. In this case, the actual result column's
+    /// representation is `xxxPartialMerge`. It will make block structure check fail somewhere, since the expected column's represiontation is
+    /// `xxx` without partial merge. The represiontaions of `xxxPartialMerge` and `xxx` are the same actually.
+    const IAggregateFunction & getBaseAggregateFunctionWithSameStateRepresentation() const override { return *nested_func; }
 };
 }

--- a/cpp-ch/local-engine/Common/DebugUtils.h
+++ b/cpp-ch/local-engine/Common/DebugUtils.h
@@ -21,6 +21,7 @@
 namespace debug
 {
 void headBlock(const DB::Block & block, size_t count = 10);
+String printBlock(const DB::Block & block, size_t count = 10);
 
 void headColumn(const DB::ColumnPtr & column, size_t count = 10);
 }

--- a/cpp-ch/local-engine/Operator/GraceAggregatingStep.cpp
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingStep.cpp
@@ -98,7 +98,7 @@ void GraceAggregatingStep::describeActions(DB::JSONBuilder::JSONMap & map) const
 void GraceAggregatingStep::updateOutputStream()
 {
     output_stream
-        = createOutputStream(input_streams.front(), buildOutputHeader(input_streams.front().header, params, true), getDataStreamTraits());
+        = createOutputStream(input_streams.front(), buildOutputHeader(input_streams.front().header, params, false), getDataStreamTraits());
 }
 
 

--- a/cpp-ch/local-engine/Operator/GraceAggregatingStep.h
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingStep.h
@@ -14,38 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <unordered_map>
-#include <Core/Block.h>
+
 #include <Interpreters/Aggregator.h>
 #include <Interpreters/Context.h>
-#include <Processors/Chunk.h>
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
 #include <Processors/QueryPlan/ITransformingStep.h>
 #include <Processors/Transforms/AggregatingTransform.h>
-#include <QueryPipeline/SizeLimits.h>
-#include <Poco/Logger.h>
-#include <Common/AggregateUtil.h>
-#include <Common/logger_useful.h>
-#include "GraceAggregatingTransform.h"
+
 
 namespace local_engine
 {
-/// It's used to merged aggregated data from intermediate aggregate stages, it's the final stage of
-/// aggregating.
-/// It support spilling data into disk when the memory usage is overflow.
-class GraceMergingAggregatedStep : public DB::ITransformingStep
+/**
+ * GraceAggregatingStep is used for partial aggregating stages.
+ */
+class GraceAggregatingStep : public DB::ITransformingStep
 {
 public:
-    explicit GraceMergingAggregatedStep(
+    explicit GraceAggregatingStep(
         DB::ContextPtr context_,
         const DB::DataStream & input_stream_,
         DB::Aggregator::Params params_,
         bool no_pre_aggregated_);
-    ~GraceMergingAggregatedStep() override = default;
+    ~GraceAggregatingStep() override = default;
 
-    String getName() const override { return "GraceMergingAggregatedStep"; }
+    String getName() const override { return "GraceAggregatingStep"; }
 
     void transformPipeline(DB::QueryPipelineBuilder & pipeline, const DB::BuildQueryPipelineSettings &) override;
 
@@ -57,6 +51,4 @@ private:
     bool no_pre_aggregated;
     void updateOutputStream() override; 
 };
-
-
 }

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
@@ -23,6 +23,8 @@
 #include <Common/QueryContext.h>
 #include <Common/formatReadable.h>
 
+#include <Common/DebugUtils.h>
+
 namespace DB::ErrorCodes
 {
 extern const int LOGICAL_ERROR;
@@ -46,6 +48,7 @@ GraceAggregatingTransform::GraceAggregatingTransform(
     , final_output(final_output_)
     , tmp_data_disk(std::make_unique<DB::TemporaryDataOnDisk>(context_->getTempDataOnDisk()))
 {
+    output_header = params->getHeader();
     auto config = GraceMergingAggregateConfig::loadFromContext(context);
     max_buckets = config.max_grace_aggregate_merging_buckets;
     throw_on_overflow_buckets = config.throw_on_overflow_grace_aggregate_merging_buckets;

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
@@ -16,21 +16,26 @@
  */
 
 #include "GraceAggregatingTransform.h"
-#include <Common/CHUtil.h>
-#include <Common/QueryContext.h>
-#include <Common/CurrentThread.h>
-#include <Common/formatReadable.h>
 #include <Common/BitHelpers.h>
+#include <Common/CHUtil.h>
+#include <Common/CurrentThread.h>
 #include <Common/GlutenConfig.h>
+#include <Common/QueryContext.h>
+#include <Common/formatReadable.h>
 
 namespace DB::ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+extern const int LOGICAL_ERROR;
 }
 
 namespace local_engine
 {
-GraceAggregatingTransform::GraceAggregatingTransform(const DB::Block &header_, DB::AggregatingTransformParamsPtr params_, DB::ContextPtr context_, bool no_pre_aggregated_, bool final_output_)
+GraceAggregatingTransform::GraceAggregatingTransform(
+    const DB::Block & header_,
+    DB::AggregatingTransformParamsPtr params_,
+    DB::ContextPtr context_,
+    bool no_pre_aggregated_,
+    bool final_output_)
     : IProcessor({header_}, {params_->getHeader()})
     , header(header_)
     , params(params_)
@@ -160,7 +165,7 @@ void GraceAggregatingTransform::work()
             return;
         }
 
-        while(block_converter->hasNext())
+        while (block_converter->hasNext())
         {
             auto block = block_converter->next();
             if (!block.rows())
@@ -195,7 +200,7 @@ bool GraceAggregatingTransform::extendBuckets()
                 "Too many buckets, limit is {}. Please consider increate offhead size or partitoin number",
                 max_buckets);
         else
-         return false;
+            return false;
     }
     LOG_DEBUG(logger, "Extend buckets num from {} to {}", current_size, next_size);
     for (size_t i = current_size; i < next_size; ++i)
@@ -214,7 +219,7 @@ void GraceAggregatingTransform::rehashDataVariants()
     no_more_keys = false;
 
     size_t bucket_n = 0;
-    while(converter->hasNext())
+    while (converter->hasNext())
     {
         auto block = converter->next();
         if (!block.rows())
@@ -227,7 +232,11 @@ void GraceAggregatingTransform::rehashDataVariants()
         for (size_t i = 0; i < current_bucket_index; ++i)
         {
             if (scattered_blocks[i].rows())
-                throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Scattered blocks should not belong to buckets with index({}) < current_bucket_index({})", i, current_bucket_index);
+                throw DB::Exception(
+                    DB::ErrorCodes::LOGICAL_ERROR,
+                    "Scattered blocks should not belong to buckets with index({}) < current_bucket_index({})",
+                    i,
+                    current_bucket_index);
         }
         for (size_t i = current_bucket_index + 1; i < getBucketsNum(); ++i)
         {
@@ -270,7 +279,8 @@ void GraceAggregatingTransform::addBlockIntoFileBucket(size_t bucket_index, cons
         return;
     if (roundUpToPowerOfTwoOrZero(bucket_index + 1) > static_cast<size_t>(block.info.bucket_num))
     {
-        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Add invalid block with bucket_num {} into bucket {}", block.info.bucket_num, bucket_index);
+        throw DB::Exception(
+            DB::ErrorCodes::LOGICAL_ERROR, "Add invalid block with bucket_num {} into bucket {}", block.info.bucket_num, bucket_index);
     }
     auto & file_stream = buckets[bucket_index];
     file_stream.pending_bytes += block.allocatedBytes();
@@ -443,7 +453,7 @@ void GraceAggregatingTransform::checkAndSetupCurrentDataVariants()
     }
 }
 
-void GraceAggregatingTransform::mergeOneBlock(const DB::Block &block, bool is_original_block)
+void GraceAggregatingTransform::mergeOneBlock(const DB::Block & block, bool is_original_block)
 {
     if (!block.rows())
         return;
@@ -504,7 +514,8 @@ void GraceAggregatingTransform::mergeOneBlock(const DB::Block &block, bool is_or
 
         if (is_original_block && no_pre_aggregated)
         {
-            params->aggregator.executeOnBlock(scattered_blocks[current_bucket_index], *current_data_variants, key_columns, aggregate_columns, no_more_keys);
+            params->aggregator.executeOnBlock(
+                scattered_blocks[current_bucket_index], *current_data_variants, key_columns, aggregate_columns, no_more_keys);
         }
         else
         {
@@ -531,7 +542,8 @@ bool GraceAggregatingTransform::isMemoryOverflow()
         {
             LOG_INFO(
                 logger,
-                "Memory is overflow. current_mem_used: {}, max_mem_used: {}, per_key_memory_usage: {}, aggregator keys: {}, buckets: {}, hash table type: {}",
+                "Memory is overflow. current_mem_used: {}, max_mem_used: {}, per_key_memory_usage: {}, aggregator keys: {}, buckets: {}, "
+                "hash table type: {}",
                 ReadableSize(current_mem_used),
                 ReadableSize(max_mem_used),
                 ReadableSize(per_key_memory_usage),
@@ -547,7 +559,8 @@ bool GraceAggregatingTransform::isMemoryOverflow()
         {
             LOG_INFO(
                 logger,
-                "Memory is overflow on half of max usage. current_mem_used: {}, max_mem_used: {}, aggregator keys: {}, buckets: {}, hash table type: {}",
+                "Memory is overflow on half of max usage. current_mem_used: {}, max_mem_used: {}, aggregator keys: {}, buckets: {}, hash "
+                "table type: {}",
                 ReadableSize(current_mem_used),
                 ReadableSize(max_mem_used),
                 current_result_rows,

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
@@ -1,0 +1,562 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GraceAggregatingTransform.h"
+#include <Common/CHUtil.h>
+#include <Common/QueryContext.h>
+#include <Common/CurrentThread.h>
+#include <Common/formatReadable.h>
+#include <Common/BitHelpers.h>
+#include <Common/GlutenConfig.h>
+
+namespace DB::ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+namespace local_engine
+{
+GraceAggregatingTransform::GraceAggregatingTransform(const DB::Block &header_, DB::AggregatingTransformParamsPtr params_, DB::ContextPtr context_, bool no_pre_aggregated_, bool final_output_)
+    : IProcessor({header_}, {params_->getHeader()})
+    , header(header_)
+    , params(params_)
+    , context(context_)
+    , key_columns(params_->params.keys_size)
+    , aggregate_columns(params_->params.aggregates_size)
+    , no_pre_aggregated(no_pre_aggregated_)
+    , final_output(final_output_)
+    , tmp_data_disk(std::make_unique<DB::TemporaryDataOnDisk>(context_->getTempDataOnDisk()))
+{
+    auto config = GraceMergingAggregateConfig::loadFromContext(context);
+    max_buckets = config.max_grace_aggregate_merging_buckets;
+    throw_on_overflow_buckets = config.throw_on_overflow_grace_aggregate_merging_buckets;
+    aggregated_keys_before_extend_buckets = config.aggregated_keys_before_extend_grace_aggregate_merging_buckets;
+    aggregated_keys_before_extend_buckets = PODArrayUtil::adjustMemoryEfficientSize(aggregated_keys_before_extend_buckets);
+    max_pending_flush_blocks_per_bucket = config.max_pending_flush_blocks_per_grace_aggregate_merging_bucket;
+    max_allowed_memory_usage_ratio = config.max_allowed_memory_usage_ratio_for_aggregate_merging;
+    // bucket 0 is for in-memory data, it's just a placeholder.
+    buckets.emplace(0, BufferFileStream());
+
+    current_data_variants = std::make_shared<DB::AggregatedDataVariants>();
+}
+
+GraceAggregatingTransform::~GraceAggregatingTransform()
+{
+    LOG_INFO(
+        logger,
+        "Metrics. total_input_blocks: {}, total_input_rows: {}, total_output_blocks: {}, total_output_rows: {}, total_spill_disk_bytes: "
+        "{}, total_spill_disk_time: {}, total_read_disk_time: {}, total_scatter_time: {}",
+        total_input_blocks,
+        total_input_rows,
+        total_output_blocks,
+        total_output_rows,
+        total_spill_disk_bytes,
+        total_spill_disk_time,
+        total_read_disk_time,
+        total_scatter_time);
+}
+
+GraceAggregatingTransform::Status GraceAggregatingTransform::prepare()
+{
+    auto & output = outputs.front();
+    auto & input = inputs.front();
+    if (output.isFinished() || isCancelled())
+    {
+        input.close();
+        return Status::Finished;
+    }
+    if (has_output)
+    {
+        if (output.canPush())
+        {
+            LOG_DEBUG(
+                logger,
+                "Output one chunk. rows: {}, bytes: {}, current memory usage: {}",
+                output_chunk.getNumRows(),
+                ReadableSize(output_chunk.bytes()),
+                ReadableSize(currentThreadGroupMemoryUsage()));
+            total_output_rows += output_chunk.getNumRows();
+            total_output_blocks++;
+            output.push(std::move(output_chunk));
+            has_output = false;
+        }
+        return Status::PortFull;
+    }
+
+    if (has_input)
+        return Status::Ready;
+
+
+    if (!input_finished)
+    {
+        if (input.isFinished())
+        {
+            input_finished = true;
+            return Status::Ready;
+        }
+        input.setNeeded();
+        if (!input.hasData())
+            return Status::NeedData;
+        input_chunk = input.pull(true);
+        LOG_DEBUG(
+            logger,
+            "Input one new chunk. rows: {}, bytes: {}, current memory usage: {}",
+            input_chunk.getNumRows(),
+            ReadableSize(input_chunk.bytes()),
+            ReadableSize(currentThreadGroupMemoryUsage()));
+        total_input_rows += input_chunk.getNumRows();
+        total_input_blocks++;
+        has_input = true;
+        return Status::Ready;
+    }
+
+    if (current_bucket_index >= getBucketsNum() && (!block_converter || !block_converter->hasNext()))
+    {
+        output.finish();
+        return Status::Finished;
+    }
+    return Status::Ready;
+}
+
+void GraceAggregatingTransform::work()
+{
+    if (has_input)
+    {
+        assert(!input_finished);
+        auto block = header.cloneWithColumns(input_chunk.detachColumns());
+        mergeOneBlock(block, true);
+        has_input = false;
+    }
+    else
+    {
+        assert(input_finished);
+        if (!block_converter || !block_converter->hasNext())
+        {
+            block_converter = nullptr;
+            while (current_bucket_index < getBucketsNum())
+            {
+                block_converter = prepareBucketOutputBlocks(current_bucket_index);
+                if (block_converter)
+                    break;
+                current_bucket_index++;
+            }
+        }
+        if (!block_converter)
+        {
+            return;
+        }
+
+        while(block_converter->hasNext())
+        {
+            auto block = block_converter->next();
+            if (!block.rows())
+                continue;
+            output_chunk = DB::Chunk(block.getColumns(), block.rows());
+            has_output = true;
+            break;
+        }
+
+        if (!block_converter->hasNext())
+        {
+            block_converter = nullptr;
+            current_bucket_index++;
+        }
+    }
+}
+
+bool GraceAggregatingTransform::extendBuckets()
+{
+    if (!current_data_variants || current_data_variants->size() < aggregated_keys_before_extend_buckets)
+        return false;
+
+    auto current_size = getBucketsNum();
+    auto next_size = current_size * 2;
+    /// We have a soft limit on the number of buckets. When throw_on_overflow_buckets = false, we just
+    /// continue to run with the current number of buckets until the executor is killed by spark scheduler.
+    if (next_size > max_buckets)
+    {
+        if (throw_on_overflow_buckets)
+            throw DB::Exception(
+                DB::ErrorCodes::LOGICAL_ERROR,
+                "Too many buckets, limit is {}. Please consider increate offhead size or partitoin number",
+                max_buckets);
+        else
+         return false;
+    }
+    LOG_DEBUG(logger, "Extend buckets num from {} to {}", current_size, next_size);
+    for (size_t i = current_size; i < next_size; ++i)
+        buckets.emplace(i, BufferFileStream());
+    return true;
+}
+
+void GraceAggregatingTransform::rehashDataVariants()
+{
+    auto before_memoery_usage = currentThreadGroupMemoryUsage();
+
+    auto converter = currentDataVariantToBlockConverter(false);
+    checkAndSetupCurrentDataVariants();
+    size_t block_rows = 0;
+    size_t block_memory_usage = 0;
+    no_more_keys = false;
+
+    size_t bucket_n = 0;
+    while(converter->hasNext())
+    {
+        auto block = converter->next();
+        if (!block.rows())
+            continue;
+        block_rows += block.rows();
+        block_memory_usage += block.allocatedBytes();
+        auto scattered_blocks = scatterBlock(block);
+        block = {};
+        /// the new scattered blocks from block will alway belongs to the buckets with index >= current_bucket_index
+        for (size_t i = 0; i < current_bucket_index; ++i)
+        {
+            if (scattered_blocks[i].rows())
+                throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Scattered blocks should not belong to buckets with index({}) < current_bucket_index({})", i, current_bucket_index);
+        }
+        for (size_t i = current_bucket_index + 1; i < getBucketsNum(); ++i)
+        {
+            addBlockIntoFileBucket(i, scattered_blocks[i], false);
+            scattered_blocks[i] = {};
+        }
+
+        params->aggregator.mergeOnBlock(scattered_blocks[current_bucket_index], *current_data_variants, no_more_keys, is_cancelled);
+    }
+    if (block_rows)
+        per_key_memory_usage = block_memory_usage * 1.0 / block_rows;
+
+    LOG_INFO(
+        logger,
+        "Rehash data variants. current_bucket_index: {}, buckets num: {}, memory usage change, from {} to {}",
+        current_bucket_index,
+        getBucketsNum(),
+        ReadableSize(before_memoery_usage),
+        ReadableSize(currentThreadGroupMemoryUsage()));
+};
+
+DB::Blocks GraceAggregatingTransform::scatterBlock(const DB::Block & block)
+{
+    if (!block.rows())
+        return {};
+    Stopwatch watch;
+    size_t bucket_num = getBucketsNum();
+    auto blocks = DB::JoinCommon::scatterBlockByHash(params->params.keys, block, bucket_num);
+    for (auto & new_block : blocks)
+    {
+        new_block.info.bucket_num = static_cast<Int32>(bucket_num);
+    }
+    total_scatter_time += watch.elapsedMilliseconds();
+    return blocks;
+}
+
+void GraceAggregatingTransform::addBlockIntoFileBucket(size_t bucket_index, const DB::Block & block, bool is_original_block)
+{
+    if (!block.rows())
+        return;
+    if (roundUpToPowerOfTwoOrZero(bucket_index + 1) > static_cast<size_t>(block.info.bucket_num))
+    {
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Add invalid block with bucket_num {} into bucket {}", block.info.bucket_num, bucket_index);
+    }
+    auto & file_stream = buckets[bucket_index];
+    file_stream.pending_bytes += block.allocatedBytes();
+    if (is_original_block && no_pre_aggregated)
+        file_stream.original_blocks.push_back(block);
+    else
+        file_stream.intermediate_blocks.push_back(block);
+    if (file_stream.pending_bytes > max_pending_flush_blocks_per_bucket)
+    {
+        flushBucket(bucket_index);
+        file_stream.pending_bytes = 0;
+    }
+}
+
+void GraceAggregatingTransform::flushBuckets()
+{
+    for (size_t i = current_bucket_index + 1; i < getBucketsNum(); ++i)
+        flushBucket(i);
+}
+
+static size_t flushBlocksInfoDisk(DB::TemporaryFileStream * file_stream, std::list<DB::Block> & blocks)
+{
+    size_t flush_bytes = 0;
+    DB::Blocks tmp_blocks;
+    while (!blocks.empty())
+    {
+        while (!blocks.empty())
+        {
+            if (!tmp_blocks.empty() && tmp_blocks.back().info.bucket_num != blocks.front().info.bucket_num)
+                break;
+            tmp_blocks.push_back(blocks.front());
+            blocks.pop_front();
+        }
+        auto bucket = tmp_blocks.front().info.bucket_num;
+        auto merged_block = BlockUtil::concatenateBlocksMemoryEfficiently(std::move(tmp_blocks));
+        merged_block.info.bucket_num = bucket;
+        tmp_blocks.clear();
+        flush_bytes += merged_block.bytes();
+        if (merged_block.rows())
+        {
+            file_stream->write(merged_block);
+        }
+    }
+    if (flush_bytes)
+        file_stream->flush();
+    return flush_bytes;
+}
+
+size_t GraceAggregatingTransform::flushBucket(size_t bucket_index)
+{
+    Stopwatch watch;
+    auto & file_stream = buckets[bucket_index];
+    size_t flush_bytes = 0;
+    if (!file_stream.original_blocks.empty())
+    {
+        if (!file_stream.original_file_stream)
+            file_stream.original_file_stream = &tmp_data_disk->createStream(header);
+        flush_bytes += flushBlocksInfoDisk(file_stream.original_file_stream, file_stream.original_blocks);
+    }
+    if (!file_stream.intermediate_blocks.empty())
+    {
+        if (!file_stream.intermediate_file_stream)
+        {
+            auto intermediate_header = params->aggregator.getHeader(false);
+            file_stream.intermediate_file_stream = &tmp_data_disk->createStream(intermediate_header);
+        }
+        flush_bytes += flushBlocksInfoDisk(file_stream.intermediate_file_stream, file_stream.intermediate_blocks);
+    }
+    total_spill_disk_bytes += flush_bytes;
+    total_spill_disk_time += watch.elapsedMilliseconds();
+    return flush_bytes;
+}
+
+std::unique_ptr<AggregateDataBlockConverter> GraceAggregatingTransform::prepareBucketOutputBlocks(size_t bucket_index)
+{
+    auto & buffer_file_stream = buckets[bucket_index];
+    if (!current_data_variants && !buffer_file_stream.intermediate_file_stream && buffer_file_stream.intermediate_blocks.empty()
+        && !buffer_file_stream.original_file_stream && buffer_file_stream.original_blocks.empty())
+    {
+        return nullptr;
+    }
+
+    size_t read_bytes = 0;
+    size_t read_rows = 0;
+    Stopwatch watch;
+
+    checkAndSetupCurrentDataVariants();
+
+    if (buffer_file_stream.intermediate_file_stream)
+    {
+        buffer_file_stream.intermediate_file_stream->finishWriting();
+        while (true)
+        {
+            auto block = buffer_file_stream.intermediate_file_stream->read();
+            if (!block.rows())
+                break;
+            read_bytes += block.bytes();
+            read_rows += block.rows();
+            mergeOneBlock(block, false);
+            block = {};
+        }
+        buffer_file_stream.intermediate_file_stream = nullptr;
+        total_read_disk_time += watch.elapsedMilliseconds();
+    }
+    if (!buffer_file_stream.intermediate_blocks.empty())
+    {
+        for (auto & block : buffer_file_stream.intermediate_blocks)
+        {
+            mergeOneBlock(block, false);
+            block = {};
+        }
+    }
+
+    if (buffer_file_stream.original_file_stream)
+    {
+        buffer_file_stream.original_file_stream->finishWriting();
+        while (true)
+        {
+            auto block = buffer_file_stream.original_file_stream->read();
+            if (!block.rows())
+                break;
+            read_bytes += block.bytes();
+            read_rows += block.rows();
+            mergeOneBlock(block, true);
+            block = {};
+        }
+        buffer_file_stream.original_file_stream = nullptr;
+        total_read_disk_time += watch.elapsedMilliseconds();
+    }
+    if (!buffer_file_stream.original_blocks.empty())
+    {
+        for (auto & block : buffer_file_stream.original_blocks)
+        {
+            mergeOneBlock(block, true);
+            block = {};
+        }
+    }
+
+    auto last_data_variants_size = current_data_variants->size();
+    auto converter = currentDataVariantToBlockConverter(final_output);
+    LOG_INFO(
+        logger,
+        "prepare to output bucket {}, aggregated result keys: {}, keys size: {}, read bytes from disk: {}, read rows: {}, time: {} ms",
+        bucket_index,
+        last_data_variants_size,
+        params->params.keys_size,
+        ReadableSize(read_bytes),
+        read_rows,
+        watch.elapsedMilliseconds());
+    return std::move(converter);
+}
+
+std::unique_ptr<AggregateDataBlockConverter> GraceAggregatingTransform::currentDataVariantToBlockConverter(bool final)
+{
+    if (!current_data_variants)
+    {
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "current data variants is null");
+    }
+    auto converter = std::make_unique<AggregateDataBlockConverter>(params->aggregator, current_data_variants, final);
+    current_data_variants = nullptr;
+    return std::move(converter);
+}
+
+void GraceAggregatingTransform::checkAndSetupCurrentDataVariants()
+{
+    if (!current_data_variants)
+    {
+        current_data_variants = std::make_shared<DB::AggregatedDataVariants>();
+        no_more_keys = false;
+    }
+}
+
+void GraceAggregatingTransform::mergeOneBlock(const DB::Block &block, bool is_original_block)
+{
+    if (!block.rows())
+        return;
+
+    checkAndSetupCurrentDataVariants();
+
+    // first to flush pending bytes into disk.
+    if (isMemoryOverflow())
+        flushBuckets();
+    // then try to extend buckets.
+    if (isMemoryOverflow() && extendBuckets())
+    {
+        rehashDataVariants();
+    }
+
+    LOG_DEBUG(
+        logger,
+        "merge on block, rows: {}, bytes:{}, bucket: {}. current bucket: {}, total bucket: {}, mem used: {}",
+        block.rows(),
+        ReadableSize(block.bytes()),
+        block.info.bucket_num,
+        current_bucket_index,
+        getBucketsNum(),
+        ReadableSize(currentThreadGroupMemoryUsage()));
+
+    /// the block could be one read from disk. block.info.bucket_num stores the number of buckets when it was scattered.
+    /// so if the buckets number is not changed since it was scattered, we don't need to scatter it again.
+    if (block.info.bucket_num == static_cast<Int32>(getBucketsNum()) || getBucketsNum() == 1)
+    {
+        if (is_original_block && no_pre_aggregated)
+            params->aggregator.executeOnBlock(block, *current_data_variants, key_columns, aggregate_columns, no_more_keys);
+        else
+            params->aggregator.mergeOnBlock(block, *current_data_variants, no_more_keys, is_cancelled);
+    }
+    else
+    {
+        auto bucket_num = block.info.bucket_num;
+        auto scattered_blocks = scatterBlock(block);
+        for (size_t i = 0; i < current_bucket_index; ++i)
+        {
+            if (scattered_blocks[i].rows())
+            {
+                throw DB::Exception(
+                    DB::ErrorCodes::LOGICAL_ERROR,
+                    "Scattered blocks should not belong to buckets with index({}) < current_bucket_index({}). bucket_num:{}. "
+                    "scattered_blocks.size: {}, total buckets: {}",
+                    i,
+                    current_bucket_index,
+                    bucket_num,
+                    scattered_blocks.size(),
+                    getBucketsNum());
+            }
+        }
+        for (size_t i = current_bucket_index + 1; i < getBucketsNum(); ++i)
+        {
+            addBlockIntoFileBucket(i, scattered_blocks[i], is_original_block);
+        }
+
+        if (is_original_block && no_pre_aggregated)
+        {
+            params->aggregator.executeOnBlock(scattered_blocks[current_bucket_index], *current_data_variants, key_columns, aggregate_columns, no_more_keys);
+        }
+        else
+        {
+            params->aggregator.mergeOnBlock(scattered_blocks[current_bucket_index], *current_data_variants, no_more_keys, is_cancelled);
+        }
+    }
+}
+
+bool GraceAggregatingTransform::isMemoryOverflow()
+{
+    /// More greedy memory usage strategy.
+    if (!current_data_variants)
+        return false;
+
+    auto memory_soft_limit = DB::CurrentThread::getGroup()->memory_tracker.getSoftLimit();
+    if (!memory_soft_limit)
+        return false;
+    auto max_mem_used = static_cast<size_t>(memory_soft_limit * max_allowed_memory_usage_ratio);
+    auto current_result_rows = current_data_variants->size();
+    auto current_mem_used = currentThreadGroupMemoryUsage();
+    if (per_key_memory_usage > 0)
+    {
+        if (current_mem_used + per_key_memory_usage * current_result_rows >= max_mem_used)
+        {
+            LOG_INFO(
+                logger,
+                "Memory is overflow. current_mem_used: {}, max_mem_used: {}, per_key_memory_usage: {}, aggregator keys: {}, buckets: {}, hash table type: {}",
+                ReadableSize(current_mem_used),
+                ReadableSize(max_mem_used),
+                ReadableSize(per_key_memory_usage),
+                current_result_rows,
+                getBucketsNum(),
+                current_data_variants->type);
+            return true;
+        }
+    }
+    else
+    {
+        if (current_mem_used * 2 >= max_mem_used)
+        {
+            LOG_INFO(
+                logger,
+                "Memory is overflow on half of max usage. current_mem_used: {}, max_mem_used: {}, aggregator keys: {}, buckets: {}, hash table type: {}",
+                ReadableSize(current_mem_used),
+                ReadableSize(max_mem_used),
+                current_result_rows,
+                getBucketsNum(),
+                current_data_variants->type);
+            return true;
+        }
+    }
+    return false;
+}
+
+}

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.h
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.h
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Core/Block.h>
+#include <Interpreters/JoinUtils.h>
+#include <Interpreters/Aggregator.h>
+#include <Interpreters/Context.h>
+#include <Processors/Chunk.h>
+#include <Processors/IProcessor.h>
+#include <Processors/Port.h>
+#include <Processors/QueryPlan/ITransformingStep.h>
+#include <Processors/Transforms/AggregatingTransform.h>
+#include <Poco/Logger.h>
+#include <Common/AggregateUtil.h>
+#include <Common/logger_useful.h>
+
+namespace local_engine
+{
+/**
+ * GraceAggregatingTransform is use to aggregate original data or merging intermediate aggregating result. It support spilling data into disk
+ * when the memory usage is over limit.
+ * If the input data is original data, no_pre_aggregated is true. If it's intermediate aggregating result, no_pre_aggregated is false.
+ * IF the output data is final aggregating result, final is true, otherwise it false.
+ */
+class GraceAggregatingTransform : public DB::IProcessor
+{
+public:
+    using Status = DB::IProcessor::Status;
+    explicit GraceAggregatingTransform(const DB::Block &header_, DB::AggregatingTransformParamsPtr params_, DB::ContextPtr context_, bool no_pre_aggregated_, bool final_output_);
+    ~GraceAggregatingTransform() override;
+
+    Status prepare() override;
+    void work() override;
+    String getName() const override { return "GraceAggregatingTransform"; }
+private:
+    bool no_pre_aggregated;
+    bool final_output;
+    DB::Block header;
+    DB::ColumnRawPtrs key_columns;
+    DB::Aggregator::AggregateColumns aggregate_columns;
+    DB::AggregatingTransformParamsPtr params;
+    DB::ContextPtr context;
+    DB::TemporaryDataOnDiskPtr tmp_data_disk;
+    DB::AggregatedDataVariantsPtr current_data_variants = nullptr;
+    size_t current_bucket_index = 0;
+    
+    /// Followings are configurations defined in context config.
+    // max buckets number, default is 32
+    size_t max_buckets = 0;
+    // If the buckets number is overflow the max_buckets, throw exception or not.
+    bool throw_on_overflow_buckets = false;
+    // Even the memory usage has reached the limit, we still allow to aggregate some more keys before
+    // extend the buckets.
+    size_t aggregated_keys_before_extend_buckets = 8196;
+    // The ratio of memory usage to the total memory usage of the whole query.
+    double max_allowed_memory_usage_ratio = 0.9;
+    // configured by max_pending_flush_blocks_per_grace_merging_bucket
+    size_t max_pending_flush_blocks_per_bucket = 0;
+
+    struct BufferFileStream
+    {
+        /// store the intermediate result blocks.
+        std::list<DB::Block> intermediate_blocks;
+        /// Only be used when there is no pre-aggregated step, store the original input blocks.
+        std::list<DB::Block> original_blocks;
+        /// store the intermediate result blocks.
+        DB::TemporaryFileStream * intermediate_file_stream = nullptr;
+        /// Only be used when there is no pre-aggregated step
+        DB::TemporaryFileStream * original_file_stream = nullptr;
+        size_t pending_bytes = 0;
+    };
+    std::unordered_map<size_t, BufferFileStream> buckets;
+
+    size_t getBucketsNum() const { return buckets.size(); }
+    bool extendBuckets();
+    void rehashDataVariants();
+    DB::Blocks scatterBlock(const DB::Block & block);
+    /// Add a block into a bucket, if the pending bytes reaches limit, flush it into disk.
+    void addBlockIntoFileBucket(size_t bucket_index, const DB::Block & block, bool is_original_block);
+    void flushBuckets();
+    size_t flushBucket(size_t bucket_index);
+    /// Load blocks from disk and merge them into a new hash table, make a new AggregateDataBlockConverter
+    /// to generate output blocks.
+    std::unique_ptr<AggregateDataBlockConverter> prepareBucketOutputBlocks(size_t bucket);
+    /// Pass current_final_blocks into a new AggregateDataBlockConverter to generate output blocks.
+    std::unique_ptr<AggregateDataBlockConverter> currentDataVariantToBlockConverter(bool final);
+    void checkAndSetupCurrentDataVariants();
+    /// Merge one block into current_data_variants.
+    void mergeOneBlock(const DB::Block &block, bool is_original_block);
+    bool isMemoryOverflow();
+
+    bool input_finished = false;
+    bool has_input = false;
+    DB::Chunk input_chunk;
+    bool has_output = false;
+    DB::Chunk output_chunk;
+    DB::BlocksList current_final_blocks;
+    std::unique_ptr<AggregateDataBlockConverter> block_converter = nullptr;
+    bool no_more_keys = false;
+
+    double per_key_memory_usage = 0;
+
+    // metrics
+    size_t total_input_blocks = 0;
+    size_t total_input_rows = 0;
+    size_t total_output_blocks = 0;
+    size_t total_output_rows = 0;
+    size_t total_spill_disk_bytes = 0;
+    size_t total_spill_disk_time = 0;
+    size_t total_read_disk_time = 0;
+    size_t total_scatter_time = 0;
+
+    Poco::Logger * logger = &Poco::Logger::get("GraceMergingAggregatedTransform");
+};
+}

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.h
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.h
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 #include <Core/Block.h>
-#include <Interpreters/JoinUtils.h>
 #include <Interpreters/Aggregator.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/JoinUtils.h>
 #include <Processors/Chunk.h>
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>
@@ -39,16 +39,23 @@ class GraceAggregatingTransform : public DB::IProcessor
 {
 public:
     using Status = DB::IProcessor::Status;
-    explicit GraceAggregatingTransform(const DB::Block &header_, DB::AggregatingTransformParamsPtr params_, DB::ContextPtr context_, bool no_pre_aggregated_, bool final_output_);
+    explicit GraceAggregatingTransform(
+        const DB::Block & header_,
+        DB::AggregatingTransformParamsPtr params_,
+        DB::ContextPtr context_,
+        bool no_pre_aggregated_,
+        bool final_output_);
     ~GraceAggregatingTransform() override;
 
     Status prepare() override;
     void work() override;
     String getName() const override { return "GraceAggregatingTransform"; }
+
 private:
     bool no_pre_aggregated;
     bool final_output;
     DB::Block header;
+    DB::Block output_header;
     DB::ColumnRawPtrs key_columns;
     DB::Aggregator::AggregateColumns aggregate_columns;
     DB::AggregatingTransformParamsPtr params;
@@ -56,7 +63,7 @@ private:
     DB::TemporaryDataOnDiskPtr tmp_data_disk;
     DB::AggregatedDataVariantsPtr current_data_variants = nullptr;
     size_t current_bucket_index = 0;
-    
+
     /// Followings are configurations defined in context config.
     // max buckets number, default is 32
     size_t max_buckets = 0;
@@ -99,7 +106,7 @@ private:
     std::unique_ptr<AggregateDataBlockConverter> currentDataVariantToBlockConverter(bool final);
     void checkAndSetupCurrentDataVariants();
     /// Merge one block into current_data_variants.
-    void mergeOneBlock(const DB::Block &block, bool is_original_block);
+    void mergeOneBlock(const DB::Block & block, bool is_original_block);
     bool isMemoryOverflow();
 
     bool input_finished = false;

--- a/cpp-ch/local-engine/Parser/AdvancedParametersParseUtil.cpp
+++ b/cpp-ch/local-engine/Parser/AdvancedParametersParseUtil.cpp
@@ -148,6 +148,16 @@ JoinOptimizationInfo JoinOptimizationInfo::parse(const String & advance)
     return info;
 }
 
+AggregateOptimizationInfo AggregateOptimizationInfo::parse(const String & advance)
+{
+    AggregateOptimizationInfo info;
+    auto kkvs = convertToKVs(advance);
+    auto & kvs = kkvs["AggregateParams"];
+    tryAssign(kvs, "hasPrePartialAggregate", info.has_pre_partial_aggregate);
+    tryAssign(kvs, "hasRequiredChildDistributionExpressions", info.has_required_child_distribution_expressions);
+    return info;
+}
+
 WindowGroupOptimizationInfo WindowGroupOptimizationInfo::parse(const String & advance)
 {
     WindowGroupOptimizationInfo info;

--- a/cpp-ch/local-engine/Parser/AdvancedParametersParseUtil.h
+++ b/cpp-ch/local-engine/Parser/AdvancedParametersParseUtil.h
@@ -39,6 +39,13 @@ struct JoinOptimizationInfo
     static JoinOptimizationInfo parse(const String & advance);
 };
 
+struct AggregateOptimizationInfo
+{
+    bool has_pre_partial_aggregate = false;
+    bool has_required_child_distribution_expressions = false;
+    static AggregateOptimizationInfo parse(const String & advance);
+};
+
 struct WindowGroupOptimizationInfo
 {
     String window_function;

--- a/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.h
@@ -56,6 +56,7 @@ private:
     bool has_final_stage = false;
     bool has_complete_stage = false;
 
+    std::list<const substrait::Rel *> * rel_stack;
     DB::QueryPlanPtr plan = nullptr;
     const substrait::AggregateRel * aggregate_rel = nullptr;
     std::vector<AggregateInfo> aggregates;

--- a/cpp-ch/local-engine/Parser/RelParsers/RelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/RelParser.cpp
@@ -95,42 +95,6 @@ RelParser::parse(std::vector<DB::QueryPlanPtr> & input_plans_, const substrait::
     return parse(std::move(input_plans_[0]), rel, rel_stack_);
 }
 
-std::map<std::string, std::string>
-RelParser::parseFormattedRelAdvancedOptimization(const substrait::extensions::AdvancedExtension & advanced_extension)
-{
-    std::map<std::string, std::string> configs;
-    if (advanced_extension.has_optimization())
-    {
-        google::protobuf::StringValue msg;
-        advanced_extension.optimization().UnpackTo(&msg);
-        Poco::StringTokenizer kvs(msg.value(), "\n");
-        for (auto & kv : kvs)
-        {
-            if (kv.empty())
-                continue;
-            auto pos = kv.find('=');
-            if (pos == std::string::npos)
-            {
-                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid optimization config:{}.", kv);
-            }
-            auto key = kv.substr(0, pos);
-            auto value = kv.substr(pos + 1);
-            configs[key] = value;
-        }
-    }
-    return configs;
-}
-
-std::string
-RelParser::getStringConfig(const std::map<std::string, std::string> & configs, const std::string & key, const std::string & default_value)
-{
-    auto it = configs.find(key);
-    if (it == configs.end())
-        return default_value;
-    return it->second;
-}
-
-
 RelParserFactory & RelParserFactory::instance()
 {
     static RelParserFactory factory;

--- a/cpp-ch/local-engine/Parser/RelParsers/RelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/RelParser.h
@@ -88,11 +88,6 @@ protected:
         return plan_parser->toFunctionNode(action_dag, function, args);
     }
 
-    static std::map<std::string, std::string>
-    parseFormattedRelAdvancedOptimization(const substrait::extensions::AdvancedExtension & advanced_extension);
-    static std::string
-    getStringConfig(const std::map<std::string, std::string> & configs, const std::string & key, const std::string & default_value = "");
-
     SerializedPlanParser * plan_parser;
 };
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #7311 

For aggregations involve `distinct`, use grace aggregate algorithm in partial aggregating stages, instead of streaming aggregating algorithm.

Following changes are made
1. introduce `GraceAggregatingStep`. It bases on codes of `GraceMergingAggregatedStep`, and supports to generate intermediate result.
2. Make `Aggregator` to support multiple aggregate phases, change is in https://github.com/Kyligence/ClickHouse/pull/504
3. Override `AggregateFunctionPartialMerge::getBaseAggregateFunctionWithSameStateRepresentation`, resolve the failure of checking columns structure equality in aggregate phase `INTERMEDIATE_TO_INTERMEDIATE`
4. Keep `requiredChildDistributionExpressions` in `MergeTwoPhasesHashBaseAggregate` that we can determine whether a aggregate step is in completed mode.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

 unit tests,  manual tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

