### PR TITLE
[GLUTEN-7174][VL] Force fallback scan operator when spark.sql.parquet.mergeSchema enabled

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -145,7 +145,8 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   override def validateScanExec(
       format: ReadFileFormat,
       fields: Array[StructField],
-      rootPaths: Seq[String]): ValidationResult = {
+      rootPaths: Seq[String],
+      properties: Map[String, String]): ValidationResult = {
 
     // Validate if all types are supported.
     def hasComplexType: Boolean = {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -142,7 +142,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       .toLowerCase(Locale.getDefault)
   }
 
-  override def validateScan(
+  override def validateScanExec(
       format: ReadFileFormat,
       fields: Array[StructField],
       rootPaths: Seq[String]): ValidationResult = {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -110,7 +110,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
         // Collect unsupported types.
         val unsupportedDataTypeReason = fields.collect(validatorFunc)
         if (unsupportedDataTypeReason.nonEmpty) {
-          Some(s"Found unsupported data type in $format: ${unsupportedDataTypeReason.mkString(", ")}.")
+          Some(
+            s"Found unsupported data type in $format: ${unsupportedDataTypeReason.mkString(", ")}.")
         } else {
           None
         }
@@ -131,7 +132,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
           val typeValidator: PartialFunction[StructField, String] = {
             // Parquet timestamp is not fully supported yet
             case StructField(_, TimestampType, _, _)
-              if GlutenConfig.getConf.forceParquetTimestampTypeScanFallbackEnabled =>
+                if GlutenConfig.getConf.forceParquetTimestampTypeScanFallbackEnabled =>
               "TimestampType(force fallback)"
           }
           if (SQLConf.get.isParquetSchemaMergingEnabled) {
@@ -147,19 +148,19 @@ object VeloxBackendSettings extends BackendSettingsApi {
           } else {
             val typeValidator: PartialFunction[StructField, String] = {
               case StructField(_, arrayType: ArrayType, _, _)
-                if arrayType.elementType.isInstanceOf[StructType] =>
+                  if arrayType.elementType.isInstanceOf[StructType] =>
                 "StructType as element in ArrayType"
               case StructField(_, arrayType: ArrayType, _, _)
-                if arrayType.elementType.isInstanceOf[ArrayType] =>
+                  if arrayType.elementType.isInstanceOf[ArrayType] =>
                 "ArrayType as element in ArrayType"
               case StructField(_, mapType: MapType, _, _)
-                if mapType.keyType.isInstanceOf[StructType] =>
+                  if mapType.keyType.isInstanceOf[StructType] =>
                 "StructType as Key in MapType"
               case StructField(_, mapType: MapType, _, _)
-                if mapType.valueType.isInstanceOf[ArrayType] =>
+                  if mapType.valueType.isInstanceOf[ArrayType] =>
                 "ArrayType as Value in MapType"
               case StructField(_, stringType: StringType, _, metadata)
-                if isCharType(stringType, metadata) =>
+                  if isCharType(stringType, metadata) =>
                 CharVarcharUtils.getRawTypeString(metadata) + "(force fallback)"
               case StructField(_, TimestampType, _, _) => "TimestampType"
             }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.{FileFormat, InsertIntoHadoopF
 import org.apache.spark.sql.types.StructField
 
 trait BackendSettingsApi {
-  def validateScan(
+  def validateScanExec(
       format: ReadFileFormat,
       fields: Array[StructField],
       rootPaths: Seq[String]): ValidationResult = ValidationResult.succeeded

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -33,7 +33,8 @@ trait BackendSettingsApi {
   def validateScanExec(
       format: ReadFileFormat,
       fields: Array[StructField],
-      rootPaths: Seq[String]): ValidationResult = ValidationResult.succeeded
+      rootPaths: Seq[String],
+      properties: Map[String, String]): ValidationResult = ValidationResult.succeeded
 
   def supportWriteFilesExec(
       format: FileFormat,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -95,7 +95,7 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
     }
 
     val validationResult = BackendsApiManager.getSettings
-      .validateScanExec(fileFormat, fields, getRootFilePaths)
+      .validateScanExec(fileFormat, fields, getRootFilePaths, getProperties)
     if (!validationResult.ok()) {
       return validationResult
     }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -95,7 +95,7 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
     }
 
     val validationResult = BackendsApiManager.getSettings
-      .validateScan(fileFormat, fields, getRootFilePaths)
+      .validateScanExec(fileFormat, fields, getRootFilePaths)
     if (!validationResult.ok()) {
       return validationResult
     }

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -861,7 +861,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenParquetFileFormatV2Suite]
   enableSuite[GlutenParquetV1FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")
     // Rewrite for supported INT96 - timestamp.
@@ -875,8 +874,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-17091: Convert IN predicate to Parquet filter push-down")
     .exclude("Support Parquet column index")
     .exclude("SPARK-34562: Bloom filter push down")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetV2FilterSuite]
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -106,54 +106,6 @@ abstract class GlutenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
     }
   }
 
-  testGluten("Filter applied on merged Parquet schema with new column should work") {
-    import testImplicits._
-    withAllParquetReaders {
-      withSQLConf(
-        SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
-        SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true") {
-        withTempPath {
-          dir =>
-            val path1 = s"${dir.getCanonicalPath}/table1"
-            (1 to 3)
-              .map(i => (i, i.toString, null: String))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path1)
-            val path2 = s"${dir.getCanonicalPath}/table2"
-            (1 to 3)
-              .map(i => (null: Integer, i.toString, i.toString))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path2)
-
-            // No matter "c = 1" gets pushed down or not, this query should work without exception.
-            val df = spark.read.parquet(path1, path2).filter("c = 1").selectExpr("c", "b", "a")
-            df.show()
-
-            // Annotated for the type check fails.
-            // checkAnswer(df, Row(1, "1", null))
-
-            val path3 = s"${dir.getCanonicalPath}/table3"
-            val dfStruct = sparkContext.parallelize(Seq((1, 1, null))).toDF("a", "b", "c")
-            dfStruct.select(struct("a").as("s")).write.parquet(path3)
-
-            val path4 = s"${dir.getCanonicalPath}/table4"
-            val dfStruct2 = sparkContext.parallelize(Seq((null, 1, 1))).toDF("a", "b", "c")
-            dfStruct2.select(struct("c").as("s")).write.parquet(path4)
-
-            // No matter "s.c = 1" gets pushed down or not, this query
-            // should work without exception.
-            val dfStruct3 = spark.read
-              .parquet(path3, path4)
-              .filter("s.c = 1")
-              .selectExpr("s")
-            checkAnswer(dfStruct3, Row(Row(null, 1)))
-        }
-      }
-    }
-  }
-
   testGluten("SPARK-12218: 'Not' is included in Parquet filter pushdown") {
     import testImplicits._
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -663,7 +663,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenParquetFileFormatV2Suite]
   enableSuite[GlutenParquetV1FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
@@ -679,11 +678,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Support Parquet column index")
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetV2FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
@@ -699,8 +695,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Support Parquet column index")
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetInteroperabilitySuite]
     .exclude("parquet timestamp conversion")
   enableSuite[GlutenParquetIOSuite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
@@ -103,54 +102,6 @@ abstract class GlutenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
               }
             }
         }
