### PR TITLE
[GLUTEN-7775][CORE] Make sure the softaffinity hash executor list is in order

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/softaffinity/strategy/SoftAffinityAllocationTrait.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/softaffinity/strategy/SoftAffinityAllocationTrait.scala
@@ -30,7 +30,5 @@ trait SoftAffinityAllocationTrait {
   )
 
   /** allocate target executors for file */
-  def allocateExecs(
-      file: String,
-      candidates: ListBuffer[Option[(String, String)]]): Array[(String, String)]
+  def allocateExecs(file: String, candidates: ListBuffer[(String, String)]): Array[(String, String)]
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/softaffinity/strategy/SoftAffinityStrategy.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/softaffinity/strategy/SoftAffinityStrategy.scala
@@ -26,7 +26,7 @@ class SoftAffinityStrategy extends SoftAffinityAllocationTrait with Logging {
   /** allocate target executors for file */
   override def allocateExecs(
       file: String,
-      candidates: ListBuffer[Option[(String, String)]]): Array[(String, String)] = {
+      candidates: ListBuffer[(String, String)]): Array[(String, String)] = {
     if (candidates.size < 1) {
       Array.empty
     } else {
@@ -37,15 +37,10 @@ class SoftAffinityStrategy extends SoftAffinityAllocationTrait with Logging {
       // TODO: try to use ConsistentHash
       val mod = file.hashCode % candidatesSize
       val c1 = if (mod < 0) (mod + candidatesSize) else mod
-      // check whether the executor with index c1 is down
-      if (candidates(c1).isDefined) {
-        resultSet.add(candidates(c1).get)
-      }
+      resultSet.add(candidates(c1))
       for (i <- 1 until softAffinityReplicationNum) {
         val c2 = (c1 + halfCandidatesSize + i) % candidatesSize
-        if (candidates(c2).isDefined) {
-          resultSet.add(candidates(c2).get)
-        }
+        resultSet.add(candidates(c2))
       }
       resultSet.toArray
     }

--- a/gluten-substrait/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
@@ -31,6 +31,8 @@ import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.test.SharedSparkSession
 
+import scala.collection.mutable.ListBuffer
+
 class SoftAffinitySuite extends QueryTest with SharedSparkSession with PredicateHelper {
 
   override protected def sparkConf: SparkConf = super.sparkConf
@@ -80,14 +82,14 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
           "fakePath0",
           0,
           100,
-          Array("host-1", "host-2")
+          Array("192.168.22.1", "host-2")
         ),
         SparkShimLoader.getSparkShims.generatePartitionedFile(
           InternalRow.empty,
           "fakePath1",
           0,
           200,
-          Array("host-4", "host-5")
+          Array("192.168.22.1", "host-5")
         )
       ).toArray
     )
@@ -98,13 +100,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
 
     val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
-    val affinityResultSet = if (scalaVersion.startsWith("2.12")) {
-      Set("host-1", "host-4", "host-5")
-    } else if (scalaVersion.startsWith("2.13")) {
-      Set("host-5", "host-4", "host-2")
-    }
-
-    assertResult(affinityResultSet) {
+    assertResult(Set("192.168.22.1", "host-5", "host-2")) {
       nativePartition.preferredLocations().toSet
     }
   }
@@ -136,30 +132,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
 
     val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
-    assertResult(Set("executor_host-2_2", "executor_host-1_0")) {
-      nativePartition.preferredLocations().toSet
-    }
-  }
-
-  def generateNativePartition4(): Unit = {
-    val partition = FilePartition(
-      0,
-      Seq(
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath_0",
-          0,
-          100)
-      ).toArray
-    )
-
-    val locations = SoftAffinity.getFilePartitionLocations(
-      partition.files.map(_.filePath.toString),
-      partition.preferredLocations())
-
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
-
-    assertResult(Set("executor_host-1_1")) {
+    assertResult(Set("executor_192.168.22.1_1", "executor_10.1.1.33_6")) {
       nativePartition.preferredLocations().toSet
     }
   }
@@ -206,11 +179,11 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     val addEvent0 = SparkListenerExecutorAdded(
       System.currentTimeMillis(),
       "0",
-      new ExecutorInfo("host-1", 3, null))
+      new ExecutorInfo("192.168.22.1", 3, null))
     val addEvent1 = SparkListenerExecutorAdded(
       System.currentTimeMillis(),
       "1",
-      new ExecutorInfo("host-1", 3, null))
+      new ExecutorInfo("192.168.22.1", 3, null))
     val addEvent2 = SparkListenerExecutorAdded(
       System.currentTimeMillis(),
       "2",
@@ -234,7 +207,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     val addEvent6 = SparkListenerExecutorAdded(
       System.currentTimeMillis(),
       "6",
-      new ExecutorInfo("host-4", 3, null))
+      new ExecutorInfo("10.1.1.33", 3, null))
 
     val removedEvent0 = SparkListenerExecutorRemoved(System.currentTimeMillis(), "0", "")
     val removedEvent1 = SparkListenerExecutorRemoved(System.currentTimeMillis(), "1", "")
@@ -256,23 +229,35 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     executorsListListener.onExecutorAdded(addEvent3_1)
 
     assert(SoftAffinityManager.nodesExecutorsMap.size == 3)
