### PR TITLE
[VL] Enhance write parquet with compression codec test

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -20,7 +20,11 @@ import org.apache.gluten.execution.VeloxWholeStageTransformerSuite
 import org.apache.gluten.test.FallbackUtil
 
 import org.apache.spark.SparkConf
+import org.apache.spark.util.Utils
 
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.junit.Assert
 
 class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
@@ -50,17 +54,11 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  testWithSpecifiedSparkVersion("test write parquet with compression codec", Some("3.2")) {
+  test("test write parquet with compression codec") {
     // compression codec details see `VeloxParquetDatasource.cc`
     Seq("snappy", "gzip", "zstd", "lz4", "none", "uncompressed")
       .foreach {
         codec =>
-          val extension = codec match {
-            case "none" | "uncompressed" => ""
-            case "gzip" => "gz"
-            case _ => codec
-          }
-
           TPCHTableDataFrames.foreach {
             case (_, df) =>
               withTempPath {
@@ -69,15 +67,25 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
                     .format("parquet")
                     .option("compression", codec)
                     .save(f.getCanonicalPath)
-                  val files = f.list()
-                  assert(files.nonEmpty, extension)
-
-                  if (!isSparkVersionGE("3.4")) {
-                    assert(
-                      files.exists(_.contains(extension)),
-                      extension
-                    ) // filename changed in spark 3.4.
+                  val expectedCodec = codec match {
+                    case "none" => "uncompressed"
+                    case _ => codec
                   }
+                  val parquetFiles = f.list((_, name) => name.contains("parquet"))
+                  assert(parquetFiles.nonEmpty, expectedCodec)
+                  assert(
+                    parquetFiles.forall {
+                      file =>
+                        val path = new Path(f.getCanonicalPath, file)
+                        val in = HadoopInputFile.fromPath(path, spark.sessionState.newHadoopConf())
+                        Utils.tryWithResource(ParquetFileReader.open(in)) {
+                          reader =>
+                            val column = reader.getFooter.getBlocks.get(0).getColumns.get(0)
+                            expectedCodec.equalsIgnoreCase(column.getCodec.toString)
+                        }
+                    },
+                    expectedCodec
+                  )
 
                   val parquetDf = spark.read
                     .format("parquet")


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `VeloxParquetWriteSuite` currently checks the compression codec based on the file extension, which is no longer applicable starting from Spark 3.4.

We could check the compression codec using Parquet metadata, making it compatible across all Spark versions.

## How was this patch tested?
Unit test:
```bash
mvn test -Phadoop-3.3 -Pscala-2.12 -Pbackends-velox -Pceleborn -Pudf -Dsuites="org.apache.spark.sql.execution.VeloxParquetWriteSuite" -pl :backends-velox -Pspark-3.4
```

