### PR TITLE
[GLUTEN-7550][CH] Rewrite `get_json_object` in `singular_or_list`

### DIFF
--- a/cpp-ch/local-engine/Rewriter/ExpressionRewriter.h
+++ b/cpp-ch/local-engine/Rewriter/ExpressionRewriter.h
@@ -104,6 +104,10 @@ private:
                 prepareOnExpression(if_then.else_());
                 break;
             }
+            case substrait::Expression::RexTypeCase::kSingularOrList: {
+                prepareOnExpression(expr.singular_or_list().value());
+                break;
+            }
             case substrait::Expression::RexTypeCase::kScalarFunction: {
                 const auto & scalar_function_pb = expr.scalar_function();
                 auto function_signature_name_opt = parser_context->getFunctionNameInSignature(scalar_function_pb);
@@ -158,6 +162,10 @@ private:
                     rewriteExpression(*ifs->Mutable(i)->mutable_then());
                 }
                 rewriteExpression(*if_then->mutable_else_());
+                break;
+            }
+            case substrait::Expression::RexTypeCase::kSingularOrList: {
+                rewriteExpression(*expr.mutable_singular_or_list()->mutable_value());
                 break;
             }
             case substrait::Expression::RexTypeCase::kScalarFunction: {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #7550

The query plan is updated to
```
Expression (Rename Output)
Header: s#0 Nullable(String)
        #18 Nullable(UInt8)
Positions:
  Expression (Project)
  Header: s Nullable(String)
          in(sparkTupleElement(scalar_function { function_reference: 1000000 output_type { struct { types { string { nullability: NULLABILITY_NULLABLE } } names: "$.a" } } arguments { value { selection { direct_reference { struct_field { } } } } } arguments { value { literal { string: "$.a" } } } },$.a_7),__set_8) Nullable(UInt8)
  Positions:
    SubstraitFileSourceStep (read local files)
    Header: s Nullable(String)
```

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