-    assert(SoftAffinityManager.fixedIdForExecutors.size == 4)
+    assert(SoftAffinityManager.sortedIdForExecutors.size == 4)
 
     executorsListListener.onExecutorRemoved(removedEvent3)
     // test removing executor repeatedly
     executorsListListener.onExecutorRemoved(removedEvent3_1)
 
     assert(SoftAffinityManager.nodesExecutorsMap.size == 2)
-    assert(SoftAffinityManager.fixedIdForExecutors.size == 4)
-    assert(SoftAffinityManager.fixedIdForExecutors.exists(_.isEmpty))
+    assert(SoftAffinityManager.sortedIdForExecutors.size == 3)
+    assert(
+      SoftAffinityManager.sortedIdForExecutors.equals(
+        ListBuffer[(String, String)](("0", "192.168.22.1"), ("1", "192.168.22.1"), ("2", "host-2"))
+      ))
 
     executorsListListener.onExecutorAdded(addEvent4)
     executorsListListener.onExecutorAdded(addEvent5)
     executorsListListener.onExecutorAdded(addEvent6)
 
     assert(SoftAffinityManager.nodesExecutorsMap.size == 4)
-    assert(SoftAffinityManager.fixedIdForExecutors.size == 6)
-    assert(!SoftAffinityManager.fixedIdForExecutors.exists(_.isEmpty))
+    assert(SoftAffinityManager.sortedIdForExecutors.size == 6)
+    assert(
+      SoftAffinityManager.sortedIdForExecutors.equals(
+        ListBuffer[(String, String)](
+          ("6", "10.1.1.33"),
+          ("0", "192.168.22.1"),
+          ("1", "192.168.22.1"),
+          ("2", "host-2"),
+          ("5", "host-2"),
+          ("4", "host-3"))
+      ))
 
     // all target hosts exist in computing hosts list, return the original hosts list
     generateNativePartition1()
@@ -286,19 +271,21 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     executorsListListener.onExecutorRemoved(removedEvent4)
 
     assert(SoftAffinityManager.nodesExecutorsMap.size == 3)
-    assert(SoftAffinityManager.fixedIdForExecutors.size == 6)
-    assert(SoftAffinityManager.fixedIdForExecutors.exists(_.isEmpty))
+    assert(SoftAffinityManager.sortedIdForExecutors.size == 4)
+    assert(
+      SoftAffinityManager.sortedIdForExecutors.equals(
+        ListBuffer[(String, String)](
+          ("6", "10.1.1.33"),
+          ("0", "192.168.22.1"),
+          ("1", "192.168.22.1"),
+          ("5", "host-2"))
+      ))
 
     executorsListListener.onExecutorRemoved(removedEvent2)
     executorsListListener.onExecutorRemoved(removedEvent4)
 
     assert(SoftAffinityManager.nodesExecutorsMap.size == 3)
-    assert(SoftAffinityManager.fixedIdForExecutors.size == 6)
-    assert(SoftAffinityManager.fixedIdForExecutors.exists(_.isEmpty))
-
-    // there are only one target host existing in computing hosts list,
-    // but the hash executors were removed, so return the original hosts list
-    generateNativePartition4()
+    assert(SoftAffinityManager.sortedIdForExecutors.size == 4)
 
     executorsListListener.onExecutorRemoved(removedEvent0)
     executorsListListener.onExecutorRemoved(removedEvent1)
@@ -307,10 +294,29 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     executorsListListener.onExecutorRemoved(removedEvent7)
 
     assert(SoftAffinityManager.nodesExecutorsMap.isEmpty)
-    assert(SoftAffinityManager.fixedIdForExecutors.size == 6)
-    assert(SoftAffinityManager.fixedIdForExecutors.exists(_.isEmpty))
+    assert(SoftAffinityManager.sortedIdForExecutors.isEmpty)
 
     // all executors were removed, return the original hosts list
     generateNativePartition5()
+
+    executorsListListener.onExecutorAdded(addEvent0)
+    executorsListListener.onExecutorAdded(addEvent1)
+    executorsListListener.onExecutorAdded(addEvent2)
+    executorsListListener.onExecutorAdded(addEvent3)
+    executorsListListener.onExecutorAdded(addEvent4)
+    executorsListListener.onExecutorAdded(addEvent5)
+    executorsListListener.onExecutorAdded(addEvent6)
+    assert(SoftAffinityManager.sortedIdForExecutors.size == 7)
+    assert(
+      SoftAffinityManager.sortedIdForExecutors.equals(
+        ListBuffer[(String, String)](
+          ("6", "10.1.1.33"),
+          ("0", "192.168.22.1"),
+          ("1", "192.168.22.1"),
+          ("2", "host-2"),
+          ("5", "host-2"),
+          ("3", "host-3"),
+          ("4", "host-3"))
+      ))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Before this pr, the order of the soft affinity hash executor list is random, will lead to cache data missing after restarting the spark applications. Now make sure the softaffinity hash executor list is in order, after restarting the spark application, the computed file preferred location are the same as the ones before restarting.

Close #7775.

(Fixes: #7775)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

