### PR TITLE
[VL] Remove a duplicated Maven dependency, and some follow-ups for #7764

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -74,12 +74,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.gluten</groupId>
-      <artifactId>gluten-substrait</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.gluten</groupId>
       <artifactId>gluten-arrow</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -21,6 +21,7 @@ import org.apache.gluten.events.GlutenPlanFallbackEvent
 import org.apache.gluten.execution.FileSourceScanExecTransformer
 import org.apache.gluten.utils.BackendTestUtils
 
+import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.{GlutenSQLTestsTrait, Row}
 import org.apache.spark.sql.execution.ProjectExec
@@ -32,6 +33,10 @@ import org.apache.spark.status.ElementTrackingStore
 import scala.collection.mutable.ArrayBuffer
 
 class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelper {
+  override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(GlutenConfig.RAS_ENABLED.key, "false")
+  }
 
   testGluten("test fallback logging") {
     val testAppender = new LogAppender("fallback reason")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -21,6 +21,7 @@ import org.apache.gluten.events.GlutenPlanFallbackEvent
 import org.apache.gluten.execution.FileSourceScanExecTransformer
 import org.apache.gluten.utils.BackendTestUtils
 
+import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.{GlutenSQLTestsTrait, Row}
 import org.apache.spark.sql.execution.ProjectExec
@@ -32,6 +33,10 @@ import org.apache.spark.status.ElementTrackingStore
 import scala.collection.mutable.ArrayBuffer
 
 class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelper {
+  override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(GlutenConfig.RAS_ENABLED.key, "false")
+  }
 
   testGluten("test fallback logging") {
     val testAppender = new LogAppender("fallback reason")


### PR DESCRIPTION
`gluten-substrait` is referred twice in `backends-velox`'s pom.xml and causes a compile time warning. Fix it.

And with a minor follow-up change for https://github.com/apache/incubator-gluten/pull/7764.