### PR TITLE
[GLUTEN-7753][CORE] Do not replace literals of expand's projects in `PullOutPreProject`

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/PullOutPreProject.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/PullOutPreProject.scala
@@ -222,7 +222,13 @@ object PullOutPreProject extends RewriteSingleNode with PullOutProjectHelper {
     case expand: ExpandExec if needsPreProject(expand) =>
       val expressionMap = new mutable.HashMap[Expression, NamedExpression]()
       val newProjections =
-        expand.projections.map(_.map(replaceExpressionWithAttribute(_, expressionMap)))
+        expand.projections.map(
+          _.map(
+            replaceExpressionWithAttribute(
+              _,
+              expressionMap,
+              replaceBoundReference = false,
+              replaceLiteral = false)))
       expand.copy(
         projections = newProjections,
         child = ProjectExec(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/PullOutProjectHelper.scala
@@ -62,7 +62,8 @@ trait PullOutProjectHelper {
   protected def replaceExpressionWithAttribute(
       expr: Expression,
       projectExprsMap: mutable.HashMap[Expression, NamedExpression],
-      replaceBoundReference: Boolean = false): Expression =
+      replaceBoundReference: Boolean = false,
+      replaceLiteral: Boolean = true): Expression =
     expr match {
       case alias: Alias =>
         alias.child match {
@@ -73,6 +74,7 @@ trait PullOutProjectHelper {
         }
       case attr: Attribute => attr
       case e: BoundReference if !replaceBoundReference => e
+      case literal: Literal if !replaceLiteral => literal
       case other =>
         projectExprsMap
           .getOrElseUpdate(other.canonicalized, Alias(other, generatePreAliasName)())


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #7753

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

