### PR TITLE
[GLUTEN-7713][CH] Fix page index reader failed with or logical operator

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/parquet/GlutenParquetColumnIndexSuite.scala
@@ -71,7 +71,19 @@ class GlutenParquetColumnIndexSuite
       45,
       Some("push down Decimal filter In")
     ),
-    ParquetData("count(*)", "index/pageindex/query05", "`142` = true", 9896)
+    ParquetData("count(*)", "index/pageindex/query05", "`142` = true", 9896),
+    ParquetData(
+      "count(*)",
+      "index/pageindex/query05",
+      "(`145` like '%GTC' and `142` = true) or (not `175` in (23,16,14,100))",
+      9896,
+      Some("endwith")),
+    ParquetData(
+      "count(*)",
+      "index/pageindex/query05",
+      "(`145` not like 'GTC%' and `154` not in(11,16,14,-99)) or `154` > 3365",
+      9896,
+      Some("not endwith"))
   )
 
   parquetData.foreach {

--- a/cpp-ch/local-engine/Storages/Parquet/ColumnIndexFilter.cpp
+++ b/cpp-ch/local-engine/Storages/Parquet/ColumnIndexFilter.cpp
@@ -958,12 +958,14 @@ RowRanges ColumnIndexFilter::calculateRowRanges(const ColumnIndexStore & index_s
                 CALL_OPERATOR(element, [](const ColumnIndex & index, const RPNElement & e) { return index.in(e.column); });
                 break;
             case RPNElement::FUNCTION_NOT_IN:
+                rpn_stack.emplace_back(RowRanges::createSingle(rowgroup_count));
                 break;
             case RPNElement::FUNCTION_UNKNOWN:
                 rpn_stack.emplace_back(RowRanges::createSingle(rowgroup_count));
                 break;
             case RPNElement::FUNCTION_NOT:
-                assert(false);
+                assert(!rpn_stack.empty());
+                rpn_stack.back() = RowRanges::createSingle(rowgroup_count);
                 break;
             case RPNElement::FUNCTION_AND:
                 CALL_LOGICAL_OP(RowRanges::intersection);
@@ -972,10 +974,10 @@ RowRanges ColumnIndexFilter::calculateRowRanges(const ColumnIndexStore & index_s
                 CALL_LOGICAL_OP(RowRanges::unionRanges);
                 break;
             case RPNElement::ALWAYS_FALSE:
-                assert(false);
+                throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "RPNElement::ALWAYS_FALSE in ColumnIndexFilter::calculateRowRanges");
                 break;
             case RPNElement::ALWAYS_TRUE:
-                assert(false);
+                throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "RPNElement::ALWAYS_TRUE in ColumnIndexFilter::calculateRowRanges");
                 break;
         }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I didn't consider that condition like `(a and b) or c` before this PR, so that `not in` and `not cond` are ignored which cause query fail.

(Fixes: \#7713)

## How was this patch tested?

Add new UTs
