### PR TITLE
[GLUTEN-7446][BUILD] build third party libs using jar from JAVA_HOME

### DIFF
--- a/dev/build-thirdparty.sh
+++ b/dev/build-thirdparty.sh
@@ -82,4 +82,4 @@ elif [ "$LINUX_OS" == "debian" ]; then
   fi
 fi
 cd $THIRDPARTY_LIB/
-jar cvf gluten-thirdparty-lib-$LINUX_OS-$VERSION-$ARCH.jar ./
+$JAVA_HOME/bin/jar cvf gluten-thirdparty-lib-$LINUX_OS-$VERSION-$ARCH.jar ./


### PR DESCRIPTION
## What changes were proposed in this pull request?

Builds third party libs jar using the `jar` binary from `JAVA_HOME`. Just using `jar` would pick up the JDK from the classpath of the system, and that is not ideal since a dev env can have multiple JDK configured.

(Fixes: \#7446)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Existing unit and integration tests



