### PR TITLE
[GLUTEN-7535][VL] CentOS 7 containerized build: Fix for automake version error

### DIFF
--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -38,6 +38,10 @@ yum -y install \
 # Link c++ to the one in devtoolset.
 ln -s /opt/rh/devtoolset-9/root/usr/bin/c++ /usr/bin/c++
 
+semver() {
+    echo "$@" | awk -F. '{ printf("%d%05d%05d", $1,$2,$3); }'
+}
+
 pip3 install --upgrade pip
 
 # cmake >= 3.28.3


### PR DESCRIPTION
When extra FS options are turned on like `--enable_s3=ON --enable_gcs=ON --enable_hdfs=ON --enable_abfs=ON` then build will fail by an automake version error. The patch fixes the issue.