### PR TITLE
[VL] Move unsafe delete operations closer to JNI wrapper

### DIFF
--- a/cpp/core/compute/Runtime.cc
+++ b/cpp/core/compute/Runtime.cc
@@ -39,10 +39,6 @@ Runtime* Runtime::create(
   return factory(std::move(memoryManager), sessionConf);
 }
 
-void Runtime::release(Runtime* runtime) {
-  delete runtime;
-}
-
 std::optional<std::string>* Runtime::localWriteFilesTempPath() {
   // This is thread-local to conform to Java side ColumnarWriteFilesExec's design.
   // FIXME: Pass the path through relevant member functions.

--- a/cpp/core/compute/Runtime.cc
+++ b/cpp/core/compute/Runtime.cc
@@ -39,6 +39,10 @@ Runtime* Runtime::create(
   return factory(std::move(memoryManager), sessionConf);
 }
 
+void Runtime::release(Runtime* runtime) {
+  delete runtime;
+}
+
 std::optional<std::string>* Runtime::localWriteFilesTempPath() {
   // This is thread-local to conform to Java side ColumnarWriteFilesExec's design.
   // FIXME: Pass the path through relevant member functions.

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -61,7 +61,6 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
       const std::string& kind,
       MemoryManager* memoryManager,
       const std::unordered_map<std::string, std::string>& sessionConf = {});
-  static void release(Runtime*);
   static std::optional<std::string>* localWriteFilesTempPath();
 
   Runtime(MemoryManager* memoryManager, const std::unordered_map<std::string, std::string>& confMap)

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -61,6 +61,7 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
       const std::string& kind,
       MemoryManager* memoryManager,
       const std::unordered_map<std::string, std::string>& sessionConf = {});
+  static void release(Runtime*);
   static std::optional<std::string>* localWriteFilesTempPath();
 
   Runtime(MemoryManager* memoryManager, const std::unordered_map<std::string, std::string>& confMap)

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -231,8 +231,7 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_releaseR
     jlong ctxHandle) {
   JNI_METHOD_START
   auto runtime = jniCastOrThrow<Runtime>(ctxHandle);
-
-  Runtime::release(runtime);
+  delete runtime;
   JNI_METHOD_END()
 }
 
@@ -311,7 +310,7 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_memory_NativeMemoryManagerJniWrapp
     jlong nmmHandle) {
   JNI_METHOD_START
   auto* memoryManager = jniCastOrThrow<MemoryManager>(nmmHandle);
-  MemoryManager::release(memoryManager);
+  delete memoryManager;
   JNI_METHOD_END()
 }
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -231,7 +231,8 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_releaseR
     jlong ctxHandle) {
   JNI_METHOD_START
   auto runtime = jniCastOrThrow<Runtime>(ctxHandle);
-  delete runtime;
+
+  Runtime::release(runtime);
   JNI_METHOD_END()
 }
 
@@ -310,7 +311,7 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_memory_NativeMemoryManagerJniWrapp
     jlong nmmHandle) {
   JNI_METHOD_START
   auto* memoryManager = jniCastOrThrow<MemoryManager>(nmmHandle);
-  delete memoryManager;
+  MemoryManager::release(memoryManager);
   JNI_METHOD_END()
 }
 

--- a/cpp/core/memory/MemoryManager.cc
+++ b/cpp/core/memory/MemoryManager.cc
@@ -35,8 +35,4 @@ MemoryManager* MemoryManager::create(const std::string& kind, std::unique_ptr<Al
   return factory(std::move(listener));
 }
 
-void MemoryManager::release(MemoryManager* memoryManager) {
-  delete memoryManager;
-}
-
 } // namespace gluten

--- a/cpp/core/memory/MemoryManager.cc
+++ b/cpp/core/memory/MemoryManager.cc
@@ -35,4 +35,8 @@ MemoryManager* MemoryManager::create(const std::string& kind, std::unique_ptr<Al
   return factory(std::move(listener));
 }
 
