### PR TITLE
[GLUTEN-7675][VL] Support parquet write with complex data type(eg. MAP, ARRYY)

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -221,6 +221,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
           fields.flatMap {
             case StructField(_, _: YearMonthIntervalType, _, _) =>
               Some("YearMonthIntervalType")
+            case StructField(_, _: StructType, _, _) =>
+              Some("StructType")
             case _ => None
           }
         case _ =>

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -216,14 +216,23 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
     // Validate if all types are supported.
     def validateDataTypes(): Option[String] = {
-      val unsupportedTypes = fields.flatMap {
-        field =>
-          field.dataType match {
-            case _: StructType => Some("StructType")
-            case _: ArrayType => Some("ArrayType")
-            case _: MapType => Some("MapType")
-            case _: YearMonthIntervalType => Some("YearMonthIntervalType")
+      val unsupportedTypes = format match {
+        case _: ParquetFileFormat =>
+          fields.flatMap {
+            case StructField(_, _: YearMonthIntervalType, _, _) =>
+              Some("YearMonthIntervalType")
             case _ => None
+          }
+        case _ =>
+          fields.flatMap {
+            field =>
+              field.dataType match {
+                case _: StructType => Some("StructType")
+                case _: ArrayType => Some("ArrayType")
+                case _: MapType => Some("MapType")
+                case _: YearMonthIntervalType => Some("YearMonthIntervalType")
+                case _ => None
+              }
           }
       }
       if (unsupportedTypes.nonEmpty) {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1523,26 +1523,30 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
 
   test("test array literal") {
     withTable("array_table") {
-      sql("create table array_table(a array<bigint>) using parquet")
-      sql("insert into table array_table select array(1)")
-      runQueryAndCompare("select size(coalesce(a, array())) from array_table") {
-        df =>
-          {
-            assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
-          }
+      withSQLConf("spark.gluten.sql.columnar.oneRowRelation" -> "false") {
+        sql("create table array_table(a array<bigint>) using parquet")
+        sql("insert into table array_table select array(1)")
+        runQueryAndCompare("select size(coalesce(a, array())) from array_table") {
+          df =>
+            {
+              assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
+            }
+        }
       }
     }
   }
 
   test("test map literal") {
     withTable("map_table") {
-      sql("create table map_table(a map<bigint, string>) using parquet")
-      sql("insert into table map_table select map(1, 'hello')")
-      runQueryAndCompare("select size(coalesce(a, map())) from map_table") {
-        df =>
-          {
-            assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
-          }
+      withSQLConf("spark.gluten.sql.columnar.oneRowRelation" -> "false") {
+        sql("create table map_table(a map<bigint, string>) using parquet")
+        sql("insert into table map_table select map(1, 'hello')")
+        runQueryAndCompare("select size(coalesce(a, map())) from map_table") {
+          df =>
+            {
+              assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
+            }
+        }
       }
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1523,30 +1523,26 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
 
   test("test array literal") {
     withTable("array_table") {
-      withSQLConf("spark.gluten.sql.columnar.oneRowRelation" -> "false") {
-        sql("create table array_table(a array<bigint>) using parquet")
-        sql("insert into table array_table select array(1)")
-        runQueryAndCompare("select size(coalesce(a, array())) from array_table") {
-          df =>
-            {
-              assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
-            }
-        }
+      sql("create table array_table(a array<bigint>) using parquet")
+      sql("insert into table array_table select array(1)")
+      runQueryAndCompare("select size(coalesce(a, array())) from array_table") {
+        df =>
+          {
+            assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
+          }
       }
     }
   }
 
   test("test map literal") {
     withTable("map_table") {
-      withSQLConf("spark.gluten.sql.columnar.oneRowRelation" -> "false") {
-        sql("create table map_table(a map<bigint, string>) using parquet")
-        sql("insert into table map_table select map(1, 'hello')")
-        runQueryAndCompare("select size(coalesce(a, map())) from map_table") {
-          df =>
-            {
-              assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
-            }
-        }
+      sql("create table map_table(a map<bigint, string>) using parquet")
+      sql("insert into table map_table select map(1, 'hello')")
+      runQueryAndCompare("select size(coalesce(a, map())) from map_table") {
+        df =>
+          {
+            assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
+          }
       }
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
@@ -21,6 +21,7 @@ import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.metrics.MetricsUpdater
+import org.apache.gluten.planner.plan.GlutenPlanModel.GroupLeafExec
 import org.apache.gluten.substrait.`type`.ColumnTypeNode
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.extensions.ExtensionBuilder
@@ -30,6 +31,7 @@ import org.apache.gluten.utils.SubstraitUtil
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.FileFormat
@@ -142,6 +144,14 @@ case class WriteFilesExecTransformer(
         t.projectList.exists(isConstantComplexType)
       case p: ProjectExec =>
         p.projectList.exists(isConstantComplexType)
+      case g: GroupLeafExec => // support the ras
+        g.metadata
+          .logicalLink()
+          .plan
+          .collectFirst {
+            case p: Project if p.projectList.exists(isConstantComplexType) => true
+          }
+          .isDefined
       case _ => false
     }
     // TODO: currently the velox don't support parquet write with complex data type

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
@@ -16,6 +16,27 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{GlutenSQLTestsBaseTrait, Row}
 
-class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTestsBaseTrait {}
+class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTestsBaseTrait {
+  testGluten("Parquet writer with ARRAY and MAP") {
+    spark.sql("""
+                |CREATE TABLE T1 (
+                | a INT,
+                | b ARRAY<STRING>,
+                | c MAP<STRING,STRING>
+                |)
+                |USING PARQUET
+                |""".stripMargin)
+
+    spark.sql("""
+                | INSERT OVERWRITE T1 VALUES
+                |  (1, ARRAY(1, 2, 3), MAP("key1","value1"))
+                |""".stripMargin)
+
+    checkAnswer(
+      spark.sql("SELECT * FROM T1"),
+      Row(1, Array("1", "2", "3"), Map("key1" -> "value1")) :: Nil
+    )
+  }
+}

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -969,6 +969,13 @@ class VeloxTestSettings extends BackendTestSettings {
     // Extra ColumnarToRow is needed to transform vanilla columnar data to gluten columnar data.
     .exclude("SPARK-37369: Avoid redundant ColumnarToRow transition on InMemoryTableScan")
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
+    .exclude("length check for input string values: nested in array")
+    .exclude("length check for input string values: nested in array")
+    .exclude("length check for input string values: nested in map key")
+    .exclude("length check for input string values: nested in map value")
+    .exclude("length check for input string values: nested in both map key and value")
+    .exclude("length check for input string values: nested in array of struct")
+    .exclude("length check for input string values: nested in array of array")
   enableSuite[GlutenDSV2CharVarcharTestSuite]
   enableSuite[GlutenColumnExpressionSuite]
     // Velox raise_error('errMsg') throws a velox_user_error exception with the message 'errMsg'.

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
@@ -16,8 +16,99 @@
  */
 package org.apache.spark.sql
 
+import org.apache.spark.SparkException
 class GlutenFileSourceCharVarcharTestSuite
   extends FileSourceCharVarcharTestSuite
-  with GlutenSQLTestsTrait {}
+  with GlutenSQLTestsTrait {
+  private def testTableWrite(f: String => Unit): Unit = {
+    withTable("t") { f("char") }
+    withTable("t") { f("varchar") }
+  }
+
+  private val ERROR_MESSAGE =
+    "[EXCEED_LIMIT_LENGTH] Exceeds char/varchar type length limitation: 5"
+
+  testGluten("length check for input string values: nested in struct") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
+      sql("INSERT INTO t SELECT struct(null)")
+      checkAnswer(spark.table("t"), Row(Row(null)))
+      val e = intercept[SparkException] {
+        sql("INSERT INTO t SELECT struct('123456')")
+      }
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in array") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c ARRAY<$typeName(5)>) USING $format")
+      sql("INSERT INTO t VALUES (array(null))")
+      checkAnswer(spark.table("t"), Row(Seq(null)))
+      val e = intercept[SparkException] {
+        sql("INSERT INTO t VALUES (array('a', '123456'))")
+      }
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in map key") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in map value") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c MAP<STRING, $typeName(5)>) USING $format")
+      sql("INSERT INTO t VALUES (map('a', null))")
+      checkAnswer(spark.table("t"), Row(Map("a" -> null)))
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in both map key and value") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
+      val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+      assert(e1.getMessage.contains(ERROR_MESSAGE))
+      val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+      assert(e2.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in struct of array") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c STRUCT<c: ARRAY<$typeName(5)>>) USING $format")
+      sql("INSERT INTO t SELECT struct(array(null))")
+      checkAnswer(spark.table("t"), Row(Row(Seq(null))))
+      val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in array of struct") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c ARRAY<STRUCT<c: $typeName(5)>>) USING $format")
+      sql("INSERT INTO t VALUES (array(struct(null)))")
+      checkAnswer(spark.table("t"), Row(Seq(Row(null))))
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in array of array") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c ARRAY<ARRAY<$typeName(5)>>) USING $format")
+      sql("INSERT INTO t VALUES (array(array(null)))")
+      checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+}
 
 class GlutenDSV2CharVarcharTestSuite extends DSV2CharVarcharTestSuite with GlutenSQLTestsTrait {}

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
@@ -21,92 +21,100 @@ class GlutenFileSourceCharVarcharTestSuite
   extends FileSourceCharVarcharTestSuite
   with GlutenSQLTestsTrait {
   private def testTableWrite(f: String => Unit): Unit = {
-    withTable("t") { f("char") }
-    withTable("t") { f("varchar") }
+    withTable("t")(f("char"))
+    withTable("t")(f("varchar"))
   }
 
   private val ERROR_MESSAGE =
-    "[EXCEED_LIMIT_LENGTH] Exceeds char/varchar type length limitation: 5"
+    "Exceeds char/varchar type length limitation: 5"
 
   testGluten("length check for input string values: nested in struct") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
-      sql("INSERT INTO t SELECT struct(null)")
-      checkAnswer(spark.table("t"), Row(Row(null)))
-      val e = intercept[SparkException] {
-        sql("INSERT INTO t SELECT struct('123456')")
-      }
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
+        sql("INSERT INTO t SELECT struct(null)")
+        checkAnswer(spark.table("t"), Row(Row(null)))
+        val e = intercept[RuntimeException] {
+          sql("INSERT INTO t SELECT struct('123456')")
+        }
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in array") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c ARRAY<$typeName(5)>) USING $format")
-      sql("INSERT INTO t VALUES (array(null))")
-      checkAnswer(spark.table("t"), Row(Seq(null)))
-      val e = intercept[SparkException] {
-        sql("INSERT INTO t VALUES (array('a', '123456'))")
-      }
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c ARRAY<$typeName(5)>) USING $format")
+        sql("INSERT INTO t VALUES (array(null))")
+        checkAnswer(spark.table("t"), Row(Seq(null)))
+        val e = intercept[SparkException] {
+          sql("INSERT INTO t VALUES (array('a', '123456'))")
+        }
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in map key") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in map value") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c MAP<STRING, $typeName(5)>) USING $format")
-      sql("INSERT INTO t VALUES (map('a', null))")
-      checkAnswer(spark.table("t"), Row(Map("a" -> null)))
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c MAP<STRING, $typeName(5)>) USING $format")
+        sql("INSERT INTO t VALUES (map('a', null))")
+        checkAnswer(spark.table("t"), Row(Map("a" -> null)))
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in both map key and value") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
-      val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
-      assert(e1.getMessage.contains(ERROR_MESSAGE))
-      val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
-      assert(e2.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
+        val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+        assert(e1.getMessage.contains(ERROR_MESSAGE))
+        val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+        assert(e2.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in struct of array") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c STRUCT<c: ARRAY<$typeName(5)>>) USING $format")
-      sql("INSERT INTO t SELECT struct(array(null))")
-      checkAnswer(spark.table("t"), Row(Row(Seq(null))))
-      val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c STRUCT<c: ARRAY<$typeName(5)>>) USING $format")
+        sql("INSERT INTO t SELECT struct(array(null))")
+        checkAnswer(spark.table("t"), Row(Row(Seq(null))))
+        val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in array of struct") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c ARRAY<STRUCT<c: $typeName(5)>>) USING $format")
-      sql("INSERT INTO t VALUES (array(struct(null)))")
-      checkAnswer(spark.table("t"), Row(Seq(Row(null))))
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c ARRAY<STRUCT<c: $typeName(5)>>) USING $format")
+        sql("INSERT INTO t VALUES (array(struct(null)))")
+        checkAnswer(spark.table("t"), Row(Seq(Row(null))))
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in array of array") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c ARRAY<ARRAY<$typeName(5)>>) USING $format")
-      sql("INSERT INTO t VALUES (array(array(null)))")
-      checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c ARRAY<ARRAY<$typeName(5)>>) USING $format")
+        sql("INSERT INTO t VALUES (array(array(null)))")
+        checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
@@ -16,6 +16,27 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{GlutenSQLTestsBaseTrait, Row}
 
