### PR TITLE
[GLUTEN-7664][VL][ARM] use arm64 triplet with vcpkg

### DIFF
--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -10,7 +10,15 @@ SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 export VCPKG_ROOT="$SCRIPT_ROOT/.vcpkg"
 export VCPKG="$SCRIPT_ROOT/.vcpkg/vcpkg"
-export VCPKG_TRIPLET=x64-linux-avx
+ARCH=`uname -m`
+if [ $ARCH == 'x86_64' ]; then
+  VCPKG_TRIPLET=x64-linux-avx
+elif [[ "$ARCH" == 'arm64' || "$ARCH" == 'aarch64' ]]; then
+  VCPKG_TRIPLET=arm64-linux
+else
+  echo "Unsupported arch: $ARCH"
+  exit 1
+fi
 export VCPKG_TRIPLET_INSTALL_DIR=${SCRIPT_ROOT}/vcpkg_installed/${VCPKG_TRIPLET}
 
 ${SCRIPT_ROOT}/init.sh "$@"

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -12,9 +12,9 @@ export VCPKG_ROOT="$SCRIPT_ROOT/.vcpkg"
 export VCPKG="$SCRIPT_ROOT/.vcpkg/vcpkg"
 ARCH=`uname -m`
 if [ $ARCH == 'x86_64' ]; then
-  VCPKG_TRIPLET=x64-linux-avx
+  export VCPKG_TRIPLET=x64-linux-avx
 elif [[ "$ARCH" == 'arm64' || "$ARCH" == 'aarch64' ]]; then
-  VCPKG_TRIPLET=arm64-linux
+  export VCPKG_TRIPLET=arm64-linux
 else
   echo "Unsupported arch: $ARCH"
   exit 1

--- a/dev/vcpkg/triplets/arm64-linux.cmake
+++ b/dev/vcpkg/triplets/arm64-linux.cmake
@@ -1,0 +1,8 @@
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_LINKER_FLAGS "-static-libstdc++ -static-libgcc")

--- a/dev/vcpkg/triplets/arm64-linux.cmake
+++ b/dev/vcpkg/triplets/arm64-linux.cmake
@@ -1,8 +1,0 @@
-set(VCPKG_BUILD_TYPE release)
-set(VCPKG_TARGET_ARCHITECTURE arm64)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
-
-set(VCPKG_CMAKE_SYSTEM_NAME Linux)
-
-set(VCPKG_LINKER_FLAGS "-static-libstdc++ -static-libgcc")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Uses the `arm64-linux` triplet when building on arm64 with vcpkg. It uses the community triplet. Currently, vcpkg uses the `x64-linux-avx` triplet, with avx-specific instructions, which gives an error.

(Fixes: https://github.com/apache/incubator-gluten/issues/7664)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

