### PR TITLE
[GLUTEN-7510][VL][CI] Change centos-8 docker image to accelerate GHA workflow

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -573,7 +573,7 @@ jobs:
   run-spark-test-spark32:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -628,7 +628,7 @@ jobs:
   run-spark-test-spark32-slow:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -678,7 +678,7 @@ jobs:
   run-spark-test-spark33:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -736,7 +736,7 @@ jobs:
   run-spark-test-spark33-slow:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -787,7 +787,7 @@ jobs:
   run-spark-test-spark34:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -845,7 +845,7 @@ jobs:
   run-spark-test-spark34-slow:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -896,7 +896,7 @@ jobs:
   run-spark-test-spark35:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -953,7 +953,7 @@ jobs:
   run-spark-test-spark35-scala213:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -1010,7 +1010,7 @@ jobs:
   run-spark-test-spark35-slow:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
     steps:
@@ -1060,7 +1060,7 @@ jobs:
 
   run-cpp-test-udf-test:
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     steps:
       - uses: actions/checkout@v2
       - name: Generate cache key

--- a/.github/workflows/velox_backend_cache.yml
+++ b/.github/workflows/velox_backend_cache.yml
@@ -60,7 +60,7 @@ jobs:
 
   cache-native-lib-centos-8:
     runs-on: ubuntu-20.04
-    container: ghcr.io/facebookincubator/velox-dev:centos8
+    container: apache/gluten:centos-8
     steps:
       - uses: actions/checkout@v2
       - name: Generate cache key

--- a/dev/ci-velox-buildshared-centos-8.sh
+++ b/dev/ci-velox-buildshared-centos-8.sh
@@ -3,5 +3,5 @@
 set -e
 
 source /opt/rh/gcc-toolset-9/enable
-./dev/builddeps-veloxbe.sh --run_setup_script=OFF --enable_ep_cache=OFF --build_tests=ON \
-    --build_examples=ON --build_benchmarks=ON --build_protobuf=ON
+./dev/builddeps-veloxbe.sh --run_setup_script=OFF --build_arrow=OFF --enable_ep_cache=OFF --build_tests=ON \
+    --build_examples=ON --build_benchmarks=ON --build_protobuf=OFF


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have included centos-8 in weekly scheduled docker build job, it can be used now.
https://hub.docker.com/r/apache/gluten/tags

## How was this patch tested?

CI.

