### PR TITLE
[GLUTEN-7480][VL] Build centos-8 docker image for GHA workflow

### DIFF
--- a/.github/workflows/docker/Dockerfile.gha
+++ b/.github/workflows/docker/Dockerfile.gha
@@ -1,0 +1,23 @@
+FROM centos:8
+
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* || true
+RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
+
+RUN yum update -y && yum install -y epel-release sudo dnf
+
+RUN dnf install -y --setopt=install_weak_deps=False gcc-toolset-9
+RUN source /opt/rh/gcc-toolset-9/enable || exit 1
+
+RUN echo "check_certificate = off" >> ~/.wgetrc
+
+RUN yum install -y java-1.8.0-openjdk-devel patch wget git perl
+RUN export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk && export PATH=$JAVA_HOME/bin:$PATH
+RUN wget --no-check-certificate https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
+    tar -xvf apache-maven-3.8.8-bin.tar.gz && \
+    mv apache-maven-3.8.8 /usr/lib/maven && \
+    export MAVEN_HOME=/usr/lib/maven && \
+    export PATH=${PATH}:${MAVEN_HOME}/bin
+
+RUN git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten
+
+RUN cd /opt/gluten && ./dev/builddeps-veloxbe.sh --run_setup_script=ON build_arrow && rm -rf /opt/gluten

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -25,7 +25,7 @@ on:
     - cron: '0 20 * * 0'
 
 jobs:
-  build:
+  build-vcpkg-centos-7:
     runs-on: ubuntu-latest
 
     steps:
@@ -48,3 +48,27 @@ jobs:
           file: dev/vcpkg/docker/Dockerfile.gha
           push: true
           tags: apache/gluten:vcpkg-centos-7
+
+  build-centos-8:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: .github/workflows/docker/Dockerfile.gha
+          push: true
+          tags: apache/gluten:centos-8


### PR DESCRIPTION
## What changes were proposed in this pull request?

In current GHA workflow, we are using one centos-8 docker image coming from Velox community. That image is no longer updated since centos-8 support is deprecated by the community.

The new docker image will be auto periodically updated with a few dependencies including arrow libs pre-installed. With this one used, the workflow will be accelerated (will create a separate pr to use it).

## How was this patch tested?

N/A

