### PR TITLE
[CORE] Update AllocationListener usage after successfully releasing memory

### DIFF
--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -84,7 +84,7 @@ bool ListenableMemoryAllocator::reallocateAligned(
 bool ListenableMemoryAllocator::free(void* p, int64_t size) {
   bool succeed = delegated_->free(p, size);
   if (succeed) {
-    updateUsage(-diff);
+    updateUsage(-size);
   }
   return succeed;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should update AllocationListener usage after successfully releasing memory to avoid exceeding the usage limit.

## How was this patch tested?

code refactor

