### PR TITLE
[GLUTEN-6887][VL] Daily Update Velox Version (2024_09_26) 

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_09_25
+VELOX_BRANCH=2024_09_26
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -224,7 +224,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDecimalPrecisionSuite]
   enableSuite[GlutenStringFunctionsSuite]
   enableSuite[GlutenRegexpExpressionsSuite]
-    .excludeByPrefix("LIKE Pattern ESCAPE")
   enableSuite[GlutenNullExpressionsSuite]
   enableSuite[GlutenPredicateSuite]
   enableSuite[GlutenMathExpressionsSuite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -162,7 +162,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("random")
     .exclude("SPARK-9127 codegen with long seed")
   enableSuite[GlutenRegexpExpressionsSuite]
-    .excludeByPrefix("LIKE Pattern ESCAPE")
   enableSuite[GlutenSortShuffleSuite]
   enableSuite[GlutenSortOrderExpressionsSuite]
   enableSuite[GlutenStringExpressionsSuite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -140,7 +140,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("random")
     .exclude("SPARK-9127 codegen with long seed")
   enableSuite[GlutenRegexpExpressionsSuite]
-    .excludeByPrefix("LIKE Pattern ESCAPE")
   enableSuite[GlutenSortShuffleSuite]
   enableSuite[GlutenSortOrderExpressionsSuite]
   enableSuite[GlutenStringExpressionsSuite]

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -143,7 +143,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("random")
     .exclude("SPARK-9127 codegen with long seed")
   enableSuite[GlutenRegexpExpressionsSuite]
-    .excludeByPrefix("LIKE Pattern ESCAPE")
   enableSuite[GlutenSortShuffleSuite]
   enableSuite[GlutenSortOrderExpressionsSuite]
   enableSuite[GlutenStringExpressionsSuite]
@@ -884,11 +883,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenInnerJoinSuiteForceShjOff]
   enableSuite[GlutenOuterJoinSuiteForceShjOn]
   enableSuite[GlutenOuterJoinSuiteForceShjOff]
-    // Caused by Velox SMJ result mismatches with Spark.
-    .exclude("basic right outer join using SortMergeJoin (whole-stage-codegen off)")
-    .exclude("basic right outer join using SortMergeJoin (whole-stage-codegen on)")
-    .exclude("right outer join with unique keys using SortMergeJoin (whole-stage-codegen off)")
-    .exclude("right outer join with unique keys using SortMergeJoin (whole-stage-codegen on)")
   enableSuite[FallbackStrategiesSuite]
   enableSuite[GlutenBroadcastExchangeSuite]
   enableSuite[GlutenLocalBroadcastExchangeSuite]


### PR DESCRIPTION
Upstream Velox's New Commits:

```
9e1280a72 Provide custom comparison functions in TimestampWithTimezone (#11025)
50784a5a5 Fix skip custom escape (#11091)
5a6a7443c Make concat function throw when there are less than 2 arguments (#11076)
451825e47 Support custom comparison in VectorHasher (#11051)
cb6c262a1 Change locaton of TableScan::getOutput() 'should exit' check. (#11085)
367faf8e7 Support custom comparison in RowContainer (#11024)
50ee5223b Support custom comparison in ContainerRowSerde (#11023)
78b6c77db Fix ParquetReader initialize schema failed for ARRAY/MAP colum (#10681)
0dd3a5db4 Fix fast_float installation problems (#11056)
a59538ca3 CMake: Make the env variable precedence by default in set_with_default (#11070)
d20ca4bd2 Fix the issue of inaccurate statistical data for parquet-251 (#10823)
2bfc0eb7d Add spill metric spillExtractVectorTimeNanos (#11049)
c3c93bf60 Cleanup old shared arbitrator configs (#11046)
3a1a60af6 Refactor spilling for RowNumber (#11082)
08bca2a7e Fix DuckDB bundling and add support for DuckDB install on MacOS (#11069)
7483a762d Fix the right join result mismatch issue (#11027)
94b485f9c Add more test scenarios for makeScanSpec (#11080)
48f356710 Fix the case row index column only exists in remaining filters (#11078)
c5d0517ac Support custom comparison in Vectors (#11022)
```

