### PR TITLE
[VL] Fix missing VELOX_HOME in builddeps-veloxbe.sh

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -193,7 +193,8 @@ function build_velox {
   # When BUILD_TESTS is on for gluten cpp, we need turn on VELOX_BUILD_TEST_UTILS via build_test_utils.
   ./build_velox.sh --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
                    --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_test_utils=$BUILD_TESTS \
-                   --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS --num_threads=$NUM_THREADS
+                   --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS --num_threads=$NUM_THREADS \
+                   --velox_home=$VELOX_HOME
 }
 
 function build_gluten_cpp {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`VELOX_HOME` should be passed as a parameter to the `build_velox.sh` script in builddeps-veloxbe.sh.

## How was this patch tested?

N/A

