### PR TITLE
[CORE] Infra: Forward GitHub discussions to Apache mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,3 +48,4 @@ notifications:
   commits: commits@gluten.apache.org
   issues: commits@gluten.apache.org
   pullrequests: commits@gluten.apache.org
+  discussions: commits@gluten.apache.org


### PR DESCRIPTION
As title. forward GitHub discussions to commits@gluten.apache.org