### PR TITLE
[GLUTEN-7489][INFRA] fix: allow to fetch artifacts from workflow `Velox backend Github Runner` in upstream repo

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -37,6 +37,7 @@ jobs:
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
         workflow_conclusion: completed
+        allow_forks: true
     - name: Publish test report
       uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 # pin @v1.8.0
       with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to set `allow_forks` as true in `Report test results` workflow.

(Fixes: \#7489)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

