### PR TITLE
[VL] Override nodename for IcebergScanTransformer

### DIFF
--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -80,6 +80,8 @@ case class IcebergScanTransformer(
   }
   // Needed for tests
   private[execution] def getKeyGroupPartitioning: Option[Seq[Expression]] = keyGroupedPartitioning
+
+  override def nodeName: String = "Iceberg" + super.nodeName
 }
 
 object IcebergScanTransformer {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Override nodename for IcebergScanTransformer to distinguish the nodename of BatchScanExecTransformer 

## How was this patch tested?

