### PR TITLE
[GLUTEN-7450][VL] Improve CollectRewriteRule for Velox

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/extension/CollectRewriteRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/CollectRewriteRule.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, Coalesce, Expression, IsN
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Window}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{AGGREGATE_EXPRESSION, WINDOW_EXPRESSION}
 import org.apache.spark.sql.types.ArrayType
 
 import scala.reflect.{classTag, ClassTag}
@@ -37,42 +38,32 @@ import scala.reflect.{classTag, ClassTag}
 case class CollectRewriteRule(spark: SparkSession) extends Rule[LogicalPlan] {
   import CollectRewriteRule._
   override def apply(plan: LogicalPlan): LogicalPlan = LogicalPlanSelector.maybe(spark, plan) {
-    val out = plan.transformUp {
-      case node =>
-        val out = replaceCollectSet(replaceCollectList(node))
-        out
-    }
-    if (out.fastEquals(plan)) {
+    if (!has[VeloxCollectSet] && !has[VeloxCollectList]) {
       return plan
     }
-    out
-  }
 
-  private def replaceCollectList(node: LogicalPlan): LogicalPlan = {
-    node.transformExpressions {
-      case func @ AggregateExpression(l: CollectList, _, _, _, _) if has[VeloxCollectList] =>
-        func.copy(VeloxCollectList(l.child))
+    val newPlan = plan.transformUp {
+      case node =>
+        replaceAggCollect(node)
     }
+    if (newPlan.fastEquals(plan)) {
+      return plan
+    }
+    newPlan
   }
 
-  private def replaceCollectSet(node: LogicalPlan): LogicalPlan = {
-    // 1. Replace null result from VeloxCollectSet with empty array to align with
-    //    vanilla Spark.
-    // 2. Filter out null inputs from VeloxCollectSet to align with vanilla Spark.
-    //
-    // Since https://github.com/apache/incubator-gluten/pull/4805
+  private def replaceAggCollect(node: LogicalPlan): LogicalPlan = {
     node match {
       case agg: Aggregate =>
-        agg.transformExpressions {
-          case ToVeloxCollectSet(newAggFunc) =>
-            val out = ensureNonNull(newAggFunc)
-            out
+        agg.transformExpressionsWithPruning(_.containsPattern(AGGREGATE_EXPRESSION)) {
+          case ToVeloxCollect(newAggExpr) =>
+            ensureNonNull(newAggExpr)
         }
       case w: Window =>
-        w.transformExpressions {
-          case func @ WindowExpression(ToVeloxCollectSet(newAggFunc), _) =>
-            val out = ensureNonNull(func.copy(newAggFunc))
-            out
+        w.transformExpressionsWithPruning(
+          _.containsAllPatterns(AGGREGATE_EXPRESSION, WINDOW_EXPRESSION)) {
+          case windowExpr @ WindowExpression(ToVeloxCollect(newAggExpr), _) =>
+            ensureNonNull(windowExpr.copy(newAggExpr))
         }
       case other => other
     }
@@ -81,26 +72,32 @@ case class CollectRewriteRule(spark: SparkSession) extends Rule[LogicalPlan] {
 
 object CollectRewriteRule {
   private def ensureNonNull(expr: Expression): Expression = {
-    val out =
+    val coalesce =
       Coalesce(List(expr, Literal.create(Seq.empty, expr.dataType)))
-    assert(!out.nullable)
-    assert(!out.dataType.asInstanceOf[ArrayType].containsNull)
-    out
+    assert(!coalesce.nullable)
+    assert(!coalesce.dataType.asInstanceOf[ArrayType].containsNull)
+    coalesce
   }
 
-  private object ToVeloxCollectSet {
+  private object ToVeloxCollect {
     def unapply(expr: Expression): Option[Expression] = expr match {
-      case aggFunc @ AggregateExpression(s: CollectSet, _, _, filter, _) if has[VeloxCollectSet] =>
+      case aggExpr @ AggregateExpression(s: CollectSet, _, _, filter, _) if has[VeloxCollectSet] =>
+        // 1. Replace null result from VeloxCollectSet with empty array to align with
+        //    vanilla Spark.
+        // 2. Filter out null inputs from VeloxCollectSet to align with vanilla Spark.
+        //
+        // Since https://github.com/apache/incubator-gluten/pull/4805
         val newFilter = (filter ++ Some(IsNotNull(s.child))).reduceOption(And)
-        val newAggFunc =
-          aggFunc.copy(aggregateFunction = VeloxCollectSet(s.child), filter = newFilter)
-        Some(newAggFunc)
+        val newAggExpr =
+          aggExpr.copy(aggregateFunction = VeloxCollectSet(s.child), filter = newFilter)
+        Some(newAggExpr)
+      case aggExpr @ AggregateExpression(l: CollectList, _, _, _, _) if has[VeloxCollectList] =>
+        val newAggExpr = aggExpr.copy(VeloxCollectList(l.child))
+        Some(newAggExpr)
       case _ => None
     }
   }
 
-  private def has[T <: Expression: ClassTag]: Boolean = {
-    val out = ExpressionMappings.expressionsMap.contains(classTag[T].runtimeClass)
-    out
-  }
+  private def has[T <: Expression: ClassTag]: Boolean =
+    ExpressionMappings.expressionsMap.contains(classTag[T].runtimeClass)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to improve `CollectRewriteRule` for Velox. These optimal points show below.
1. Short circuiting of `CollectRewriteRule` in advance.
2. Use tree traversal with pruning instead of full traversal.
3. Remove ensureNonNull since `CollectSet` override the `defaultResult`.
4. Unify the replacement for `CollectSet` and `CollectList`.
5. Use more meaningful variable names. e.g. `coalesce`.
6. Use correct variable names. e.g. `aggExpr`.
7. Other simplifications.

## How was this patch tested?

integration tests

