### PR TITLE
[GLUTEN-7749][VL] Trim ISOControl characters in string for casting to integral type

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -739,7 +739,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
         }
       case ByteType | ShortType | IntegerType | LongType =>
         c.child.dataType match {
-          case StringType =>
+          case StringType if GlutenConfig.getConf.castFromVarcharAddTrimNode =>
             val trimNode = StringTrim(c.child, Some(Literal(trimWhitespaceStr + isoControlControlStr)))
             c.withNewChildren(Seq(trimNode)).asInstanceOf[Cast]
           case _ =>

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -723,6 +723,8 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     val trimParaSepStr = "\u2029"
     // Needs to be trimmed for casting to float/double/decimal
     val trimSpaceStr = ('\u0000' to '\u0020').toList.mkString
+    // ISOControl characters, refer java.lang.Character.isISOControl(int)
+    val isoControlControlStr = (('\u0000' to '\u001F') ++ ('\u007F' to '\u009F')).toList.mkString
     // scalastyle:on nonascii
     c.dataType match {
       case BinaryType | _: ArrayType | _: MapType | _: StructType | _: UserDefinedType[_] =>
@@ -731,6 +733,14 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
         c.child.dataType match {
           case StringType if GlutenConfig.getConf.castFromVarcharAddTrimNode =>
             val trimNode = StringTrim(c.child, Some(Literal(trimSpaceStr)))
+            c.withNewChildren(Seq(trimNode)).asInstanceOf[Cast]
+          case _ =>
+            c
+        }
+      case ByteType | ShortType | IntegerType | LongType =>
+        c.child.dataType match {
+          case StringType =>
+            val trimNode = StringTrim(c.child, Some(Literal(trimWhitespaceStr + isoControlControlStr)))
             c.withNewChildren(Seq(trimNode)).asInstanceOf[Cast]
           case _ =>
             c

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -724,7 +724,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     // Needs to be trimmed for casting to float/double/decimal
     val trimSpaceStr = ('\u0000' to '\u0020').toList.mkString
     // ISOControl characters, refer java.lang.Character.isISOControl(int)
-    val isoControlControlStr = (('\u0000' to '\u001F') ++ ('\u007F' to '\u009F')).toList.mkString
+    val isoControlStr = (('\u0000' to '\u001F') ++ ('\u007F' to '\u009F')).toList.mkString
     // scalastyle:on nonascii
     if (GlutenConfig.getConf.castFromVarcharAddTrimNode && c.child.dataType == StringType) {
       val trimStr = c.dataType match {
@@ -735,7 +735,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
         case _ =>
           Some(
             (trimWhitespaceStr + trimSpaceSepStr + trimLineSepStr
-              + trimParaSepStr + isoControlControlStr).toSet.mkString
+              + trimParaSepStr + isoControlStr).toSet.mkString
           )
       }
       trimStr

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -732,10 +732,11 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
           None
         case FloatType | DoubleType | _: DecimalType =>
           Some(trimSpaceStr)
-        case ByteType | ShortType | IntegerType | LongType =>
-          Some((trimWhitespaceStr + isoControlControlStr).toSet.mkString)
         case _ =>
-          Some(trimWhitespaceStr + trimSpaceSepStr + trimLineSepStr + trimParaSepStr)
+          Some(
+            (trimWhitespaceStr + trimSpaceSepStr + trimLineSepStr
+              + trimParaSepStr + isoControlControlStr).toSet.mkString
+          )
       }
       trimStr
         .map {

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -327,11 +327,20 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
     withSQLConf(GlutenConfig.CAST_FROM_VARCHAR_ADD_TRIM_NODE.key -> "true") {
       def checkResult(df: DataFrame, expectedResult: Seq[Row]): Unit = {
         checkAnswer(df, expectedResult)
-        assert(find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
+        assert(
+          find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
       }
 
       // scalastyle:off nonascii
-      Seq(" 123", "123 ", " 123 ", "\u2000123\n\n\n", "123\r\r\r", "123\f\f\f", "123\u000C", "123\u0000")
+      Seq(
+        " 123",
+        "123 ",
+        " 123 ",
+        "\u2000123\n\n\n",
+        "123\r\r\r",
+        "123\f\f\f",
+        "123\u000C",
+        "123\u0000")
         .toDF("col1")
         .createOrReplaceTempView("t1")
       // scalastyle:on nonascii

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.execution.{ProjectExecTransformer, WholeStageTransformer}
 
 import org.apache.spark.SparkException
@@ -323,41 +324,43 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
   }
 
   testGluten("Allow leading/trailing whitespace in string before casting") {
-    def checkResult(df: DataFrame, expectedResult: Seq[Row]): Unit = {
-      checkAnswer(df, expectedResult)
-      assert(find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
+    withSQLConf(GlutenConfig.CAST_FROM_VARCHAR_ADD_TRIM_NODE.key -> "true") {
+      def checkResult(df: DataFrame, expectedResult: Seq[Row]): Unit = {
+        checkAnswer(df, expectedResult)
+        assert(find(df.queryExecution.executedPlan)(_.isInstanceOf[ProjectExecTransformer]).isDefined)
+      }
+
+      // scalastyle:off nonascii
+      Seq(" 123", "123 ", " 123 ", "\u2000123\n\n\n", "123\r\r\r", "123\f\f\f", "123\u000C", "123\u0000")
+        .toDF("col1")
+        .createOrReplaceTempView("t1")
+      // scalastyle:on nonascii
+      val expectedIntResult = Row(123) :: Row(123) ::
+        Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Nil
+      var df = spark.sql("select cast(col1 as int) from t1")
+      checkResult(df, expectedIntResult)
+      df = spark.sql("select cast(col1 as long) from t1")
+      checkResult(df, expectedIntResult)
+
+      Seq(" 123.5", "123.5 ", " 123.5 ", "123.5\n\n\n", "123.5\r\r\r", "123.5\f\f\f", "123.5\u000C")
+        .toDF("col1")
+        .createOrReplaceTempView("t1")
+      val expectedFloatResult = Row(123.5) :: Row(123.5) ::
+        Row(123.5) :: Row(123.5) :: Row(123.5) :: Row(123.5) :: Row(123.5) :: Nil
+      df = spark.sql("select cast(col1 as float) from t1")
+      checkResult(df, expectedFloatResult)
+      df = spark.sql("select cast(col1 as double) from t1")
+      checkResult(df, expectedFloatResult)
+
+      // scalastyle:off nonascii
+      val rawData =
+        Seq(" abc", "abc ", " abc ", "\u2000abc\n\n\n", "abc\r\r\r", "abc\f\f\f", "abc\u000C")
+      // scalastyle:on nonascii
+      rawData.toDF("col1").createOrReplaceTempView("t1")
+      val expectedBinaryResult = rawData.map(d => Row(d.getBytes(StandardCharsets.UTF_8))).seq
+      df = spark.sql("select cast(col1 as binary) from t1")
+      checkResult(df, expectedBinaryResult)
     }
-
-    // scalastyle:off nonascii
-    Seq(" 123", "123 ", " 123 ", "\u2000123\n\n\n", "123\r\r\r", "123\f\f\f", "123\u000C", "123\u0000")
-      .toDF("col1")
-      .createOrReplaceTempView("t1")
-    // scalastyle:on nonascii
-    val expectedIntResult = Row(123) :: Row(123) ::
-      Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Nil
-    var df = spark.sql("select cast(col1 as int) from t1")
-    checkResult(df, expectedIntResult)
-    df = spark.sql("select cast(col1 as long) from t1")
-    checkResult(df, expectedIntResult)
-
-    Seq(" 123.5", "123.5 ", " 123.5 ", "123.5\n\n\n", "123.5\r\r\r", "123.5\f\f\f", "123.5\u000C")
-      .toDF("col1")
-      .createOrReplaceTempView("t1")
-    val expectedFloatResult = Row(123.5) :: Row(123.5) ::
-      Row(123.5) :: Row(123.5) :: Row(123.5) :: Row(123.5) :: Row(123.5) :: Nil
-    df = spark.sql("select cast(col1 as float) from t1")
-    checkResult(df, expectedFloatResult)
-    df = spark.sql("select cast(col1 as double) from t1")
-    checkResult(df, expectedFloatResult)
-
-    // scalastyle:off nonascii
-    val rawData =
-      Seq(" abc", "abc ", " abc ", "\u2000abc\n\n\n", "abc\r\r\r", "abc\f\f\f", "abc\u000C")
-    // scalastyle:on nonascii
-    rawData.toDF("col1").createOrReplaceTempView("t1")
-    val expectedBinaryResult = rawData.map(d => Row(d.getBytes(StandardCharsets.UTF_8))).seq
-    df = spark.sql("select cast(col1 as binary) from t1")
-    checkResult(df, expectedBinaryResult)
   }
 
   private def withExpr(newExpr: Expression): Column = new Column(newExpr)

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -329,12 +329,12 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
     }
 
     // scalastyle:off nonascii
-    Seq(" 123", "123 ", " 123 ", "\u2000123\n\n\n", "123\r\r\r", "123\f\f\f", "123\u000C")
+    Seq(" 123", "123 ", " 123 ", "\u2000123\n\n\n", "123\r\r\r", "123\f\f\f", "123\u000C", "123\u0000")
       .toDF("col1")
       .createOrReplaceTempView("t1")
     // scalastyle:on nonascii
     val expectedIntResult = Row(123) :: Row(123) ::
-      Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Nil
+      Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Row(123) :: Nil
     var df = spark.sql("select cast(col1 as int) from t1")
     checkResult(df, expectedIntResult)
     df = spark.sql("select cast(col1 as long) from t1")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes: #7749, to align with Spark's change introduced by https://github.com/apache/spark/pull/41535.

## How was this patch tested?

added unit test

