### PR TITLE
[VL] Do not use --version-script link option on Darwin

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -197,7 +197,7 @@ endif()
 
 add_library(velox SHARED ${VELOX_SRCS})
 
-if(ENABLE_GLUTEN_VCPKG)
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
   # Hide symbols of static dependencies
   target_link_options(
     velox PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -197,8 +197,8 @@ endif()
 
 add_library(velox SHARED ${VELOX_SRCS})
 
-if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  # Hide symbols of static dependencies
+if(ENABLE_GLUTEN_VCPKG AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  # Hide some symbols to avoid conflict.
   target_link_options(
     velox PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 endif()

--- a/cpp/velox/symbols.map
+++ b/cpp/velox/symbols.map
@@ -11,6 +11,4 @@
   local:
     # Hide symbols from glog and gflags.
     *google::*;
-    # Hide all other symbols except the above global symbols.
-    #*;
 };

--- a/cpp/velox/symbols.map
+++ b/cpp/velox/symbols.map
@@ -9,6 +9,8 @@
     JNI_OnLoad;
     JNI_OnUnload;
   local:
-    # Hide symbols of static dependencies
+    # Hide symbols from glog and gflags.
+    *google::*;
+    # Hide all other symbols except the above global symbols.
     *;
 };

--- a/cpp/velox/symbols.map
+++ b/cpp/velox/symbols.map
@@ -9,6 +9,6 @@
     JNI_OnLoad;
     JNI_OnUnload;
   local:
-    # Hide symbols from glog and gflags.
-    *google::*;
+    # Hide all other symbols except the above global symbols.
+    *;
 };

--- a/cpp/velox/symbols.map
+++ b/cpp/velox/symbols.map
@@ -12,5 +12,5 @@
     # Hide symbols from glog and gflags.
     *google::*;
     # Hide all other symbols except the above global symbols.
-    *;
+    #*;
 };

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -28,8 +28,7 @@ function(add_velox_test TEST_EXEC)
   add_executable(${TEST_EXEC} ${SOURCES} ${VELOX_TEST_COMMON_SRCS})
   target_include_directories(${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox
                                                   ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main
-                        google::glog)
+  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main)
   gtest_discover_tests(${TEST_EXEC} DISCOVERY_MODE PRE_TEST)
 endfunction()
 

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -26,9 +26,8 @@ function(add_velox_test TEST_EXEC)
     message(FATAL_ERROR "No sources specified for test ${TEST_NAME}")
   endif()
   add_executable(${TEST_EXEC} ${SOURCES} ${VELOX_TEST_COMMON_SRCS})
-  target_include_directories(
-    ${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox ${CMAKE_SOURCE_DIR}/src
-                         ${VELOX_BUILD_PATH}/_deps/duckdb-src/src/include)
+  target_include_directories(${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox
+                                                  ${CMAKE_SOURCE_DIR}/src)
   target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main
                         google::glog)
   gtest_discover_tests(${TEST_EXEC} DISCOVERY_MODE PRE_TEST)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up pr for [this comment](https://github.com/apache/incubator-gluten/pull/7497#issuecomment-2408417284).

If not hidden, the below error can be reported when running gluten CPP test.
```
something wrong with flag 'velox_memory_num_shared_leaf_pools' in file '/__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/velox/flag_definitions/flags.cpp'.  One possibility: file '/__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/velox/flag_definitions/flags.cpp' is being linked both statically and dynamically into this executable.
CMake Error at /usr/local/lib64/python3.9/site-packages/cmake/data/share/cmake-3.28/Modules/GoogleTestAddTests.cmake:112 (message):
Error running test executable.

  Path: '/__w/incubator-gluten/incubator-gluten/cpp/build/velox/tests/velox_shuffle_writer_test'
```
`velox_memory_num_shared_leaf_pools` is declared in Velox under `google` namespace. See `DEFINE_int32` used by [this velox code](https://github.com/facebookincubator/velox/blob/main/velox/flag_definitions/flags.cpp#L21). Even though `local: *;` is defined for version script, we have to explicitly make all symbols under `*google::*` namespace hidden. The possible reason is that the specified global `*facebook::velox::*` symbols cover those `*google::*` symbols.

## How was this patch tested?

CI.

