### PR TITLE
[VL] RAS: Fix fallen back plan nodes are not tagged with meaningful fallback reasons

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -484,7 +484,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           c)
       case c if c.getClass.getSimpleName.equals("CheckOverflowInTableInsert") =>
         throw new GlutenNotSupportException(
-          "CheckOverflowInTableInsert is used in ansi mode, but gluten does not support ANSI mode."
+          "CheckOverflowInTableInsert is used in ANSI mode, but Gluten does not support ANSI mode."
         )
       case b: BinaryArithmetic if DecimalArithmeticUtil.isDecimalArithmetic(b) =>
         DecimalArithmeticUtil.checkAllowDecimalArithmetic()

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
@@ -104,9 +104,9 @@ class GlutenExpressionMappingSuite
       sql("create table t2 (b decimal(10,4)) using parquet")
 
       val msg =
-        "CheckOverflowInTableInsert is used in ansi mode, but gluten does not support ANSI mode."
+        "CheckOverflowInTableInsert is used in ANSI mode, but Gluten does not support ANSI mode."
       import org.apache.spark.sql.execution.GlutenImplicits._
-      val fallbackSummary = sql("insert overwrite t2 select * from t1").fallbackSummary
+      val fallbackSummary = sql("insert overwrite t2 select * from t1").fallbackSummary()
       assert(fallbackSummary.fallbackNodeToReason.flatMap(_.values).exists(_.contains(msg)))
     }
   }


### PR DESCRIPTION
Part of #7143

This fixes UT `GlutenExpressionMappingSuite.GLUTEN-7213: Check fallback reason with CheckOverflowInTableInsert` in RAS.