### PR TITLE
[VL] pass phase in recusive invocation of spillTree

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/TreeMemoryTargets.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/TreeMemoryTargets.java
@@ -70,7 +70,7 @@ public class TreeMemoryTargets {
     long remainingBytes = bytes;
     while (q.peek() != null && remainingBytes > 0) {
       TreeMemoryTarget head = q.remove();
-      long spilled = spillTree(head, remainingBytes);
+      long spilled = spillTree(head, phase, remainingBytes);
       remainingBytes -= spilled;
     }
 


### PR DESCRIPTION
Currently recursive invocation of spillTree calls ` spillTree(TreeMemoryTarget node, final long bytes)`, which always process `SPILL` phase.