### PR TITLE
[GLUTEN-7313][VL] Explicit Arrow transitions, part 2: new algorithm to find optimal transition

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -49,7 +49,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 class CHBackend extends SubstraitBackend {
   override def name(): String = CHConf.BACKEND_NAME
-  override def batchType: Convention.BatchType = CHBatch
+  override def defaultBatchType: Convention.BatchType = CHBatch
   override def buildInfo(): Backend.BuildInfo =
     Backend.BuildInfo("ClickHouse", CH_BRANCH, CH_COMMIT, "UNKNOWN")
   override def iteratorApi(): IteratorApi = new CHIteratorApi

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.backendsapi.clickhouse
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.ListenerApi
+import org.apache.gluten.columnarbatch.CHBatch
 import org.apache.gluten.execution.CHBroadcastBuildSideCache
 import org.apache.gluten.execution.datasource.{GlutenOrcWriterInjects, GlutenParquetWriterInjects, GlutenRowSplitter}
 import org.apache.gluten.expression.UDFMappings
@@ -68,6 +69,8 @@ class CHListenerApi extends ListenerApi with Logging {
   override def onExecutorShutdown(): Unit = shutdown()
 
   private def initialize(conf: SparkConf, isDriver: Boolean): Unit = {
+    // Force batch type initializations.
+    CHBatch.getClass
     SparkDirectoryUtil.init(conf)
     val libPath = conf.get(GlutenConfig.GLUTEN_LIB_PATH, StringUtils.EMPTY)
     if (StringUtils.isBlank(libPath)) {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/columnarbatch/CHBatch.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/columnarbatch/CHBatch.scala
@@ -23,8 +23,9 @@ import org.apache.spark.sql.execution.{CHColumnarToRowExec, RowToCHNativeColumna
 /**
  * ClickHouse batch convention.
  *
- * [[fromRow]] and [[toRow]] need a [[TransitionDef]] instance. The scala allows an compact way to
- * implement trait using a lambda function.
+ * [[fromRow]] and [[toRow]] need a
+ * [[org.apache.gluten.extension.columnar.transition.TransitionDef]] instance. The scala allows an
+ * compact way to implement trait using a lambda function.
  *
  * Here the detail definition is given in [[CHBatch.fromRow]].
  * {{{

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -25,7 +25,7 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.ValidationResult
-import org.apache.gluten.extension.columnar.transition.Convention
+import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc, ConventionReq}
 import org.apache.gluten.extension.columnar.transition.ConventionFunc.BatchOverride
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, CumeDist, DenseRank, De
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, ApproximatePercentile}
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.execution.ColumnarCachedBatchSerializer
+import org.apache.spark.sql.execution.{ColumnarCachedBatchSerializer, SparkPlan}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand
 import org.apache.spark.sql.execution.datasources.{FileFormat, InsertIntoHadoopFsRelationCommand}
@@ -51,14 +51,10 @@ import org.apache.hadoop.fs.Path
 import scala.util.control.Breaks.breakable
 
 class VeloxBackend extends SubstraitBackend {
+  import VeloxBackend._
   override def name(): String = VeloxBackend.BACKEND_NAME
   override def batchType: Convention.BatchType = VeloxBatch
-  override def batchTypeFunc(): BatchOverride = {
-    case i: InMemoryTableScanExec
-        if i.supportsColumnar && i.relation.cacheBuilder.serializer
-          .isInstanceOf[ColumnarCachedBatchSerializer] =>
-      VeloxBatch
-  }
+  override def convFuncOverride(): ConventionFunc.Override = new ConvFunc()
   override def buildInfo(): Backend.BuildInfo =
     Backend.BuildInfo("Velox", VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME)
   override def iteratorApi(): IteratorApi = new VeloxIteratorApi
@@ -74,6 +70,17 @@ class VeloxBackend extends SubstraitBackend {
 object VeloxBackend {
   val BACKEND_NAME: String = "velox"
   val CONF_PREFIX: String = GlutenConfig.prefixOf(BACKEND_NAME)
+
+  private class ConvFunc() extends ConventionFunc.Override {
+    override def rowTypeOf: PartialFunction[SparkPlan, Convention.RowType] = PartialFunction.empty
+    override def batchTypeOf: PartialFunction[SparkPlan, Convention.BatchType] = {
+      case i: InMemoryTableScanExec
+          if i.supportsColumnar && i.relation.cacheBuilder.serializer
+            .isInstanceOf[ColumnarCachedBatchSerializer] =>
+        VeloxBatch
+    }
+    override def conventionReqOf: PartialFunction[SparkPlan, ConventionReq] = PartialFunction.empty
+  }
 }
 
 object VeloxBackendSettings extends BackendSettingsApi {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -25,8 +25,7 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.ValidationResult
-import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc, ConventionReq}
-import org.apache.gluten.extension.columnar.transition.ConventionFunc.BatchOverride
+import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc}
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -52,7 +52,7 @@ import scala.util.control.Breaks.breakable
 class VeloxBackend extends SubstraitBackend {
   import VeloxBackend._
   override def name(): String = VeloxBackend.BACKEND_NAME
-  override def batchType: Convention.BatchType = VeloxBatch
+  override def defaultBatchType: Convention.BatchType = VeloxBatch
   override def convFuncOverride(): ConventionFunc.Override = new ConvFunc()
   override def buildInfo(): Backend.BuildInfo =
     Backend.BuildInfo("Velox", VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME)

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -72,14 +72,12 @@ object VeloxBackend {
   val CONF_PREFIX: String = GlutenConfig.prefixOf(BACKEND_NAME)
 
   private class ConvFunc() extends ConventionFunc.Override {
-    override def rowTypeOf: PartialFunction[SparkPlan, Convention.RowType] = PartialFunction.empty
     override def batchTypeOf: PartialFunction[SparkPlan, Convention.BatchType] = {
       case i: InMemoryTableScanExec
           if i.supportsColumnar && i.relation.cacheBuilder.serializer
             .isInstanceOf[ColumnarCachedBatchSerializer] =>
         VeloxBatch
     }
-    override def conventionReqOf: PartialFunction[SparkPlan, ConventionReq] = PartialFunction.empty
   }
 }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -18,6 +18,8 @@ package org.apache.gluten.backendsapi.velox
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.ListenerApi
+import org.apache.gluten.columnarbatch.ArrowBatches.{ArrowJavaBatch, ArrowNativeBatch}
+import org.apache.gluten.columnarbatch.VeloxBatch
 import org.apache.gluten.execution.datasource.{GlutenOrcWriterInjects, GlutenParquetWriterInjects, GlutenRowSplitter}
 import org.apache.gluten.expression.UDFMappings
 import org.apache.gluten.init.NativeBackendInitializer
@@ -119,6 +121,12 @@ class VeloxListenerApi extends ListenerApi with Logging {
   override def onExecutorShutdown(): Unit = shutdown()
 
   private def initialize(conf: SparkConf): Unit = {
+    // Force batch type initializations.
+    VeloxBatch.getClass
+    ArrowJavaBatch.getClass
+    ArrowNativeBatch.getClass
+
+    // Sets this configuration only once, since not undoable.
     if (conf.getBoolean(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE, defaultValue = false)) {
       val debugDir = conf.get(GlutenConfig.GLUTEN_DEBUG_KEEP_JNI_WORKSPACE_DIR)
       JniWorkspace.enableDebug(debugDir)

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
@@ -198,10 +198,6 @@ class VeloxTransitionSuite extends SharedSparkSession {
   }
 
   override protected def beforeAll(): Unit = {
-    // Force object initializations.
-    VeloxBatch.getClass
-    ArrowJavaBatch.getClass
-    ArrowNativeBatch.getClass
     api.onExecutorStart(MockVeloxBackend.mockPluginContext())
     super.beforeAll()
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
@@ -92,11 +92,12 @@ class VeloxTransitionSuite extends SharedSparkSession {
 
   test("Vanilla-to-ArrowNative C2C") {
     val in = BatchUnary(ArrowNativeBatch, BatchLeaf(VanillaBatch))
-    assertThrows[GlutenException] {
-      // No viable transitions.
-      // FIXME: Support this case.
-      Transitions.insertTransitions(in, outputsColumnar = false)
-    }
+    val out = Transitions.insertTransitions(in, outputsColumnar = false)
+    assert(
+      out == ColumnarToRowExec(
+        LoadArrowDataExec(BatchUnary(
+          ArrowNativeBatch,
+          RowToVeloxColumnarExec(ColumnarToRowExec(BatchLeaf(VanillaBatch)))))))
   }
 
   test("ArrowNative-to-Vanilla C2C") {
@@ -121,11 +122,10 @@ class VeloxTransitionSuite extends SharedSparkSession {
 
   test("ArrowJava R2C - requires Arrow input") {
     val in = BatchUnary(ArrowJavaBatch, RowLeaf())
-    assertThrows[GlutenException] {
-      // No viable transitions.
-      // FIXME: Support this case.
-      Transitions.insertTransitions(in, outputsColumnar = false)
-    }
+    val out = Transitions.insertTransitions(in, outputsColumnar = false)
+    assert(
+      out == ColumnarToRowExec(
+        BatchUnary(ArrowJavaBatch, LoadArrowDataExec(RowToVeloxColumnarExec(RowLeaf())))))
   }
 
   test("ArrowJava-to-Velox C2C") {
@@ -146,11 +146,12 @@ class VeloxTransitionSuite extends SharedSparkSession {
 
   test("Vanilla-to-ArrowJava C2C") {
     val in = BatchUnary(ArrowJavaBatch, BatchLeaf(VanillaBatch))
-    assertThrows[GlutenException] {
-      // No viable transitions.
-      // FIXME: Support this case.
-      Transitions.insertTransitions(in, outputsColumnar = false)
-    }
+    val out = Transitions.insertTransitions(in, outputsColumnar = false)
+    assert(
+      out == ColumnarToRowExec(
+        BatchUnary(
+          ArrowJavaBatch,
+          LoadArrowDataExec(RowToVeloxColumnarExec(ColumnarToRowExec(BatchLeaf(VanillaBatch)))))))
   }
 
   test("ArrowJava-to-Vanilla C2C") {
@@ -195,8 +196,7 @@ class VeloxTransitionSuite extends SharedSparkSession {
     val in = BatchUnary(VanillaBatch, BatchLeaf(VeloxBatch))
     val out = Transitions.insertTransitions(in, outputsColumnar = false)
     assert(
-      out == ColumnarToRowExec(
-        BatchUnary(VanillaBatch, RowToColumnarExec(VeloxColumnarToRowExec(BatchLeaf(VeloxBatch))))))
+      out == ColumnarToRowExec(BatchUnary(VanillaBatch, LoadArrowDataExec(BatchLeaf(VeloxBatch)))))
   }
 
   override protected def beforeAll(): Unit = {

--- a/gluten-core/src/main/scala/org/apache/gluten/backend/Backend.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backend/Backend.scala
@@ -45,9 +45,10 @@ trait Backend {
   /**
    * Overrides [[org.apache.gluten.extension.columnar.transition.ConventionFunc]] Gluten is using to
    * determine the convention (its row-based processing / columnar-batch processing support) of a
-   * plan with a user-defined function that accepts a plan then returns batch type it outputs.
+   * plan with a user-defined function that accepts a plan then returns convention type it outputs,
+   * and input conventions it requires.
    */
-  def batchTypeFunc(): ConventionFunc.BatchOverride = PartialFunction.empty
+  def convFuncOverride(): ConventionFunc.Override = ConventionFunc.Override.Empty
 
   /** Query planner rules. */
   def injectRules(injector: RuleInjector): Unit

--- a/gluten-core/src/main/scala/org/apache/gluten/backend/Backend.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backend/Backend.scala
@@ -39,8 +39,8 @@ trait Backend {
   def onExecutorStart(pc: PluginContext): Unit = {}
   def onExecutorShutdown(): Unit = {}
 
-  /** The columnar-batch type this backend is using. */
-  def batchType: Convention.BatchType
+  /** The columnar-batch type this backend is by default using. */
+  def defaultBatchType: Convention.BatchType
 
   /**
    * Overrides [[org.apache.gluten.extension.columnar.transition.ConventionFunc]] Gluten is using to

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -61,7 +61,9 @@ object Convention {
     Impl(rowType, batchType)
   }
 
-  sealed trait RowType
+  sealed trait RowType extends TransitionGraph.Vertex with Serializable {
+    Transition.graph.addVertex(this)
+  }
 
   object RowType {
     // None indicates that the plan doesn't support row-based processing.
@@ -69,23 +71,25 @@ object Convention {
     final case object VanillaRow extends RowType
   }
 
-  trait BatchType extends Serializable {
-    final def fromRow(transitionDef: TransitionDef): Unit = {
-      Transition.factory.update().defineFromRowTransition(this, transitionDef)
+  trait BatchType extends TransitionGraph.Vertex with Serializable {
+    Transition.graph.addVertex(this)
+
+    protected final def fromRow(transitionDef: TransitionDef): Unit = {
+      Transition.graph.addEdge(RowType.VanillaRow, this, transitionDef.create())
     }
 
-    final def toRow(transitionDef: TransitionDef): Unit = {
-      Transition.factory.update().defineToRowTransition(this, transitionDef)
+    protected final def toRow(transitionDef: TransitionDef): Unit = {
+      Transition.graph.addEdge(this, RowType.VanillaRow, transitionDef.create())
     }
 
-    final def fromBatch(from: BatchType, transitionDef: TransitionDef): Unit = {
+    protected final def fromBatch(from: BatchType, transitionDef: TransitionDef): Unit = {
       assert(from != this)
-      Transition.factory.update().defineBatchTransition(from, this, transitionDef)
+      Transition.graph.addEdge(from, this, transitionDef.create())
     }
 
-    final def toBatch(to: BatchType, transitionDef: TransitionDef): Unit = {
+    protected final def toBatch(to: BatchType, transitionDef: TransitionDef): Unit = {
       assert(to != this)
-      Transition.factory.update().defineBatchTransition(this, to, transitionDef)
+      Transition.graph.addEdge(this, to, transitionDef.create())
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -74,20 +74,20 @@ object Convention {
   trait BatchType extends TransitionGraph.Vertex with Serializable {
     Transition.graph.addVertex(this)
 
-    protected final def fromRow(transitionDef: TransitionDef): Unit = {
+    final protected def fromRow(transitionDef: TransitionDef): Unit = {
       Transition.graph.addEdge(RowType.VanillaRow, this, transitionDef.create())
     }
 
-    protected final def toRow(transitionDef: TransitionDef): Unit = {
+    final protected def toRow(transitionDef: TransitionDef): Unit = {
       Transition.graph.addEdge(this, RowType.VanillaRow, transitionDef.create())
     }
 
-    protected final def fromBatch(from: BatchType, transitionDef: TransitionDef): Unit = {
+    final protected def fromBatch(from: BatchType, transitionDef: TransitionDef): Unit = {
       assert(from != this)
       Transition.graph.addEdge(from, this, transitionDef.create())
     }
 
-    protected final def toBatch(to: BatchType, transitionDef: TransitionDef): Unit = {
+    final protected def toBatch(to: BatchType, transitionDef: TransitionDef): Unit = {
       assert(to != this)
       Transition.graph.addEdge(this, to, transitionDef.create())
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionFunc.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionFunc.scala
@@ -94,7 +94,7 @@ object ConventionFunc {
         val batchType = if (a.supportsColumnar) {
           // By default, we execute columnar AQE with backend batch output.
           // See org.apache.gluten.extension.columnar.transition.InsertTransitions.apply
-          Backend.get().batchType
+          Backend.get().defaultBatchType
         } else {
           Convention.BatchType.None
         }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionFunc.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionFunc.scala
@@ -33,19 +33,13 @@ sealed trait ConventionFunc {
 
 object ConventionFunc {
   trait Override {
-    def rowTypeOf: PartialFunction[SparkPlan, Convention.RowType]
-    def batchTypeOf: PartialFunction[SparkPlan, Convention.BatchType]
-    def conventionReqOf: PartialFunction[SparkPlan, ConventionReq]
+    def rowTypeOf: PartialFunction[SparkPlan, Convention.RowType] = PartialFunction.empty
+    def batchTypeOf: PartialFunction[SparkPlan, Convention.BatchType] = PartialFunction.empty
+    def conventionReqOf: PartialFunction[SparkPlan, ConventionReq] = PartialFunction.empty
   }
 
   object Override {
-    object Empty extends Override {
-      override def rowTypeOf: PartialFunction[SparkPlan, Convention.RowType] = PartialFunction.empty
-      override def batchTypeOf: PartialFunction[SparkPlan, Convention.BatchType] =
-        PartialFunction.empty
-      override def conventionReqOf: PartialFunction[SparkPlan, ConventionReq] =
-        PartialFunction.empty
-    }
+    object Empty extends Override
   }
 
   // For testing, to make things work without a backend loaded.

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionReq.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionReq.scala
@@ -58,7 +58,7 @@ object ConventionReq {
   val vanillaBatch: ConventionReq =
     Impl(RowType.Any, BatchType.Is(Convention.BatchType.VanillaBatch))
   lazy val backendBatch: ConventionReq =
-    Impl(RowType.Any, BatchType.Is(Backend.get().batchType))
+    Impl(RowType.Any, BatchType.Is(Backend.get().defaultBatchType))
 
   def get(plan: SparkPlan): ConventionReq = ConventionFunc.create().conventionReqOf(plan)
   def of(rowType: RowType, batchType: BatchType): ConventionReq = Impl(rowType, batchType)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.extension.columnar.transition
 import scala.collection.mutable
 
 /**
- * Floyd–Warshall algorithm for finding e.g., cheapest transition between query plan nodes.
+ * Floyd-Warshall algorithm for finding e.g., cheapest transition between query plan nodes.
  *
  * https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm
  */

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
@@ -31,7 +31,7 @@ trait FloydWarshallGraph[V <: AnyRef, E <: AnyRef] {
 
 object FloydWarshallGraph {
   trait Cost {
-    def :+(other: Cost): Cost
+    def +(other: Cost): Cost
   }
 
   trait CostModel[E <: AnyRef] {
@@ -54,7 +54,7 @@ object FloydWarshallGraph {
     private case class Impl[E <: AnyRef](override val edges: Seq[E])(costModel: CostModel[E])
       extends Path[E] {
       override val cost: Cost = {
-        edges.map(costModel.costOf).reduceOption(_ :+ _).getOrElse(costModel.zero())
+        edges.map(costModel.costOf).reduceOption(_ + _).getOrElse(costModel.zero())
       }
     }
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar.transition
+
+/**
+ * Floyd–Warshall algorithm for finding e.g., cheapest transition between query plan nodes.
+ *
+ * https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm
+ */
+trait FloydWarshallGraph[V <: AnyRef, E <: AnyRef] {
+  import FloydWarshallGraph._
+  def hasPath(from: V, to: V): Boolean
+  def pathOf(from: V, to: V): Path[E]
+}
+
+object FloydWarshallGraph {
+  trait Cost {
+    def :+(other: Cost): Cost
+  }
+
+  trait CostModel[E <: AnyRef] {
+    def costOf(edge: E): Cost
+    def costComparator(): Ordering[Cost]
+  }
+
+  trait Path[E <: AnyRef] {
+    def edges(): Seq[E]
+    def cost(): Cost
+  }
+
+  def builder[V <: AnyRef, E <: AnyRef](costModel: CostModel[E]): Builder[V, E] = {
+    Builder.create(costModel)
+  }
+
+  private object Path {
+    def apply[E <: AnyRef](edges: Seq[E], cost: Cost): Path[E] = new Impl(edges, cost)
+    private class Impl[E <: AnyRef](override val edges: Seq[E], override val cost: Cost)
+      extends Path[E]
+  }
+
+  private class Impl[V <: AnyRef, E <: AnyRef](pathTable: Map[V, Map[V, Path[E]]])
+    extends FloydWarshallGraph[V, E] {
+    override def hasPath(from: V, to: V): Boolean = {
+      if (!pathTable.contains(from)) {
+        return false
+      }
+      val vec = pathTable(from)
+      if (!vec.contains(to)) {
+        return false
+      }
+      true
+    }
+
+    override def pathOf(from: V, to: V): Path[E] = {
+      assert(hasPath(from, to))
+      val path = pathTable(from)(to)
+      path
+    }
+  }
+
+  trait Builder[V <: AnyRef, E <: AnyRef] {
+    def addVertex(v: V): Builder[V, E]
+    def addEdge(from: V, to: V, edge: E): Builder[V, E]
+    def build(): FloydWarshallGraph[V, E]
+  }
+
+  private object Builder {
+    private class Impl[V <: AnyRef, E <: AnyRef](costModel: CostModel[E]) extends Builder[V, E] {
+      override def addVertex(v: V): Builder[V, E] = ???
+      override def addEdge(from: V, to: V, edge: E): Builder[V, E] = ???
+      override def build(): FloydWarshallGraph[V, E] = ???
+    }
+
+    def create[V <: AnyRef, E <: AnyRef](costModel: CostModel[E]): Builder[V, E] = {
+      new Impl(costModel)
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.extension.columnar.transition
 
 import org.apache.gluten.exception.GlutenException
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -35,7 +36,7 @@ trait Transition {
     out
   }
 
-  final lazy val isEmpty: Boolean = {
+  final val isEmpty: Boolean = {
     // Tests if a transition is actually no-op.
     val plan = DummySparkPlan()
     val out = apply0(plan)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
@@ -80,11 +80,15 @@ object Transition {
     }
 
     final def satisfies(conv: Convention, req: ConventionReq): Boolean = {
-      val none = new Transition {
+      val abort = new Transition {
         override protected def apply0(plan: SparkPlan): SparkPlan =
           throw new UnsupportedOperationException()
       }
-      val transition = findTransition(conv, req)(none)
+      val transition = findTransition(conv, req)(abort)
+      if (transition == abort) {
+        // Not found.
+        return false
+      }
       transition.isEmpty
     }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
@@ -55,6 +55,8 @@ object TransitionDef {
 }
 
 object Transition {
+  trait Vertex
+
   val empty: Transition = (plan: SparkPlan) => plan
   val factory: Factory = Factory.newBuiltin()
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -17,9 +17,13 @@
 package org.apache.gluten.extension.columnar.transition
 
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.util.SparkReflectionUtil
 
 object TransitionGraph {
-  trait Vertex
+  trait Vertex {
+    override def toString: String = SparkReflectionUtil.getSimpleClassName(this.getClass)
+  }
+
   type Builder = FloydWarshallGraph.Builder[TransitionGraph.Vertex, Transition]
 
   def builder(): Builder = {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gluten.extension.columnar.transition
+
+type TransitionGraph = FloydWarshallGraph[Transition.Vertex, Transition]
+type TransitionGraphBuilder = FloydWarshallGraph.Builder[Transition.Vertex, Transition]
+
+object TransitionGraph {
+  def builder(): TransitionGraphBuilder = {
+    FloydWarshallGraph.builder(TransitionCostModel)
+  }
+
+  private case class TransitionCost(count: Int) extends FloydWarshallGraph.Cost {
+    override def :+(other: FloydWarshallGraph.Cost): FloydWarshallGraph.Cost = {
+      other match {
+        case TransitionCost(otherCount) => TransitionCost(count + otherCount)
+      }
+    }
+  }
+
+  private object TransitionCostModel extends FloydWarshallGraph.CostModel[Transition] {
+    override def zero(): FloydWarshallGraph.Cost = TransitionCost(0)
+    override def costOf(edge: Transition): FloydWarshallGraph.Cost = TransitionCost(1)
+    override def costComparator(): Ordering[FloydWarshallGraph.Cost] = Ordering.Int.on {
+      case TransitionCost(c) => c
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.gluten.extension.columnar.transition
 
 import org.apache.spark.sql.execution.SparkPlan

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -84,7 +84,7 @@ object TransitionGraph {
     private def costOf0(transition: Transition): TransitionCost = transition match {
       case t if t.isEmpty => TransitionCost(0)
       case ChainedTransition(f, s) => costOf0(f) + costOf0(s)
-      case _ => TransitionCost(0)
+      case _ => TransitionCost(1)
     }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
@@ -89,7 +89,7 @@ object Transitions {
   }
 
   def toBackendBatchPlan(plan: SparkPlan): SparkPlan = {
-    val backendBatchType = Backend.get().batchType
+    val backendBatchType = Backend.get().defaultBatchType
     val out = toBatchPlan(plan, backendBatchType)
     out
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
 import org.apache.spark.sql.execution.debug.DebugExec
 
 package object transition {
+  type TransitionGraph = FloydWarshallGraph[TransitionGraph.Vertex, Transition]
   // These 5 plan operators (as of Spark 3.5) are operators that have the
   // same convention with their children.
   //

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkReflectionUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkReflectionUtil.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util
+
+object SparkReflectionUtil {
+  def getSimpleClassName(cls: Class[_]): String = {
+    Utils.getSimpleName(cls)
+  }
+}

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
@@ -88,7 +88,7 @@ private object FloydWarshallGraphSuite {
   }
 
   private case class LongCost(c: Long) extends FloydWarshallGraph.Cost {
-    override def :+(other: FloydWarshallGraph.Cost): FloydWarshallGraph.Cost = other match {
+    override def +(other: FloydWarshallGraph.Cost): FloydWarshallGraph.Cost = other match {
       case LongCost(o) => LongCost(c + o)
     }
   }

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.gluten.extension.columnar.transition
 
 import org.scalatest.funsuite.AnyFunSuite

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gluten.extension.columnar.transition
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class FloydWarshallGraphSuite extends AnyFunSuite {
+  import FloydWarshallGraphSuite._
+  test("Sanity") {
+    val v0 = Vertex()
+    val v1 = Vertex()
+    val v2 = Vertex()
+    val v3 = Vertex()
+    val v4 = Vertex()
+
+    val e01 = Edge(5)
+    val e12 = Edge(6)
+    val e03 = Edge(2)
+    val e34 = Edge(1)
+    val e42 = Edge(3)
+
+    val graph = FloydWarshallGraph
+      .builder(CostModel)
+      .addVertex(v0)
+      .addVertex(v1)
+      .addVertex(v2)
+      .addVertex(v3)
+      .addVertex(v4)
+      .addEdge(v0, v1, e01)
+      .addEdge(v1, v2, e12)
+      .addEdge(v0, v3, e03)
+      .addEdge(v3, v4, e34)
+      .addEdge(v4, v2, e42)
+      .build()
+
+    assert(graph.hasPath(v0, v1))
+    assert(graph.hasPath(v0, v2))
+    assert(!graph.hasPath(v1, v0))
+    assert(!graph.hasPath(v2, v0))
+
+    assert(graph.pathOf(v0, v1).edges() == Seq(e01))
+    assert(graph.pathOf(v1, v2).edges() == Seq(e12))
+    assert(graph.pathOf(v0, v3).edges() == Seq(e03))
+    assert(graph.pathOf(v3, v4).edges() == Seq(e34))
+    assert(graph.pathOf(v4, v2).edges() == Seq(e42))
+
+    assert(graph.pathOf(v0, v2).edges() == Seq(e03, e34, e42))
+
+  }
+}
+
+private object FloydWarshallGraphSuite {
+  case class Vertex private (id: Int)
+
+  private object Vertex {
+    private val id = new AtomicInteger(0)
+
+    def apply(): Vertex = {
+      Vertex(id.getAndIncrement())
+    }
+  }
+
+  case class Edge private (id: Int, distance: Long)
+
+  private object Edge {
+    private val id = new AtomicInteger(0)
+
+    def apply(distance: Long): Edge = {
+      Edge(id.getAndIncrement(), distance)
+    }
+  }
+
+  private case class LongCost(c: Long) extends FloydWarshallGraph.Cost {
+    override def :+(other: FloydWarshallGraph.Cost): FloydWarshallGraph.Cost = other match {
+      case LongCost(o) => LongCost(c + o)
+    }
+  }
+
+  private object CostModel extends FloydWarshallGraph.CostModel[Edge] {
+    override def costOf(edge: Edge): FloydWarshallGraph.Cost = LongCost(edge.distance * 10)
+    override def costComparator(): Ordering[FloydWarshallGraph.Cost] = Ordering.Long.on {
+      case LongCost(c) => c
+    }
+  }
+}

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
@@ -55,6 +55,8 @@ class FloydWarshallGraphSuite extends AnyFunSuite {
     assert(!graph.hasPath(v1, v0))
     assert(!graph.hasPath(v2, v0))
 
+    assert(graph.pathOf(v0, v0).edges() == Nil)
+
     assert(graph.pathOf(v0, v1).edges() == Seq(e01))
     assert(graph.pathOf(v1, v2).edges() == Seq(e12))
     assert(graph.pathOf(v0, v3).edges() == Seq(e03))
@@ -62,7 +64,6 @@ class FloydWarshallGraphSuite extends AnyFunSuite {
     assert(graph.pathOf(v4, v2).edges() == Seq(e42))
 
     assert(graph.pathOf(v0, v2).edges() == Seq(e03, e34, e42))
-
   }
 }
 
@@ -94,6 +95,7 @@ private object FloydWarshallGraphSuite {
   }
 
   private object CostModel extends FloydWarshallGraph.CostModel[Edge] {
+    override def zero(): FloydWarshallGraph.Cost = LongCost(0)
     override def costOf(edge: Edge): FloydWarshallGraph.Cost = LongCost(edge.distance * 10)
     override def costComparator(): Ordering[FloydWarshallGraph.Cost] = Ordering.Long.on {
       case LongCost(c) => c

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
@@ -109,7 +109,7 @@ trait GlutenPlan extends SparkPlan with Convention.KnownBatchType with LogLevelU
   }
 
   protected def batchType0(): Convention.BatchType = {
-    Backend.get().batchType
+    Backend.get().defaultBatchType
   }
 
   protected def doValidateInternal(): ValidationResult = ValidationResult.succeeded

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/PlanUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/PlanUtil.scala
@@ -27,7 +27,7 @@ import scala.annotation.tailrec
 
 object PlanUtil {
   private def isGlutenTableCacheInternal(i: InMemoryTableScanExec): Boolean = {
-    Convention.get(i).batchType == Backend.get().batchType
+    Convention.get(i).batchType == Backend.get().defaultBatchType
   }
 
   @tailrec
@@ -47,6 +47,6 @@ object PlanUtil {
   }
 
   def isGlutenColumnarOp(plan: SparkPlan): Boolean = {
-    Convention.get(plan).batchType == Backend.get().batchType
+    Convention.get(plan).batchType == Backend.get().defaultBatchType
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -166,7 +166,7 @@ case class ColumnarInputAdapter(child: SparkPlan)
   override def output: Seq[Attribute] = child.output
   override def supportsColumnar: Boolean = true
   override def batchType(): Convention.BatchType =
-    Backend.get().batchType
+    Backend.get().defaultBatchType
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child.executeColumnar()
   override def outputPartitioning: Partitioning = child.outputPartitioning


### PR DESCRIPTION
Employs [new algorithm](https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm) to look for suitable transition between two adjacent plan nodes.

This could:

1. Create transitions that are non-trivial to define due to large number of hops or complicated code module hierarchy. E.g., `RowToVeloxColumn -> VeloxToArrowNative -> ArrowNativeToArrowJava` (R2C2C2C)
2. Improve performance finding transitions.
3. Minimize transition definition code.