+void MemoryManager::release(MemoryManager* memoryManager) {
+  delete memoryManager;
+}
+
 } // namespace gluten

--- a/cpp/core/memory/MemoryManager.h
+++ b/cpp/core/memory/MemoryManager.h
@@ -28,7 +28,6 @@ class MemoryManager {
   using Factory = std::function<MemoryManager*(std::unique_ptr<AllocationListener> listener)>;
   static void registerFactory(const std::string& kind, Factory factory);
   static MemoryManager* create(const std::string& kind, std::unique_ptr<AllocationListener> listener);
-  static void release(MemoryManager*);
 
   MemoryManager() = default;
 

--- a/cpp/core/memory/MemoryManager.h
+++ b/cpp/core/memory/MemoryManager.h
@@ -25,14 +25,19 @@ namespace gluten {
 
 class MemoryManager {
  public:
-  using Factory = std::function<MemoryManager*(std::unique_ptr<AllocationListener> listener)>;
-  static void registerFactory(const std::string& kind, Factory factory);
+  using Factory = std::function<MemoryManager*(const std::string& kind, std::unique_ptr<AllocationListener> listener)>;
+  using Releaser = std::function<void(MemoryManager*)>;
+  static void registerFactory(const std::string& kind, Factory factory, Releaser releaser);
   static MemoryManager* create(const std::string& kind, std::unique_ptr<AllocationListener> listener);
   static void release(MemoryManager*);
 
-  MemoryManager() = default;
+  MemoryManager(const std::string& kind) : kind_(kind){};
 
   virtual ~MemoryManager() = default;
+
+  virtual std::string kind() {
+    return kind_;
+  }
 
   virtual arrow::MemoryPool* getArrowMemoryPool() = 0;
 
@@ -44,6 +49,9 @@ class MemoryManager {
   // destroyed. Which means, a call to this function would make sure the memory blocks directly or indirectly managed
   // by this manager, be guaranteed safe to access during the period that this manager is alive.
   virtual void hold() = 0;
+
+ private:
+  std::string kind_;
 };
 
 } // namespace gluten

--- a/cpp/core/memory/MemoryManager.h
+++ b/cpp/core/memory/MemoryManager.h
@@ -28,6 +28,7 @@ class MemoryManager {
   using Factory = std::function<MemoryManager*(std::unique_ptr<AllocationListener> listener)>;
   static void registerFactory(const std::string& kind, Factory factory);
   static MemoryManager* create(const std::string& kind, std::unique_ptr<AllocationListener> listener);
+  static void release(MemoryManager*);
 
   MemoryManager() = default;
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -30,6 +30,8 @@
 #include "velox/common/memory/MmapAllocator.h"
 
 namespace gluten {
+// This kind string must be same with VeloxBackend#name in java side.
+inline static const std::string kVeloxBackendKind{"velox"};
 /// As a static instance in per executor, initialized at executor startup.
 /// Should not put heavily work here.
 class VeloxBackend {

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -56,8 +56,11 @@ using namespace facebook;
 
 namespace gluten {
 
-VeloxRuntime::VeloxRuntime(VeloxMemoryManager* vmm, const std::unordered_map<std::string, std::string>& confMap)
-    : Runtime(vmm, confMap) {
+VeloxRuntime::VeloxRuntime(
+    const std::string& kind,
+    VeloxMemoryManager* vmm,
+    const std::unordered_map<std::string, std::string>& confMap)
+    : Runtime(kind, vmm, confMap) {
   // Refresh session config.
   veloxCfg_ =
       std::make_shared<facebook::velox::config::ConfigBase>(std::unordered_map<std::string, std::string>(confMap_));

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -28,12 +28,12 @@
 
 namespace gluten {
 
-// This kind string must be same with VeloxBackend#name in java side.
-inline static const std::string kVeloxBackendKind{"velox"};
-
 class VeloxRuntime final : public Runtime {
  public:
-  explicit VeloxRuntime(VeloxMemoryManager* vmm, const std::unordered_map<std::string, std::string>& confMap);
+  explicit VeloxRuntime(
+      const std::string& kind,
+      VeloxMemoryManager* vmm,
+      const std::unordered_map<std::string, std::string>& confMap);
 
   void parsePlan(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) override;
 

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -200,8 +200,8 @@ class ArbitratorFactoryRegister {
   gluten::AllocationListener* listener_;
 };
 
-VeloxMemoryManager::VeloxMemoryManager(std::unique_ptr<AllocationListener> listener)
-    : MemoryManager(), listener_(std::move(listener)) {
+VeloxMemoryManager::VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener)
+    : MemoryManager(kind), listener_(std::move(listener)) {
   auto reservationBlockSize = VeloxBackend::get()->getBackendConf()->get<uint64_t>(
       kMemoryReservationBlockSize, kMemoryReservationBlockSizeDefault);
   auto memInitCapacity =

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "compute/VeloxBackend.h"
 #include "memory/AllocationListener.h"
 #include "memory/MemoryAllocator.h"
 #include "memory/MemoryManager.h"
@@ -28,7 +29,7 @@ namespace gluten {
 // Make sure the class is thread safe
 class VeloxMemoryManager final : public MemoryManager {
  public:
-  VeloxMemoryManager(std::unique_ptr<AllocationListener> listener);
+  VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener);
 
   ~VeloxMemoryManager() override;
   VeloxMemoryManager(const VeloxMemoryManager&) = delete;
@@ -88,7 +89,8 @@ class VeloxMemoryManager final : public MemoryManager {
 
 /// Not tracked by Spark and should only used in test or validation.
 inline std::shared_ptr<gluten::VeloxMemoryManager> getDefaultMemoryManager() {
-  static auto memoryManager = std::make_shared<gluten::VeloxMemoryManager>(gluten::AllocationListener::noop());
+  static auto memoryManager =
+      std::make_shared<gluten::VeloxMemoryManager>(gluten::kVeloxBackendKind, gluten::AllocationListener::noop());
   return memoryManager;
 }
 

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ add_velox_test(
   VeloxToSubstraitTypeTest.cc)
 add_velox_test(spark_functions_test SOURCES SparkFunctionTest.cc
                FunctionTest.cc)
-add_velox_test(execution_ctx_test SOURCES RuntimeTest.cc)
+add_velox_test(runtime_test SOURCES RuntimeTest.cc)
 add_velox_test(velox_memory_test SOURCES MemoryManagerTest.cc)
 add_velox_test(buffer_outputstream_test SOURCES BufferOutputStreamTest.cc)
 if(BUILD_EXAMPLES)

--- a/cpp/velox/tests/MemoryManagerTest.cc
+++ b/cpp/velox/tests/MemoryManagerTest.cc
@@ -53,7 +53,7 @@ class MemoryManagerTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    vmm_ = std::make_unique<VeloxMemoryManager>(std::make_unique<MockAllocationListener>());
+    vmm_ = std::make_unique<VeloxMemoryManager>(gluten::kVeloxBackendKind, std::make_unique<MockAllocationListener>());
     listener_ = vmm_->getListener();
     allocator_ = vmm_->allocator();
   }
@@ -335,7 +335,7 @@ class MultiMemoryManagerTest : public ::testing::Test {
   }
 
   std::unique_ptr<VeloxMemoryManager> newVeloxMemoryManager(std::unique_ptr<AllocationListener> listener) {
-    return std::make_unique<VeloxMemoryManager>(std::move(listener));
+    return std::make_unique<VeloxMemoryManager>(gluten::kVeloxBackendKind, std::move(listener));
   }
 };
 


### PR DESCRIPTION
Requires release hooks to be registered when registering factories for `Runtime` and `MemoryManager` instances. So the unsafe `new` and `delete` operations will be organized in the same manner in code.