-class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTestsBaseTrait {}
+class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTestsBaseTrait {
+  testGluten("Parquet writer with ARRAY and MAP") {
+    spark.sql("""
+                |CREATE TABLE T1 (
+                | a INT,
+                | b ARRAY<STRING>,
+                | c MAP<STRING,STRING>
+                |)
+                |USING PARQUET
+                |""".stripMargin)
+
+    spark.sql("""
+                | INSERT OVERWRITE T1 VALUES
+                |  (1, ARRAY(1, 2, 3), MAP("key1","value1"))
+                |""".stripMargin)
+
+    checkAnswer(
+      spark.sql("SELECT * FROM T1"),
+      Row(1, Array("1", "2", "3"), Map("key1" -> "value1")) :: Nil
+    )
+  }
+}

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -989,6 +989,13 @@ class VeloxTestSettings extends BackendTestSettings {
     // Extra ColumnarToRow is needed to transform vanilla columnar data to gluten columnar data.
     .exclude("SPARK-37369: Avoid redundant ColumnarToRow transition on InMemoryTableScan")
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
+    .exclude("length check for input string values: nested in array")
+    .exclude("length check for input string values: nested in array")
+    .exclude("length check for input string values: nested in map key")
+    .exclude("length check for input string values: nested in map value")
+    .exclude("length check for input string values: nested in both map key and value")
+    .exclude("length check for input string values: nested in array of struct")
+    .exclude("length check for input string values: nested in array of array")
   enableSuite[GlutenDSV2CharVarcharTestSuite]
   enableSuite[GlutenColumnExpressionSuite]
     // Velox raise_error('errMsg') throws a velox_user_error exception with the message 'errMsg'.

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
@@ -16,8 +16,100 @@
  */
 package org.apache.spark.sql
 
+import org.apache.spark.SparkException
+
 class GlutenFileSourceCharVarcharTestSuite
   extends FileSourceCharVarcharTestSuite
-  with GlutenSQLTestsTrait {}
+  with GlutenSQLTestsTrait {
+  private def testTableWrite(f: String => Unit): Unit = {
+    withTable("t") { f("char") }
+    withTable("t") { f("varchar") }
+  }
+
+  private val ERROR_MESSAGE =
+    "[EXCEED_LIMIT_LENGTH] Exceeds char/varchar type length limitation: 5"
+
+  testGluten("length check for input string values: nested in struct") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
+      sql("INSERT INTO t SELECT struct(null)")
+      checkAnswer(spark.table("t"), Row(Row(null)))
+      val e = intercept[SparkException] {
+        sql("INSERT INTO t SELECT struct('123456')")
+      }
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in array") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c ARRAY<$typeName(5)>) USING $format")
+      sql("INSERT INTO t VALUES (array(null))")
+      checkAnswer(spark.table("t"), Row(Seq(null)))
+      val e = intercept[SparkException] {
+        sql("INSERT INTO t VALUES (array('a', '123456'))")
+      }
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in map key") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in map value") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c MAP<STRING, $typeName(5)>) USING $format")
+      sql("INSERT INTO t VALUES (map('a', null))")
+      checkAnswer(spark.table("t"), Row(Map("a" -> null)))
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in both map key and value") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
+      val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+      assert(e1.getMessage.contains(ERROR_MESSAGE))
+      val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+      assert(e2.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in struct of array") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c STRUCT<c: ARRAY<$typeName(5)>>) USING $format")
+      sql("INSERT INTO t SELECT struct(array(null))")
+      checkAnswer(spark.table("t"), Row(Row(Seq(null))))
+      val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in array of struct") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c ARRAY<STRUCT<c: $typeName(5)>>) USING $format")
+      sql("INSERT INTO t VALUES (array(struct(null)))")
+      checkAnswer(spark.table("t"), Row(Seq(Row(null))))
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+
+  testGluten("length check for input string values: nested in array of array") {
+    testTableWrite { typeName =>
+      sql(s"CREATE TABLE t(c ARRAY<ARRAY<$typeName(5)>>) USING $format")
+      sql("INSERT INTO t VALUES (array(array(null)))")
+      checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
+      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
+      assert(e.getMessage.contains(ERROR_MESSAGE))
+    }
+  }
+}
 
 class GlutenDSV2CharVarcharTestSuite extends DSV2CharVarcharTestSuite with GlutenSQLTestsTrait {}

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
@@ -35,7 +35,7 @@ class GlutenFileSourceCharVarcharTestSuite
         sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
         sql("INSERT INTO t SELECT struct(null)")
         checkAnswer(spark.table("t"), Row(Row(null)))
