### PR TITLE
[GLUTEN-7356][CORE] Make GlutenConfig.GLUTEN_CONFIG_PREFIX private

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -48,7 +48,7 @@ import java.util.Locale
 import scala.util.control.Breaks.{break, breakable}
 
 class CHBackend extends SubstraitBackend {
-  override def name(): String = CHBackend.BACKEND_NAME
+  override def name(): String = CHConf.BACKEND_NAME
   override def batchType: Convention.BatchType = CHBatch
   override def buildInfo(): Backend.BuildInfo =
     Backend.BuildInfo("ClickHouse", CH_BRANCH, CH_COMMIT, "UNKNOWN")
@@ -60,10 +60,6 @@ class CHBackend extends SubstraitBackend {
   override def listenerApi(): ListenerApi = new CHListenerApi
   override def ruleApi(): RuleApi = new CHRuleApi
   override def settings(): BackendSettingsApi = CHBackendSettings
-}
-
-object CHBackend {
-  val BACKEND_NAME: String = CHConf.BACKEND_NAME
 }
 
 object CHBackendSettings extends BackendSettingsApi with Logging {

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriterFactory.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriterFactory.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.clickhouse.CHBackend
+import org.apache.gluten.backend.Backend
 
 import org.apache.spark.TaskContext
 import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
@@ -26,7 +26,7 @@ import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 
 class CHCelebornColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
-  override def backendName(): String = CHBackend.BACKEND_NAME
+  override def backendName(): String = Backend.get().name()
 
   override def createShuffleWriterInstance[K, V](
       shuffleId: Int,

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -533,7 +533,7 @@ object GlutenConfig {
   val GLUTEN_IAA_BACKEND_NAME = "iaa"
   val GLUTEN_IAA_SUPPORTED_CODEC: Set[String] = Set("gzip")
 
-  val GLUTEN_CONFIG_PREFIX = "spark.gluten.sql.columnar.backend."
+  private val GLUTEN_CONFIG_PREFIX = "spark.gluten.sql.columnar.backend."
 
   // Private Spark configs.
   val SPARK_ONHEAP_SIZE_KEY = "spark.executor.memory"


### PR DESCRIPTION
## What changes were proposed in this pull request?

After https://github.com/apache/incubator-gluten/pull/7265 and https://github.com/apache/incubator-gluten/pull/7279, we can make `GlutenConfig.GLUTEN_CONFIG_PREFIX` private to force use `GlutenConfig.prefixOf()`

In Clickhouse backend, please use `CHConf.prefixOf()`, `CHConf.runtimeConfig()` and `CHConf.runtimeSettings()`, I also remove `CHBackend.BACKEND_NAME` and use `Backend.get().name()` per #7265

(Fixes: \#7356)

## How was this patch tested?
Using existed UTs.

