### PR TITLE
[GLUTEN-7557][VL] ArrowConvertorRule should use transformUp

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/datasource/ArrowConvertorRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/datasource/ArrowConvertorRule.scala
@@ -44,7 +44,7 @@ case class ArrowConvertorRule(session: SparkSession) extends Rule[LogicalPlan] {
     if (!BackendsApiManager.getSettings.enableNativeArrowReadFiles()) {
       return plan
     }
-    plan.resolveOperators {
+    plan.transform {
       case l @ LogicalRelation(
             r @ HadoopFsRelation(_, _, dataSchema, _, _: CSVFileFormat, options),
             _,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Spark, the resolveOperatorsUp used to analysis rule, but transformUp used to optimize rule.
This PR proposes to make `ArrowConvertorRule` use `transformUp`.

## How was this patch tested?

integration tests