### PR TITLE
[VL] Fix sort based shuffle oom in spill when compress was disabled

### DIFF
--- a/cpp/core/shuffle/rss/RssPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/RssPartitionWriter.cc
@@ -85,7 +85,7 @@ arrow::Status RssPartitionWriter::doEvict(
       inMemoryPayload->toBlockPayload(
           payloadType, payloadPool_.get(), codec_ ? codec_.get() : nullptr, std::move(compressed)));
   // Copy payload to arrow buffered os.
-  ARROW_ASSIGN_OR_RAISE(auto rssBufferOs, arrow::io::BufferOutputStream::Create(options_.pushBufferMaxSize, pool_));
+  ARROW_ASSIGN_OR_RAISE(auto rssBufferOs, arrow::io::BufferOutputStream::Create(options_.pushBufferMaxSize));
   RETURN_NOT_OK(payload->serialize(rssBufferOs.get()));
   payload = nullptr; // Invalidate payload immediately.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix oom when compress was disabled in spill.

![image](https://github.com/user-attachments/assets/032bddf4-1cf8-4c5f-a6cc-4a634df5a979)

