### PR TITLE
[VL] Enable excluded tests in GlutenParquetColumnIndexSuite and GlutenParquetEncodingSuite

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -29,12 +29,11 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    //createTPCHNotNullTables()
+    createTPCHNotNullTables()
   }
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf.set("spark.gluten.sql.native.writer.enabled", "true")
-      .set("spark.gluten.sql.debug", "true")
   }
 
   test("test Array(Struct) fallback") {
@@ -124,15 +123,6 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
         "CREATE TABLE bucket USING PARQUET CLUSTERED BY (p) INTO 7 BUCKETS " +
           "AS SELECT * FROM bucket_temp")
       Assert.assertTrue(FallbackUtil.hasFallback(df.queryExecution.executedPlan))
-    }
-  }
-
-  test("yc test") {
-    withTable("t") {
-      sql("create table t (id string) using parquet");
-      sql("insert into t values('\\t\\n\\u001F 123\\u000B')")
-      sql("select * from t").show()
-      sql("select cast(id as int) from t").show()
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -29,11 +29,12 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    createTPCHNotNullTables()
+    //createTPCHNotNullTables()
   }
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf.set("spark.gluten.sql.native.writer.enabled", "true")
+      .set("spark.gluten.sql.debug", "true")
   }
 
   test("test Array(Struct) fallback") {
@@ -123,6 +124,15 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
         "CREATE TABLE bucket USING PARQUET CLUSTERED BY (p) INTO 7 BUCKETS " +
           "AS SELECT * FROM bucket_temp")
       Assert.assertTrue(FallbackUtil.hasFallback(df.queryExecution.executedPlan))
+    }
+  }
+
+  test("yc test") {
+    withTable("t") {
+      sql("create table t (id string) using parquet");
+      sql("insert into t values('\\t\\n\\u001F 123\\u000B')")
+      sql("select * from t").show()
+      sql("select cast(id as int) from t").show()
     }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -652,6 +652,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]
   enableSuite[GlutenParquetDeltaEncodingLong]
+    // Velox does not support rle encoding.
+    .exclude("parquet v2 pages - rle encoding for boolean value columns")
   enableSuite[GlutenParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[GlutenParquetEncodingSuite]
   enableSuite[GlutenParquetFieldIdIOSuite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -648,16 +648,12 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - without partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetColumnIndexSuite]
-    // Rewrite by just removing test timestamp.
-    .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]
   enableSuite[GlutenParquetDeltaEncodingLong]
   enableSuite[GlutenParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[GlutenParquetEncodingSuite]
-    // Velox does not support rle encoding.
-    .exclude("parquet v2 pages - rle encoding for boolean value columns")
   enableSuite[GlutenParquetFieldIdIOSuite]
   enableSuite[GlutenParquetFileFormatV1Suite]
   enableSuite[GlutenParquetFileFormatV2Suite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -652,10 +652,10 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]
   enableSuite[GlutenParquetDeltaEncodingLong]
-    // Velox does not support rle encoding.
-    .exclude("parquet v2 pages - rle encoding for boolean value columns")
   enableSuite[GlutenParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[GlutenParquetEncodingSuite]
+    // Velox does not support rle encoding.
+    .exclude("parquet v2 pages - rle encoding for boolean value columns")
   enableSuite[GlutenParquetFieldIdIOSuite]
   enableSuite[GlutenParquetFileFormatV1Suite]
   enableSuite[GlutenParquetFileFormatV2Suite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -16,30 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
-class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
-  private val actions: Seq[DataFrame => DataFrame] = Seq(
-    "_1 = 500",
-    "_1 = 500 or _1 = 1500",
-    "_1 = 500 or _1 = 501 or _1 = 1500",
-    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
-    "_1 >= 500 and _1 < 1000",
-    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
-  ).map(f => (df: DataFrame) => df.filter(f))
-
-  testGluten("test reading unaligned pages - test all types") {
-    val df = spark
-      .range(0, 2000)
-      .selectExpr(
-        "id as _1",
-        "cast(id as short) as _3",
-        "cast(id as int) as _4",
-        "cast(id as float) as _5",
-        "cast(id as double) as _6",
-        "cast(id as decimal(20,0)) as _7",
-        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9"
-      )
-    checkUnalignedPages(df)(actions: _*)
-  }
-}
+class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {}

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -629,16 +629,12 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - without partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetColumnIndexSuite]
-    // Rewrite by just removing test timestamp.
-    .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]
   enableSuite[GlutenParquetDeltaEncodingLong]
   enableSuite[GlutenParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[GlutenParquetEncodingSuite]
-    // Velox does not support rle encoding, but it can pass when native writer enabled.
-    .exclude("parquet v2 pages - rle encoding for boolean value columns")
   enableSuite[GlutenParquetFieldIdIOSuite]
   enableSuite[GlutenParquetFileFormatV1Suite]
   enableSuite[GlutenParquetFileFormatV2Suite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -16,30 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
-class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
-  private val actions: Seq[DataFrame => DataFrame] = Seq(
-    "_1 = 500",
-    "_1 = 500 or _1 = 1500",
-    "_1 = 500 or _1 = 501 or _1 = 1500",
-    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
-    "_1 >= 500 and _1 < 1000",
-    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
-  ).map(f => (df: DataFrame) => df.filter(f))
-
-  testGluten("test reading unaligned pages - test all types") {
-    val df = spark
-      .range(0, 2000)
-      .selectExpr(
-        "id as _1",
-        "cast(id as short) as _3",
-        "cast(id as int) as _4",
-        "cast(id as float) as _5",
-        "cast(id as double) as _6",
-        "cast(id as decimal(20,0)) as _7",
-        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9"
-      )
-    checkUnalignedPages(df)(actions: _*)
-  }
-}
+class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {}

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -640,16 +640,12 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - without partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetColumnIndexSuite]
-    // Rewrite by just removing test timestamp.
-    .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]
   enableSuite[GlutenParquetDeltaEncodingLong]
   enableSuite[GlutenParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[GlutenParquetEncodingSuite]
-    // Velox does not support rle encoding, but it can pass when native writer enabled.
-    .exclude("parquet v2 pages - rle encoding for boolean value columns")
   enableSuite[GlutenParquetFieldIdIOSuite]
   enableSuite[GlutenParquetFileFormatV1Suite]
   enableSuite[GlutenParquetFileFormatV2Suite]

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -16,30 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
+import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
-class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
-  private val actions: Seq[DataFrame => DataFrame] = Seq(
-    "_1 = 500",
-    "_1 = 500 or _1 = 1500",
-    "_1 = 500 or _1 = 501 or _1 = 1500",
-    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
-    "_1 >= 500 and _1 < 1000",
-    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
-  ).map(f => (df: DataFrame) => df.filter(f))
-
-  testGluten("test reading unaligned pages - test all types") {
-    val df = spark
-      .range(0, 2000)
-      .selectExpr(
-        "id as _1",
-        "cast(id as short) as _3",
-        "cast(id as int) as _4",
-        "cast(id as float) as _5",
-        "cast(id as double) as _6",
-        "cast(id as decimal(20,0)) as _7",
-        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9"
-      )
-    checkUnalignedPages(df)(actions: _*)
-  }
-}
+class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable `test reading unaligned pages - test all types` for Spark33,34,35.
Enable `parquet v2 pages - rle encoding for boolean value columns` for Spark34,35, cause native write was enabled by default after Spark34.