-        val e = intercept[SparkException] {
+        val e = intercept[RuntimeException] {
           sql("INSERT INTO t SELECT struct('123456')")
         }
         assert(e.getMessage.contains(ERROR_MESSAGE))

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenCharVarcharTestSuite.scala
@@ -22,92 +22,100 @@ class GlutenFileSourceCharVarcharTestSuite
   extends FileSourceCharVarcharTestSuite
   with GlutenSQLTestsTrait {
   private def testTableWrite(f: String => Unit): Unit = {
-    withTable("t") { f("char") }
-    withTable("t") { f("varchar") }
+    withTable("t")(f("char"))
+    withTable("t")(f("varchar"))
   }
 
   private val ERROR_MESSAGE =
-    "[EXCEED_LIMIT_LENGTH] Exceeds char/varchar type length limitation: 5"
+    "Exceeds char/varchar type length limitation: 5"
 
   testGluten("length check for input string values: nested in struct") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
-      sql("INSERT INTO t SELECT struct(null)")
-      checkAnswer(spark.table("t"), Row(Row(null)))
-      val e = intercept[SparkException] {
-        sql("INSERT INTO t SELECT struct('123456')")
-      }
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c STRUCT<c: $typeName(5)>) USING $format")
+        sql("INSERT INTO t SELECT struct(null)")
+        checkAnswer(spark.table("t"), Row(Row(null)))
+        val e = intercept[SparkException] {
+          sql("INSERT INTO t SELECT struct('123456')")
+        }
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in array") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c ARRAY<$typeName(5)>) USING $format")
-      sql("INSERT INTO t VALUES (array(null))")
-      checkAnswer(spark.table("t"), Row(Seq(null)))
-      val e = intercept[SparkException] {
-        sql("INSERT INTO t VALUES (array('a', '123456'))")
-      }
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c ARRAY<$typeName(5)>) USING $format")
+        sql("INSERT INTO t VALUES (array(null))")
+        checkAnswer(spark.table("t"), Row(Seq(null)))
+        val e = intercept[SparkException] {
+          sql("INSERT INTO t VALUES (array('a', '123456'))")
+        }
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in map key") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in map value") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c MAP<STRING, $typeName(5)>) USING $format")
-      sql("INSERT INTO t VALUES (map('a', null))")
-      checkAnswer(spark.table("t"), Row(Map("a" -> null)))
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c MAP<STRING, $typeName(5)>) USING $format")
+        sql("INSERT INTO t VALUES (map('a', null))")
+        checkAnswer(spark.table("t"), Row(Map("a" -> null)))
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in both map key and value") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
-      val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
-      assert(e1.getMessage.contains(ERROR_MESSAGE))
-      val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
-      assert(e2.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
+        val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
+        assert(e1.getMessage.contains(ERROR_MESSAGE))
+        val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
+        assert(e2.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in struct of array") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c STRUCT<c: ARRAY<$typeName(5)>>) USING $format")
-      sql("INSERT INTO t SELECT struct(array(null))")
-      checkAnswer(spark.table("t"), Row(Row(Seq(null))))
-      val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c STRUCT<c: ARRAY<$typeName(5)>>) USING $format")
+        sql("INSERT INTO t SELECT struct(array(null))")
+        checkAnswer(spark.table("t"), Row(Row(Seq(null))))
+        val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in array of struct") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c ARRAY<STRUCT<c: $typeName(5)>>) USING $format")
-      sql("INSERT INTO t VALUES (array(struct(null)))")
-      checkAnswer(spark.table("t"), Row(Seq(Row(null))))
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c ARRAY<STRUCT<c: $typeName(5)>>) USING $format")
+        sql("INSERT INTO t VALUES (array(struct(null)))")
+        checkAnswer(spark.table("t"), Row(Seq(Row(null))))
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 
   testGluten("length check for input string values: nested in array of array") {
-    testTableWrite { typeName =>
-      sql(s"CREATE TABLE t(c ARRAY<ARRAY<$typeName(5)>>) USING $format")
-      sql("INSERT INTO t VALUES (array(array(null)))")
-      checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
-      val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
-      assert(e.getMessage.contains(ERROR_MESSAGE))
+    testTableWrite {
+      typeName =>
+        sql(s"CREATE TABLE t(c ARRAY<ARRAY<$typeName(5)>>) USING $format")
+        sql("INSERT INTO t VALUES (array(array(null)))")
+        checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
+        val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
+        assert(e.getMessage.contains(ERROR_MESSAGE))
     }
   }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
@@ -39,33 +39,4 @@ class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTe
       Row(1, Array("1", "2", "3"), Map("key1" -> "value1")) :: Nil
     )
   }
