### PR TITLE
[GLUTEN-7364][CORE] Simplify the RuleInjector

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -45,7 +45,7 @@ class CHRuleApi extends RuleApi {
 
 private object CHRuleApi {
   def injectSpark(injector: SparkInjector): Unit = {
-    // Regular Spark rules.
+    // Inject the regular Spark rules directly.
     injector.injectQueryStagePrepRule(FallbackBroadcastHashJoinPrepQueryStage.apply)
     injector.injectQueryStagePrepRule(spark => CHAQEPropagateEmptyRelation(spark))
     injector.injectParser(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -46,7 +46,7 @@ class VeloxRuleApi extends RuleApi {
 
 private object VeloxRuleApi {
   def injectSpark(injector: SparkInjector): Unit = {
-    // Regular Spark rules.
+    // Inject the regular Spark rules directly.
     injector.injectOptimizerRule(CollectRewriteRule.apply)
     injector.injectOptimizerRule(HLLRewriteRule.apply)
     injector.injectPostHocResolutionRule(ArrowConvertorRule.apply)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenSessionExtensions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenSessionExtensions.scala
@@ -23,9 +23,9 @@ import org.apache.spark.sql.SparkSessionExtensions
 
 private[gluten] class GlutenSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(exts: SparkSessionExtensions): Unit = {
-    val injector = new RuleInjector()
+    val injector = new RuleInjector(exts)
     Backend.get().injectRules(injector)
-    injector.inject(exts)
+    injector.inject()
   }
 }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/injector/GlutenInjector.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/injector/GlutenInjector.scala
@@ -35,8 +35,7 @@ class GlutenInjector private[injector] {
   val ras: RasInjector = new RasInjector()
 
   private[injector] def inject(extensions: SparkSessionExtensions): Unit = {
-    val ruleBuilder = (session: SparkSession) => new GlutenColumnarRule(session, applier)
-    extensions.injectColumnar(session => ruleBuilder(session))
+    extensions.injectColumnar(session => new GlutenColumnarRule(session, applier))
   }
 
   private def applier(session: SparkSession): ColumnarRuleApplier = {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/injector/RuleInjector.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/injector/RuleInjector.scala
@@ -19,12 +19,13 @@ package org.apache.gluten.extension.injector
 import org.apache.spark.sql.SparkSessionExtensions
 
 /** Injector used to inject query planner rules into Spark and Gluten. */
-class RuleInjector {
-  val spark: SparkInjector = new SparkInjector()
+class RuleInjector(extensions: SparkSessionExtensions) {
+  val spark: SparkInjector = new SparkInjector(extensions)
   val gluten: GlutenInjector = new GlutenInjector()
 
-  private[extension] def inject(extensions: SparkSessionExtensions): Unit = {
-    spark.inject(extensions)
+  private[extension] def inject(): Unit = {
+    // The regular Spark rules already injected with the `injectRules` of `RuleApi` directly.
+    // Only inject the Spark columnar rule here.
     gluten.inject(extensions)
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/RuleApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/RuleApi.scala
@@ -19,6 +19,6 @@ package org.apache.gluten.backendsapi
 import org.apache.gluten.extension.injector.RuleInjector
 
 trait RuleApi {
-  // Injects all Gluten / Spark query planner rules used by the backend.
+  // Injects all Spark query planner rules used by the Gluten backend.
   def injectRules(injector: RuleInjector): Unit
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to simplify the `RuleInjector`.
The change increases the readability. There are two change.

1. Avoid copy code from `SparkSessionExtensions` and simplify the `SparkInjector`.  The related `RuleApi` also updated. In fact, we can remove the `SparkInjector`, but I suspect it already became the public API.
2. Simplify the `GlutenInjector`.

## How was this patch tested?

integration tests

