### PR TITLE
[VL] In `ColumnarBatchSerializerJniWrapper_serialize`, check if the byte array is constructed successfully

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1078,6 +1078,10 @@ JNIEXPORT jobject JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchSeriali
   auto serializer = ctx->createColumnarBatchSerializer(nullptr);
   auto buffer = serializer->serializeColumnarBatches(batches);
   auto bufferArr = env->NewByteArray(buffer->size());
+  GLUTEN_CHECK(
+      bufferArr != nullptr,
+      "Cannot construct a byte array of size " + std::to_string(buffer->size()) +
+          " byte(s) to serialize columnar batches");
   env->SetByteArrayRegion(bufferArr, 0, buffer->size(), reinterpret_cast<const jbyte*>(buffer->data()));
 
   jobject columnarBatchSerializeResult =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a check to determine whether a byte array is constructed when trying to serialize columnar batches, rather than crashing.

Relates: \#7624

## How was this patch tested?
integration tests