-    }
-  }
-
-  testGluten("Filter applied on merged Parquet schema with new column should work") {
-    import testImplicits._
-    withAllParquetReaders {
-      withSQLConf(
-        SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
-        SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true") {
-        withTempPath {
-          dir =>
-            val path1 = s"${dir.getCanonicalPath}/table1"
-            (1 to 3)
-              .map(i => (i, i.toString, null: String))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path1)
-            val path2 = s"${dir.getCanonicalPath}/table2"
-            (1 to 3)
-              .map(i => (null: Integer, i.toString, i.toString))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path2)
-
-            // No matter "c = 1" gets pushed down or not, this query should work without exception.
-            val df = spark.read.parquet(path1, path2).filter("c = 1").selectExpr("c", "b", "a")
-            df.show()
-
-            // Annotated for the type check fails.
-            // checkAnswer(df, Row(1, "1", null))
-
-            val path3 = s"${dir.getCanonicalPath}/table3"
-            val dfStruct = sparkContext.parallelize(Seq((1, 1, null))).toDF("a", "b", "c")
-            dfStruct.select(struct("a").as("s")).write.parquet(path3)
-
-            val path4 = s"${dir.getCanonicalPath}/table4"
-            val dfStruct2 = sparkContext.parallelize(Seq((null, 1, 1))).toDF("a", "b", "c")
-            dfStruct2.select(struct("c").as("s")).write.parquet(path4)
-
-            // No matter "s.c = 1" gets pushed down or not, this query should work
-            // without exception.
-            val dfStruct3 = spark.read
-              .parquet(path3, path4)
-              .filter("s.c = 1")
-              .selectExpr("s")
-            checkAnswer(dfStruct3, Row(Row(null, 1)))
-        }
-      }
     }
   }
 

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -644,7 +644,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenParquetFileFormatV2Suite]
   enableSuite[GlutenParquetV1FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
@@ -660,11 +659,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
     .exclude("filter pushdown - StringPredicate")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetV2FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
@@ -680,8 +676,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
     .exclude("filter pushdown - StringPredicate")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetInteroperabilitySuite]
     .exclude("parquet timestamp conversion")
   enableSuite[GlutenParquetIOSuite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
@@ -102,54 +101,6 @@ abstract class GlutenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
               }
             }
         }
