### PR TITLE
[GLUTEN-7143][VL] RAS: Catch exceptions thrown from rewrite rules

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
@@ -24,10 +24,11 @@ import org.apache.gluten.ras.path.Pattern
 import org.apache.gluten.ras.path.Pattern.node
 import org.apache.gluten.ras.rule.{RasRule, Shape}
 import org.apache.gluten.ras.rule.Shapes.pattern
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
 
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{classTag, ClassTag}
 
 trait RasOffload {
   def offload(plan: SparkPlan): SparkPlan
@@ -70,7 +71,9 @@ object RasOffload {
       new RuleImpl(base, validator)
     }
 
-    private class RuleImpl(base: RasOffload, validator: Validator) extends RasRule[SparkPlan] with Logging {
+    private class RuleImpl(base: RasOffload, validator: Validator)
+      extends RasRule[SparkPlan]
+      with Logging {
       private val typeIdentifier: TypeIdentifier = base.typeIdentifier()
 
       final override def shift(node: SparkPlan): Iterable[SparkPlan] = {
@@ -86,22 +89,25 @@ object RasOffload {
         }
 
         // 2. Rewrite the node to form that native library supports.
-        val rewritten = try {
-          rewrites.foldLeft(node) {
-            case (node, rewrite) =>
-              node.transformUp {
-                case p =>
-                  val out = rewrite.rewrite(p)
-                  out
-              }
+        val rewritten =
+          try {
+            rewrites.foldLeft(node) {
+              case (node, rewrite) =>
+                node.transformUp {
+                  case p =>
+                    val out = rewrite.rewrite(p)
+                    out
+                }
+            }
+          } catch {
+            case e: Exception =>
+              // TODO: Remove this catch block
+              //  See https://github.com/apache/incubator-gluten/issues/7766
+              logWarning(
+                s"Exception thrown during rewriting the plan ${node.nodeName}. Skip offloading it",
+                e)
+              return List.empty
           }
-        } catch {
-          case e: Exception =>
-            // TODO: Remove this catch block
-            //  See https://github.com/apache/incubator-gluten/issues/7766
-            logWarning(s"Exception thrown during rewriting the plan ${node.nodeName}. Skip offloading it", e)
-            return List.empty
-        }
 
         // 3. Walk the rewritten tree.
         val offloaded = rewritten.transformUp {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteSparkPlanRulesManager.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/rewrite/RewriteSparkPlanRulesManager.scala
@@ -88,7 +88,10 @@ class RewriteSparkPlanRulesManager private (rewriteRules: Seq[RewriteSingleNode]
       }
       (rewrittenPlan, None)
     } catch {
-      case e: Exception => (origin, Option(e.getMessage))
+      case e: Exception =>
+        // TODO: Remove this catch block
+        //  See https://github.com/apache/incubator-gluten/issues/7766
+        (origin, Option(e.getMessage))
     }
   }
 


### PR DESCRIPTION
Part of https://github.com/apache/incubator-gluten/issues/7143

Catch the exceptions to align with legacy planner.

Moving forward, should fix https://github.com/apache/incubator-gluten/issues/7766.

This fixes UT `GlutenReplaceHashWithSortAggSuite | Gluten - replace partial and final hash aggregate together with sort aggregate`