-
-  testGluten("Parquet writer with STRUCT") {
-    spark.sql("""
-                |CREATE TABLE IF NOT EXISTS people (
-                |    id INT,
-                |    name STRING,
-                |    age INT,
-                |    address STRUCT<
-                |        street: STRING,
-                |        city: STRING,
-                |        zip: STRING
-                |    >
-                |)
-                |USING parquet
-                |""".stripMargin)
-
-    spark.sql("""
-                |INSERT INTO people VALUES
-                |    (1, "Alice", 30, struct("123 Main St", "Springfield", "12345")),
-                |    (2, "Bob", 25, struct("456 Maple Ave", "Shelbyville", "54321")),
-                |    (3, "Charlie", 35, struct("789 Oak St", "Capital City", "67890"))
-                |""".stripMargin)
-    checkAnswer(
-      spark.sql("SELECT * FROM people"),
-      Row(1, "Alice", 30, Row("123 Main St", "Springfield", "12345")) ::
-        Row(2, "Bob", 25, Row("456 Maple Ave", "Shelbyville", "54321")) ::
-        Row(3, "Charlie", 35, Row("789 Oak St", "Capital City", "67890")) :: Nil
-    )
-  }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFieldIdIOSuite.scala
@@ -16,6 +16,56 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{GlutenSQLTestsBaseTrait, Row}
 
