### PR TITLE
[GLUTEN-7143][VL] Fix several UTs for RAS

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -97,7 +97,9 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
   }
 
   test("fallback with collect") {
-    withSQLConf(GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
+    withSQLConf(
+      GlutenConfig.RAS_ENABLED.key -> "false",
+      GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
       runQueryAndCompare("SELECT count(*) FROM tmp1") {
         df =>
           val columnarToRow = collectColumnarToRow(df.queryExecution.executedPlan)
@@ -141,6 +143,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
 
   test("fallback final aggregate of collect_list") {
     withSQLConf(
+      GlutenConfig.RAS_ENABLED.key -> "false",
       GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1",
       GlutenConfig.COLUMNAR_FALLBACK_IGNORE_ROW_TO_COLUMNAR.key -> "false",
       GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
@@ -159,6 +162,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
   // until we can exactly align with vanilla Spark.
   ignore("fallback final aggregate of collect_set") {
     withSQLConf(
+      GlutenConfig.RAS_ENABLED.key -> "false",
       GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1",
       GlutenConfig.COLUMNAR_FALLBACK_IGNORE_ROW_TO_COLUMNAR.key -> "false",
       GlutenConfig.EXPRESSION_BLACK_LIST.key -> "element_at"
@@ -191,7 +195,9 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
   }
 
   test("Do not fallback eagerly with ColumnarToRowExec") {
-    withSQLConf(GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
+    withSQLConf(
+      GlutenConfig.RAS_ENABLED.key -> "false",
+      GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
       runQueryAndCompare("select count(*) from tmp1") {
         df =>
           assert(

--- a/backends-velox/src/test/scala/org/apache/gluten/planner/VeloxRasSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/planner/VeloxRasSuite.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.extension.columnar.transition.ConventionReq
 import org.apache.gluten.planner.cost.GlutenCostModel
 import org.apache.gluten.planner.property.Conv
 import org.apache.gluten.ras.{Cost, CostModel, Ras}
-import org.apache.gluten.ras.Best.BestNotFoundException
 import org.apache.gluten.ras.RasSuiteBase._
 import org.apache.gluten.ras.path.RasPath
 import org.apache.gluten.ras.property.PropertySet
@@ -111,13 +110,10 @@ class VeloxRasSuite extends SharedSparkSession {
     val out = planner.plan()
     assert(out == RowUnary(RowLeaf(EMPTY_SCHEMA)))
 
-    assertThrows[BestNotFoundException] {
-      // Could not optimize to columnar output since R2C transitions for empty schema node
-      // is not allowed.
-      val planner2 =
-        newRas().newPlanner(in, PropertySet(List(Conv.req(ConventionReq.vanillaBatch))))
-      planner2.plan()
-    }
+    val planner2 =
+      newRas().newPlanner(in, PropertySet(List(Conv.req(ConventionReq.vanillaBatch))))
+    val out2 = planner2.plan()
+    assert(out2 == RowToColumnarExec(RowUnary(RowLeaf(EMPTY_SCHEMA))))
   }
 
   test("User cost model") {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenSessionExtensions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenSessionExtensions.scala
@@ -32,7 +32,7 @@ private[gluten] class GlutenSessionExtensions
     injector.control.disableOn {
       session =>
         val glutenEnabledGlobally = session.conf
-          .get(GlutenConfig.GLUTEN_ENABLED_KEY, GlutenConfig.GLUTEN_ENABLE_BY_DEFAULT.toString)
+          .get(GlutenConfig.GLUTEN_ENABLED_KEY, GlutenConfig.GLUTEN_ENABLED_BY_DEFAULT.toString)
           .toBoolean
         val disabled = !glutenEnabledGlobally
         logDebug(s"Gluten is disabled by variable: glutenEnabledGlobally: $glutenEnabledGlobally")

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
@@ -82,7 +82,8 @@ case class EnumeratedTransform(session: SparkSession, outputsColumnar: Boolean)
         .from(SparkShimLoader.getSparkShims.isWindowGroupLimitExec, OffloadOthers()),
       RasOffload.from[LimitExec](OffloadOthers()),
       RasOffload.from[GenerateExec](OffloadOthers()),
-      RasOffload.from[EvalPythonExec](OffloadOthers())
+      RasOffload.from[EvalPythonExec](OffloadOthers()),
+      RasOffload.from[SampleExec](OffloadOthers())
     ).map(RasOffload.Rule(_, validator))
 
   private val optimization = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
@@ -16,9 +16,8 @@
  */
 package org.apache.gluten.planner.cost
 
-import org.apache.gluten.extension.columnar.transition.{ColumnarToRowLike, RowToColumnarLike}
+import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
-
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
 
 /**
@@ -36,6 +35,7 @@ class LegacyCostModel extends LongCostModel {
       case RowToColumnarExec(_) => 10L
       case ColumnarToRowLike(_) => 10L
       case RowToColumnarLike(_) => 10L
+      case ColumnarToColumnarLike(_) => 5L
       case p if PlanUtil.isGlutenColumnarOp(p) => 10L
       // 1. 100L << 1000L, to keep the pulled out non-offload-able projects if the main op
       // turns into offload-able after pulling.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.planner.cost
 import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
 
-import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarToRowExec, ColumnarWriteFilesExec, ProjectExec, RowToColumnarExec, SparkPlan}
 
 /**
  * A cost model that is supposed to drive RAS planner create the same query plan with legacy
@@ -32,6 +32,7 @@ class LegacyCostModel extends LongCostModel {
   // much as possible.
   override def selfLongCostOf(node: SparkPlan): Long = {
     node match {
+      case ColumnarWriteFilesExec.OnNoopLeafPath(_) => 0
       case ColumnarToRowExec(_) => 10L
       case RowToColumnarExec(_) => 10L
       case ColumnarToRowLike(_) => 10L

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/LegacyCostModel.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.planner.cost
 
 import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
+
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
 
 /**

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, 
 import org.apache.gluten.utils.PlanUtil
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
-import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarToRowExec, ColumnarWriteFilesExec, ProjectExec, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 
 /** A rough cost model with some empirical heuristics. */
@@ -29,6 +29,7 @@ class RoughCostModel extends LongCostModel {
 
   override def selfLongCostOf(node: SparkPlan): Long = {
     node match {
+      case ColumnarWriteFilesExec.OnNoopLeafPath(_) => 0
       case ProjectExec(projectList, _) if projectList.forall(isCheapExpression) =>
         // Make trivial ProjectExec has the same cost as ProjectExecTransform to reduce unnecessary
         // c2r and r2c.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -17,9 +17,8 @@
 package org.apache.gluten.planner.cost
 
 import org.apache.gluten.execution.RowToColumnarExecBase
-import org.apache.gluten.extension.columnar.transition.{ColumnarToRowLike, RowToColumnarLike}
+import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
-
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
@@ -41,6 +40,7 @@ class RoughCostModel extends LongCostModel {
       case RowToColumnarExec(_) => 10L
       case ColumnarToRowLike(_) => 10L
       case RowToColumnarLike(_) => 10L
+      case ColumnarToColumnarLike(_) => 5L
       case p if PlanUtil.isGlutenColumnarOp(p) => 10L
       case p if PlanUtil.isVanillaColumnarOp(p) => 1000L
       // Other row ops. Usually a vanilla row op.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/cost/RoughCostModel.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.planner.cost
 import org.apache.gluten.execution.RowToColumnarExecBase
 import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
+
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ProjectExec, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/planner/property/Conv.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/planner/property/Conv.scala
@@ -89,10 +89,6 @@ object ConvDef extends PropertyDef[SparkPlan, Conv] {
 
 case class ConvEnforcerRule(reqConv: Conv) extends RasRule[SparkPlan] {
   override def shift(node: SparkPlan): Iterable[SparkPlan] = {
-    if (node.output.isEmpty) {
-      // Disable transitions for node that has output with empty schema.
-      return List.empty
-    }
     val conv = Conv.get(node)
     if (conv.satisfies(reqConv)) {
       return List.empty

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/PlanUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/PlanUtil.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.gluten.utils
 
-import org.apache.gluten.backend.Backend
 import org.apache.gluten.extension.columnar.transition.Convention
 
 import org.apache.spark.sql.execution._
@@ -27,7 +26,7 @@ import scala.annotation.tailrec
 
 object PlanUtil {
   private def isGlutenTableCacheInternal(i: InMemoryTableScanExec): Boolean = {
-    Convention.get(i).batchType == Backend.get().defaultBatchType
+    isGlutenBatchType(Convention.get(i).batchType)
   }
 
   @tailrec
@@ -47,6 +46,10 @@ object PlanUtil {
   }
 
   def isGlutenColumnarOp(plan: SparkPlan): Boolean = {
-    Convention.get(plan).batchType == Backend.get().defaultBatchType
+    isGlutenBatchType(Convention.get(plan).batchType)
+  }
+
+  private def isGlutenBatchType(batchType: Convention.BatchType) = {
+    batchType != Convention.BatchType.None && batchType != Convention.BatchType.VanillaBatch
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -139,6 +140,7 @@ object ColumnarWriteFilesExec {
         bucketSpec,
         options,
         staticPartitions)
+    right.foreach(node => node.setTagValue(NoopTag, true))
 
     BackendsApiManager.getSparkPlanExecApiInstance.createColumnarWriteFilesExec(
       child,
@@ -148,6 +150,33 @@ object ColumnarWriteFilesExec {
       bucketSpec,
       options,
       staticPartitions)
+  }
+
+  private val NoopTag =
+    TreeNodeTag[Boolean]("org.apache.spark.sql.execution.ColumnarWriteFilesExec.NoopTag")
+
+  // Decides whether a plan not is on the dummy `WriteFilesExec + NoopLeaf` path.
+  object OnNoopLeafPath {
+    def unapply(plan: SparkPlan): Option[NoopLeaf] = {
+      val leafs = traverseDown(plan)
+      if (leafs.size > 1) {
+        throw new IllegalArgumentException(s"More than one noop leafs were found in plan: $plan")
+      }
+      leafs.headOption
+    }
+
+    private def traverseDown(plan: SparkPlan): Seq[NoopLeaf] = {
+      val hasNoopTag = plan.getTagValue(NoopTag).getOrElse(false)
+      if (!hasNoopTag) {
+        return Nil
+      }
+      plan match {
+        case leaf: NoopLeaf =>
+          Seq(leaf)
+        case other =>
+          other.children.map(traverseDown).reduce(_ ++ _)
+      }
+    }
   }
 
   case class NoopLeaf() extends LeafExecNode {

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -470,7 +470,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 object GlutenConfig {
   import SQLConf._
 
-  var GLUTEN_ENABLE_BY_DEFAULT = true
+  var GLUTEN_ENABLED_BY_DEFAULT = true
   val GLUTEN_ENABLED_KEY = "spark.gluten.enabled"
   val GLUTEN_LIB_NAME = "spark.gluten.sql.columnar.libname"
   val GLUTEN_LIB_PATH = "spark.gluten.sql.columnar.libpath"
@@ -815,7 +815,7 @@ object GlutenConfig {
       .doc("Whether to enable gluten. Default value is true. Just an experimental property." +
         " Recommend to enable/disable Gluten through the setting for spark.plugins.")
       .booleanConf
-      .createWithDefault(GLUTEN_ENABLE_BY_DEFAULT)
+      .createWithDefault(GLUTEN_ENABLED_BY_DEFAULT)
 
   // FIXME the option currently controls both JVM and native validation against a Substrait plan.
   val NATIVE_VALIDATION_ENABLED =


### PR DESCRIPTION
Part of #7143

Fix following UTs when RAS=ON:
```
	Line  3111: 2024-10-28T03:45:33.5270060Z - fallback final aggregate of collect_list *** FAILED ***
	Line  3272: 2024-10-28T03:45:44.0086490Z - count(1) on csv scan *** FAILED ***
	Line  4403: 2024-10-28T03:47:23.3298481Z - Date type *** FAILED ***
	Line  4794: 2024-10-28T03:47:41.5650328Z - Date type *** FAILED ***
	Line  5030: 2024-10-28T03:47:50.0627363Z - count(1) on csv scan *** FAILED ***
	Line  5129: 2024-10-28T03:47:50.4155755Z - Struct Literal *** FAILED ***
	Line  5131: 2024-10-28T03:47:50.4905146Z - Array Literal *** FAILED ***
	Line  5133: 2024-10-28T03:47:50.5682606Z - Map Literal *** FAILED ***
	Line  5135: 2024-10-28T03:47:50.6383717Z - Null Literal *** FAILED ***
	Line  5137: 2024-10-28T03:47:50.7036012Z - Scalar Type Literal *** FAILED ***
	Line  5156: 2024-10-28T03:47:52.2401153Z - arrow_udf test: without projection *** FAILED ***
	Line  5161: 2024-10-28T03:47:52.2709234Z - arrow_udf test: with unrelated projection *** FAILED ***
	Line  6657: 2024-10-28T03:52:33.4765722Z - test hive static partition write table *** FAILED ***
	Line  7025: 2024-10-28T03:52:34.9769802Z - test hive write table *** FAILED ***
	Line 31956: 2024-10-28T03:55:26.4473034Z - test OneRowRelation *** FAILED ***
	Line 32130: 2024-10-28T03:55:37.9358997Z - Test sample op *** FAILED ***
	Line 32372: 2024-10-28T03:56:02.3208216Z - cast date to timestamp with timezone *** FAILED ***
	Line 33543: 2024-10-28T03:56:57.4949591Z *** 18 TESTS FAILED ***
```

Remaining unfixed:
```
	Line  3149: 2024-10-28T03:45:35.3305691Z - test ignore row to columnar *** FAILED ***
        ... (more)
```