### PR TITLE
[VL] CI: One OOM GHA job has passed, stop ignoring its result

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -359,8 +359,7 @@ jobs:
             -d=OFFHEAP_SIZE:4g,spark.memory.offHeap.size=4g \
             -d=OVER_ACQUIRE:0.3,spark.gluten.memory.overAcquiredMemoryRatio=0.3 \
             -d=OVER_ACQUIRE:0.5,spark.gluten.memory.overAcquiredMemoryRatio=0.5
-      - name: (To be fixed) TPC-DS SF30.0 Parquet local spark3.2 Q95 low memory, memory isolation on
-        continue-on-error: true
+      - name: TPC-DS SF30.0 Parquet local spark3.2 Q95 low memory, memory isolation on
         run: |
           cd tools/gluten-it \
           && GLUTEN_IT_JVM_ARGS=-Xmx3G sbin/gluten-it.sh parameterized \


### PR DESCRIPTION
Job name: `TPC-DS SF30.0 Parquet local spark3.2 Q95 low memory, memory isolation on`

Stop ignoring its result to make it be able to fail CI.