### PR TITLE
[GLUTEN-7575] [CH] fix empty needle in regex_replace throw exception

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
@@ -190,10 +190,14 @@ case class CHRegExpReplaceTransformer(
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     // In CH: replaceRegexpAll(subject, regexp, rep), which is equivalent
     // In Spark: regexp_replace(subject, regexp, rep, pos=1)
+    // In CH: thre regexp should not be empty
     val posNode = childrenWithPos(3).doTransform(args)
+    val needleNode = childrenWithPos(1).doTransform(args)
     if (
       !posNode.isInstanceOf[IntLiteralNode] ||
-      posNode.asInstanceOf[IntLiteralNode].getValue != 1
+      posNode.asInstanceOf[IntLiteralNode].getValue != 1 ||
+      !needleNode.isInstanceOf[StringLiteralNode] ||
+      needleNode.asInstanceOf[StringLiteralNode].getValue.isEmpty
     ) {
       throw new UnsupportedOperationException(s"$original not supported yet.")
     }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
@@ -347,7 +347,7 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
       )
     }
   }
- 
+
   test("GLUTEN-7575: empty needle in regex_replace") {
     withTable("test_7575") {
       spark.sql("create table test_7575 (a string) using parquet")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
@@ -358,7 +358,7 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
           |""".stripMargin,
         true,
         false
-      )(df => checkFallbackOperators(df, 1))
+      )(df => checkFallbackOperators(df, 0))
     }
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
@@ -347,5 +347,16 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
       )
     }
   }
-
+ 
+  test("GLUTEN-7575: empty needle in regex_replace") {
+    withTable("test_7575") {
+      spark.sql("create table test_7575 (a string) using parquet")
+      spark.sql("insert into test_7575 values ('abc')")
+      runQueryAndCompare(
+        """
+          |SELECT regexp_replace(a, '''', '') from test_7575
+          |""".stripMargin
+      )(df => checkFallbackOperators(df, 1))
+    }
+  }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
@@ -355,7 +355,9 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
       runQueryAndCompare(
         """
           |SELECT regexp_replace(a, '''', '') from test_7575
-          |""".stripMargin
+          |""".stripMargin,
+        true,
+        false
       )(df => checkFallbackOperators(df, 1))
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Regex_replace which has empty needle will fallback to vanilla spark.

(Fixes: \#7575)

## How was this patch tested?

This patch was tested by unit tests.


