### PR TITLE
[GLUTEN-7243][VL] Suspend the Velox task while reading an input Java iterator to make the task spillable

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -225,18 +225,6 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   std::string logPrefix{"Spill[" + poolName + "]: "};
   int64_t shrunken = memoryManager_->shrink(size);
   if (spillStrategy_ == "auto") {
-    if (task_->numThreads() != 0) {
-      // Task should have zero running threads, otherwise there's
-      // possibility that this spill call hangs. See https://github.com/apache/incubator-gluten/issues/7243.
-      // As of now, non-zero running threads usually happens when:
-      // 1. Task A spills task B;
-      // 2. Task A trys to grow buffers created by task B, during which spill is requested on task A again;
-      LOG(INFO) << fmt::format(
-          "{} spill is requested on a task {} that has non-zero running threads, which is not currently supported. Skipping.",
-          logPrefix,
-          task_->taskId());
-      return shrunken;
-    }
     int64_t remaining = size - shrunken;
     LOG(INFO) << fmt::format("{} trying to request spill for {}.", logPrefix, velox::succinctBytes(remaining));
     auto mm = memoryManager_->getMemoryManager();

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -131,7 +131,9 @@ class ValueStream : public facebook::velox::exec::SourceOperator {
             operatorId,
             valueStreamNode->id(),
             valueStreamNode->name().data()) {
-    rvStream_ = std::make_unique<RowVectorStream>(driverCtx, pool(), valueStreamNode->iterator(), outputType_);
+    ResultIterator* itr = valueStreamNode->iterator();
+    VELOX_CHECK_NOT_NULL(itr);
+    rvStream_ = std::make_unique<RowVectorStream>(driverCtx, pool(), itr, outputType_);
   }
 
   facebook::velox::RowVectorPtr getOutput() override {

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -88,7 +88,7 @@ class ValueStreamNode final : public facebook::velox::core::PlanNode {
   ValueStreamNode(
       const facebook::velox::core::PlanNodeId& id,
       const facebook::velox::RowTypePtr& outputType,
-      std::unique_ptr<ResultIterator> iterator)
+      std::shared_ptr<ResultIterator> iterator)
       : facebook::velox::core::PlanNode(id), outputType_(outputType), iterator_(std::move(iterator)) {
     VELOX_CHECK_NOT_NULL(iterator_);
   }
@@ -117,7 +117,7 @@ class ValueStreamNode final : public facebook::velox::core::PlanNode {
   void addDetails(std::stringstream& stream) const override{};
 
   const facebook::velox::RowTypePtr outputType_;
-  std::unique_ptr<ResultIterator> iterator_;
+  std::shared_ptr<ResultIterator> iterator_;
   const std::vector<facebook::velox::core::PlanNodePtr> kEmptySources_;
 };
 

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -89,9 +89,7 @@ class ValueStreamNode final : public facebook::velox::core::PlanNode {
       const facebook::velox::core::PlanNodeId& id,
       const facebook::velox::RowTypePtr& outputType,
       std::shared_ptr<ResultIterator> iterator)
-      : facebook::velox::core::PlanNode(id), outputType_(outputType), iterator_(std::move(iterator)) {
-    VELOX_CHECK_NOT_NULL(iterator_);
-  }
+      : facebook::velox::core::PlanNode(id), outputType_(outputType), iterator_(std::move(iterator)) {}
 
   const facebook::velox::RowTypePtr& outputType() const override {
     return outputType_;
@@ -133,15 +131,15 @@ class ValueStream : public facebook::velox::exec::SourceOperator {
             operatorId,
             valueStreamNode->id(),
             valueStreamNode->name().data()) {
-    valueStream_ = std::make_unique<RowVectorStream>(driverCtx, pool(), valueStreamNode->iterator(), outputType_);
+    rvStream_ = std::make_unique<RowVectorStream>(driverCtx, pool(), valueStreamNode->iterator(), outputType_);
   }
 
   facebook::velox::RowVectorPtr getOutput() override {
     if (finished_) {
       return nullptr;
     }
-    if (valueStream_->hasNext()) {
-      return valueStream_->next();
+    if (rvStream_->hasNext()) {
+      return rvStream_->next();
     } else {
       finished_ = true;
       return nullptr;
@@ -158,7 +156,7 @@ class ValueStream : public facebook::velox::exec::SourceOperator {
 
  private:
   bool finished_ = false;
-  std::unique_ptr<RowVectorStream> valueStream_;
+  std::unique_ptr<RowVectorStream> rvStream_;
 };
 
 class RowVectorStreamOperatorTranslator : public facebook::velox::exec::Operator::PlanNodeTranslator {

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -45,7 +45,7 @@ class RowVectorStream {
       // possibility that this spill call hangs. See https://github.com/apache/incubator-gluten/issues/7243.
       // As of now, non-zero running threads usually happens when:
       // 1. Task A spills task B;
-      // 2. Task A trys to grow buffers created by task B, during which spill is requested on task A again;
+      // 2. Task A trys to grow buffers created by task B, during which spill is requested on task A again.
       facebook::velox::exec::SuspendedSection(driverCtx_->driver);
       hasNext = iterator_->hasNext();
     }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1129,8 +1129,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::constructValueStreamNode(
     VELOX_CHECK_LT(streamIdx, inputIters_.size(), "Could not find stream index {} in input iterator list.", streamIdx);
     iterator = inputIters_[streamIdx];
   }
-  auto valueStream = std::make_unique<RowVectorStream>(pool_, iterator, outputType);
-  auto node = std::make_shared<ValueStreamNode>(nextPlanNodeId(), outputType, std::move(valueStream));
+  auto node = std::make_shared<ValueStreamNode>(nextPlanNodeId(), outputType, std::move(iterator));
 
   auto splitInfo = std::make_shared<SplitInfo>();
   splitInfo->isStream = true;

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
@@ -62,16 +62,16 @@ trait GlutenPlan extends SparkPlan with Convention.KnownBatchType with LogLevelU
    * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
    */
   final def doValidate(): ValidationResult = {
-    val schemaVaidationResult = BackendsApiManager.getValidatorApiInstance
+    val schemaValidationResult = BackendsApiManager.getValidatorApiInstance
       .doSchemaValidate(schema)
       .map {
         reason =>
           ValidationResult.failed(s"Found schema check failure for $schema, due to: $reason")
       }
       .getOrElse(ValidationResult.succeeded)
-    if (!schemaVaidationResult.ok()) {
+    if (!schemaValidationResult.ok()) {
       TestStats.addFallBackClassName(this.getClass.toString)
-      return schemaVaidationResult
+      return schemaValidationResult
     }
     try {
       TransformerState.enterValidation


### PR DESCRIPTION
This could be a better approach to replace https://github.com/apache/incubator-gluten/pull/7244.

Could remove [this commit](https://github.com/oap-project/velox/commit/b55c4dc49c1ea5c3f29793452dc48f77569164b2) from Gluten's Velox fork when this change is landed.