### PR TITLE
[GLUTEN-7344][CH] Fix the error default database name and table name for the mergetree file format when using path based

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2Base.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2Base.scala
@@ -29,6 +29,8 @@ import java.{util => ju}
 
 trait ClickHouseTableV2Base {
 
+  val DEFAULT_DATABASE = "clickhouse_db"
+
   def deltaProperties(): ju.Map[String, String]
 
   def deltaCatalog(): Option[CatalogTable]
@@ -39,7 +41,7 @@ trait ClickHouseTableV2Base {
 
   lazy val dataBaseName = deltaCatalog
     .map(_.identifier.database.getOrElse("default"))
-    .getOrElse("clickhouse")
+    .getOrElse(DEFAULT_DATABASE)
 
   lazy val tableName = deltaCatalog
     .map(_.identifier.table)

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -83,7 +83,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
       (table.catalogTable.get.identifier.database.get, table.catalogTable.get.identifier.table)
     } else {
       // for file_format.`file_path`
-      ("default", "file_format")
+      (table.DEFAULT_DATABASE, table.deltaPath.toUri.getPath)
     }
     val engine = "MergeTree"
     val relativeTablePath = fileIndex.deltaLog.dataPath.toUri.getPath.substring(1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the error default database name and table name for the mergetree file format when using path based

Close #7344.


(Fixes: #7344)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

