### PR TITLE
[GLUTEN-7458][VL] Upgrade GCC to version 11 in gluten-te's ubuntu dockerfile

### DIFF
--- a/tools/gluten-te/ubuntu/dockerfile-buildenv
+++ b/tools/gluten-te/ubuntu/dockerfile-buildenv
@@ -108,8 +108,17 @@ RUN cd /opt && wget https://github.com/Kitware/CMake/releases/download/v3.28.3/c
     && mkdir cmake \
     && bash cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/opt/cmake \
     && ln -s /opt/cmake/bin/cmake /usr/bin/cmake
-
 RUN cmake --version
+
+# Install GCC 11
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-11 g++-11
+RUN rm -f /usr/bin/gcc /usr/bin/g++
+RUN ln -s /usr/bin/gcc-11 /usr/bin/gcc
+RUN ln -s /usr/bin/g++-11 /usr/bin/g++
+RUN cc --version
+RUN c++ --version
 
 # Spark binaries
 WORKDIR /opt


### PR DESCRIPTION
A follow-up for https://github.com/apache/incubator-gluten/pull/7578 to fix the [ubuntu-based containerized build](https://github.com/apache/incubator-gluten/tree/main/tools/gluten-te/ubuntu/examples/buildhere-veloxbe-portable-libs).

Test will be run locally.