### PR TITLE
[CORE] Minor: Fix warnings and rename event handler better

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenBuildInfo.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenBuildInfo.scala
@@ -32,7 +32,7 @@ object GlutenBuildInfo {
     throw new GlutenException(s"Can not load the core build file: $buildFile")
   }
 
-  val unknown = "<unknown>"
+  private val unknown = "<unknown>"
   private val props = new Properties()
 
   try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes import and renamed SQLExecutionEnd to proper name. Also refactors Gluten Build Info to remove warnings.

## How was this patch tested?

CI

