### PR TITLE
[GLUTEN-7499][VL] CI: Remove GHA binary cache

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -59,16 +59,6 @@ jobs:
     container: apache/gluten:vcpkg-centos-7
     steps:
       - uses: actions/checkout@v2
-      - name: Generate cache key
-        run: |
-          echo ${{ hashFiles('./ep/build-velox/src/**', './dev/**', './cpp/*', './.github/workflows/*') }} > cache-key
-      - name: Cache
-        id: cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ./cpp/build/releases/
-          key: cache-velox-build-centos-7-${{ hashFiles('./cache-key') }}
       - name: Get Ccache
         uses: actions/cache/restore@v3
         with:
@@ -77,7 +67,6 @@ jobs:
           restore-keys: |
             ccache-centos7-release-default
       - name: Build Gluten native libraries
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           df -a
           yum install ccache -y
@@ -978,19 +967,6 @@ jobs:
     container: apache/gluten:centos-8
     steps:
       - uses: actions/checkout@v2
-      - name: Generate cache key
-        run: |
-          echo ${{ hashFiles('./ep/build-velox/src/**', './dev/**', './cpp/*', './.github/workflows/*') }} > cache-key
-      - name: Cache
-        id: cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ./cpp/build/releases/
-            ./cpp/build/velox/udf/examples/
-            ./cpp/build/velox/benchmarks/
-            /root/.m2/repository/org/apache/arrow/
-          key: cache-velox-build-centos-8-${{ hashFiles('./cache-key') }}
       - name: Get Ccache
         uses: actions/cache/restore@v3
         with:
@@ -1005,7 +981,6 @@ jobs:
           yum install sudo patch java-1.8.0-openjdk-devel wget -y
           $SETUP install_maven
       - name: Build Gluten native libraries
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           df -a
           bash dev/ci-velox-buildshared-centos-8.sh

--- a/.github/workflows/velox_backend_cache.yml
+++ b/.github/workflows/velox_backend_cache.yml
@@ -34,17 +34,6 @@ jobs:
     container: apache/gluten:vcpkg-centos-7
     steps:
       - uses: actions/checkout@v2
-      - name: Generate cache key
-        run: |
-          echo ${{ hashFiles('./ep/build-velox/src/**', './dev/**', './cpp/*', './.github/workflows/*') }} > cache-key
-      - name: Check existing caches
-        id: check-cache
-        uses: actions/cache/restore@v3
-        with:
-          lookup-only: true
-          path: |
-            ./cpp/build/releases/
-          key: cache-velox-build-centos-7-${{ hashFiles('./cache-key') }}
       - name: Get Ccache
         uses: actions/cache/restore@v3
         with:
@@ -58,40 +47,18 @@ jobs:
           df -a
           yum install ccache -y
           bash dev/ci-velox-buildstatic-centos-7.sh
-      - name: "Save ccache"
+      - name: Save ccache
         uses: actions/cache/save@v3
         id: ccache
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos7-release-default-${{github.sha}}
-      - name: Cache
-        if: steps.check-cache.outputs.cache-hit != 'true'
-        id: cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ./cpp/build/releases/
-          key: cache-velox-build-centos-7-${{ hashFiles('./cache-key') }}
 
   cache-native-lib-centos-8:
     runs-on: ubuntu-20.04
     container: apache/gluten:centos-8
     steps:
       - uses: actions/checkout@v2
-      - name: Generate cache key
-        run: |
-          echo ${{ hashFiles('./ep/build-velox/src/**', './dev/**', './cpp/*', './.github/workflows/*') }} > cache-key
-      - name: Check existing caches
-        id: check-cache
-        uses: actions/cache/restore@v3
-        with:
-          lookup-only: true
-          path: |
-            ./cpp/build/releases/
-            ./cpp/build/velox/udf/examples/
-            ./cpp/build/velox/benchmarks/
-            /root/.m2/repository/org/apache/arrow/
-          key: cache-velox-build-centos-8-${{ hashFiles('./cache-key') }}
       - name: Get Ccache
         uses: actions/cache/restore@v3
         with:
@@ -112,23 +79,12 @@ jobs:
           df -a
           bash dev/ci-velox-buildshared-centos-8.sh
           ccache -s
-      - name: "Save ccache"
+      - name: Save ccache
         uses: actions/cache/save@v3
         id: ccache
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos8-release-default-${{github.sha}}
-      - name: Cache
-        if: steps.check-cache.outputs.cache-hit != 'true'
-        id: cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ./cpp/build/releases/
-            ./cpp/build/velox/udf/examples/
-            ./cpp/build/velox/benchmarks/
-            /root/.m2/repository/org/apache/arrow/
-          key: cache-velox-build-centos-8-${{ hashFiles('./cache-key') }}
 
   # ccache-native-lib-ubuntu-velox-ut:
   #   runs-on: ubuntu-20.04

--- a/.github/workflows/velox_backend_cache.yml
+++ b/.github/workflows/velox_backend_cache.yml
@@ -42,7 +42,6 @@ jobs:
           restore-keys: |
             ccache-centos7-release-default
       - name: Build Gluten native libraries
-        if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           df -a
           yum install ccache -y
@@ -67,14 +66,12 @@ jobs:
           restore-keys: |
             ccache-centos8-release-default
       - name: Setup java and maven
-        if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* || true
           sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
           yum install sudo patch java-1.8.0-openjdk-devel wget -y
           bash .github/workflows/util/setup_helper.sh install_maven
       - name: Build Gluten native libraries
-        if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           df -a
           bash dev/ci-velox-buildshared-centos-8.sh


### PR DESCRIPTION
We are [migrating to shared ccache](https://github.com/apache/incubator-gluten/pull/7546) in GHA CI, so ideally we can remove the legacy way that caches the C++ binaries. Since the part of legacy code is not trivial to maintain.