-    }
-  }
-
-  testGluten("Filter applied on merged Parquet schema with new column should work") {
-    import testImplicits._
-    withAllParquetReaders {
-      withSQLConf(
-        SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
-        SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true") {
-        withTempPath {
-          dir =>
-            val path1 = s"${dir.getCanonicalPath}/table1"
-            (1 to 3)
-              .map(i => (i, i.toString, null: String))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path1)
-            val path2 = s"${dir.getCanonicalPath}/table2"
-            (1 to 3)
-              .map(i => (null: Integer, i.toString, i.toString))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path2)
-
-            // No matter "c = 1" gets pushed down or not, this query should work without exception.
-            val df = spark.read.parquet(path1, path2).filter("c = 1").selectExpr("c", "b", "a")
-            df.show()
-
-            // Annotated for the type check fails.
-            // checkAnswer(df, Row(1, "1", null))
-
-            val path3 = s"${dir.getCanonicalPath}/table3"
-            val dfStruct = sparkContext.parallelize(Seq((1, 1, null))).toDF("a", "b", "c")
-            dfStruct.select(struct("a").as("s")).write.parquet(path3)
-
-            val path4 = s"${dir.getCanonicalPath}/table4"
-            val dfStruct2 = sparkContext.parallelize(Seq((null, 1, 1))).toDF("a", "b", "c")
-            dfStruct2.select(struct("c").as("s")).write.parquet(path4)
-
-            // No matter "s.c = 1" gets pushed down or not, this query should work
-            // without exception.
-            val dfStruct3 = spark.read
-              .parquet(path3, path4)
-              .filter("s.c = 1")
-              .selectExpr("s")
-            checkAnswer(dfStruct3, Row(Row(null, 1)))
-        }
-      }
     }
   }
 

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -655,7 +655,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenParquetFileFormatV2Suite]
   enableSuite[GlutenParquetV1FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
@@ -671,11 +670,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
     .exclude("filter pushdown - StringPredicate")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetV2FilterSuite]
     // Rewrite.
-    .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
@@ -691,8 +687,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
     .exclude("filter pushdown - StringPredicate")
-    // https://github.com/apache/incubator-gluten/issues/7174
-    .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetInteroperabilitySuite]
     .exclude("parquet timestamp conversion")
   enableSuite[GlutenParquetIOSuite]

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
@@ -102,54 +101,6 @@ abstract class GlutenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
               }
             }
         }
-    }
-  }
-
-  testGluten("Filter applied on merged Parquet schema with new column should work") {
-    import testImplicits._
-    withAllParquetReaders {
-      withSQLConf(
-        SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
-        SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true") {
-        withTempPath {
-          dir =>
-            val path1 = s"${dir.getCanonicalPath}/table1"
-            (1 to 3)
-              .map(i => (i, i.toString, null: String))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path1)
-            val path2 = s"${dir.getCanonicalPath}/table2"
-            (1 to 3)
-              .map(i => (null: Integer, i.toString, i.toString))
-              .toDF("a", "b", "c")
-              .write
-              .parquet(path2)
-
-            // No matter "c = 1" gets pushed down or not, this query should work without exception.
-            val df = spark.read.parquet(path1, path2).filter("c = 1").selectExpr("c", "b", "a")
-            df.show()
-
-            // Annotated for the type check fails.
-            // checkAnswer(df, Row(1, "1", null))
-
-            val path3 = s"${dir.getCanonicalPath}/table3"
-            val dfStruct = sparkContext.parallelize(Seq((1, 1, null))).toDF("a", "b", "c")
-            dfStruct.select(struct("a").as("s")).write.parquet(path3)
-
-            val path4 = s"${dir.getCanonicalPath}/table4"
-            val dfStruct2 = sparkContext.parallelize(Seq((null, 1, 1))).toDF("a", "b", "c")
-            dfStruct2.select(struct("c").as("s")).write.parquet(path4)
-
-            // No matter "s.c = 1" gets pushed down or not, this query should work
-            // without exception.
-            val dfStruct3 = spark.read
-              .parquet(path3, path4)
-              .filter("s.c = 1")
-              .selectExpr("s")
-            checkAnswer(dfStruct3, Row(Row(null, 1)))
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox treat missing column as null, will output incorrect results when spark.sql.parquet.mergeSchema enabled.

Fixes: #7174

## How was this patch tested?

Enable some excluded tests.
