### PR TITLE
[VL] Fix vcpkg binary caching in docker image

### DIFF
--- a/.github/workflows/build_bundle_package.yml
+++ b/.github/workflows/build_bundle_package.yml
@@ -50,10 +50,9 @@ jobs:
           cd $GITHUB_WORKSPACE/ep/build-velox/src && \
           ./get_velox.sh && \
           source /opt/rh/devtoolset-9/enable && \
-          source /opt/gluten//dev/vcpkg/env.sh && \
           cd $GITHUB_WORKSPACE/ && \
           export NUM_THREADS=4
-          ./dev/builddeps-veloxbe.sh --build_tests=OFF  --build_benchmarks=OFF --enable_s3=OFF \
+          ./dev/builddeps-veloxbe.sh --enable_vcpkg=ON --build_tests=OFF  --build_benchmarks=OFF --enable_s3=OFF \
           --enable_gcs=OFF --enable_hdfs=ON --enable_abfs=OFF
       - name: Upload native libs
         uses: actions/upload-artifact@v2

--- a/dev/vcpkg/README.md
+++ b/dev/vcpkg/README.md
@@ -40,22 +40,12 @@ For unsupported linux distro, you can install the following packages from packag
 * openjdk 8
 * maven
 
-### Build and setup thirdparty depends
+### Build gluten + velox with vcpkg installed dependencies
 
-Simply run:
-
-``` sh
-source $GLUTEN_REPO/dev/vcpkg/env.sh
-```
-
-This script will install all static libraries into the `./vcpkg_installed/`
-directory and set the `$PATH` and `$CMAKE_TOOLCHAIN_FILE`.
-This make build systems to locate the binary tools and libraries.
-It will take about 15~30 minutes to download and build all dependencies from source.
-You can configure [binary cache](https://learn.microsoft.com/en-us/vcpkg/users/binarycaching) to accelerate the next setup.
-
-### Build gluten + velox
+With `--enable_vcpkg=ON`, the below script will install all static libraries into `./vcpkg_installed/`. And it will
+also set `$PATH` and `$CMAKE_TOOLCHAIN_FILE` to make CMake to locate the binary tools and libraries.
+You can configure [binary cache](https://learn.microsoft.com/en-us/vcpkg/users/binarycaching) to accelerate the build.
 
 ``` sh
-$GLUTEN_REPO/dev/buildbundle-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON
+$GLUTEN_REPO/dev/buildbundle-veloxbe.sh --enable_vcpkg=ON --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON
 ```

--- a/dev/vcpkg/docker/Dockerfile.gha
+++ b/dev/vcpkg/docker/Dockerfile.gha
@@ -27,6 +27,6 @@ ENV VCPKG_BINARY_SOURCES=clear;files,/var/cache/vcpkg,readwrite
 
 # Build arrow, then install the native libs to system paths and jar package to .m2/ directory.
 RUN cd /opt/gluten && source /opt/rh/devtoolset-9/enable && \
-    source ./dev/vcpkg/env.sh --build_tests=ON --enable_s3=ON --enable_gcs=ON \
-                              --enable_hdfs=ON --enable_abfs=ON && \
-    bash ./dev/builddeps-veloxbe.sh build_arrow && rm -rf /opt/gluten
+    bash ./dev/builddeps-veloxbe.sh --enable_vcpkg=ON --build_tests=ON --enable_s3=ON --enable_gcs=ON \
+                                    --enable_hdfs=ON --enable_abfs=ON  build_arrow && \
+    rm -rf /opt/gluten

--- a/dev/vcpkg/docker/Dockerfile.gha
+++ b/dev/vcpkg/docker/Dockerfile.gha
@@ -26,5 +26,7 @@ RUN mkdir -p /var/cache/vcpkg
 ENV VCPKG_BINARY_SOURCES=clear;files,/var/cache/vcpkg,readwrite
 
 # Build arrow, then install the native libs to system paths and jar package to .m2/ directory.
-RUN cd /opt/gluten && source /opt/rh/devtoolset-9/enable && source ./dev/vcpkg/env.sh && \
+RUN cd /opt/gluten && source /opt/rh/devtoolset-9/enable && \
+    source ./dev/vcpkg/env.sh --build_tests=ON --enable_s3=ON --enable_gcs=ON \
+                              --enable_hdfs=ON --enable_abfs=ON && \
     bash ./dev/builddeps-veloxbe.sh build_arrow && rm -rf /opt/gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since #7052, we need to enable all vcpkg features to generate binary cache in docker image, which can save CI build time.

## How was this patch tested?

Local test.