-class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTestsBaseTrait {}
+class GlutenParquetFieldIdIOSuite extends ParquetFieldIdIOSuite with GlutenSQLTestsBaseTrait {
+  testGluten("Parquet writer with ARRAY and MAP") {
+    spark.sql("""
+                |CREATE TABLE T1 (
+                | a INT,
+                | b ARRAY<STRING>,
+                | c MAP<STRING,STRING>
+                |)
+                |USING PARQUET
+                |""".stripMargin)
+
+    spark.sql("""
+                | INSERT OVERWRITE T1 VALUES
+                |  (1, ARRAY(1, 2, 3), MAP("key1","value1"))
+                |""".stripMargin)
+
+    checkAnswer(
+      spark.sql("SELECT * FROM T1"),
+      Row(1, Array("1", "2", "3"), Map("key1" -> "value1")) :: Nil
+    )
+  }
+
+  testGluten("Parquet writer with STRUCT") {
+    spark.sql("""
+                |CREATE TABLE IF NOT EXISTS people (
+                |    id INT,
+                |    name STRING,
+                |    age INT,
+                |    address STRUCT<
+                |        street: STRING,
+                |        city: STRING,
+                |        zip: STRING
+                |    >
+                |)
+                |USING parquet
+                |""".stripMargin)
+
+    spark.sql("""
+                |INSERT INTO people VALUES
+                |    (1, "Alice", 30, struct("123 Main St", "Springfield", "12345")),
+                |    (2, "Bob", 25, struct("456 Maple Ave", "Shelbyville", "54321")),
+                |    (3, "Charlie", 35, struct("789 Oak St", "Capital City", "67890"))
+                |""".stripMargin)
+    checkAnswer(
+      spark.sql("SELECT * FROM people"),
+      Row(1, "Alice", 30, Row("123 Main St", "Springfield", "12345")) ::
+        Row(2, "Bob", 25, Row("456 Maple Ave", "Shelbyville", "54321")) ::
+        Row(3, "Charlie", 35, Row("789 Oak St", "Capital City", "67890")) :: Nil
+    )
+  }
+}


### PR DESCRIPTION

## What changes were proposed in this pull request?
The velox has supported parquet writer with the complex data type, such as MAP, ARRYY, so we may support them in gluten.


(Fixes: https://github.com/apache/incubator-gluten/issues/7675)

## How was this patch tested?

Add unittests



