### PR TITLE
[VL] Follow-up fix for gcc upgrade PR

### DIFF
--- a/dev/docker/Dockerfile.centos8-dynamic-build
+++ b/dev/docker/Dockerfile.centos8-dynamic-build
@@ -3,7 +3,7 @@ FROM centos:8
 RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* || true
 RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true
 
-RUN yum update -y && yum install -y epel-release sudo dnf ccache
+RUN yum update -y && yum install -y epel-release sudo dnf && yum install -y ccache
 RUN dnf install -y --setopt=install_weak_deps=False gcc-toolset-11
 RUN echo "check_certificate = off" >> ~/.wgetrc
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up fix for https://github.com/apache/incubator-gluten/pull/7578.
ccache is available to install after epel-release is installed.

## How was this patch tested?

Local test.
