### PR TITLE
[GLUTEN-7243][VL] Fix hanging by cross-task spilling

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -165,8 +165,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
   }
 
   override def injectWriteFilesTempPath(path: String, fileName: String): Unit = {
-    val transKernel = NativePlanEvaluator.create()
-    transKernel.injectWriteFilesTempPath(path)
+    NativePlanEvaluator.injectWriteFilesTempPath(path)
   }
 
   /** Generate Iterator[ColumnarBatch] for first stage. */

--- a/cpp/core/compute/Runtime.cc
+++ b/cpp/core/compute/Runtime.cc
@@ -68,4 +68,11 @@ void Runtime::release(Runtime* runtime) {
   delete runtime;
 }
 
+std::optional<std::string>* Runtime::localWriteFilesTempPath() {
+  // This is thread-local to conform to Java side ColumnarWriteFilesExec's design.
+  // FIXME: Pass the path through relevant member functions.
+  static thread_local std::optional<std::string> path;
+  return &path;
+}
+
 } // namespace gluten

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -62,6 +62,7 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
       std::unique_ptr<AllocationListener> listener,
       const std::unordered_map<std::string, std::string>& sessionConf = {});
   static void release(Runtime*);
+  static std::optional<std::string>* localWriteFilesTempPath();
 
   Runtime(std::shared_ptr<MemoryManager> memoryManager, const std::unordered_map<std::string, std::string>& confMap)
       : memoryManager_(memoryManager), confMap_(confMap) {}
@@ -73,8 +74,6 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
   virtual void parseSplitInfo(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) = 0;
 
   virtual std::string planString(bool details, const std::unordered_map<std::string, std::string>& sessionConf) = 0;
-
-  virtual void injectWriteFilesTempPath(const std::string& path) = 0;
 
   // Just for benchmark
   ::substrait::Plan& getPlan() {
@@ -134,7 +133,6 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
 
   ::substrait::Plan substraitPlan_;
   std::vector<::substrait::ReadRel_LocalFiles> localFiles_;
-  std::optional<std::string> writeFilesTempPath_;
   SparkTaskInfo taskInfo_;
 };
 } // namespace gluten

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -311,16 +311,13 @@ JNIEXPORT jstring JNICALL Java_org_apache_gluten_vectorized_PlanEvaluatorJniWrap
 
 JNIEXPORT void JNICALL Java_org_apache_gluten_vectorized_PlanEvaluatorJniWrapper_injectWriteFilesTempPath( // NOLINT
     JNIEnv* env,
-    jobject wrapper,
+    jclass,
     jbyteArray path) {
   JNI_METHOD_START
-
   auto len = env->GetArrayLength(path);
   auto safeArray = gluten::getByteArrayElementsSafe(env, path);
   std::string pathStr(reinterpret_cast<char*>(safeArray.elems()), len);
-  auto ctx = gluten::getRuntime(env, wrapper);
-  ctx->injectWriteFilesTempPath(pathStr);
-
+  *gluten::Runtime::localWriteFilesTempPath() = pathStr;
   JNI_METHOD_END()
 }
 

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -337,7 +337,7 @@ auto BM_Generic = [](::benchmark::State& state,
               return static_cast<FileReaderIterator*>(iter->getInputIter());
             });
       }
