### PR TITLE
[GLUTEN-7327][INFRA] Publish Velox Backend Test Result Report in Github Action

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Report test results
+on:
+  workflow_run:
+    workflows: ["Velox backend Github Runner"]
+    types:
+      - completed
+
+jobs:
+  test_report:
+    if: github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
+    steps:
+    - name: Download test results to report
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # pin @v6
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        commit: ${{ github.event.workflow_run.head_commit.id }}
+        workflow_conclusion: completed
+    - name: Publish test report
+      uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 # pin @v1.8.0
+      with:
+        check_name: Report test results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        report_paths: "**/surefire-reports/TEST-*.xml"
+        commit: ${{ github.event.workflow_run.head_commit.id }}

--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -617,12 +617,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.2 -Pspark-ut -Pbackends-velox -Pceleborn -Piceberg \
           -Pdelta -Phudi -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark32/spark_home/" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags
-      - name: Upload golden files
-        if: failure()
+      - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: golden-files-spark32
-          path: /tmp/tpch-approved-plan/**
+          name: test-report-spark32
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-spark-test-spark32-slow:
     needs: build-native-lib-centos-7
@@ -667,6 +667,12 @@ jobs:
           cd $GITHUB_WORKSPACE/
           $MVN_CMD clean test -Pspark-3.2 -Pspark-ut -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Phudi \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark32/spark_home/" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark32-slow
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-spark-test-spark33:
     needs: build-native-lib-centos-7
@@ -718,12 +724,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.3 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Phudi -Pspark-ut \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark33/spark_home/" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags
-      - name: Upload golden files
-        if: failure()
+      - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: golden-files-spark33
-          path: /tmp/tpch-approved-plan/**
+          name: test-report-spark33
+          path: '**/surefire-reports/TEST-*.xml'
 
 
   run-spark-test-spark33-slow:
@@ -770,6 +776,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.3 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Phudi -Pspark-ut \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark33/spark_home/" \
           -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark33-slow
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-spark-test-spark34:
     needs: build-native-lib-centos-7
@@ -821,12 +833,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.4 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Phudi -Pspark-ut \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark34/spark_home/" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags
-      - name: Upload golden files
-        if: failure()
+      - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: golden-files-spark34
-          path: /tmp/tpch-approved-plan/**
+          name: test-report-spark34
+          path: '**/surefire-reports/TEST-*.xml'
 
 
   run-spark-test-spark34-slow:
@@ -873,6 +885,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.4 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Pspark-ut -Phudi \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark34/spark_home/" \
           -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark34-slow
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-spark-test-spark35:
     needs: build-native-lib-centos-7
@@ -924,12 +942,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.5 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Phudi -Pspark-ut \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark35/spark_home/" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags
-      - name: Upload golden files
-        if: failure()
+      - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: golden-files-spark35
-          path: /tmp/tpch-approved-plan/**
+          name: test-report-spark35
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-spark-test-spark35-scala213:
     needs: build-native-lib-centos-7
@@ -981,6 +999,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.5 -Pscala-2.13 -Pbackends-velox -Pceleborn -Piceberg \
           -Pdelta -Pspark-ut -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark35/spark_home/" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark35-scala213
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-spark-test-spark35-slow:
     needs: build-native-lib-centos-7
@@ -1026,6 +1050,12 @@ jobs:
           $MVN_CMD clean test -Pspark-3.5 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Phudi -Pspark-ut \
           -DargLine="-Dspark.test.home=$GITHUB_WORKSPACE//shims/spark35/spark_home/" \
           -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark35-slow
+          path: '**/surefire-reports/TEST-*.xml'
 
   run-cpp-test-udf-test:
     runs-on: ubuntu-20.04

--- a/pom.xml
+++ b/pom.xml
@@ -875,6 +875,7 @@
           <artifactId>scalatest-maven-plugin</artifactId>
           <version>${scalatest-maven-plugin.version}</version>
           <configuration>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <testFailureIgnore>false</testFailureIgnore>
             <junitxml>.</junitxml>
           </configuration>


### PR DESCRIPTION

## What changes were proposed in this pull request?

This PR aims to use action-surefire-report to publish the test reports. With this feature, we can quickly see the failed tests and the information in the PR.

(Fixes: \#7327)

## How was this patch tested?

![image](https://github.com/user-attachments/assets/aeac7daa-cc5e-4d0c-aa7c-bbfddb0ff788)

