### PR TITLE
[GLUTEN-7037][VL][1.2] Add dwarf dependency to folly when building with vcpkg

### DIFF
--- a/dev/vcpkg/ports/folly/vcpkg.json
+++ b/dev/vcpkg/ports/folly/vcpkg.json
@@ -25,6 +25,7 @@
     "glog",
     "libevent",
     "openssl",
+    "libdwarf",
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION


(cherry picked from commit 65cdf22c07ff681c991c89ad30d34efda7ab1f01)

## What changes were proposed in this pull request?

Backport #7038 to branch 1.2

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

