### PR TITLE
[CORE] Remove member TransformContext#inputAttributes as unused

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
@@ -209,7 +209,7 @@ case class CHHashAggregateExecTransformer(
         RelBuilder.makeReadRelForInputIteratorWithoutRegister(typeList, nameList, context)
       (getAggRel(context, operatorId, aggParams, readRel), inputAttrs, outputAttrs)
     }
-    TransformContext(inputAttributes, outputAttributes, relNode)
+    TransformContext(outputAttributes, relNode)
   }
 
   override def getAggRel(

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHWindowGroupLimitExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHWindowGroupLimitExecTransformer.scala
@@ -182,6 +182,6 @@ case class CHWindowGroupLimitExecTransformer(
     val currRel =
       getWindowGroupLimitRel(context, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Window Group Limit Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -72,7 +72,7 @@ abstract class HashAggregateExecTransformer(
     val aggParams = new AggregationParams
     val operatorId = context.nextOperatorId(this.nodeName)
     val relNode = getAggRel(context, operatorId, aggParams, childCtx.root)
-    TransformContext(childCtx.outputAttributes, output, relNode)
+    TransformContext(output, relNode)
   }
 
   // Return whether the outputs partial aggregation should be combined for Velox computing.

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/TopNTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/TopNTransformer.scala
@@ -79,7 +79,7 @@ case class TopNTransformer(
         child.output,
         childCtx.root,
         validation = false)
-    TransformContext(child.output, child.output, relNode)
+    TransformContext(child.output, relNode)
   }
 
   private def getRelNode(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -156,7 +156,7 @@ abstract class FilterExecTransformerBase(val cond: Expression, val input: SparkP
       context.registerEmptyRelToOperator(operatorId)
       // Since some columns' nullability will be removed after this filter, we need to update the
       // outputAttributes of child context.
-      return TransformContext(childCtx.inputAttributes, output, childCtx.root)
+      return TransformContext(output, childCtx.root)
     }
     val currRel = getRelNode(
       context,
@@ -166,7 +166,7 @@ abstract class FilterExecTransformerBase(val cond: Expression, val input: SparkP
       childCtx.root,
       validation = false)
     assert(currRel != null, "Filter rel should be valid.")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 }
 
@@ -205,7 +205,7 @@ abstract class ProjectExecTransformerBase(val list: Seq[NamedExpression], val in
     val currRel =
       getRelNode(context, list, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Project Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override def output: Seq[Attribute] = list.map(_.toAttribute)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -162,6 +162,6 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
       extensionNode,
       context,
       context.nextOperatorId(this.nodeName))
-    TransformContext(output, output, readNode)
+    TransformContext(output, readNode)
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/CartesianProductExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/CartesianProductExecTransformer.scala
@@ -105,7 +105,7 @@ case class CartesianProductExecTransformer(
       context,
       operatorId
     )
-    TransformContext(inputLeftOutput ++ inputRightOutput, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override protected def doValidateInternal(): ValidationResult = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ExpandExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ExpandExecTransformer.scala
@@ -122,7 +122,7 @@ case class ExpandExecTransformer(
     val currRel =
       getRelNode(context, projections, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Expand Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ExpandExecTransformer =

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
@@ -79,7 +79,7 @@ abstract class GenerateExecTransformerBase(
   override protected def doTransform(context: SubstraitContext): TransformContext = {
     val childCtx = child.asInstanceOf[TransformSupport].transform(context)
     val relNode = getRelNode(context, childCtx.root, getGeneratorNode(context), validation = false)
-    TransformContext(child.output, output, relNode)
+    TransformContext(output, relNode)
   }
 
   protected def getExtensionNodeForValidation: AdvancedExtensionNode = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinUtils.scala
@@ -312,7 +312,7 @@ object JoinUtils {
     } else {
       inputStreamedOutput ++ inputBuildOutput
     }
-    TransformContext(inputAttributes, output, rel)
+    TransformContext(output, rel)
   }
 
   def createCrossRel(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/LimitExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/LimitExecTransformer.scala
@@ -57,7 +57,7 @@ case class LimitExecTransformer(child: SparkPlan, offset: Long, count: Long)
     val childCtx = child.asInstanceOf[TransformSupport].transform(context)
     val operatorId = context.nextOperatorId(this.nodeName)
     val relNode = getRelNode(context, operatorId, offset, count, child.output, childCtx.root, false)
-    TransformContext(child.output, child.output, relNode)
+    TransformContext(child.output, relNode)
   }
 
   def getRelNode(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/SampleExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/SampleExecTransformer.scala
@@ -118,7 +118,7 @@ case class SampleExecTransformer(
     val currRel =
       getRelNode(context, condition, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Filter rel should be valid.")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SampleExecTransformer =

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/SortExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/SortExecTransformer.scala
@@ -113,7 +113,7 @@ case class SortExecTransformer(
     val currRel =
       getRelNode(context, sortOrder, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Sort Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SortExecTransformer =

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -47,10 +47,7 @@ import com.google.common.collect.Lists
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-case class TransformContext(
-    inputAttributes: Seq[Attribute],
-    outputAttributes: Seq[Attribute],
-    root: RelNode)
+case class TransformContext(outputAttributes: Seq[Attribute], root: RelNode)
 
 case class WholeStageTransformContext(root: PlanNode, substraitContext: SubstraitContext = null)
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WindowExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WindowExecTransformer.scala
@@ -187,7 +187,7 @@ case class WindowExecTransformer(
     val currRel =
       getWindowRel(context, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Window Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): WindowExecTransformer =

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WindowGroupLimitExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WindowGroupLimitExecTransformer.scala
@@ -163,6 +163,6 @@ case class WindowGroupLimitExecTransformer(
     val currRel =
       getWindowGroupLimitRel(context, child.output, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Window Group Limit Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
@@ -185,7 +185,7 @@ case class WriteFilesExecTransformer(
     val currRel =
       getRelNode(context, getFinalChildOutput, operatorId, childCtx.root, validation = false)
     assert(currRel != null, "Write Rel should be valid")
-    TransformContext(childCtx.outputAttributes, output, currRel)
+    TransformContext(output, currRel)
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): WriteFilesExecTransformer =

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -75,7 +75,7 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
   override protected def doTransform(context: SubstraitContext): TransformContext = {
     val operatorId = context.nextOperatorId(nodeName)
     val readRel = RelBuilder.makeReadRelForInputIterator(child.output.asJava, context, operatorId)
-    TransformContext(output, output, readRel)
+    TransformContext(output, readRel)
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan = {

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -99,7 +99,7 @@ case class EvalPythonExecTransformer(
 
     val relNode =
       getRelNode(childCtx.root, expressionNodes, context, operatorId, child.output, false)
-    TransformContext(child.output, output, relNode)
+    TransformContext(output, relNode)
   }
 
   def getRelNode(


### PR DESCRIPTION
A code cleanup to remove used member `TransformContext#inputAttributes`.