### PR TITLE
[GLUTEN-7313][VL] Explicit Arrow transitions, part 3: code cleanups

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/columnarbatch/CHBatch.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/columnarbatch/CHBatch.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.columnarbatch
 
 import org.apache.gluten.extension.columnar.transition.Convention
 
-import org.apache.spark.sql.execution.{CHColumnarToRowExec, RowToCHNativeColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.{CHColumnarToRowExec, RowToCHNativeColumnarExec}
 
 /**
  * ClickHouse batch convention.
@@ -38,15 +38,6 @@ import org.apache.spark.sql.execution.{CHColumnarToRowExec, RowToCHNativeColumna
  * }}}
  */
 object CHBatch extends Convention.BatchType {
-  fromRow(
-    () =>
-      (plan: SparkPlan) => {
-        RowToCHNativeColumnarExec(plan)
-      })
-
-  toRow(
-    () =>
-      (plan: SparkPlan) => {
-        CHColumnarToRowExec(plan)
-      })
+  fromRow(RowToCHNativeColumnarExec.apply)
+  toRow(CHColumnarToRowExec.apply)
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/columnarbatch/VeloxBatch.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/columnarbatch/VeloxBatch.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.columnarbatch
 
-import org.apache.gluten.execution.{LoadArrowDataExec, OffloadArrowDataExec, RowToVeloxColumnarExec, VeloxColumnarToRowExec}
+import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
 import org.apache.gluten.extension.columnar.transition.{Convention, TransitionDef}
 
 import org.apache.spark.sql.execution.SparkPlan
@@ -36,27 +36,6 @@ object VeloxBatch extends Convention.BatchType {
 
   // TODO: Add explicit transitions between Arrow native batch and Velox batch.
   //  See https://github.com/apache/incubator-gluten/issues/7313.
-
-  fromBatch(
-    ArrowBatches.ArrowJavaBatch,
-    () =>
-      (plan: SparkPlan) => {
-        OffloadArrowDataExec(plan)
-      })
-
-  toBatch(
-    ArrowBatches.ArrowJavaBatch,
-    () =>
-      (plan: SparkPlan) => {
-        LoadArrowDataExec(plan)
-      })
-
-  fromBatch(
-    ArrowBatches.ArrowNativeBatch,
-    () =>
-      (plan: SparkPlan) => {
-        LoadArrowDataExec(plan)
-      })
-
+  fromBatch(ArrowBatches.ArrowNativeBatch, TransitionDef.empty)
   toBatch(ArrowBatches.ArrowNativeBatch, TransitionDef.empty)
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/columnarbatch/VeloxBatch.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/columnarbatch/VeloxBatch.scala
@@ -17,25 +17,13 @@
 package org.apache.gluten.columnarbatch
 
 import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
-import org.apache.gluten.extension.columnar.transition.{Convention, TransitionDef}
-
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.gluten.extension.columnar.transition.{Convention, Transition}
 
 object VeloxBatch extends Convention.BatchType {
-  fromRow(
-    () =>
-      (plan: SparkPlan) => {
-        RowToVeloxColumnarExec(plan)
-      })
-
-  toRow(
-    () =>
-      (plan: SparkPlan) => {
-        VeloxColumnarToRowExec(plan)
-      })
-
+  fromRow(RowToVeloxColumnarExec.apply)
+  toRow(VeloxColumnarToRowExec.apply)
   // TODO: Add explicit transitions between Arrow native batch and Velox batch.
   //  See https://github.com/apache/incubator-gluten/issues/7313.
-  fromBatch(ArrowBatches.ArrowNativeBatch, TransitionDef.empty)
-  toBatch(ArrowBatches.ArrowNativeBatch, TransitionDef.empty)
+  fromBatch(ArrowBatches.ArrowNativeBatch, Transition.empty)
+  toBatch(ArrowBatches.ArrowNativeBatch, Transition.empty)
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
@@ -52,21 +52,21 @@ class VeloxTransitionSuite extends SharedSparkSession {
   test("ArrowNative C2R - outputs row") {
     val in = BatchLeaf(ArrowNativeBatch)
     val out = Transitions.insertTransitions(in, outputsColumnar = false)
-    assert(out == ColumnarToRowExec(LoadArrowDataExec(BatchLeaf(ArrowNativeBatch))))
+    assert(out == VeloxColumnarToRowExec(BatchLeaf(ArrowNativeBatch)))
   }
 
   test("ArrowNative C2R - requires row input") {
     val in = RowUnary(BatchLeaf(ArrowNativeBatch))
     val out = Transitions.insertTransitions(in, outputsColumnar = false)
-    assert(out == RowUnary(ColumnarToRowExec(LoadArrowDataExec(BatchLeaf(ArrowNativeBatch)))))
+    assert(out == RowUnary(VeloxColumnarToRowExec(BatchLeaf(ArrowNativeBatch))))
   }
 
   test("ArrowNative R2C - requires Arrow input") {
     val in = BatchUnary(ArrowNativeBatch, RowLeaf())
     val out = Transitions.insertTransitions(in, outputsColumnar = false)
     assert(
-      out == ColumnarToRowExec(
-        LoadArrowDataExec(BatchUnary(ArrowNativeBatch, RowToVeloxColumnarExec(RowLeaf())))))
+      out == VeloxColumnarToRowExec(
+        BatchUnary(ArrowNativeBatch, RowToVeloxColumnarExec(RowLeaf()))))
   }
 
   test("ArrowNative-to-Velox C2C") {
@@ -75,27 +75,23 @@ class VeloxTransitionSuite extends SharedSparkSession {
     // No explicit transition needed for ArrowNative-to-Velox.
     // FIXME: Add explicit transitions.
     //  See https://github.com/apache/incubator-gluten/issues/7313.
-    assert(
-      out == VeloxColumnarToRowExec(
-        BatchUnary(VeloxBatch, LoadArrowDataExec(BatchLeaf(ArrowNativeBatch)))))
+    assert(out == VeloxColumnarToRowExec(BatchUnary(VeloxBatch, BatchLeaf(ArrowNativeBatch))))
   }
 
   test("Velox-to-ArrowNative C2C") {
     val in = BatchUnary(ArrowNativeBatch, BatchLeaf(VeloxBatch))
     val out = Transitions.insertTransitions(in, outputsColumnar = false)
-    assert(
-      out == ColumnarToRowExec(
-        LoadArrowDataExec(BatchUnary(ArrowNativeBatch, BatchLeaf(VeloxBatch)))))
+    assert(out == VeloxColumnarToRowExec(BatchUnary(ArrowNativeBatch, BatchLeaf(VeloxBatch))))
   }
 
   test("Vanilla-to-ArrowNative C2C") {
     val in = BatchUnary(ArrowNativeBatch, BatchLeaf(VanillaBatch))
     val out = Transitions.insertTransitions(in, outputsColumnar = false)
     assert(
-      out == ColumnarToRowExec(
-        LoadArrowDataExec(BatchUnary(
+      out == VeloxColumnarToRowExec(
+        BatchUnary(
           ArrowNativeBatch,
-          RowToVeloxColumnarExec(ColumnarToRowExec(BatchLeaf(VanillaBatch)))))))
+          RowToVeloxColumnarExec(ColumnarToRowExec(BatchLeaf(VanillaBatch))))))
   }
 
   test("ArrowNative-to-Vanilla C2C") {

--- a/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ArrowBatches.scala
+++ b/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ArrowBatches.scala
@@ -17,10 +17,8 @@
 package org.apache.gluten.columnarbatch
 
 import org.apache.gluten.execution.{LoadArrowDataExec, OffloadArrowDataExec}
-import org.apache.gluten.extension.columnar.transition.{Convention, TransitionDef}
+import org.apache.gluten.extension.columnar.transition.{Convention, Transition}
 import org.apache.gluten.extension.columnar.transition.Convention.BatchType.VanillaBatch
-
-import org.apache.spark.sql.execution.SparkPlan
 
 object ArrowBatches {
 
@@ -35,7 +33,7 @@ object ArrowBatches {
    * implementations.
    */
   object ArrowJavaBatch extends Convention.BatchType {
-    toBatch(VanillaBatch, TransitionDef.empty)
+    toBatch(VanillaBatch, Transition.empty)
   }
 
   /**
@@ -46,18 +44,7 @@ object ArrowBatches {
    * [[ColumnarBatches]].
    */
   object ArrowNativeBatch extends Convention.BatchType {
-    fromBatch(
-      ArrowJavaBatch,
-      () =>
-        (plan: SparkPlan) => {
-          OffloadArrowDataExec(plan)
-        })
-
-    toBatch(
-      ArrowJavaBatch,
-      () =>
-        (plan: SparkPlan) => {
-          LoadArrowDataExec(plan)
-        })
+    fromBatch(ArrowJavaBatch, OffloadArrowDataExec.apply)
+    toBatch(ArrowJavaBatch, LoadArrowDataExec.apply)
   }
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ArrowBatches.scala
+++ b/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ArrowBatches.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.execution.{LoadArrowDataExec, OffloadArrowDataExec}
 import org.apache.gluten.extension.columnar.transition.{Convention, TransitionDef}
 import org.apache.gluten.extension.columnar.transition.Convention.BatchType.VanillaBatch
 
-import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
 
 object ArrowBatches {
 
@@ -35,12 +35,6 @@ object ArrowBatches {
    * implementations.
    */
   object ArrowJavaBatch extends Convention.BatchType {
-    toRow(
-      () =>
-        (plan: SparkPlan) => {
-          ColumnarToRowExec(plan)
-        })
-
     toBatch(VanillaBatch, TransitionDef.empty)
   }
 
@@ -52,19 +46,6 @@ object ArrowBatches {
    * [[ColumnarBatches]].
    */
   object ArrowNativeBatch extends Convention.BatchType {
-    toRow(
-      () =>
-        (plan: SparkPlan) => {
-          ColumnarToRowExec(LoadArrowDataExec(plan))
-        })
-
-    toBatch(
-      VanillaBatch,
-      () =>
-        (plan: SparkPlan) => {
-          LoadArrowDataExec(plan)
-        })
-
     fromBatch(
       ArrowJavaBatch,
       () =>

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -74,22 +74,22 @@ object Convention {
   trait BatchType extends TransitionGraph.Vertex with Serializable {
     Transition.graph.addVertex(this)
 
-    final protected def fromRow(transitionDef: TransitionDef): Unit = {
-      Transition.graph.addEdge(RowType.VanillaRow, this, transitionDef.create())
+    final protected def fromRow(transition: Transition): Unit = {
+      Transition.graph.addEdge(RowType.VanillaRow, this, transition)
     }
 
-    final protected def toRow(transitionDef: TransitionDef): Unit = {
-      Transition.graph.addEdge(this, RowType.VanillaRow, transitionDef.create())
+    final protected def toRow(transition: Transition): Unit = {
+      Transition.graph.addEdge(this, RowType.VanillaRow, transition)
     }
 
-    final protected def fromBatch(from: BatchType, transitionDef: TransitionDef): Unit = {
+    final protected def fromBatch(from: BatchType, transition: Transition): Unit = {
       assert(from != this)
-      Transition.graph.addEdge(from, this, transitionDef.create())
+      Transition.graph.addEdge(from, this, transition)
     }
 
-    final protected def toBatch(to: BatchType, transitionDef: TransitionDef): Unit = {
+    final protected def toBatch(to: BatchType, transition: Transition): Unit = {
       assert(to != this)
-      Transition.graph.addEdge(this, to, transitionDef.create())
+      Transition.graph.addEdge(this, to, transition)
     }
   }
 
@@ -97,17 +97,8 @@ object Convention {
     // None indicates that the plan doesn't support batch-based processing.
     final case object None extends BatchType
     final case object VanillaBatch extends BatchType {
-      fromRow(
-        () =>
-          (plan: SparkPlan) => {
-            RowToColumnarExec(plan)
-          })
-
-      toRow(
-        () =>
-          (plan: SparkPlan) => {
-            ColumnarToRowExec(plan)
-          })
+      fromRow(RowToColumnarExec.apply)
+      toRow(ColumnarToRowExec.apply)
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
@@ -47,14 +47,6 @@ trait Transition {
   protected def apply0(plan: SparkPlan): SparkPlan
 }
 
-trait TransitionDef {
-  def create(): Transition
-}
-
-object TransitionDef {
-  val empty: TransitionDef = () => Transition.empty
-}
-
 object Transition {
   val empty: Transition = (plan: SparkPlan) => plan
   private val abort: Transition = (_: SparkPlan) => throw new UnsupportedOperationException("Abort")

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
@@ -85,59 +85,20 @@ class TransitionSuite extends SharedSparkSession {
 
 object TransitionSuite extends TransitionSuiteBase {
   object TypeA extends Convention.BatchType {
-    fromRow(
-      () =>
-        (plan: SparkPlan) => {
-          RowToBatch(this, plan)
-        })
-
-    toRow(
-      () =>
-        (plan: SparkPlan) => {
-          BatchToRow(this, plan)
-        })
+    fromRow(RowToBatch(this, _))
+    toRow(BatchToRow(this, _))
   }
 
   object TypeB extends Convention.BatchType {
-    fromRow(
-      () =>
-        (plan: SparkPlan) => {
-          RowToBatch(this, plan)
-        })
-
-    toRow(
-      () =>
-        (plan: SparkPlan) => {
-          BatchToRow(this, plan)
-        })
+    fromRow(RowToBatch(this, _))
+    toRow(BatchToRow(this, _))
   }
 
   object TypeC extends Convention.BatchType {
-    fromRow(
-      () =>
-        (plan: SparkPlan) => {
-          RowToBatch(this, plan)
-        })
-
-    toRow(
-      () =>
-        (plan: SparkPlan) => {
-          BatchToRow(this, plan)
-        })
-
-    fromBatch(
-      TypeA,
-      () =>
-        (plan: SparkPlan) => {
-          BatchToBatch(TypeA, this, plan)
-        })
-
-    toBatch(
-      TypeA,
-      () =>
-        (plan: SparkPlan) => {
-          BatchToBatch(this, TypeA, plan)
-        })
+    fromRow(RowToBatch(this, _))
+    toRow(BatchToRow(this, _))
+    fromBatch(TypeA, BatchToBatch(TypeA, this, _))
+    toBatch(TypeA, BatchToBatch(this, TypeA, _))
   }
 
   object TypeD extends Convention.BatchType {}


### PR DESCRIPTION
1. Remove unnecessary transition definitions since the algorithm introduced in https://github.com/apache/incubator-gluten/pull/7372 can find long transition paths.
2. Remove class `TransitionDef` to simplify code.