-      runtime->injectWriteFilesTempPath(FLAGS_write_path);
+      *Runtime::localWriteFilesTempPath() = FLAGS_write_path;
       runtime->parsePlan(reinterpret_cast<uint8_t*>(plan.data()), plan.size(), std::nullopt);
       for (auto& split : splits) {
         runtime->parseSplitInfo(reinterpret_cast<uint8_t*>(split.data()), split.size(), std::nullopt);

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -128,10 +128,6 @@ std::string VeloxRuntime::planString(bool details, const std::unordered_map<std:
   return veloxPlan->toString(details, true);
 }
 
-void VeloxRuntime::injectWriteFilesTempPath(const std::string& path) {
-  writeFilesTempPath_ = path;
-}
-
 VeloxMemoryManager* VeloxRuntime::memoryManager() {
   return vmm_;
 }
@@ -142,7 +138,8 @@ std::shared_ptr<ResultIterator> VeloxRuntime::createResultIterator(
     const std::unordered_map<std::string, std::string>& sessionConf) {
   LOG_IF(INFO, debugModeEnabled_) << "VeloxRuntime session config:" << printConfig(confMap_);
 
-  VeloxPlanConverter veloxPlanConverter(inputs, vmm_->getLeafMemoryPool().get(), sessionConf, writeFilesTempPath_);
+  VeloxPlanConverter veloxPlanConverter(
+      inputs, vmm_->getLeafMemoryPool().get(), sessionConf, *localWriteFilesTempPath());
   veloxPlan_ = veloxPlanConverter.toVeloxPlan(substraitPlan_, std::move(localFiles_));
 
   // Scan node can be required.

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -78,8 +78,6 @@ class VeloxRuntime final : public Runtime {
 
   std::string planString(bool details, const std::unordered_map<std::string, std::string>& sessionConf) override;
 
-  void injectWriteFilesTempPath(const std::string& path) override;
-
   void dumpConf(const std::string& path) override;
 
   std::shared_ptr<const facebook::velox::core::PlanNode> getVeloxPlan() {

--- a/cpp/velox/tests/RuntimeTest.cc
+++ b/cpp/velox/tests/RuntimeTest.cc
@@ -91,9 +91,6 @@ class DummyRuntime final : public Runtime {
   std::string planString(bool details, const std::unordered_map<std::string, std::string>& sessionConf) override {
     throw GlutenException("Not yet implemented");
   }
-  void injectWriteFilesTempPath(const std::string& path) override {
-    throw GlutenException("Not yet implemented");
-  }
 
   void dumpConf(const std::string& path) override {
     throw GlutenException("Not yet implemented");

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -49,8 +49,8 @@ public class NativePlanEvaluator {
     return jniWrapper.nativeValidateWithFailureReason(subPlan);
   }
 
-  public void injectWriteFilesTempPath(String path) {
-    jniWrapper.injectWriteFilesTempPath(path.getBytes(StandardCharsets.UTF_8));
+  public static void injectWriteFilesTempPath(String path) {
+    PlanEvaluatorJniWrapper.injectWriteFilesTempPath(path.getBytes(StandardCharsets.UTF_8));
   }
 
   // Used by WholeStageTransform to create the native computing pipeline and

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -28,10 +28,13 @@ import org.apache.spark.TaskContext;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class NativePlanEvaluator {
+  private static final AtomicInteger id = new AtomicInteger(0);
+  private final Runtime runtime =
+      Runtimes.contextInstance(String.format("NativePlanEvaluator-%d", id.getAndIncrement()));
 
-  private final Runtime runtime = Runtimes.contextInstance("WholeStageIterator");
   private final PlanEvaluatorJniWrapper jniWrapper;
 
   private NativePlanEvaluator() {

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/PlanEvaluatorJniWrapper.java
@@ -41,6 +41,8 @@ public class PlanEvaluatorJniWrapper implements RuntimeAware {
     return runtime.getHandle();
   }
 
+  public static native void injectWriteFilesTempPath(byte[] path);
+
   /**
    * Validate the Substrait plan in native compute engine.
    *
@@ -50,8 +52,6 @@ public class PlanEvaluatorJniWrapper implements RuntimeAware {
   native NativePlanValidationInfo nativeValidateWithFailureReason(byte[] subPlan);
 
   public native String nativePlanString(byte[] substraitPlan, Boolean details);
-
-  public native void injectWriteFilesTempPath(byte[] path);
 
   /**
    * Create a native compute kernel and return a columnar result iterator.


### PR DESCRIPTION
As a follow-up of https://github.com/apache/incubator-gluten/pull/7244 cause https://github.com/apache/incubator-gluten/issues/7243 was not completely fixed.

The patch is to create different root Velox memory pools for different Velox tasks by assigning isolated Velox runtimes to the tasks.

Hang stack:
```
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x00007f044de29e3e in folly::detail::(anonymous namespace)::nativeFutexWaitImpl (waitMask=4294967295, absSteadyTime=0x0, absSystemTime=0x0, expected=4294967293, addr=0x7f05d4d037f8)
    at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/detail/Futex.cpp:126
#2  folly::detail::futexWaitImpl (futex=futex@entry=0x7f05d4d037f8, expected=expected@entry=4294967293, absSystemTime=absSystemTime@entry=0x0, absSteadyTime=absSteadyTime@entry=0x0,
    waitMask=waitMask@entry=4294967295) at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/detail/Futex.cpp:254
#3  0x00007f044de71416 in folly::detail::futexWait<std::atomic<unsigned int> > (waitMask=4294967295, expected=4294967293, futex=0x7f05d4d037f8)
    at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/detail/Futex-inl.h:94
#4  folly::detail::MemoryIdler::futexWait<std::atomic<unsigned int>, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > (expected=4294967293, waitMask=4294967295, stackToRetain=1024,
    timeoutVariationFrac=0.5, idleTimeout=..., fut=std::atomic<unsigned int> = { 4294967293 })
    at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/detail/MemoryIdler.h:128
#5  folly::fibers::Baton::waitThread (this=0x7f05d4d037f8) at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/fibers/Baton.cpp:70
#6  0x00007f044de716e0 in folly::fibers::Baton::wait<folly::fibers::Baton::wait()::<lambda()> > (mainContextFunc=..., this=0x7f05d4d037f8)
    at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/fibers/Baton-inl.h:54
#7  folly::fibers::Baton::wait (this=this@entry=0x7f05d4d037f8) at /opt/gluten/dev/vcpkg/.vcpkg/buildtrees/folly/src/4.05.20.00-935b4335b7.clean/folly/fibers/Baton.cpp:46
#8  0x00007f044a513abe in folly::futures::detail::waitImpl<folly::SemiFuture<folly::Unit>, folly::Unit> (f=...)
    at /opt/gluten/dev/vcpkg/vcpkg_installed/x64-linux-avx/include/folly/futures/Future-inl.h:2230
#9  0x00007f044a513f90 in folly::SemiFuture<folly::Unit>::wait() & (this=0x7f05d4d03928) at /opt/gluten/dev/vcpkg/vcpkg_installed/x64-linux-avx/include/folly/futures/Future-inl.h:2337
#10 0x00007f044b39aa48 in folly::SemiFuture<folly::Unit>::wait() && (this=0x7f05d4d03928) at /opt/gluten/dev/vcpkg/vcpkg_installed/x64-linux-avx/include/folly/futures/Future-inl.h:2343
#11 facebook::velox::exec::Task::MemoryReclaimer::reclaimTask (this=0x7f04807707b0, task=std::shared_ptr<facebook::velox::exec::Task> (use count 6, weak count 3) = {...}, targetBytes=18035507,
    maxWaitMs=0, stats=...) at /opt/gluten/ep/build-velox/build/velox_ep/velox/exec/Task.cpp:2996
#12 0x00007f044b39b0d1 in facebook::velox::exec::Task::MemoryReclaimer::reclaim (this=0x7f04807707b0, pool=0x7f02a670f450, targetBytes=18035507, maxWaitMs=0, stats=...)
    at /opt/gluten/ep/build-velox/build/velox_ep/velox/exec/Task.cpp:2970
#13 0x00007f044a70a4f9 in facebook::velox::memory::MemoryReclaimer::reclaim (this=<optimized out>, pool=<optimized out>, targetBytes=<optimized out>, maxWaitMs=0, stats=...)
    at /opt/gluten/ep/build-velox/build/velox_ep/velox/common/memory/MemoryArbitrator.cpp:266
#14 0x00007f044a539dc5 in gluten::ListenableArbitrator::shrinkCapacity (this=0x7f04810b4010, targetBytes=18035507, allowSpill=<optimized out>, allowAbort=<optimized out>)
    at /opt/gluten/cpp/velox/memory/VeloxMemoryManager.cc:122
#15 0x00007f044a51c285 in gluten::WholeStageResultIterator::spillFixedSize (this=0x7f04803627c0, size=<optimized out>) at /opt/gluten/cpp/velox/compute/WholeStageResultIterator.cc:250
#16 0x00007f05ce621c35 in gluten::ResultIterator::spillFixedSize (size=18035507, this=0x7f048044b380) at /opt/gluten/cpp/core/compute/ResultIterator.h:71
#17 Java_org_apache_gluten_vectorized_ColumnarBatchOutIterator_nativeSpill (env=0x7f046860aa60, wrapper=<optimized out>, iterHandle=75136157876230, size=18035507)
    at /opt/gluten/cpp/core/jni/JniWrapper.cc:516
#18 0x00007f06dd018427 in ?? ()
#19 0x0000000772211e98 in ?? ()
#20 0x4908b36b977f1f00 in ?? ()
#21 0x0000000600000001 in ?? ()
#22 0x00007f05cce302e8 in ?? ()
#23 0x00007f05d4d03fe8 in ?? ()
#24 0x00007f05d4d03f78 in ?? ()
#25 0x0000000000000000 in ?? ()
```
