### PR TITLE
[GLUTEN-7847][CORE] Distinguish between native scan and vanilla spark scan in plan tree string

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -564,12 +564,6 @@ jobs:
         with:
           name: test-report-spark32
           path: '**/surefire-reports/TEST-*.xml'
-      - name: Upload golden files
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: golden-files-spark32
-          path: /tmp/tpch-approved-plan/**
 
   run-spark-test-spark32-slow:
     needs: build-native-lib-centos-7
@@ -639,12 +633,6 @@ jobs:
         with:
           name: test-report-spark33
           path: '**/surefire-reports/TEST-*.xml'
-      - name: Upload golden files
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: golden-files-spark33
-          path: /tmp/tpch-approved-plan/**
 
 
   run-spark-test-spark33-slow:
@@ -716,12 +704,6 @@ jobs:
         with:
           name: test-report-spark34
           path: '**/surefire-reports/TEST-*.xml'
-      - name: Upload golden files
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: golden-files-spark34
-          path: /tmp/tpch-approved-plan/**
 
 
   run-spark-test-spark34-slow:
@@ -793,12 +775,6 @@ jobs:
         with:
           name: test-report-spark35
           path: '**/surefire-reports/TEST-*.xml'
-      - name: Upload golden files
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: golden-files-spark35
-          path: /tmp/tpch-approved-plan/**
 
   run-spark-test-spark35-scala213:
     needs: build-native-lib-centos-7

--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -564,6 +564,12 @@ jobs:
         with:
           name: test-report-spark32
           path: '**/surefire-reports/TEST-*.xml'
+      - name: Upload golden files
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-files-spark32
+          path: /tmp/tpch-approved-plan/**
 
   run-spark-test-spark32-slow:
     needs: build-native-lib-centos-7
@@ -633,6 +639,12 @@ jobs:
         with:
           name: test-report-spark33
           path: '**/surefire-reports/TEST-*.xml'
+      - name: Upload golden files
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-files-spark33
+          path: /tmp/tpch-approved-plan/**
 
 
   run-spark-test-spark33-slow:
@@ -704,6 +716,12 @@ jobs:
         with:
           name: test-report-spark34
           path: '**/surefire-reports/TEST-*.xml'
+      - name: Upload golden files
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-files-spark34
+          path: /tmp/tpch-approved-plan/**
 
 
   run-spark-test-spark34-slow:
@@ -775,6 +793,12 @@ jobs:
         with:
           name: test-report-spark35
           path: '**/surefire-reports/TEST-*.xml'
+      - name: Upload golden files
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-files-spark35
+          path: /tmp/tpch-approved-plan/**
 
   run-spark-test-spark35-scala213:
     needs: build-native-lib-centos-7

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
@@ -128,7 +128,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
         assert(plans.size === 4)
 
         val parquetScan = plans(3).asInstanceOf[FileSourceScanExecTransformer]
-        assert(parquetScan.nodeName.startsWith("Scan parquet "))
+        assert(parquetScan.nodeName.startsWith("ScanTransformer parquet "))
 
         val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil)
@@ -348,7 +348,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       assert(scanExec.size === 1)
 
       val parquetScan = scanExec.head
-      assert(parquetScan.nodeName.startsWith("Scan parquet"))
+      assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
 
       val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
       val addFiles = fileIndex.matchingFiles(Nil, Nil)
@@ -678,7 +678,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
         assert(scanExec.size === 1)
 
         val parquetScan = scanExec.head
-        assert(parquetScan.nodeName.startsWith("Scan parquet"))
+        assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
         assert(parquetScan.metrics("numFiles").value === 201)
 
         val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
@@ -736,7 +736,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
         assert(scanExec.size === 1)
 
         val parquetScan = scanExec.head
-        assert(parquetScan.nodeName.startsWith("Scan parquet"))
+        assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
 
         val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil)
@@ -863,7 +863,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
         assert(plans.size === 4)
 
         val parquetScan = plans(3).asInstanceOf[FileSourceScanExecTransformer]
-        assert(parquetScan.nodeName.startsWith("Scan parquet"))
+        assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
 
         val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil)
@@ -975,7 +975,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       assert(scanExec.size === 1)
 
       val parquetScan = scanExec.head
-      assert(parquetScan.nodeName.startsWith("Scan parquet"))
+      assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
 
       val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
       val addFiles = fileIndex.matchingFiles(Nil, Nil)
@@ -997,7 +997,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       assert(scanExec.size === 1)
 
       val parquetScan = scanExec.head
-      assert(parquetScan.nodeName.startsWith("Scan parquet"))
+      assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
 
       val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]
       val addFiles = fileIndex.matchingFiles(Nil, Nil)
@@ -1192,7 +1192,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
         assert(scanExec.size === 1)
 
         val parquetScan = scanExec.head
-        assert(parquetScan.nodeName.startsWith("Scan parquet"))
+        assert(parquetScan.nodeName.startsWith("ScanTransformer parquet"))
         assert(parquetScan.metrics("numFiles").value === 200)
 
         val fileIndex = parquetScan.relation.location.asInstanceOf[TahoeFileIndex]

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHSuite.scala
@@ -47,7 +47,7 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
         }
         assert(scanExec.size == 1)
 
-        assert(scanExec(0).nodeName.startsWith("Scan mergetree"))
+        assert(scanExec(0).nodeName.startsWith("ScanTransformer mergetree"))
 
         val sortExec = df.queryExecution.executedPlan.collect {
           case sortExec: SortExecTransformer => sortExec

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
@@ -178,7 +178,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])
@@ -286,7 +286,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])
@@ -389,7 +389,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])
@@ -478,7 +478,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])
@@ -582,7 +582,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
@@ -148,7 +148,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(4)(plans.size)
 
         val mergetreeScan = plans(3).asInstanceOf[FileSourceScanExecTransformer]
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -239,7 +239,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(4)(plans.size)
 
         val mergetreeScan = plans(3).asInstanceOf[FileSourceScanExecTransformer]
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -383,7 +383,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       assertResult(1)(scanExec.size)
 
       val mergetreeScan = scanExec.head
-      assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+      assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
       val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
       assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -416,7 +416,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       assertResult(1)(scanExec.size)
 
       val mergetreeScan = scanExec.head
-      assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+      assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
       val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
       val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])
@@ -608,7 +608,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -715,7 +715,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
         assertResult(3744)(mergetreeScan.metrics("numFiles").value)
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
@@ -804,7 +804,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -908,7 +908,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -1077,7 +1077,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -1251,7 +1251,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
           assertResult(1)(scanExec.size)
 
           val mergetreeScan = scanExec.head
-          assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+          assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
           val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
           val addFiles =

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
@@ -144,7 +144,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -229,7 +229,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -401,7 +401,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
         assertResult(6)(mergetreeScan.metrics("numFiles").value)
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
@@ -504,7 +504,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -585,7 +585,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
@@ -144,7 +144,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -229,7 +229,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -401,7 +401,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
         assertResult(6)(mergetreeScan.metrics("numFiles").value)
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
@@ -504,7 +504,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -585,7 +585,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
@@ -158,7 +158,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -289,7 +289,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -461,7 +461,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
         assertResult(6)(mergetreeScan.metrics("numFiles").value)
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
@@ -565,7 +565,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -646,7 +646,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -765,7 +765,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
           assertResult(1)(scanExec.size)
 
           val mergetreeScan = scanExec.head
-          assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+          assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
           val plans = collect(df.queryExecution.executedPlan) {
             case scanExec: BasicScanExecTransformer => scanExec

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -136,7 +136,7 @@ class GlutenClickHouseMergeTreeWriteSuite
           assertResult(4)(plans.size)
 
           val mergetreeScan = plans(3).asInstanceOf[FileSourceScanExecTransformer]
-          assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+          assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
           val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
           assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -602,7 +602,7 @@ class GlutenClickHouseMergeTreeWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -770,7 +770,7 @@ class GlutenClickHouseMergeTreeWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
         assertResult(3745)(mergetreeScan.metrics("numFiles").value)
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
@@ -878,7 +878,7 @@ class GlutenClickHouseMergeTreeWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -1084,7 +1084,7 @@ class GlutenClickHouseMergeTreeWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -1297,7 +1297,7 @@ class GlutenClickHouseMergeTreeWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -1383,7 +1383,7 @@ class GlutenClickHouseMergeTreeWriteSuite
         assertResult(1)(scanExec.size)
 
         val mergetreeScan = scanExec.head
-        assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+        assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
         val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
         assert(ClickHouseTableV2.getTable(fileIndex.deltaLog).clickhouseTableConfigs.nonEmpty)
@@ -1507,7 +1507,7 @@ class GlutenClickHouseMergeTreeWriteSuite
       assertResult(1)(scanExec.size)
 
       val mergetreeScan = scanExec.head
-      assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+      assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
       val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
       val addFiles = fileIndex.matchingFiles(Nil, Nil).map(f => f.asInstanceOf[AddMergeTreeParts])
@@ -1588,7 +1588,7 @@ class GlutenClickHouseMergeTreeWriteSuite
           assertResult(1)(scanExec.size)
 
           val mergetreeScan = scanExec.head
-          assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+          assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
           val fileIndex = mergetreeScan.relation.location.asInstanceOf[TahoeFileIndex]
           val addFiles =
@@ -1797,7 +1797,7 @@ class GlutenClickHouseMergeTreeWriteSuite
               assertResult(1)(scanExec.size)
 
               val mergetreeScan = scanExec.head
-              assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+              assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
               val plans = collect(df.queryExecution.executedPlan) {
                 case scanExec: BasicScanExecTransformer => scanExec
@@ -1821,7 +1821,7 @@ class GlutenClickHouseMergeTreeWriteSuite
           assertResult(1)(scanExec.size)
 
           val mergetreeScan = scanExec.head
-          assert(mergetreeScan.nodeName.startsWith("Scan mergetree"))
+          assert(mergetreeScan.nodeName.startsWith("ScanTransformer mergetree"))
 
           val plans = collect(df.queryExecution.executedPlan) {
             case scanExec: BasicScanExecTransformer => scanExec

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/10.txt
@@ -18,24 +18,24 @@ AdaptiveSparkPlan (68)
                                     :     :- ^ ProjectExecTransformer (12)
                                     :     :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                                     :     :     :- ^ FilterExecTransformer (2)
-                                    :     :     :  +- ^ Scan parquet (1)
+                                    :     :     :  +- ^ ScanTransformer parquet  (1)
                                     :     :     +- ^ InputIteratorTransformer (10)
                                     :     :        +- BroadcastQueryStage (8)
                                     :     :           +- ColumnarBroadcastExchange (7)
                                     :     :              +- ^ ProjectExecTransformer (5)
                                     :     :                 +- ^ FilterExecTransformer (4)
-                                    :     :                    +- ^ Scan parquet (3)
+                                    :     :                    +- ^ ScanTransformer parquet  (3)
                                     :     +- ^ InputIteratorTransformer (20)
                                     :        +- BroadcastQueryStage (18)
                                     :           +- ColumnarBroadcastExchange (17)
                                     :              +- ^ ProjectExecTransformer (15)
                                     :                 +- ^ FilterExecTransformer (14)
-                                    :                    +- ^ Scan parquet (13)
+                                    :                    +- ^ ScanTransformer parquet  (13)
                                     +- ^ InputIteratorTransformer (29)
                                        +- BroadcastQueryStage (27)
                                           +- ColumnarBroadcastExchange (26)
                                              +- ^ FilterExecTransformer (24)
-                                                +- ^ Scan parquet (23)
+                                                +- ^ ScanTransformer parquet  (23)
 +- == Initial Plan ==
    TakeOrderedAndProject (67)
    +- HashAggregate (66)
@@ -62,7 +62,7 @@ AdaptiveSparkPlan (68)
                         +- Scan parquet (59)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ ReadSchema: struct<c_custkey:bigint,c_name:string,c_address:string,c_nationkey:b
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Arguments: (isnotnull(c_custkey#X) AND isnotnull(c_nationkey#X))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -115,7 +115,7 @@ Join condition: None
 Output [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -157,7 +157,7 @@ Join condition: None
 Output [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 Input [11]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X]
 
-(23) Scan parquet
+(23) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/11.txt
@@ -20,18 +20,18 @@ AdaptiveSparkPlan (60)
                                                 :- ^ ProjectExecTransformer (11)
                                                 :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                 :     :- ^ FilterExecTransformer (2)
-                                                :     :  +- ^ Scan parquet (1)
+                                                :     :  +- ^ ScanTransformer parquet  (1)
                                                 :     +- ^ InputIteratorTransformer (9)
                                                 :        +- BroadcastQueryStage (7)
                                                 :           +- ColumnarBroadcastExchange (6)
                                                 :              +- ^ FilterExecTransformer (4)
-                                                :                 +- ^ Scan parquet (3)
+                                                :                 +- ^ ScanTransformer parquet  (3)
                                                 +- ^ InputIteratorTransformer (19)
                                                    +- BroadcastQueryStage (17)
                                                       +- ColumnarBroadcastExchange (16)
                                                          +- ^ ProjectExecTransformer (14)
                                                             +- ^ FilterExecTransformer (13)
-                                                               +- ^ Scan parquet (12)
+                                                               +- ^ ScanTransformer parquet  (12)
 +- == Initial Plan ==
    Sort (59)
    +- Exchange (58)
@@ -54,7 +54,7 @@ AdaptiveSparkPlan (60)
                                  +- Scan parquet (48)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -65,7 +65,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int,ps_supply
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Arguments: isnotnull(ps_suppkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 Input [6]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X, s_suppkey#X, s_nationkey#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/12.txt
@@ -20,10 +20,10 @@ AdaptiveSparkPlan (44)
                                              :  +- BroadcastQueryStage (5)
                                              :     +- ColumnarBroadcastExchange (4)
                                              :        +- ^ FilterExecTransformer (2)
-                                             :           +- ^ Scan parquet (1)
+                                             :           +- ^ ScanTransformer parquet  (1)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (43)
    +- Exchange (42)
@@ -40,7 +40,7 @@ AdaptiveSparkPlan (44)
                            +- Scan parquet (34)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -69,7 +69,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (7) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/13.txt
@@ -24,13 +24,13 @@ AdaptiveSparkPlan (55)
                                                             +- ^ FlushableHashAggregateExecTransformer (12)
                                                                +- ^ ProjectExecTransformer (11)
                                                                   +- ^ BroadcastHashJoinExecTransformer LeftOuter BuildRight (10)
-                                                                     :- ^ Scan parquet (1)
+                                                                     :- ^ ScanTransformer parquet  (1)
                                                                      +- ^ InputIteratorTransformer (9)
                                                                         +- BroadcastQueryStage (7)
                                                                            +- ColumnarBroadcastExchange (6)
                                                                               +- ^ ProjectExecTransformer (4)
                                                                                  +- ^ FilterExecTransformer (3)
-                                                                                    +- ^ Scan parquet (2)
+                                                                                    +- ^ ScanTransformer parquet  (2)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,13 +49,13 @@ AdaptiveSparkPlan (55)
                                        +- Scan parquet (41)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
 ReadSchema: struct<c_custkey:bigint>
 
-(2) Scan parquet
+(2) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/14.txt
@@ -13,12 +13,12 @@ AdaptiveSparkPlan (35)
                            +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                               :- ^ ProjectExecTransformer (3)
                               :  +- ^ FilterExecTransformer (2)
-                              :     +- ^ Scan parquet (1)
+                              :     +- ^ ScanTransformer parquet  (1)
                               +- ^ InputIteratorTransformer (10)
                                  +- BroadcastQueryStage (8)
                                     +- ColumnarBroadcastExchange (7)
                                        +- ^ FilterExecTransformer (5)
-                                          +- ^ Scan parquet (4)
+                                          +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (34)
    +- Exchange (33)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (35)
                      +- Scan parquet (27)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -48,7 +48,7 @@ Arguments: (((isnotnull(l_shipdate#X) AND (l_shipdate#X >= 1995-09-01)) AND (l_s
 Output [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 Input [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/15.txt
@@ -13,7 +13,7 @@ AdaptiveSparkPlan (46)
                         :  +- BroadcastQueryStage (5)
                         :     +- ColumnarBroadcastExchange (4)
                         :        +- ^ FilterExecTransformer (2)
-                        :           +- ^ Scan parquet (1)
+                        :           +- ^ ScanTransformer parquet  (1)
                         +- ^ FilterExecTransformer (20)
                            +- ^ RegularHashAggregateExecTransformer (19)
                               +- ^ InputIteratorTransformer (18)
@@ -24,7 +24,7 @@ AdaptiveSparkPlan (46)
                                              +- ^ FlushableHashAggregateExecTransformer (11)
                                                 +- ^ ProjectExecTransformer (10)
                                                    +- ^ FilterExecTransformer (9)
-                                                      +- ^ Scan parquet (8)
+                                                      +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -71,7 +71,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (7) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/16.txt
@@ -24,12 +24,12 @@ AdaptiveSparkPlan (59)
                                                             +- ^ ProjectExecTransformer (11)
                                                                +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                                   :- ^ FilterExecTransformer (2)
-                                                                  :  +- ^ Scan parquet (1)
+                                                                  :  +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (9)
                                                                      +- BroadcastQueryStage (7)
                                                                         +- ColumnarBroadcastExchange (6)
                                                                            +- ^ FilterExecTransformer (4)
-                                                                              +- ^ Scan parquet (3)
+                                                                              +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (58)
    +- Exchange (57)
@@ -53,7 +53,7 @@ AdaptiveSparkPlan (59)
                                     +- Scan parquet (46)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -64,7 +64,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint>
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 Arguments: isnotnull(ps_partkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/18.txt
@@ -18,10 +18,10 @@ AdaptiveSparkPlan (88)
                                  :     :  +- BroadcastQueryStage (5)
                                  :     :     +- ColumnarBroadcastExchange (4)
                                  :     :        +- ^ FilterExecTransformer (2)
-                                 :     :           +- ^ Scan parquet (1)
+                                 :     :           +- ^ ScanTransformer parquet  (1)
                                  :     +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (27)
                                  :        :- ^ FilterExecTransformer (9)
-                                 :        :  +- ^ Scan parquet (8)
+                                 :        :  +- ^ ScanTransformer parquet  (8)
                                  :        +- ^ InputIteratorTransformer (26)
                                  :           +- BroadcastQueryStage (24)
                                  :              +- ColumnarBroadcastExchange (23)
@@ -34,13 +34,13 @@ AdaptiveSparkPlan (88)
                                  :                                   +- VeloxResizeBatches (14)
                                  :                                      +- ^ ProjectExecTransformer (12)
                                  :                                         +- ^ FlushableHashAggregateExecTransformer (11)
-                                 :                                            +- ^ Scan parquet (10)
+                                 :                                            +- ^ ScanTransformer parquet  (10)
                                  +- ^ InputIteratorTransformer (41)
                                     +- BroadcastQueryStage (39)
                                        +- ColumnarBroadcastExchange (38)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (36)
                                              :- ^ FilterExecTransformer (31)
-                                             :  +- ^ Scan parquet (30)
+                                             :  +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (35)
                                                 +- BroadcastQueryStage (33)
                                                    +- ReusedExchange (32)
@@ -79,7 +79,7 @@ AdaptiveSparkPlan (88)
                                           +- Scan parquet (73)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -108,7 +108,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ ReadSchema: struct<o_orderkey:bigint,o_custkey:bigint,o_totalprice:decimal(12,2)
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Arguments: (isnotnull(o_custkey#X) AND isnotnull(o_orderkey#X))
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -205,7 +205,7 @@ Join condition: None
 Output [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 Input [6]: [c_custkey#X, c_name#X, o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/19.txt
@@ -12,12 +12,12 @@ AdaptiveSparkPlan (34)
                         +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                            :- ^ ProjectExecTransformer (3)
                            :  +- ^ FilterExecTransformer (2)
-                           :     +- ^ Scan parquet (1)
+                           :     +- ^ ScanTransformer parquet  (1)
                            +- ^ InputIteratorTransformer (10)
                               +- BroadcastQueryStage (8)
                                  +- ColumnarBroadcastExchange (7)
                                     +- ^ FilterExecTransformer (5)
-                                       +- ^ Scan parquet (4)
+                                       +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (33)
    +- Exchange (32)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (34)
                      +- Scan parquet (26)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ Arguments: ((((isnotnull(l_shipinstruct#X) AND l_shipmode#X IN (AIR,AIR REG)) AN
 Output [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/20.txt
@@ -18,7 +18,7 @@ AdaptiveSparkPlan (112)
                         :     :           +- VeloxResizeBatches (5)
                         :     :              +- ^ ProjectExecTransformer (3)
                         :     :                 +- ^ FilterExecTransformer (2)
-                        :     :                    +- ^ Scan parquet (1)
+                        :     :                    +- ^ ScanTransformer parquet  (1)
                         :     +- ^ InputIteratorTransformer (52)
                         :        +- BroadcastQueryStage (50)
                         :           +- ColumnarBroadcastExchange (49)
@@ -29,13 +29,13 @@ AdaptiveSparkPlan (112)
                         :                    :     +- ColumnarBroadcastExchange (23)
                         :                    :        +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (21)
                         :                    :           :- ^ FilterExecTransformer (12)
-                        :                    :           :  +- ^ Scan parquet (11)
+                        :                    :           :  +- ^ ScanTransformer parquet  (11)
                         :                    :           +- ^ InputIteratorTransformer (20)
                         :                    :              +- BroadcastQueryStage (18)
                         :                    :                 +- ColumnarBroadcastExchange (17)
                         :                    :                    +- ^ ProjectExecTransformer (15)
                         :                    :                       +- ^ FilterExecTransformer (14)
-                        :                    :                          +- ^ Scan parquet (13)
+                        :                    :                          +- ^ ScanTransformer parquet  (13)
                         :                    +- ^ FilterExecTransformer (45)
                         :                       +- ^ ProjectExecTransformer (44)
                         :                          +- ^ RegularHashAggregateExecTransformer (43)
@@ -48,7 +48,7 @@ AdaptiveSparkPlan (112)
                         :                                               +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (34)
                         :                                                  :- ^ ProjectExecTransformer (29)
                         :                                                  :  +- ^ FilterExecTransformer (28)
-                        :                                                  :     +- ^ Scan parquet (27)
+                        :                                                  :     +- ^ ScanTransformer parquet  (27)
                         :                                                  +- ^ InputIteratorTransformer (33)
                         :                                                     +- BroadcastQueryStage (31)
                         :                                                        +- ReusedExchange (30)
@@ -57,7 +57,7 @@ AdaptiveSparkPlan (112)
                               +- ColumnarBroadcastExchange (59)
                                  +- ^ ProjectExecTransformer (57)
                                     +- ^ FilterExecTransformer (56)
-                                       +- ^ Scan parquet (55)
+                                       +- ^ ScanTransformer parquet  (55)
 +- == Initial Plan ==
    Sort (111)
    +- Exchange (110)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (112)
                      +- Scan parquet (104)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -140,7 +140,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (10) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -151,7 +151,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int>
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Arguments: ((isnotnull(ps_availqty#X) AND isnotnull(ps_partkey#X)) AND isnotnull(ps_suppkey#X))
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -207,7 +207,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (26) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -324,7 +324,7 @@ Join condition: None
 Output [3]: [s_name#X, s_address#X, s_nationkey#X]
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(55) Scan parquet
+(55) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/21.txt
@@ -20,34 +20,34 @@ AdaptiveSparkPlan (93)
                                  :     :     :  +- BroadcastQueryStage (5)
                                  :     :     :     +- ColumnarBroadcastExchange (4)
                                  :     :     :        +- ^ FilterExecTransformer (2)
-                                 :     :     :           +- ^ Scan parquet (1)
+                                 :     :     :           +- ^ ScanTransformer parquet  (1)
                                  :     :     +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (26)
                                  :     :        :- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (17)
                                  :     :        :  :- ^ ProjectExecTransformer (10)
                                  :     :        :  :  +- ^ FilterExecTransformer (9)
-                                 :     :        :  :     +- ^ Scan parquet (8)
+                                 :     :        :  :     +- ^ ScanTransformer parquet  (8)
                                  :     :        :  +- ^ InputIteratorTransformer (16)
                                  :     :        :     +- BroadcastQueryStage (14)
                                  :     :        :        +- ColumnarBroadcastExchange (13)
-                                 :     :        :           +- ^ Scan parquet (11)
+                                 :     :        :           +- ^ ScanTransformer parquet  (11)
                                  :     :        +- ^ InputIteratorTransformer (25)
                                  :     :           +- BroadcastQueryStage (23)
                                  :     :              +- ColumnarBroadcastExchange (22)
                                  :     :                 +- ^ ProjectExecTransformer (20)
                                  :     :                    +- ^ FilterExecTransformer (19)
-                                 :     :                       +- ^ Scan parquet (18)
+                                 :     :                       +- ^ ScanTransformer parquet  (18)
                                  :     +- ^ InputIteratorTransformer (36)
                                  :        +- BroadcastQueryStage (34)
                                  :           +- ColumnarBroadcastExchange (33)
                                  :              +- ^ ProjectExecTransformer (31)
                                  :                 +- ^ FilterExecTransformer (30)
-                                 :                    +- ^ Scan parquet (29)
+                                 :                    +- ^ ScanTransformer parquet  (29)
                                  +- ^ InputIteratorTransformer (46)
                                     +- BroadcastQueryStage (44)
                                        +- ColumnarBroadcastExchange (43)
                                           +- ^ ProjectExecTransformer (41)
                                              +- ^ FilterExecTransformer (40)
-                                                +- ^ Scan parquet (39)
+                                                +- ^ ScanTransformer parquet  (39)
 +- == Initial Plan ==
    TakeOrderedAndProject (92)
    +- HashAggregate (91)
@@ -83,7 +83,7 @@ AdaptiveSparkPlan (93)
                            +- Scan parquet (83)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -112,7 +112,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -127,7 +127,7 @@ Arguments: ((((isnotnull(l_receiptdate#X) AND isnotnull(l_commitdate#X)) AND (l_
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Input [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(18) Scan parquet
+(18) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -203,7 +203,7 @@ Join condition: None
 Output [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 Input [5]: [s_suppkey#X, s_name#X, s_nationkey#X, l_orderkey#X, l_suppkey#X]
 
-(29) Scan parquet
+(29) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -245,7 +245,7 @@ Join condition: None
 Output [2]: [s_name#X, s_nationkey#X]
 Input [4]: [s_name#X, s_nationkey#X, l_orderkey#X, o_orderkey#X]
 
-(39) Scan parquet
+(39) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/22.txt
@@ -17,11 +17,11 @@ AdaptiveSparkPlan (40)
                                        +- ^ ProjectExecTransformer (10)
                                           +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (9)
                                              :- ^ FilterExecTransformer (2)
-                                             :  +- ^ Scan parquet (1)
+                                             :  +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (8)
                                                 +- BroadcastQueryStage (6)
                                                    +- ColumnarBroadcastExchange (5)
-                                                      +- ^ Scan parquet (3)
+                                                      +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (39)
    +- Exchange (38)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (40)
                         +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ ReadSchema: struct<c_custkey:bigint,c_phone:string,c_acctbal:decimal(12,2)>
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Arguments: ((isnotnull(c_acctbal#X) AND substring(c_phone#X, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#X as decimal(16,6)) > Subquery subquery#X, [id=#X]))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/3.txt
@@ -20,15 +20,15 @@ AdaptiveSparkPlan (54)
                                     :     :     +- ColumnarBroadcastExchange (5)
                                     :     :        +- ^ ProjectExecTransformer (3)
                                     :     :           +- ^ FilterExecTransformer (2)
-                                    :     :              +- ^ Scan parquet (1)
+                                    :     :              +- ^ ScanTransformer parquet  (1)
                                     :     +- ^ FilterExecTransformer (10)
-                                    :        +- ^ Scan parquet (9)
+                                    :        +- ^ ScanTransformer parquet  (9)
                                     +- ^ InputIteratorTransformer (20)
                                        +- BroadcastQueryStage (18)
                                           +- ColumnarBroadcastExchange (17)
                                              +- ^ ProjectExecTransformer (15)
                                                 +- ^ FilterExecTransformer (14)
-                                                   +- ^ Scan parquet (13)
+                                                   +- ^ ScanTransformer parquet  (13)
 +- == Initial Plan ==
    TakeOrderedAndProject (53)
    +- HashAggregate (52)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (54)
                            +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 Input [5]: [c_custkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/4.txt
@@ -18,13 +18,13 @@ AdaptiveSparkPlan (46)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (12)
                                              :- ^ ProjectExecTransformer (3)
                                              :  +- ^ FilterExecTransformer (2)
-                                             :     +- ^ Scan parquet (1)
+                                             :     +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (11)
                                                 +- BroadcastQueryStage (9)
                                                    +- ColumnarBroadcastExchange (8)
                                                       +- ^ ProjectExecTransformer (6)
                                                          +- ^ FilterExecTransformer (5)
-                                                            +- ^ Scan parquet (4)
+                                                            +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -57,7 +57,7 @@ Arguments: ((isnotnull(o_orderdate#X) AND (o_orderdate#X >= 1993-07-01)) AND (o_
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Input [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/5.txt
@@ -28,31 +28,31 @@ AdaptiveSparkPlan (102)
                                              :     :     :     :     :  +- BroadcastQueryStage (5)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ ProjectExecTransformer (10)
                                              :     :     :     :        +- ^ FilterExecTransformer (9)
-                                             :     :     :     :           +- ^ Scan parquet (8)
+                                             :     :     :     :           +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (47)
                                                 +- BroadcastQueryStage (45)
                                                    +- ColumnarBroadcastExchange (44)
                                                       +- ^ ProjectExecTransformer (42)
                                                          +- ^ FilterExecTransformer (41)
-                                                            +- ^ Scan parquet (40)
+                                                            +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (101)
    +- Exchange (100)
@@ -90,7 +90,7 @@ AdaptiveSparkPlan (102)
                               +- Scan parquet (91)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -143,7 +143,7 @@ Join condition: None
 Output [2]: [c_nationkey#X, o_orderkey#X]
 Input [4]: [c_custkey#X, c_nationkey#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -181,7 +181,7 @@ Join condition: None
 Output [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [c_nationkey#X, o_orderkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -219,7 +219,7 @@ Join condition: None
 Output [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -257,7 +257,7 @@ Join condition: None
 Output [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 Input [6]: [l_extendedprice#X, l_discount#X, s_nationkey#X, n_nationkey#X, n_name#X, n_regionkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/7.txt
@@ -28,24 +28,24 @@ AdaptiveSparkPlan (95)
                                              :     :     :     :     :  +- BroadcastQueryStage (5)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (9)
-                                             :     :     :     :        +- ^ Scan parquet (8)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (18)
                                              :     :     :        +- BroadcastQueryStage (16)
                                              :     :     :           +- ColumnarBroadcastExchange (15)
                                              :     :     :              +- ^ FilterExecTransformer (13)
-                                             :     :     :                 +- ^ Scan parquet (12)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (12)
                                              :     :     +- ^ InputIteratorTransformer (27)
                                              :     :        +- BroadcastQueryStage (25)
                                              :     :           +- ColumnarBroadcastExchange (24)
                                              :     :              +- ^ FilterExecTransformer (22)
-                                             :     :                 +- ^ Scan parquet (21)
+                                             :     :                 +- ^ ScanTransformer parquet  (21)
                                              :     +- ^ InputIteratorTransformer (36)
                                              :        +- BroadcastQueryStage (34)
                                              :           +- ColumnarBroadcastExchange (33)
                                              :              +- ^ FilterExecTransformer (31)
-                                             :                 +- ^ Scan parquet (30)
+                                             :                 +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (42)
                                                 +- BroadcastQueryStage (40)
                                                    +- ReusedExchange (39)
@@ -84,7 +84,7 @@ AdaptiveSparkPlan (95)
                            +- Scan parquet (85)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -113,7 +113,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -133,7 +133,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Input [7]: [s_suppkey#X, s_nationkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 Input [7]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_orderkey#X, o_custkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -209,7 +209,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 Input [7]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X, c_custkey#X, c_nationkey#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/8.txt
@@ -34,40 +34,40 @@ AdaptiveSparkPlan (131)
                                                 :     :     :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                                 :     :     :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                                 :     :     :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                                :     :     :     :     :     :     :              +- ^ Scan parquet (1)
+                                                :     :     :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                                 :     :     :     :     :     :     +- ^ FilterExecTransformer (10)
-                                                :     :     :     :     :     :        +- ^ Scan parquet (9)
+                                                :     :     :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                                 :     :     :     :     :     +- ^ InputIteratorTransformer (19)
                                                 :     :     :     :     :        +- BroadcastQueryStage (17)
                                                 :     :     :     :     :           +- ColumnarBroadcastExchange (16)
                                                 :     :     :     :     :              +- ^ FilterExecTransformer (14)
-                                                :     :     :     :     :                 +- ^ Scan parquet (13)
+                                                :     :     :     :     :                 +- ^ ScanTransformer parquet  (13)
                                                 :     :     :     :     +- ^ InputIteratorTransformer (28)
                                                 :     :     :     :        +- BroadcastQueryStage (26)
                                                 :     :     :     :           +- ColumnarBroadcastExchange (25)
                                                 :     :     :     :              +- ^ FilterExecTransformer (23)
-                                                :     :     :     :                 +- ^ Scan parquet (22)
+                                                :     :     :     :                 +- ^ ScanTransformer parquet  (22)
                                                 :     :     :     +- ^ InputIteratorTransformer (37)
                                                 :     :     :        +- BroadcastQueryStage (35)
                                                 :     :     :           +- ColumnarBroadcastExchange (34)
                                                 :     :     :              +- ^ FilterExecTransformer (32)
-                                                :     :     :                 +- ^ Scan parquet (31)
+                                                :     :     :                 +- ^ ScanTransformer parquet  (31)
                                                 :     :     +- ^ InputIteratorTransformer (46)
                                                 :     :        +- BroadcastQueryStage (44)
                                                 :     :           +- ColumnarBroadcastExchange (43)
                                                 :     :              +- ^ FilterExecTransformer (41)
-                                                :     :                 +- ^ Scan parquet (40)
+                                                :     :                 +- ^ ScanTransformer parquet  (40)
                                                 :     +- ^ InputIteratorTransformer (55)
                                                 :        +- BroadcastQueryStage (53)
                                                 :           +- ColumnarBroadcastExchange (52)
                                                 :              +- ^ FilterExecTransformer (50)
-                                                :                 +- ^ Scan parquet (49)
+                                                :                 +- ^ ScanTransformer parquet  (49)
                                                 +- ^ InputIteratorTransformer (65)
                                                    +- BroadcastQueryStage (63)
                                                       +- ColumnarBroadcastExchange (62)
                                                          +- ^ ProjectExecTransformer (60)
                                                             +- ^ FilterExecTransformer (59)
-                                                               +- ^ Scan parquet (58)
+                                                               +- ^ ScanTransformer parquet  (58)
 +- == Initial Plan ==
    Sort (130)
    +- Exchange (129)
@@ -115,7 +115,7 @@ AdaptiveSparkPlan (131)
                               +- Scan parquet (120)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -148,7 +148,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -168,7 +168,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -206,7 +206,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -244,7 +244,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 Input [7]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X, c_custkey#X, c_nationkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -320,7 +320,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X, n_nationkey#X, n_regionkey#X]
 
-(49) Scan parquet
+(49) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -358,7 +358,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X, n_nationkey#X, n_name#X]
 
-(58) Scan parquet
+(58) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/9.txt
@@ -29,29 +29,29 @@ AdaptiveSparkPlan (100)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                              :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                              :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :              +- ^ Scan parquet (1)
+                                             :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (10)
-                                             :     :     :     :        +- ^ Scan parquet (9)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (46)
                                                 +- BroadcastQueryStage (44)
                                                    +- ColumnarBroadcastExchange (43)
                                                       +- ^ FilterExecTransformer (41)
-                                                         +- ^ Scan parquet (40)
+                                                         +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (99)
    +- Exchange (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -121,7 +121,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -141,7 +141,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [7]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -179,7 +179,7 @@ Join condition: None
 Output [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [8]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -217,7 +217,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 Input [10]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -255,7 +255,7 @@ Join condition: None
 Output [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 Input [8]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderkey#X, o_orderdate#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/10.txt
@@ -18,24 +18,24 @@ AdaptiveSparkPlan (68)
                                     :     :- ^ ProjectExecTransformer (12)
                                     :     :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                                     :     :     :- ^ FilterExecTransformer (2)
-                                    :     :     :  +- ^ Scan parquet (1)
+                                    :     :     :  +- ^ ScanTransformer parquet  (1)
                                     :     :     +- ^ InputIteratorTransformer (10)
                                     :     :        +- BroadcastQueryStage (8), Statistics(X)
                                     :     :           +- ColumnarBroadcastExchange (7)
                                     :     :              +- ^ ProjectExecTransformer (5)
                                     :     :                 +- ^ FilterExecTransformer (4)
-                                    :     :                    +- ^ Scan parquet (3)
+                                    :     :                    +- ^ ScanTransformer parquet  (3)
                                     :     +- ^ InputIteratorTransformer (20)
                                     :        +- BroadcastQueryStage (18), Statistics(X)
                                     :           +- ColumnarBroadcastExchange (17)
                                     :              +- ^ ProjectExecTransformer (15)
                                     :                 +- ^ FilterExecTransformer (14)
-                                    :                    +- ^ Scan parquet (13)
+                                    :                    +- ^ ScanTransformer parquet  (13)
                                     +- ^ InputIteratorTransformer (29)
                                        +- BroadcastQueryStage (27), Statistics(X)
                                           +- ColumnarBroadcastExchange (26)
                                              +- ^ FilterExecTransformer (24)
-                                                +- ^ Scan parquet (23)
+                                                +- ^ ScanTransformer parquet  (23)
 +- == Initial Plan ==
    TakeOrderedAndProject (67)
    +- HashAggregate (66)
@@ -62,7 +62,7 @@ AdaptiveSparkPlan (68)
                         +- Scan parquet (59)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ ReadSchema: struct<c_custkey:bigint,c_name:string,c_address:string,c_nationkey:b
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Arguments: (isnotnull(c_custkey#X) AND isnotnull(c_nationkey#X))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -115,7 +115,7 @@ Join condition: None
 Output [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -157,7 +157,7 @@ Join condition: None
 Output [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 Input [11]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X]
 
-(23) Scan parquet
+(23) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/11.txt
@@ -20,18 +20,18 @@ AdaptiveSparkPlan (60)
                                                 :- ^ ProjectExecTransformer (11)
                                                 :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                 :     :- ^ FilterExecTransformer (2)
-                                                :     :  +- ^ Scan parquet (1)
+                                                :     :  +- ^ ScanTransformer parquet  (1)
                                                 :     +- ^ InputIteratorTransformer (9)
                                                 :        +- BroadcastQueryStage (7), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (6)
                                                 :              +- ^ FilterExecTransformer (4)
-                                                :                 +- ^ Scan parquet (3)
+                                                :                 +- ^ ScanTransformer parquet  (3)
                                                 +- ^ InputIteratorTransformer (19)
                                                    +- BroadcastQueryStage (17), Statistics(X)
                                                       +- ColumnarBroadcastExchange (16)
                                                          +- ^ ProjectExecTransformer (14)
                                                             +- ^ FilterExecTransformer (13)
-                                                               +- ^ Scan parquet (12)
+                                                               +- ^ ScanTransformer parquet  (12)
 +- == Initial Plan ==
    Sort (59)
    +- Exchange (58)
@@ -54,7 +54,7 @@ AdaptiveSparkPlan (60)
                                  +- Scan parquet (48)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -65,7 +65,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int,ps_supply
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Arguments: isnotnull(ps_suppkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 Input [6]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X, s_suppkey#X, s_nationkey#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -337,7 +337,7 @@ AdaptiveSparkPlan (102)
                               :- ^ ProjectExecTransformer (68)
                               :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (67)
                               :     :- ^ FilterExecTransformer (62)
-                              :     :  +- ^ Scan parquet (61)
+                              :     :  +- ^ ScanTransformer parquet  (61)
                               :     +- ^ InputIteratorTransformer (66)
                               :        +- BroadcastQueryStage (64), Statistics(X)
                               :           +- ReusedExchange (63)
@@ -363,7 +363,7 @@ AdaptiveSparkPlan (102)
                         +- Scan parquet (93)
 
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/12.txt
@@ -20,10 +20,10 @@ AdaptiveSparkPlan (44)
                                              :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     +- ColumnarBroadcastExchange (4)
                                              :        +- ^ FilterExecTransformer (2)
-                                             :           +- ^ Scan parquet (1)
+                                             :           +- ^ ScanTransformer parquet  (1)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (43)
    +- Exchange (42)
@@ -40,7 +40,7 @@ AdaptiveSparkPlan (44)
                            +- Scan parquet (34)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -69,7 +69,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (7) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/13.txt
@@ -24,13 +24,13 @@ AdaptiveSparkPlan (55)
                                                             +- ^ FlushableHashAggregateExecTransformer (12)
                                                                +- ^ ProjectExecTransformer (11)
                                                                   +- ^ BroadcastHashJoinExecTransformer LeftOuter BuildRight (10)
-                                                                     :- ^ Scan parquet (1)
+                                                                     :- ^ ScanTransformer parquet  (1)
                                                                      +- ^ InputIteratorTransformer (9)
                                                                         +- BroadcastQueryStage (7), Statistics(X)
                                                                            +- ColumnarBroadcastExchange (6)
                                                                               +- ^ ProjectExecTransformer (4)
                                                                                  +- ^ FilterExecTransformer (3)
-                                                                                    +- ^ Scan parquet (2)
+                                                                                    +- ^ ScanTransformer parquet  (2)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,13 +49,13 @@ AdaptiveSparkPlan (55)
                                        +- Scan parquet (41)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
 ReadSchema: struct<c_custkey:bigint>
 
-(2) Scan parquet
+(2) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/14.txt
@@ -13,12 +13,12 @@ AdaptiveSparkPlan (35)
                            +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                               :- ^ ProjectExecTransformer (3)
                               :  +- ^ FilterExecTransformer (2)
-                              :     +- ^ Scan parquet (1)
+                              :     +- ^ ScanTransformer parquet  (1)
                               +- ^ InputIteratorTransformer (10)
                                  +- BroadcastQueryStage (8), Statistics(X)
                                     +- ColumnarBroadcastExchange (7)
                                        +- ^ FilterExecTransformer (5)
-                                          +- ^ Scan parquet (4)
+                                          +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (34)
    +- Exchange (33)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (35)
                      +- Scan parquet (27)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -48,7 +48,7 @@ Arguments: (((isnotnull(l_shipdate#X) AND (l_shipdate#X >= 1995-09-01)) AND (l_s
 Output [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 Input [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/15.txt
@@ -12,7 +12,7 @@ AdaptiveSparkPlan (43)
                      :  +- BroadcastQueryStage (5), Statistics(X)
                      :     +- ColumnarBroadcastExchange (4)
                      :        +- ^ FilterExecTransformer (2)
-                     :           +- ^ Scan parquet (1)
+                     :           +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (20)
                         +- ^ RegularHashAggregateExecTransformer (19)
                            +- ^ InputIteratorTransformer (18)
@@ -23,7 +23,7 @@ AdaptiveSparkPlan (43)
                                           +- ^ FlushableHashAggregateExecTransformer (11)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (42)
    +- Exchange (41)
@@ -41,7 +41,7 @@ AdaptiveSparkPlan (43)
                               +- Scan parquet (32)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -70,7 +70,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (7) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -252,7 +252,7 @@ AdaptiveSparkPlan (69)
                               +- ^ FlushableHashAggregateExecTransformer (47)
                                  +- ^ ProjectExecTransformer (46)
                                     +- ^ FilterExecTransformer (45)
-                                       +- ^ Scan parquet (44)
+                                       +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    HashAggregate (68)
    +- HashAggregate (67)
@@ -264,7 +264,7 @@ AdaptiveSparkPlan (69)
                      +- Scan parquet (61)
 
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/16.txt
@@ -24,12 +24,12 @@ AdaptiveSparkPlan (59)
                                                             +- ^ ProjectExecTransformer (11)
                                                                +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                                   :- ^ FilterExecTransformer (2)
-                                                                  :  +- ^ Scan parquet (1)
+                                                                  :  +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (9)
                                                                      +- BroadcastQueryStage (7), Statistics(X)
                                                                         +- ColumnarBroadcastExchange (6)
                                                                            +- ^ FilterExecTransformer (4)
-                                                                              +- ^ Scan parquet (3)
+                                                                              +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (58)
    +- Exchange (57)
@@ -53,7 +53,7 @@ AdaptiveSparkPlan (59)
                                     +- Scan parquet (46)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -64,7 +64,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint>
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 Arguments: isnotnull(ps_partkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/18.txt
@@ -18,10 +18,10 @@ AdaptiveSparkPlan (88)
                                  :     :  +- BroadcastQueryStage (5), Statistics(X)
                                  :     :     +- ColumnarBroadcastExchange (4)
                                  :     :        +- ^ FilterExecTransformer (2)
-                                 :     :           +- ^ Scan parquet (1)
+                                 :     :           +- ^ ScanTransformer parquet  (1)
                                  :     +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (27)
                                  :        :- ^ FilterExecTransformer (9)
-                                 :        :  +- ^ Scan parquet (8)
+                                 :        :  +- ^ ScanTransformer parquet  (8)
                                  :        +- ^ InputIteratorTransformer (26)
                                  :           +- BroadcastQueryStage (24), Statistics(X)
                                  :              +- ColumnarBroadcastExchange (23)
@@ -34,13 +34,13 @@ AdaptiveSparkPlan (88)
                                  :                                   +- VeloxResizeBatches (14)
                                  :                                      +- ^ ProjectExecTransformer (12)
                                  :                                         +- ^ FlushableHashAggregateExecTransformer (11)
-                                 :                                            +- ^ Scan parquet (10)
+                                 :                                            +- ^ ScanTransformer parquet  (10)
                                  +- ^ InputIteratorTransformer (41)
                                     +- BroadcastQueryStage (39), Statistics(X)
                                        +- ColumnarBroadcastExchange (38)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (36)
                                              :- ^ FilterExecTransformer (31)
-                                             :  +- ^ Scan parquet (30)
+                                             :  +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (35)
                                                 +- BroadcastQueryStage (33), Statistics(X)
                                                    +- ReusedExchange (32)
@@ -79,7 +79,7 @@ AdaptiveSparkPlan (88)
                                           +- Scan parquet (73)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -108,7 +108,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ ReadSchema: struct<o_orderkey:bigint,o_custkey:bigint,o_totalprice:decimal(12,2)
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Arguments: (isnotnull(o_custkey#X) AND isnotnull(o_orderkey#X))
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -205,7 +205,7 @@ Join condition: None
 Output [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 Input [6]: [c_custkey#X, c_name#X, o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/19.txt
@@ -12,12 +12,12 @@ AdaptiveSparkPlan (34)
                         +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                            :- ^ ProjectExecTransformer (3)
                            :  +- ^ FilterExecTransformer (2)
-                           :     +- ^ Scan parquet (1)
+                           :     +- ^ ScanTransformer parquet  (1)
                            +- ^ InputIteratorTransformer (10)
                               +- BroadcastQueryStage (8), Statistics(X)
                                  +- ColumnarBroadcastExchange (7)
                                     +- ^ FilterExecTransformer (5)
-                                       +- ^ Scan parquet (4)
+                                       +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (33)
    +- Exchange (32)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (34)
                      +- Scan parquet (26)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ Arguments: ((((isnotnull(l_shipinstruct#X) AND l_shipmode#X IN (AIR,AIR REG)) AN
 Output [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/20.txt
@@ -17,7 +17,7 @@ AdaptiveSparkPlan (109)
                      :     :           +- VeloxResizeBatches (5)
                      :     :              +- ^ ProjectExecTransformer (3)
                      :     :                 +- ^ FilterExecTransformer (2)
-                     :     :                    +- ^ Scan parquet (1)
+                     :     :                    +- ^ ScanTransformer parquet  (1)
                      :     +- ^ InputIteratorTransformer (52)
                      :        +- BroadcastQueryStage (50), Statistics(X)
                      :           +- ColumnarBroadcastExchange (49)
@@ -28,13 +28,13 @@ AdaptiveSparkPlan (109)
                      :                    :     +- ColumnarBroadcastExchange (23)
                      :                    :        +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (21)
                      :                    :           :- ^ FilterExecTransformer (12)
-                     :                    :           :  +- ^ Scan parquet (11)
+                     :                    :           :  +- ^ ScanTransformer parquet  (11)
                      :                    :           +- ^ InputIteratorTransformer (20)
                      :                    :              +- BroadcastQueryStage (18), Statistics(X)
                      :                    :                 +- ColumnarBroadcastExchange (17)
                      :                    :                    +- ^ ProjectExecTransformer (15)
                      :                    :                       +- ^ FilterExecTransformer (14)
-                     :                    :                          +- ^ Scan parquet (13)
+                     :                    :                          +- ^ ScanTransformer parquet  (13)
                      :                    +- ^ FilterExecTransformer (45)
                      :                       +- ^ ProjectExecTransformer (44)
                      :                          +- ^ RegularHashAggregateExecTransformer (43)
@@ -47,7 +47,7 @@ AdaptiveSparkPlan (109)
                      :                                               +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (34)
                      :                                                  :- ^ ProjectExecTransformer (29)
                      :                                                  :  +- ^ FilterExecTransformer (28)
-                     :                                                  :     +- ^ Scan parquet (27)
+                     :                                                  :     +- ^ ScanTransformer parquet  (27)
                      :                                                  +- ^ InputIteratorTransformer (33)
                      :                                                     +- BroadcastQueryStage (31), Statistics(X)
                      :                                                        +- ReusedExchange (30)
@@ -56,7 +56,7 @@ AdaptiveSparkPlan (109)
                            +- ColumnarBroadcastExchange (59)
                               +- ^ ProjectExecTransformer (57)
                                  +- ^ FilterExecTransformer (56)
-                                    +- ^ Scan parquet (55)
+                                    +- ^ ScanTransformer parquet  (55)
 +- == Initial Plan ==
    Sort (108)
    +- Exchange (107)
@@ -98,7 +98,7 @@ AdaptiveSparkPlan (109)
                      +- Scan parquet (101)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -139,7 +139,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (10) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -150,7 +150,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int>
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Arguments: ((isnotnull(ps_availqty#X) AND isnotnull(ps_partkey#X)) AND isnotnull(ps_suppkey#X))
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -206,7 +206,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (26) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -323,7 +323,7 @@ Join condition: None
 Output [3]: [s_name#X, s_address#X, s_nationkey#X]
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(55) Scan parquet
+(55) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/21.txt
@@ -19,34 +19,34 @@ AdaptiveSparkPlan (92)
                               :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                               :     :     :     +- ColumnarBroadcastExchange (4)
                               :     :     :        +- ^ FilterExecTransformer (2)
-                              :     :     :           +- ^ Scan parquet (1)
+                              :     :     :           +- ^ ScanTransformer parquet  (1)
                               :     :     +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (26)
                               :     :        :- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (17)
                               :     :        :  :- ^ ProjectExecTransformer (10)
                               :     :        :  :  +- ^ FilterExecTransformer (9)
-                              :     :        :  :     +- ^ Scan parquet (8)
+                              :     :        :  :     +- ^ ScanTransformer parquet  (8)
                               :     :        :  +- ^ InputIteratorTransformer (16)
                               :     :        :     +- BroadcastQueryStage (14), Statistics(X)
                               :     :        :        +- ColumnarBroadcastExchange (13)
-                              :     :        :           +- ^ Scan parquet (11)
+                              :     :        :           +- ^ ScanTransformer parquet  (11)
                               :     :        +- ^ InputIteratorTransformer (25)
                               :     :           +- BroadcastQueryStage (23), Statistics(X)
                               :     :              +- ColumnarBroadcastExchange (22)
                               :     :                 +- ^ ProjectExecTransformer (20)
                               :     :                    +- ^ FilterExecTransformer (19)
-                              :     :                       +- ^ Scan parquet (18)
+                              :     :                       +- ^ ScanTransformer parquet  (18)
                               :     +- ^ InputIteratorTransformer (36)
                               :        +- BroadcastQueryStage (34), Statistics(X)
                               :           +- ColumnarBroadcastExchange (33)
                               :              +- ^ ProjectExecTransformer (31)
                               :                 +- ^ FilterExecTransformer (30)
-                              :                    +- ^ Scan parquet (29)
+                              :                    +- ^ ScanTransformer parquet  (29)
                               +- ^ InputIteratorTransformer (46)
                                  +- BroadcastQueryStage (44), Statistics(X)
                                     +- ColumnarBroadcastExchange (43)
                                        +- ^ ProjectExecTransformer (41)
                                           +- ^ FilterExecTransformer (40)
-                                             +- ^ Scan parquet (39)
+                                             +- ^ ScanTransformer parquet  (39)
 +- == Initial Plan ==
    TakeOrderedAndProject (91)
    +- HashAggregate (90)
@@ -82,7 +82,7 @@ AdaptiveSparkPlan (92)
                            +- Scan parquet (82)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -111,7 +111,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -126,7 +126,7 @@ Arguments: ((((isnotnull(l_receiptdate#X) AND isnotnull(l_commitdate#X)) AND (l_
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Input [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -155,7 +155,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(18) Scan parquet
+(18) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -202,7 +202,7 @@ Join condition: None
 Output [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 Input [5]: [s_suppkey#X, s_name#X, s_nationkey#X, l_orderkey#X, l_suppkey#X]
 
-(29) Scan parquet
+(29) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -244,7 +244,7 @@ Join condition: None
 Output [2]: [s_name#X, s_nationkey#X]
 Input [4]: [s_name#X, s_nationkey#X, l_orderkey#X, o_orderkey#X]
 
-(39) Scan parquet
+(39) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/22.txt
@@ -17,11 +17,11 @@ AdaptiveSparkPlan (40)
                                        +- ^ ProjectExecTransformer (10)
                                           +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (9)
                                              :- ^ FilterExecTransformer (2)
-                                             :  +- ^ Scan parquet (1)
+                                             :  +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (8)
                                                 +- BroadcastQueryStage (6), Statistics(X)
                                                    +- ColumnarBroadcastExchange (5)
-                                                      +- ^ Scan parquet (3)
+                                                      +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (39)
    +- Exchange (38)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (40)
                         +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ ReadSchema: struct<c_custkey:bigint,c_phone:string,c_acctbal:decimal(12,2)>
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Arguments: ((isnotnull(c_acctbal#X) AND substring(c_phone#X, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#X as decimal(16,6)) > Subquery subquery#X, [id=#X]))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -227,7 +227,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)
@@ -237,7 +237,7 @@ AdaptiveSparkPlan (60)
                +- Scan parquet (54)
 
 
-(41) Scan parquet
+(41) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -344,7 +344,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/3.txt
@@ -20,15 +20,15 @@ AdaptiveSparkPlan (54)
                                     :     :     +- ColumnarBroadcastExchange (5)
                                     :     :        +- ^ ProjectExecTransformer (3)
                                     :     :           +- ^ FilterExecTransformer (2)
-                                    :     :              +- ^ Scan parquet (1)
+                                    :     :              +- ^ ScanTransformer parquet  (1)
                                     :     +- ^ FilterExecTransformer (10)
-                                    :        +- ^ Scan parquet (9)
+                                    :        +- ^ ScanTransformer parquet  (9)
                                     +- ^ InputIteratorTransformer (20)
                                        +- BroadcastQueryStage (18), Statistics(X)
                                           +- ColumnarBroadcastExchange (17)
                                              +- ^ ProjectExecTransformer (15)
                                                 +- ^ FilterExecTransformer (14)
-                                                   +- ^ Scan parquet (13)
+                                                   +- ^ ScanTransformer parquet  (13)
 +- == Initial Plan ==
    TakeOrderedAndProject (53)
    +- HashAggregate (52)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (54)
                            +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 Input [5]: [c_custkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/4.txt
@@ -18,13 +18,13 @@ AdaptiveSparkPlan (46)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (12)
                                              :- ^ ProjectExecTransformer (3)
                                              :  +- ^ FilterExecTransformer (2)
-                                             :     +- ^ Scan parquet (1)
+                                             :     +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (11)
                                                 +- BroadcastQueryStage (9), Statistics(X)
                                                    +- ColumnarBroadcastExchange (8)
                                                       +- ^ ProjectExecTransformer (6)
                                                          +- ^ FilterExecTransformer (5)
-                                                            +- ^ Scan parquet (4)
+                                                            +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -57,7 +57,7 @@ Arguments: ((isnotnull(o_orderdate#X) AND (o_orderdate#X >= 1993-07-01)) AND (o_
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Input [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/5.txt
@@ -28,31 +28,31 @@ AdaptiveSparkPlan (102)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ ProjectExecTransformer (10)
                                              :     :     :     :        +- ^ FilterExecTransformer (9)
-                                             :     :     :     :           +- ^ Scan parquet (8)
+                                             :     :     :     :           +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (47)
                                                 +- BroadcastQueryStage (45), Statistics(X)
                                                    +- ColumnarBroadcastExchange (44)
                                                       +- ^ ProjectExecTransformer (42)
                                                          +- ^ FilterExecTransformer (41)
-                                                            +- ^ Scan parquet (40)
+                                                            +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (101)
    +- Exchange (100)
@@ -90,7 +90,7 @@ AdaptiveSparkPlan (102)
                               +- Scan parquet (91)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -143,7 +143,7 @@ Join condition: None
 Output [2]: [c_nationkey#X, o_orderkey#X]
 Input [4]: [c_custkey#X, c_nationkey#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -181,7 +181,7 @@ Join condition: None
 Output [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [c_nationkey#X, o_orderkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -219,7 +219,7 @@ Join condition: None
 Output [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -257,7 +257,7 @@ Join condition: None
 Output [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 Input [6]: [l_extendedprice#X, l_discount#X, s_nationkey#X, n_nationkey#X, n_name#X, n_regionkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/7.txt
@@ -28,24 +28,24 @@ AdaptiveSparkPlan (95)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (9)
-                                             :     :     :     :        +- ^ Scan parquet (8)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (18)
                                              :     :     :        +- BroadcastQueryStage (16), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (15)
                                              :     :     :              +- ^ FilterExecTransformer (13)
-                                             :     :     :                 +- ^ Scan parquet (12)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (12)
                                              :     :     +- ^ InputIteratorTransformer (27)
                                              :     :        +- BroadcastQueryStage (25), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (24)
                                              :     :              +- ^ FilterExecTransformer (22)
-                                             :     :                 +- ^ Scan parquet (21)
+                                             :     :                 +- ^ ScanTransformer parquet  (21)
                                              :     +- ^ InputIteratorTransformer (36)
                                              :        +- BroadcastQueryStage (34), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (33)
                                              :              +- ^ FilterExecTransformer (31)
-                                             :                 +- ^ Scan parquet (30)
+                                             :                 +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (42)
                                                 +- BroadcastQueryStage (40), Statistics(X)
                                                    +- ReusedExchange (39)
@@ -84,7 +84,7 @@ AdaptiveSparkPlan (95)
                            +- Scan parquet (85)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -113,7 +113,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -133,7 +133,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Input [7]: [s_suppkey#X, s_nationkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 Input [7]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_orderkey#X, o_custkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -209,7 +209,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 Input [7]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X, c_custkey#X, c_nationkey#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/8.txt
@@ -34,40 +34,40 @@ AdaptiveSparkPlan (131)
                                                 :     :     :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                                 :     :     :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                                 :     :     :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                                :     :     :     :     :     :     :              +- ^ Scan parquet (1)
+                                                :     :     :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                                 :     :     :     :     :     :     +- ^ FilterExecTransformer (10)
-                                                :     :     :     :     :     :        +- ^ Scan parquet (9)
+                                                :     :     :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                                 :     :     :     :     :     +- ^ InputIteratorTransformer (19)
                                                 :     :     :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                                 :     :     :     :     :           +- ColumnarBroadcastExchange (16)
                                                 :     :     :     :     :              +- ^ FilterExecTransformer (14)
-                                                :     :     :     :     :                 +- ^ Scan parquet (13)
+                                                :     :     :     :     :                 +- ^ ScanTransformer parquet  (13)
                                                 :     :     :     :     +- ^ InputIteratorTransformer (28)
                                                 :     :     :     :        +- BroadcastQueryStage (26), Statistics(X)
                                                 :     :     :     :           +- ColumnarBroadcastExchange (25)
                                                 :     :     :     :              +- ^ FilterExecTransformer (23)
-                                                :     :     :     :                 +- ^ Scan parquet (22)
+                                                :     :     :     :                 +- ^ ScanTransformer parquet  (22)
                                                 :     :     :     +- ^ InputIteratorTransformer (37)
                                                 :     :     :        +- BroadcastQueryStage (35), Statistics(X)
                                                 :     :     :           +- ColumnarBroadcastExchange (34)
                                                 :     :     :              +- ^ FilterExecTransformer (32)
-                                                :     :     :                 +- ^ Scan parquet (31)
+                                                :     :     :                 +- ^ ScanTransformer parquet  (31)
                                                 :     :     +- ^ InputIteratorTransformer (46)
                                                 :     :        +- BroadcastQueryStage (44), Statistics(X)
                                                 :     :           +- ColumnarBroadcastExchange (43)
                                                 :     :              +- ^ FilterExecTransformer (41)
-                                                :     :                 +- ^ Scan parquet (40)
+                                                :     :                 +- ^ ScanTransformer parquet  (40)
                                                 :     +- ^ InputIteratorTransformer (55)
                                                 :        +- BroadcastQueryStage (53), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (52)
                                                 :              +- ^ FilterExecTransformer (50)
-                                                :                 +- ^ Scan parquet (49)
+                                                :                 +- ^ ScanTransformer parquet  (49)
                                                 +- ^ InputIteratorTransformer (65)
                                                    +- BroadcastQueryStage (63), Statistics(X)
                                                       +- ColumnarBroadcastExchange (62)
                                                          +- ^ ProjectExecTransformer (60)
                                                             +- ^ FilterExecTransformer (59)
-                                                               +- ^ Scan parquet (58)
+                                                               +- ^ ScanTransformer parquet  (58)
 +- == Initial Plan ==
    Sort (130)
    +- Exchange (129)
@@ -115,7 +115,7 @@ AdaptiveSparkPlan (131)
                               +- Scan parquet (120)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -148,7 +148,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -168,7 +168,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -206,7 +206,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -244,7 +244,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 Input [7]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X, c_custkey#X, c_nationkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -320,7 +320,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X, n_nationkey#X, n_regionkey#X]
 
-(49) Scan parquet
+(49) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -358,7 +358,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X, n_nationkey#X, n_name#X]
 
-(58) Scan parquet
+(58) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/9.txt
@@ -29,29 +29,29 @@ AdaptiveSparkPlan (100)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                              :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                              :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :              +- ^ Scan parquet (1)
+                                             :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (10)
-                                             :     :     :     :        +- ^ Scan parquet (9)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (46)
                                                 +- BroadcastQueryStage (44), Statistics(X)
                                                    +- ColumnarBroadcastExchange (43)
                                                       +- ^ FilterExecTransformer (41)
-                                                         +- ^ Scan parquet (40)
+                                                         +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (99)
    +- Exchange (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -121,7 +121,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -141,7 +141,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [7]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -179,7 +179,7 @@ Join condition: None
 Output [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [8]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -217,7 +217,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 Input [10]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -255,7 +255,7 @@ Join condition: None
 Output [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 Input [8]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderkey#X, o_orderdate#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/10.txt
@@ -18,24 +18,24 @@ AdaptiveSparkPlan (68)
                                     :     :- ^ ProjectExecTransformer (12)
                                     :     :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                                     :     :     :- ^ FilterExecTransformer (2)
-                                    :     :     :  +- ^ Scan parquet (1)
+                                    :     :     :  +- ^ ScanTransformer parquet  (1)
                                     :     :     +- ^ InputIteratorTransformer (10)
                                     :     :        +- BroadcastQueryStage (8), Statistics(X)
                                     :     :           +- ColumnarBroadcastExchange (7)
                                     :     :              +- ^ ProjectExecTransformer (5)
                                     :     :                 +- ^ FilterExecTransformer (4)
-                                    :     :                    +- ^ Scan parquet (3)
+                                    :     :                    +- ^ ScanTransformer parquet  (3)
                                     :     +- ^ InputIteratorTransformer (20)
                                     :        +- BroadcastQueryStage (18), Statistics(X)
                                     :           +- ColumnarBroadcastExchange (17)
                                     :              +- ^ ProjectExecTransformer (15)
                                     :                 +- ^ FilterExecTransformer (14)
-                                    :                    +- ^ Scan parquet (13)
+                                    :                    +- ^ ScanTransformer parquet  (13)
                                     +- ^ InputIteratorTransformer (29)
                                        +- BroadcastQueryStage (27), Statistics(X)
                                           +- ColumnarBroadcastExchange (26)
                                              +- ^ FilterExecTransformer (24)
-                                                +- ^ Scan parquet (23)
+                                                +- ^ ScanTransformer parquet  (23)
 +- == Initial Plan ==
    TakeOrderedAndProject (67)
    +- HashAggregate (66)
@@ -62,7 +62,7 @@ AdaptiveSparkPlan (68)
                         +- Scan parquet (59)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ ReadSchema: struct<c_custkey:bigint,c_name:string,c_address:string,c_nationkey:b
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Arguments: (isnotnull(c_custkey#X) AND isnotnull(c_nationkey#X))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -116,7 +116,7 @@ Join condition: None
 Output [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -159,7 +159,7 @@ Join condition: None
 Output [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 Input [11]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X]
 
-(23) Scan parquet
+(23) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/11.txt
@@ -20,18 +20,18 @@ AdaptiveSparkPlan (60)
                                                 :- ^ ProjectExecTransformer (11)
                                                 :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                 :     :- ^ FilterExecTransformer (2)
-                                                :     :  +- ^ Scan parquet (1)
+                                                :     :  +- ^ ScanTransformer parquet  (1)
                                                 :     +- ^ InputIteratorTransformer (9)
                                                 :        +- BroadcastQueryStage (7), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (6)
                                                 :              +- ^ FilterExecTransformer (4)
-                                                :                 +- ^ Scan parquet (3)
+                                                :                 +- ^ ScanTransformer parquet  (3)
                                                 +- ^ InputIteratorTransformer (19)
                                                    +- BroadcastQueryStage (17), Statistics(X)
                                                       +- ColumnarBroadcastExchange (16)
                                                          +- ^ ProjectExecTransformer (14)
                                                             +- ^ FilterExecTransformer (13)
-                                                               +- ^ Scan parquet (12)
+                                                               +- ^ ScanTransformer parquet  (12)
 +- == Initial Plan ==
    Sort (59)
    +- Exchange (58)
@@ -54,7 +54,7 @@ AdaptiveSparkPlan (60)
                                  +- Scan parquet (48)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -65,7 +65,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int,ps_supply
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Arguments: isnotnull(ps_suppkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -104,7 +104,7 @@ Join condition: None
 Output [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 Input [6]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X, s_suppkey#X, s_nationkey#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -341,7 +341,7 @@ AdaptiveSparkPlan (102)
                               :- ^ ProjectExecTransformer (68)
                               :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (67)
                               :     :- ^ FilterExecTransformer (62)
-                              :     :  +- ^ Scan parquet (61)
+                              :     :  +- ^ ScanTransformer parquet  (61)
                               :     +- ^ InputIteratorTransformer (66)
                               :        +- BroadcastQueryStage (64), Statistics(X)
                               :           +- ReusedExchange (63)
@@ -367,7 +367,7 @@ AdaptiveSparkPlan (102)
                         +- Scan parquet (93)
 
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/12.txt
@@ -20,10 +20,10 @@ AdaptiveSparkPlan (44)
                                              :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     +- ColumnarBroadcastExchange (4)
                                              :        +- ^ FilterExecTransformer (2)
-                                             :           +- ^ Scan parquet (1)
+                                             :           +- ^ ScanTransformer parquet  (1)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (43)
    +- Exchange (42)
@@ -40,7 +40,7 @@ AdaptiveSparkPlan (44)
                            +- Scan parquet (34)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -69,7 +69,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (7) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/13.txt
@@ -24,13 +24,13 @@ AdaptiveSparkPlan (55)
                                                             +- ^ FlushableHashAggregateExecTransformer (12)
                                                                +- ^ ProjectExecTransformer (11)
                                                                   +- ^ BroadcastHashJoinExecTransformer LeftOuter BuildRight (10)
-                                                                     :- ^ Scan parquet (1)
+                                                                     :- ^ ScanTransformer parquet  (1)
                                                                      +- ^ InputIteratorTransformer (9)
                                                                         +- BroadcastQueryStage (7), Statistics(X)
                                                                            +- ColumnarBroadcastExchange (6)
                                                                               +- ^ ProjectExecTransformer (4)
                                                                                  +- ^ FilterExecTransformer (3)
-                                                                                    +- ^ Scan parquet (2)
+                                                                                    +- ^ ScanTransformer parquet  (2)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,13 +49,13 @@ AdaptiveSparkPlan (55)
                                        +- Scan parquet (41)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
 ReadSchema: struct<c_custkey:bigint>
 
-(2) Scan parquet
+(2) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/14.txt
@@ -13,12 +13,12 @@ AdaptiveSparkPlan (35)
                            +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                               :- ^ ProjectExecTransformer (3)
                               :  +- ^ FilterExecTransformer (2)
-                              :     +- ^ Scan parquet (1)
+                              :     +- ^ ScanTransformer parquet  (1)
                               +- ^ InputIteratorTransformer (10)
                                  +- BroadcastQueryStage (8), Statistics(X)
                                     +- ColumnarBroadcastExchange (7)
                                        +- ^ FilterExecTransformer (5)
-                                          +- ^ Scan parquet (4)
+                                          +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (34)
    +- Exchange (33)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (35)
                      +- Scan parquet (27)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -48,7 +48,7 @@ Arguments: (((isnotnull(l_shipdate#X) AND (l_shipdate#X >= 1995-09-01)) AND (l_s
 Output [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 Input [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/15.txt
@@ -12,7 +12,7 @@ AdaptiveSparkPlan (43)
                      :  +- BroadcastQueryStage (5), Statistics(X)
                      :     +- ColumnarBroadcastExchange (4)
                      :        +- ^ FilterExecTransformer (2)
-                     :           +- ^ Scan parquet (1)
+                     :           +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (20)
                         +- ^ RegularHashAggregateExecTransformer (19)
                            +- ^ InputIteratorTransformer (18)
@@ -23,7 +23,7 @@ AdaptiveSparkPlan (43)
                                           +- ^ FlushableHashAggregateExecTransformer (11)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (42)
    +- Exchange (41)
@@ -41,7 +41,7 @@ AdaptiveSparkPlan (43)
                               +- Scan parquet (32)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -70,7 +70,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (7) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -254,7 +254,7 @@ AdaptiveSparkPlan (69)
                               +- ^ FlushableHashAggregateExecTransformer (47)
                                  +- ^ ProjectExecTransformer (46)
                                     +- ^ FilterExecTransformer (45)
-                                       +- ^ Scan parquet (44)
+                                       +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    HashAggregate (68)
    +- HashAggregate (67)
@@ -266,7 +266,7 @@ AdaptiveSparkPlan (69)
                      +- Scan parquet (61)
 
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/16.txt
@@ -24,12 +24,12 @@ AdaptiveSparkPlan (59)
                                                             +- ^ ProjectExecTransformer (11)
                                                                +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                                   :- ^ FilterExecTransformer (2)
-                                                                  :  +- ^ Scan parquet (1)
+                                                                  :  +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (9)
                                                                      +- BroadcastQueryStage (7), Statistics(X)
                                                                         +- ColumnarBroadcastExchange (6)
                                                                            +- ^ FilterExecTransformer (4)
-                                                                              +- ^ Scan parquet (3)
+                                                                              +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (58)
    +- Exchange (57)
@@ -53,7 +53,7 @@ AdaptiveSparkPlan (59)
                                     +- Scan parquet (46)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -64,7 +64,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint>
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 Arguments: isnotnull(ps_partkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/18.txt
@@ -18,10 +18,10 @@ AdaptiveSparkPlan (88)
                                  :     :  +- BroadcastQueryStage (5), Statistics(X)
                                  :     :     +- ColumnarBroadcastExchange (4)
                                  :     :        +- ^ FilterExecTransformer (2)
-                                 :     :           +- ^ Scan parquet (1)
+                                 :     :           +- ^ ScanTransformer parquet  (1)
                                  :     +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (27)
                                  :        :- ^ FilterExecTransformer (9)
-                                 :        :  +- ^ Scan parquet (8)
+                                 :        :  +- ^ ScanTransformer parquet  (8)
                                  :        +- ^ InputIteratorTransformer (26)
                                  :           +- BroadcastQueryStage (24), Statistics(X)
                                  :              +- ColumnarBroadcastExchange (23)
@@ -34,13 +34,13 @@ AdaptiveSparkPlan (88)
                                  :                                   +- VeloxResizeBatches (14)
                                  :                                      +- ^ ProjectExecTransformer (12)
                                  :                                         +- ^ FlushableHashAggregateExecTransformer (11)
-                                 :                                            +- ^ Scan parquet (10)
+                                 :                                            +- ^ ScanTransformer parquet  (10)
                                  +- ^ InputIteratorTransformer (41)
                                     +- BroadcastQueryStage (39), Statistics(X)
                                        +- ColumnarBroadcastExchange (38)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (36)
                                              :- ^ FilterExecTransformer (31)
-                                             :  +- ^ Scan parquet (30)
+                                             :  +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (35)
                                                 +- BroadcastQueryStage (33), Statistics(X)
                                                    +- ReusedExchange (32)
@@ -79,7 +79,7 @@ AdaptiveSparkPlan (88)
                                           +- Scan parquet (73)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -108,7 +108,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ ReadSchema: struct<o_orderkey:bigint,o_custkey:bigint,o_totalprice:decimal(12,2)
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Arguments: (isnotnull(o_custkey#X) AND isnotnull(o_orderkey#X))
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -207,7 +207,7 @@ Join condition: None
 Output [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 Input [6]: [c_custkey#X, c_name#X, o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/19.txt
@@ -12,12 +12,12 @@ AdaptiveSparkPlan (34)
                         +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                            :- ^ ProjectExecTransformer (3)
                            :  +- ^ FilterExecTransformer (2)
-                           :     +- ^ Scan parquet (1)
+                           :     +- ^ ScanTransformer parquet  (1)
                            +- ^ InputIteratorTransformer (10)
                               +- BroadcastQueryStage (8), Statistics(X)
                                  +- ColumnarBroadcastExchange (7)
                                     +- ^ FilterExecTransformer (5)
-                                       +- ^ Scan parquet (4)
+                                       +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (33)
    +- Exchange (32)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (34)
                      +- Scan parquet (26)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ Arguments: ((((isnotnull(l_shipinstruct#X) AND l_shipmode#X IN (AIR,AIR REG)) AN
 Output [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/20.txt
@@ -11,7 +11,7 @@ AdaptiveSparkPlan (98)
                      :- ^ ProjectExecTransformer (46)
                      :  +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (45)
                      :     :- ^ FilterExecTransformer (2)
-                     :     :  +- ^ Scan parquet (1)
+                     :     :  +- ^ ScanTransformer parquet  (1)
                      :     +- ^ InputIteratorTransformer (44)
                      :        +- BroadcastQueryStage (42), Statistics(X)
                      :           +- ColumnarBroadcastExchange (41)
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (98)
                      :                    :     +- ColumnarBroadcastExchange (15)
                      :                    :        +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (13)
                      :                    :           :- ^ FilterExecTransformer (4)
-                     :                    :           :  +- ^ Scan parquet (3)
+                     :                    :           :  +- ^ ScanTransformer parquet  (3)
                      :                    :           +- ^ InputIteratorTransformer (12)
                      :                    :              +- BroadcastQueryStage (10), Statistics(X)
                      :                    :                 +- ColumnarBroadcastExchange (9)
                      :                    :                    +- ^ ProjectExecTransformer (7)
                      :                    :                       +- ^ FilterExecTransformer (6)
-                     :                    :                          +- ^ Scan parquet (5)
+                     :                    :                          +- ^ ScanTransformer parquet  (5)
                      :                    +- ^ FilterExecTransformer (37)
                      :                       +- ^ ProjectExecTransformer (36)
                      :                          +- ^ RegularHashAggregateExecTransformer (35)
@@ -41,7 +41,7 @@ AdaptiveSparkPlan (98)
                      :                                               +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (26)
                      :                                                  :- ^ ProjectExecTransformer (21)
                      :                                                  :  +- ^ FilterExecTransformer (20)
-                     :                                                  :     +- ^ Scan parquet (19)
+                     :                                                  :     +- ^ ScanTransformer parquet  (19)
                      :                                                  +- ^ InputIteratorTransformer (25)
                      :                                                     +- BroadcastQueryStage (23), Statistics(X)
                      :                                                        +- ReusedExchange (22)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (98)
                            +- ColumnarBroadcastExchange (51)
                               +- ^ ProjectExecTransformer (49)
                                  +- ^ FilterExecTransformer (48)
-                                    +- ^ Scan parquet (47)
+                                    +- ^ ScanTransformer parquet  (47)
 +- == Initial Plan ==
    Sort (97)
    +- Exchange (96)
@@ -89,7 +89,7 @@ AdaptiveSparkPlan (98)
                      +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ ReadSchema: struct<s_suppkey:bigint,s_name:string,s_address:string,s_nationkey:b
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Arguments: isnotnull(s_nationkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -111,7 +111,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int>
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Arguments: ((isnotnull(ps_availqty#X) AND isnotnull(ps_partkey#X)) AND isnotnull(ps_suppkey#X))
 
-(5) Scan parquet
+(5) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -168,7 +168,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -288,7 +288,7 @@ Join condition: None
 Output [3]: [s_name#X, s_address#X, s_nationkey#X]
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/21.txt
@@ -19,34 +19,34 @@ AdaptiveSparkPlan (92)
                               :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                               :     :     :     +- ColumnarBroadcastExchange (4)
                               :     :     :        +- ^ FilterExecTransformer (2)
-                              :     :     :           +- ^ Scan parquet (1)
+                              :     :     :           +- ^ ScanTransformer parquet  (1)
                               :     :     +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (26)
                               :     :        :- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (17)
                               :     :        :  :- ^ ProjectExecTransformer (10)
                               :     :        :  :  +- ^ FilterExecTransformer (9)
-                              :     :        :  :     +- ^ Scan parquet (8)
+                              :     :        :  :     +- ^ ScanTransformer parquet  (8)
                               :     :        :  +- ^ InputIteratorTransformer (16)
                               :     :        :     +- BroadcastQueryStage (14), Statistics(X)
                               :     :        :        +- ColumnarBroadcastExchange (13)
-                              :     :        :           +- ^ Scan parquet (11)
+                              :     :        :           +- ^ ScanTransformer parquet  (11)
                               :     :        +- ^ InputIteratorTransformer (25)
                               :     :           +- BroadcastQueryStage (23), Statistics(X)
                               :     :              +- ColumnarBroadcastExchange (22)
                               :     :                 +- ^ ProjectExecTransformer (20)
                               :     :                    +- ^ FilterExecTransformer (19)
-                              :     :                       +- ^ Scan parquet (18)
+                              :     :                       +- ^ ScanTransformer parquet  (18)
                               :     +- ^ InputIteratorTransformer (36)
                               :        +- BroadcastQueryStage (34), Statistics(X)
                               :           +- ColumnarBroadcastExchange (33)
                               :              +- ^ ProjectExecTransformer (31)
                               :                 +- ^ FilterExecTransformer (30)
-                              :                    +- ^ Scan parquet (29)
+                              :                    +- ^ ScanTransformer parquet  (29)
                               +- ^ InputIteratorTransformer (46)
                                  +- BroadcastQueryStage (44), Statistics(X)
                                     +- ColumnarBroadcastExchange (43)
                                        +- ^ ProjectExecTransformer (41)
                                           +- ^ FilterExecTransformer (40)
-                                             +- ^ Scan parquet (39)
+                                             +- ^ ScanTransformer parquet  (39)
 +- == Initial Plan ==
    TakeOrderedAndProject (91)
    +- HashAggregate (90)
@@ -82,7 +82,7 @@ AdaptiveSparkPlan (92)
                            +- Scan parquet (82)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -111,7 +111,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -126,7 +126,7 @@ Arguments: ((((isnotnull(l_receiptdate#X) AND isnotnull(l_commitdate#X)) AND (l_
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Input [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Right keys [1]: [l_orderkey#X]
 Join type: LeftSemi
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(18) Scan parquet
+(18) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -205,7 +205,7 @@ Join condition: None
 Output [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 Input [5]: [s_suppkey#X, s_name#X, s_nationkey#X, l_orderkey#X, l_suppkey#X]
 
-(29) Scan parquet
+(29) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -248,7 +248,7 @@ Join condition: None
 Output [2]: [s_name#X, s_nationkey#X]
 Input [4]: [s_name#X, s_nationkey#X, l_orderkey#X, o_orderkey#X]
 
-(39) Scan parquet
+(39) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/22.txt
@@ -17,11 +17,11 @@ AdaptiveSparkPlan (40)
                                        +- ^ ProjectExecTransformer (10)
                                           +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (9)
                                              :- ^ FilterExecTransformer (2)
-                                             :  +- ^ Scan parquet (1)
+                                             :  +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (8)
                                                 +- BroadcastQueryStage (6), Statistics(X)
                                                    +- ColumnarBroadcastExchange (5)
-                                                      +- ^ Scan parquet (3)
+                                                      +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (39)
    +- Exchange (38)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (40)
                         +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ ReadSchema: struct<c_custkey:bigint,c_phone:string,c_acctbal:decimal(12,2)>
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Arguments: ((isnotnull(c_acctbal#X) AND substring(c_phone#X, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#X as decimal(16,6)) > Subquery subquery#X, [id=#X]))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -229,7 +229,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)
@@ -239,7 +239,7 @@ AdaptiveSparkPlan (60)
                +- Scan parquet (54)
 
 
-(41) Scan parquet
+(41) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -346,7 +346,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/3.txt
@@ -20,15 +20,15 @@ AdaptiveSparkPlan (54)
                                     :     :     +- ColumnarBroadcastExchange (5)
                                     :     :        +- ^ ProjectExecTransformer (3)
                                     :     :           +- ^ FilterExecTransformer (2)
-                                    :     :              +- ^ Scan parquet (1)
+                                    :     :              +- ^ ScanTransformer parquet  (1)
                                     :     +- ^ FilterExecTransformer (10)
-                                    :        +- ^ Scan parquet (9)
+                                    :        +- ^ ScanTransformer parquet  (9)
                                     +- ^ InputIteratorTransformer (20)
                                        +- BroadcastQueryStage (18), Statistics(X)
                                           +- ColumnarBroadcastExchange (17)
                                              +- ^ ProjectExecTransformer (15)
                                                 +- ^ FilterExecTransformer (14)
-                                                   +- ^ Scan parquet (13)
+                                                   +- ^ ScanTransformer parquet  (13)
 +- == Initial Plan ==
    TakeOrderedAndProject (53)
    +- HashAggregate (52)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (54)
                            +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -104,7 +104,7 @@ Join condition: None
 Output [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 Input [5]: [c_custkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/4.txt
@@ -18,13 +18,13 @@ AdaptiveSparkPlan (46)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (12)
                                              :- ^ ProjectExecTransformer (3)
                                              :  +- ^ FilterExecTransformer (2)
-                                             :     +- ^ Scan parquet (1)
+                                             :     +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (11)
                                                 +- BroadcastQueryStage (9), Statistics(X)
                                                    +- ColumnarBroadcastExchange (8)
                                                       +- ^ ProjectExecTransformer (6)
                                                          +- ^ FilterExecTransformer (5)
-                                                            +- ^ Scan parquet (4)
+                                                            +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -57,7 +57,7 @@ Arguments: ((isnotnull(o_orderdate#X) AND (o_orderdate#X >= 1993-07-01)) AND (o_
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Input [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/5.txt
@@ -28,31 +28,31 @@ AdaptiveSparkPlan (102)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ ProjectExecTransformer (10)
                                              :     :     :     :        +- ^ FilterExecTransformer (9)
-                                             :     :     :     :           +- ^ Scan parquet (8)
+                                             :     :     :     :           +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (47)
                                                 +- BroadcastQueryStage (45), Statistics(X)
                                                    +- ColumnarBroadcastExchange (44)
                                                       +- ^ ProjectExecTransformer (42)
                                                          +- ^ FilterExecTransformer (41)
-                                                            +- ^ Scan parquet (40)
+                                                            +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (101)
    +- Exchange (100)
@@ -90,7 +90,7 @@ AdaptiveSparkPlan (102)
                               +- Scan parquet (91)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -144,7 +144,7 @@ Join condition: None
 Output [2]: [c_nationkey#X, o_orderkey#X]
 Input [4]: [c_custkey#X, c_nationkey#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -183,7 +183,7 @@ Join condition: None
 Output [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [c_nationkey#X, o_orderkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -222,7 +222,7 @@ Join condition: None
 Output [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -261,7 +261,7 @@ Join condition: None
 Output [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 Input [6]: [l_extendedprice#X, l_discount#X, s_nationkey#X, n_nationkey#X, n_name#X, n_regionkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/7.txt
@@ -28,24 +28,24 @@ AdaptiveSparkPlan (95)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (9)
-                                             :     :     :     :        +- ^ Scan parquet (8)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (18)
                                              :     :     :        +- BroadcastQueryStage (16), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (15)
                                              :     :     :              +- ^ FilterExecTransformer (13)
-                                             :     :     :                 +- ^ Scan parquet (12)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (12)
                                              :     :     +- ^ InputIteratorTransformer (27)
                                              :     :        +- BroadcastQueryStage (25), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (24)
                                              :     :              +- ^ FilterExecTransformer (22)
-                                             :     :                 +- ^ Scan parquet (21)
+                                             :     :                 +- ^ ScanTransformer parquet  (21)
                                              :     +- ^ InputIteratorTransformer (36)
                                              :        +- BroadcastQueryStage (34), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (33)
                                              :              +- ^ FilterExecTransformer (31)
-                                             :                 +- ^ Scan parquet (30)
+                                             :                 +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (42)
                                                 +- BroadcastQueryStage (40), Statistics(X)
                                                    +- ReusedExchange (39)
@@ -84,7 +84,7 @@ AdaptiveSparkPlan (95)
                            +- Scan parquet (85)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -113,7 +113,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -134,7 +134,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Input [7]: [s_suppkey#X, s_nationkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 Input [7]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_orderkey#X, o_custkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -212,7 +212,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 Input [7]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X, c_custkey#X, c_nationkey#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/8.txt
@@ -34,40 +34,40 @@ AdaptiveSparkPlan (131)
                                                 :     :     :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                                 :     :     :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                                 :     :     :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                                :     :     :     :     :     :     :              +- ^ Scan parquet (1)
+                                                :     :     :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                                 :     :     :     :     :     :     +- ^ FilterExecTransformer (10)
-                                                :     :     :     :     :     :        +- ^ Scan parquet (9)
+                                                :     :     :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                                 :     :     :     :     :     +- ^ InputIteratorTransformer (19)
                                                 :     :     :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                                 :     :     :     :     :           +- ColumnarBroadcastExchange (16)
                                                 :     :     :     :     :              +- ^ FilterExecTransformer (14)
-                                                :     :     :     :     :                 +- ^ Scan parquet (13)
+                                                :     :     :     :     :                 +- ^ ScanTransformer parquet  (13)
                                                 :     :     :     :     +- ^ InputIteratorTransformer (28)
                                                 :     :     :     :        +- BroadcastQueryStage (26), Statistics(X)
                                                 :     :     :     :           +- ColumnarBroadcastExchange (25)
                                                 :     :     :     :              +- ^ FilterExecTransformer (23)
-                                                :     :     :     :                 +- ^ Scan parquet (22)
+                                                :     :     :     :                 +- ^ ScanTransformer parquet  (22)
                                                 :     :     :     +- ^ InputIteratorTransformer (37)
                                                 :     :     :        +- BroadcastQueryStage (35), Statistics(X)
                                                 :     :     :           +- ColumnarBroadcastExchange (34)
                                                 :     :     :              +- ^ FilterExecTransformer (32)
-                                                :     :     :                 +- ^ Scan parquet (31)
+                                                :     :     :                 +- ^ ScanTransformer parquet  (31)
                                                 :     :     +- ^ InputIteratorTransformer (46)
                                                 :     :        +- BroadcastQueryStage (44), Statistics(X)
                                                 :     :           +- ColumnarBroadcastExchange (43)
                                                 :     :              +- ^ FilterExecTransformer (41)
-                                                :     :                 +- ^ Scan parquet (40)
+                                                :     :                 +- ^ ScanTransformer parquet  (40)
                                                 :     +- ^ InputIteratorTransformer (55)
                                                 :        +- BroadcastQueryStage (53), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (52)
                                                 :              +- ^ FilterExecTransformer (50)
-                                                :                 +- ^ Scan parquet (49)
+                                                :                 +- ^ ScanTransformer parquet  (49)
                                                 +- ^ InputIteratorTransformer (65)
                                                    +- BroadcastQueryStage (63), Statistics(X)
                                                       +- ColumnarBroadcastExchange (62)
                                                          +- ^ ProjectExecTransformer (60)
                                                             +- ^ FilterExecTransformer (59)
-                                                               +- ^ Scan parquet (58)
+                                                               +- ^ ScanTransformer parquet  (58)
 +- == Initial Plan ==
    Sort (130)
    +- Exchange (129)
@@ -115,7 +115,7 @@ AdaptiveSparkPlan (131)
                               +- Scan parquet (120)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -148,7 +148,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -169,7 +169,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -208,7 +208,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -247,7 +247,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 Input [7]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -286,7 +286,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X, c_custkey#X, c_nationkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -325,7 +325,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X, n_nationkey#X, n_regionkey#X]
 
-(49) Scan parquet
+(49) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -364,7 +364,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X, n_nationkey#X, n_name#X]
 
-(58) Scan parquet
+(58) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/9.txt
@@ -29,29 +29,29 @@ AdaptiveSparkPlan (100)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                              :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                              :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :              +- ^ Scan parquet (1)
+                                             :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (10)
-                                             :     :     :     :        +- ^ Scan parquet (9)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (46)
                                                 +- BroadcastQueryStage (44), Statistics(X)
                                                    +- ColumnarBroadcastExchange (43)
                                                       +- ^ FilterExecTransformer (41)
-                                                         +- ^ Scan parquet (40)
+                                                         +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (99)
    +- Exchange (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -121,7 +121,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -142,7 +142,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [7]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -181,7 +181,7 @@ Join condition: None
 Output [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [8]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -220,7 +220,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 Input [10]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -259,7 +259,7 @@ Join condition: None
 Output [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 Input [8]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderkey#X, o_orderdate#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/10.txt
@@ -18,24 +18,24 @@ AdaptiveSparkPlan (68)
                                     :     :- ^ ProjectExecTransformer (12)
                                     :     :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                                     :     :     :- ^ FilterExecTransformer (2)
-                                    :     :     :  +- ^ Scan parquet (1)
+                                    :     :     :  +- ^ ScanTransformer parquet  (1)
                                     :     :     +- ^ InputIteratorTransformer (10)
                                     :     :        +- BroadcastQueryStage (8)
                                     :     :           +- ColumnarBroadcastExchange (7)
                                     :     :              +- ^ ProjectExecTransformer (5)
                                     :     :                 +- ^ FilterExecTransformer (4)
-                                    :     :                    +- ^ Scan parquet (3)
+                                    :     :                    +- ^ ScanTransformer parquet  (3)
                                     :     +- ^ InputIteratorTransformer (20)
                                     :        +- BroadcastQueryStage (18)
                                     :           +- ColumnarBroadcastExchange (17)
                                     :              +- ^ ProjectExecTransformer (15)
                                     :                 +- ^ FilterExecTransformer (14)
-                                    :                    +- ^ Scan parquet (13)
+                                    :                    +- ^ ScanTransformer parquet  (13)
                                     +- ^ InputIteratorTransformer (29)
                                        +- BroadcastQueryStage (27)
                                           +- ColumnarBroadcastExchange (26)
                                              +- ^ FilterExecTransformer (24)
-                                                +- ^ Scan parquet (23)
+                                                +- ^ ScanTransformer parquet  (23)
 +- == Initial Plan ==
    TakeOrderedAndProject (67)
    +- HashAggregate (66)
@@ -62,7 +62,7 @@ AdaptiveSparkPlan (68)
                         +- Scan parquet (59)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ ReadSchema: struct<c_custkey:bigint,c_name:string,c_address:string,c_nationkey:b
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Arguments: (isnotnull(c_custkey#X) AND isnotnull(c_nationkey#X))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -115,7 +115,7 @@ Join condition: None
 Output [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -157,7 +157,7 @@ Join condition: None
 Output [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 Input [11]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X]
 
-(23) Scan parquet
+(23) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/11.txt
@@ -20,18 +20,18 @@ AdaptiveSparkPlan (60)
                                                 :- ^ ProjectExecTransformer (11)
                                                 :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                 :     :- ^ FilterExecTransformer (2)
-                                                :     :  +- ^ Scan parquet (1)
+                                                :     :  +- ^ ScanTransformer parquet  (1)
                                                 :     +- ^ InputIteratorTransformer (9)
                                                 :        +- BroadcastQueryStage (7)
                                                 :           +- ColumnarBroadcastExchange (6)
                                                 :              +- ^ FilterExecTransformer (4)
-                                                :                 +- ^ Scan parquet (3)
+                                                :                 +- ^ ScanTransformer parquet  (3)
                                                 +- ^ InputIteratorTransformer (19)
                                                    +- BroadcastQueryStage (17)
                                                       +- ColumnarBroadcastExchange (16)
                                                          +- ^ ProjectExecTransformer (14)
                                                             +- ^ FilterExecTransformer (13)
-                                                               +- ^ Scan parquet (12)
+                                                               +- ^ ScanTransformer parquet  (12)
 +- == Initial Plan ==
    Sort (59)
    +- Exchange (58)
@@ -54,7 +54,7 @@ AdaptiveSparkPlan (60)
                                  +- Scan parquet (48)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -65,7 +65,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int,ps_supply
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Arguments: isnotnull(ps_suppkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 Input [6]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X, s_suppkey#X, s_nationkey#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/12.txt
@@ -20,10 +20,10 @@ AdaptiveSparkPlan (44)
                                              :  +- BroadcastQueryStage (5)
                                              :     +- ColumnarBroadcastExchange (4)
                                              :        +- ^ FilterExecTransformer (2)
-                                             :           +- ^ Scan parquet (1)
+                                             :           +- ^ ScanTransformer parquet  (1)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (43)
    +- Exchange (42)
@@ -40,7 +40,7 @@ AdaptiveSparkPlan (44)
                            +- Scan parquet (34)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -69,7 +69,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (7) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/13.txt
@@ -24,13 +24,13 @@ AdaptiveSparkPlan (55)
                                                             +- ^ FlushableHashAggregateExecTransformer (12)
                                                                +- ^ ProjectExecTransformer (11)
                                                                   +- ^ BroadcastHashJoinExecTransformer LeftOuter BuildRight (10)
-                                                                     :- ^ Scan parquet (1)
+                                                                     :- ^ ScanTransformer parquet  (1)
                                                                      +- ^ InputIteratorTransformer (9)
                                                                         +- BroadcastQueryStage (7)
                                                                            +- ColumnarBroadcastExchange (6)
                                                                               +- ^ ProjectExecTransformer (4)
                                                                                  +- ^ FilterExecTransformer (3)
-                                                                                    +- ^ Scan parquet (2)
+                                                                                    +- ^ ScanTransformer parquet  (2)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,13 +49,13 @@ AdaptiveSparkPlan (55)
                                        +- Scan parquet (41)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
 ReadSchema: struct<c_custkey:bigint>
 
-(2) Scan parquet
+(2) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/14.txt
@@ -13,12 +13,12 @@ AdaptiveSparkPlan (35)
                            +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                               :- ^ ProjectExecTransformer (3)
                               :  +- ^ FilterExecTransformer (2)
-                              :     +- ^ Scan parquet (1)
+                              :     +- ^ ScanTransformer parquet  (1)
                               +- ^ InputIteratorTransformer (10)
                                  +- BroadcastQueryStage (8)
                                     +- ColumnarBroadcastExchange (7)
                                        +- ^ FilterExecTransformer (5)
-                                          +- ^ Scan parquet (4)
+                                          +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (34)
    +- Exchange (33)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (35)
                      +- Scan parquet (27)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -48,7 +48,7 @@ Arguments: (((isnotnull(l_shipdate#X) AND (l_shipdate#X >= 1995-09-01)) AND (l_s
 Output [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 Input [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/15.txt
@@ -13,7 +13,7 @@ AdaptiveSparkPlan (46)
                         :  +- BroadcastQueryStage (5)
                         :     +- ColumnarBroadcastExchange (4)
                         :        +- ^ FilterExecTransformer (2)
-                        :           +- ^ Scan parquet (1)
+                        :           +- ^ ScanTransformer parquet  (1)
                         +- ^ FilterExecTransformer (20)
                            +- ^ RegularHashAggregateExecTransformer (19)
                               +- ^ InputIteratorTransformer (18)
@@ -24,7 +24,7 @@ AdaptiveSparkPlan (46)
                                              +- ^ FlushableHashAggregateExecTransformer (11)
                                                 +- ^ ProjectExecTransformer (10)
                                                    +- ^ FilterExecTransformer (9)
-                                                      +- ^ Scan parquet (8)
+                                                      +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -71,7 +71,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (7) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/16.txt
@@ -24,12 +24,12 @@ AdaptiveSparkPlan (59)
                                                             +- ^ ProjectExecTransformer (11)
                                                                +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                                   :- ^ FilterExecTransformer (2)
-                                                                  :  +- ^ Scan parquet (1)
+                                                                  :  +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (9)
                                                                      +- BroadcastQueryStage (7)
                                                                         +- ColumnarBroadcastExchange (6)
                                                                            +- ^ FilterExecTransformer (4)
-                                                                              +- ^ Scan parquet (3)
+                                                                              +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (58)
    +- Exchange (57)
@@ -53,7 +53,7 @@ AdaptiveSparkPlan (59)
                                     +- Scan parquet (46)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -64,7 +64,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint>
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 Arguments: isnotnull(ps_partkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/18.txt
@@ -18,10 +18,10 @@ AdaptiveSparkPlan (88)
                                  :     :  +- BroadcastQueryStage (5)
                                  :     :     +- ColumnarBroadcastExchange (4)
                                  :     :        +- ^ FilterExecTransformer (2)
-                                 :     :           +- ^ Scan parquet (1)
+                                 :     :           +- ^ ScanTransformer parquet  (1)
                                  :     +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (27)
                                  :        :- ^ FilterExecTransformer (9)
-                                 :        :  +- ^ Scan parquet (8)
+                                 :        :  +- ^ ScanTransformer parquet  (8)
                                  :        +- ^ InputIteratorTransformer (26)
                                  :           +- BroadcastQueryStage (24)
                                  :              +- ColumnarBroadcastExchange (23)
@@ -34,13 +34,13 @@ AdaptiveSparkPlan (88)
                                  :                                   +- VeloxResizeBatches (14)
                                  :                                      +- ^ ProjectExecTransformer (12)
                                  :                                         +- ^ FlushableHashAggregateExecTransformer (11)
-                                 :                                            +- ^ Scan parquet (10)
+                                 :                                            +- ^ ScanTransformer parquet  (10)
                                  +- ^ InputIteratorTransformer (41)
                                     +- BroadcastQueryStage (39)
                                        +- ColumnarBroadcastExchange (38)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (36)
                                              :- ^ FilterExecTransformer (31)
-                                             :  +- ^ Scan parquet (30)
+                                             :  +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (35)
                                                 +- BroadcastQueryStage (33)
                                                    +- ReusedExchange (32)
@@ -79,7 +79,7 @@ AdaptiveSparkPlan (88)
                                           +- Scan parquet (73)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -108,7 +108,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ ReadSchema: struct<o_orderkey:bigint,o_custkey:bigint,o_totalprice:decimal(12,2)
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Arguments: (isnotnull(o_custkey#X) AND isnotnull(o_orderkey#X))
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -205,7 +205,7 @@ Join condition: None
 Output [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 Input [6]: [c_custkey#X, c_name#X, o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/19.txt
@@ -12,12 +12,12 @@ AdaptiveSparkPlan (34)
                         +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                            :- ^ ProjectExecTransformer (3)
                            :  +- ^ FilterExecTransformer (2)
-                           :     +- ^ Scan parquet (1)
+                           :     +- ^ ScanTransformer parquet  (1)
                            +- ^ InputIteratorTransformer (10)
                               +- BroadcastQueryStage (8)
                                  +- ColumnarBroadcastExchange (7)
                                     +- ^ FilterExecTransformer (5)
-                                       +- ^ Scan parquet (4)
+                                       +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (33)
    +- Exchange (32)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (34)
                      +- Scan parquet (26)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ Arguments: ((((isnotnull(l_shipinstruct#X) AND l_shipmode#X IN (AIR,AIR REG)) AN
 Output [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/20.txt
@@ -18,7 +18,7 @@ AdaptiveSparkPlan (112)
                         :     :           +- VeloxResizeBatches (5)
                         :     :              +- ^ ProjectExecTransformer (3)
                         :     :                 +- ^ FilterExecTransformer (2)
-                        :     :                    +- ^ Scan parquet (1)
+                        :     :                    +- ^ ScanTransformer parquet  (1)
                         :     +- ^ InputIteratorTransformer (52)
                         :        +- BroadcastQueryStage (50)
                         :           +- ColumnarBroadcastExchange (49)
@@ -29,13 +29,13 @@ AdaptiveSparkPlan (112)
                         :                    :     +- ColumnarBroadcastExchange (23)
                         :                    :        +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (21)
                         :                    :           :- ^ FilterExecTransformer (12)
-                        :                    :           :  +- ^ Scan parquet (11)
+                        :                    :           :  +- ^ ScanTransformer parquet  (11)
                         :                    :           +- ^ InputIteratorTransformer (20)
                         :                    :              +- BroadcastQueryStage (18)
                         :                    :                 +- ColumnarBroadcastExchange (17)
                         :                    :                    +- ^ ProjectExecTransformer (15)
                         :                    :                       +- ^ FilterExecTransformer (14)
-                        :                    :                          +- ^ Scan parquet (13)
+                        :                    :                          +- ^ ScanTransformer parquet  (13)
                         :                    +- ^ FilterExecTransformer (45)
                         :                       +- ^ ProjectExecTransformer (44)
                         :                          +- ^ RegularHashAggregateExecTransformer (43)
@@ -48,7 +48,7 @@ AdaptiveSparkPlan (112)
                         :                                               +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (34)
                         :                                                  :- ^ ProjectExecTransformer (29)
                         :                                                  :  +- ^ FilterExecTransformer (28)
-                        :                                                  :     +- ^ Scan parquet (27)
+                        :                                                  :     +- ^ ScanTransformer parquet  (27)
                         :                                                  +- ^ InputIteratorTransformer (33)
                         :                                                     +- BroadcastQueryStage (31)
                         :                                                        +- ReusedExchange (30)
@@ -57,7 +57,7 @@ AdaptiveSparkPlan (112)
                               +- ColumnarBroadcastExchange (59)
                                  +- ^ ProjectExecTransformer (57)
                                     +- ^ FilterExecTransformer (56)
-                                       +- ^ Scan parquet (55)
+                                       +- ^ ScanTransformer parquet  (55)
 +- == Initial Plan ==
    Sort (111)
    +- Exchange (110)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (112)
                      +- Scan parquet (104)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -140,7 +140,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (10) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -151,7 +151,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int>
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Arguments: ((isnotnull(ps_availqty#X) AND isnotnull(ps_partkey#X)) AND isnotnull(ps_suppkey#X))
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -207,7 +207,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (26) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -324,7 +324,7 @@ Join condition: None
 Output [3]: [s_name#X, s_address#X, s_nationkey#X]
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(55) Scan parquet
+(55) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/21.txt
@@ -20,34 +20,34 @@ AdaptiveSparkPlan (93)
                                  :     :     :  +- BroadcastQueryStage (5)
                                  :     :     :     +- ColumnarBroadcastExchange (4)
                                  :     :     :        +- ^ FilterExecTransformer (2)
-                                 :     :     :           +- ^ Scan parquet (1)
+                                 :     :     :           +- ^ ScanTransformer parquet  (1)
                                  :     :     +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (26)
                                  :     :        :- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (17)
                                  :     :        :  :- ^ ProjectExecTransformer (10)
                                  :     :        :  :  +- ^ FilterExecTransformer (9)
-                                 :     :        :  :     +- ^ Scan parquet (8)
+                                 :     :        :  :     +- ^ ScanTransformer parquet  (8)
                                  :     :        :  +- ^ InputIteratorTransformer (16)
                                  :     :        :     +- BroadcastQueryStage (14)
                                  :     :        :        +- ColumnarBroadcastExchange (13)
-                                 :     :        :           +- ^ Scan parquet (11)
+                                 :     :        :           +- ^ ScanTransformer parquet  (11)
                                  :     :        +- ^ InputIteratorTransformer (25)
                                  :     :           +- BroadcastQueryStage (23)
                                  :     :              +- ColumnarBroadcastExchange (22)
                                  :     :                 +- ^ ProjectExecTransformer (20)
                                  :     :                    +- ^ FilterExecTransformer (19)
-                                 :     :                       +- ^ Scan parquet (18)
+                                 :     :                       +- ^ ScanTransformer parquet  (18)
                                  :     +- ^ InputIteratorTransformer (36)
                                  :        +- BroadcastQueryStage (34)
                                  :           +- ColumnarBroadcastExchange (33)
                                  :              +- ^ ProjectExecTransformer (31)
                                  :                 +- ^ FilterExecTransformer (30)
-                                 :                    +- ^ Scan parquet (29)
+                                 :                    +- ^ ScanTransformer parquet  (29)
                                  +- ^ InputIteratorTransformer (46)
                                     +- BroadcastQueryStage (44)
                                        +- ColumnarBroadcastExchange (43)
                                           +- ^ ProjectExecTransformer (41)
                                              +- ^ FilterExecTransformer (40)
-                                                +- ^ Scan parquet (39)
+                                                +- ^ ScanTransformer parquet  (39)
 +- == Initial Plan ==
    TakeOrderedAndProject (92)
    +- HashAggregate (91)
@@ -83,7 +83,7 @@ AdaptiveSparkPlan (93)
                            +- Scan parquet (83)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -112,7 +112,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -127,7 +127,7 @@ Arguments: ((((isnotnull(l_receiptdate#X) AND isnotnull(l_commitdate#X)) AND (l_
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Input [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(18) Scan parquet
+(18) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -203,7 +203,7 @@ Join condition: None
 Output [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 Input [5]: [s_suppkey#X, s_name#X, s_nationkey#X, l_orderkey#X, l_suppkey#X]
 
-(29) Scan parquet
+(29) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -245,7 +245,7 @@ Join condition: None
 Output [2]: [s_name#X, s_nationkey#X]
 Input [4]: [s_name#X, s_nationkey#X, l_orderkey#X, o_orderkey#X]
 
-(39) Scan parquet
+(39) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/22.txt
@@ -17,11 +17,11 @@ AdaptiveSparkPlan (40)
                                        +- ^ ProjectExecTransformer (10)
                                           +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (9)
                                              :- ^ FilterExecTransformer (2)
-                                             :  +- ^ Scan parquet (1)
+                                             :  +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (8)
                                                 +- BroadcastQueryStage (6)
                                                    +- ColumnarBroadcastExchange (5)
-                                                      +- ^ Scan parquet (3)
+                                                      +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (39)
    +- Exchange (38)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (40)
                         +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ ReadSchema: struct<c_custkey:bigint,c_phone:string,c_acctbal:decimal(12,2)>
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Arguments: ((isnotnull(c_acctbal#X) AND substring(c_phone#X, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#X as decimal(16,6)) > Subquery subquery#X, [id=#X]))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/3.txt
@@ -20,15 +20,15 @@ AdaptiveSparkPlan (54)
                                     :     :     +- ColumnarBroadcastExchange (5)
                                     :     :        +- ^ ProjectExecTransformer (3)
                                     :     :           +- ^ FilterExecTransformer (2)
-                                    :     :              +- ^ Scan parquet (1)
+                                    :     :              +- ^ ScanTransformer parquet  (1)
                                     :     +- ^ FilterExecTransformer (10)
-                                    :        +- ^ Scan parquet (9)
+                                    :        +- ^ ScanTransformer parquet  (9)
                                     +- ^ InputIteratorTransformer (20)
                                        +- BroadcastQueryStage (18)
                                           +- ColumnarBroadcastExchange (17)
                                              +- ^ ProjectExecTransformer (15)
                                                 +- ^ FilterExecTransformer (14)
-                                                   +- ^ Scan parquet (13)
+                                                   +- ^ ScanTransformer parquet  (13)
 +- == Initial Plan ==
    TakeOrderedAndProject (53)
    +- HashAggregate (52)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (54)
                            +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 Input [5]: [c_custkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/4.txt
@@ -18,13 +18,13 @@ AdaptiveSparkPlan (46)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (12)
                                              :- ^ ProjectExecTransformer (3)
                                              :  +- ^ FilterExecTransformer (2)
-                                             :     +- ^ Scan parquet (1)
+                                             :     +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (11)
                                                 +- BroadcastQueryStage (9)
                                                    +- ColumnarBroadcastExchange (8)
                                                       +- ^ ProjectExecTransformer (6)
                                                          +- ^ FilterExecTransformer (5)
-                                                            +- ^ Scan parquet (4)
+                                                            +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -57,7 +57,7 @@ Arguments: ((isnotnull(o_orderdate#X) AND (o_orderdate#X >= 1993-07-01)) AND (o_
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Input [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/5.txt
@@ -28,31 +28,31 @@ AdaptiveSparkPlan (102)
                                              :     :     :     :     :  +- BroadcastQueryStage (5)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ ProjectExecTransformer (10)
                                              :     :     :     :        +- ^ FilterExecTransformer (9)
-                                             :     :     :     :           +- ^ Scan parquet (8)
+                                             :     :     :     :           +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (47)
                                                 +- BroadcastQueryStage (45)
                                                    +- ColumnarBroadcastExchange (44)
                                                       +- ^ ProjectExecTransformer (42)
                                                          +- ^ FilterExecTransformer (41)
-                                                            +- ^ Scan parquet (40)
+                                                            +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (101)
    +- Exchange (100)
@@ -90,7 +90,7 @@ AdaptiveSparkPlan (102)
                               +- Scan parquet (91)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -143,7 +143,7 @@ Join condition: None
 Output [2]: [c_nationkey#X, o_orderkey#X]
 Input [4]: [c_custkey#X, c_nationkey#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -181,7 +181,7 @@ Join condition: None
 Output [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [c_nationkey#X, o_orderkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -219,7 +219,7 @@ Join condition: None
 Output [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -257,7 +257,7 @@ Join condition: None
 Output [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 Input [6]: [l_extendedprice#X, l_discount#X, s_nationkey#X, n_nationkey#X, n_name#X, n_regionkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/7.txt
@@ -28,24 +28,24 @@ AdaptiveSparkPlan (95)
                                              :     :     :     :     :  +- BroadcastQueryStage (5)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (9)
-                                             :     :     :     :        +- ^ Scan parquet (8)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (18)
                                              :     :     :        +- BroadcastQueryStage (16)
                                              :     :     :           +- ColumnarBroadcastExchange (15)
                                              :     :     :              +- ^ FilterExecTransformer (13)
-                                             :     :     :                 +- ^ Scan parquet (12)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (12)
                                              :     :     +- ^ InputIteratorTransformer (27)
                                              :     :        +- BroadcastQueryStage (25)
                                              :     :           +- ColumnarBroadcastExchange (24)
                                              :     :              +- ^ FilterExecTransformer (22)
-                                             :     :                 +- ^ Scan parquet (21)
+                                             :     :                 +- ^ ScanTransformer parquet  (21)
                                              :     +- ^ InputIteratorTransformer (36)
                                              :        +- BroadcastQueryStage (34)
                                              :           +- ColumnarBroadcastExchange (33)
                                              :              +- ^ FilterExecTransformer (31)
-                                             :                 +- ^ Scan parquet (30)
+                                             :                 +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (42)
                                                 +- BroadcastQueryStage (40)
                                                    +- ReusedExchange (39)
@@ -84,7 +84,7 @@ AdaptiveSparkPlan (95)
                            +- Scan parquet (85)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -113,7 +113,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -133,7 +133,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Input [7]: [s_suppkey#X, s_nationkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 Input [7]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_orderkey#X, o_custkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -209,7 +209,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 Input [7]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X, c_custkey#X, c_nationkey#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/8.txt
@@ -34,40 +34,40 @@ AdaptiveSparkPlan (131)
                                                 :     :     :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                                 :     :     :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                                 :     :     :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                                :     :     :     :     :     :     :              +- ^ Scan parquet (1)
+                                                :     :     :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                                 :     :     :     :     :     :     +- ^ FilterExecTransformer (10)
-                                                :     :     :     :     :     :        +- ^ Scan parquet (9)
+                                                :     :     :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                                 :     :     :     :     :     +- ^ InputIteratorTransformer (19)
                                                 :     :     :     :     :        +- BroadcastQueryStage (17)
                                                 :     :     :     :     :           +- ColumnarBroadcastExchange (16)
                                                 :     :     :     :     :              +- ^ FilterExecTransformer (14)
-                                                :     :     :     :     :                 +- ^ Scan parquet (13)
+                                                :     :     :     :     :                 +- ^ ScanTransformer parquet  (13)
                                                 :     :     :     :     +- ^ InputIteratorTransformer (28)
                                                 :     :     :     :        +- BroadcastQueryStage (26)
                                                 :     :     :     :           +- ColumnarBroadcastExchange (25)
                                                 :     :     :     :              +- ^ FilterExecTransformer (23)
-                                                :     :     :     :                 +- ^ Scan parquet (22)
+                                                :     :     :     :                 +- ^ ScanTransformer parquet  (22)
                                                 :     :     :     +- ^ InputIteratorTransformer (37)
                                                 :     :     :        +- BroadcastQueryStage (35)
                                                 :     :     :           +- ColumnarBroadcastExchange (34)
                                                 :     :     :              +- ^ FilterExecTransformer (32)
-                                                :     :     :                 +- ^ Scan parquet (31)
+                                                :     :     :                 +- ^ ScanTransformer parquet  (31)
                                                 :     :     +- ^ InputIteratorTransformer (46)
                                                 :     :        +- BroadcastQueryStage (44)
                                                 :     :           +- ColumnarBroadcastExchange (43)
                                                 :     :              +- ^ FilterExecTransformer (41)
-                                                :     :                 +- ^ Scan parquet (40)
+                                                :     :                 +- ^ ScanTransformer parquet  (40)
                                                 :     +- ^ InputIteratorTransformer (55)
                                                 :        +- BroadcastQueryStage (53)
                                                 :           +- ColumnarBroadcastExchange (52)
                                                 :              +- ^ FilterExecTransformer (50)
-                                                :                 +- ^ Scan parquet (49)
+                                                :                 +- ^ ScanTransformer parquet  (49)
                                                 +- ^ InputIteratorTransformer (65)
                                                    +- BroadcastQueryStage (63)
                                                       +- ColumnarBroadcastExchange (62)
                                                          +- ^ ProjectExecTransformer (60)
                                                             +- ^ FilterExecTransformer (59)
-                                                               +- ^ Scan parquet (58)
+                                                               +- ^ ScanTransformer parquet  (58)
 +- == Initial Plan ==
    Sort (130)
    +- Exchange (129)
@@ -115,7 +115,7 @@ AdaptiveSparkPlan (131)
                               +- Scan parquet (120)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -148,7 +148,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -168,7 +168,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -206,7 +206,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -244,7 +244,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 Input [7]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X, c_custkey#X, c_nationkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -320,7 +320,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X, n_nationkey#X, n_regionkey#X]
 
-(49) Scan parquet
+(49) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -358,7 +358,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X, n_nationkey#X, n_name#X]
 
-(58) Scan parquet
+(58) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/9.txt
@@ -29,29 +29,29 @@ AdaptiveSparkPlan (100)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                              :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                              :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :              +- ^ Scan parquet (1)
+                                             :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (10)
-                                             :     :     :     :        +- ^ Scan parquet (9)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (46)
                                                 +- BroadcastQueryStage (44)
                                                    +- ColumnarBroadcastExchange (43)
                                                       +- ^ FilterExecTransformer (41)
-                                                         +- ^ Scan parquet (40)
+                                                         +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (99)
    +- Exchange (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -121,7 +121,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -141,7 +141,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [7]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -179,7 +179,7 @@ Join condition: None
 Output [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [8]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -217,7 +217,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 Input [10]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -255,7 +255,7 @@ Join condition: None
 Output [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 Input [8]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderkey#X, o_orderdate#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/10.txt
@@ -18,24 +18,24 @@ AdaptiveSparkPlan (68)
                                     :     :- ^ ProjectExecTransformer (12)
                                     :     :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                                     :     :     :- ^ FilterExecTransformer (2)
-                                    :     :     :  +- ^ Scan parquet (1)
+                                    :     :     :  +- ^ ScanTransformer parquet  (1)
                                     :     :     +- ^ InputIteratorTransformer (10)
                                     :     :        +- BroadcastQueryStage (8), Statistics(X)
                                     :     :           +- ColumnarBroadcastExchange (7)
                                     :     :              +- ^ ProjectExecTransformer (5)
                                     :     :                 +- ^ FilterExecTransformer (4)
-                                    :     :                    +- ^ Scan parquet (3)
+                                    :     :                    +- ^ ScanTransformer parquet  (3)
                                     :     +- ^ InputIteratorTransformer (20)
                                     :        +- BroadcastQueryStage (18), Statistics(X)
                                     :           +- ColumnarBroadcastExchange (17)
                                     :              +- ^ ProjectExecTransformer (15)
                                     :                 +- ^ FilterExecTransformer (14)
-                                    :                    +- ^ Scan parquet (13)
+                                    :                    +- ^ ScanTransformer parquet  (13)
                                     +- ^ InputIteratorTransformer (29)
                                        +- BroadcastQueryStage (27), Statistics(X)
                                           +- ColumnarBroadcastExchange (26)
                                              +- ^ FilterExecTransformer (24)
-                                                +- ^ Scan parquet (23)
+                                                +- ^ ScanTransformer parquet  (23)
 +- == Initial Plan ==
    TakeOrderedAndProject (67)
    +- HashAggregate (66)
@@ -62,7 +62,7 @@ AdaptiveSparkPlan (68)
                         +- Scan parquet (59)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ ReadSchema: struct<c_custkey:bigint,c_name:string,c_address:string,c_nationkey:b
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Arguments: (isnotnull(c_custkey#X) AND isnotnull(c_nationkey#X))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -115,7 +115,7 @@ Join condition: None
 Output [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -157,7 +157,7 @@ Join condition: None
 Output [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 Input [11]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X]
 
-(23) Scan parquet
+(23) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/11.txt
@@ -20,18 +20,18 @@ AdaptiveSparkPlan (60)
                                                 :- ^ ProjectExecTransformer (11)
                                                 :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                 :     :- ^ FilterExecTransformer (2)
-                                                :     :  +- ^ Scan parquet (1)
+                                                :     :  +- ^ ScanTransformer parquet  (1)
                                                 :     +- ^ InputIteratorTransformer (9)
                                                 :        +- BroadcastQueryStage (7), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (6)
                                                 :              +- ^ FilterExecTransformer (4)
-                                                :                 +- ^ Scan parquet (3)
+                                                :                 +- ^ ScanTransformer parquet  (3)
                                                 +- ^ InputIteratorTransformer (19)
                                                    +- BroadcastQueryStage (17), Statistics(X)
                                                       +- ColumnarBroadcastExchange (16)
                                                          +- ^ ProjectExecTransformer (14)
                                                             +- ^ FilterExecTransformer (13)
-                                                               +- ^ Scan parquet (12)
+                                                               +- ^ ScanTransformer parquet  (12)
 +- == Initial Plan ==
    Sort (59)
    +- Exchange (58)
@@ -54,7 +54,7 @@ AdaptiveSparkPlan (60)
                                  +- Scan parquet (48)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -65,7 +65,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int,ps_supply
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Arguments: isnotnull(ps_suppkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 Input [6]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X, s_suppkey#X, s_nationkey#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -337,7 +337,7 @@ AdaptiveSparkPlan (102)
                               :- ^ ProjectExecTransformer (68)
                               :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (67)
                               :     :- ^ FilterExecTransformer (62)
-                              :     :  +- ^ Scan parquet (61)
+                              :     :  +- ^ ScanTransformer parquet  (61)
                               :     +- ^ InputIteratorTransformer (66)
                               :        +- BroadcastQueryStage (64), Statistics(X)
                               :           +- ReusedExchange (63)
@@ -363,7 +363,7 @@ AdaptiveSparkPlan (102)
                         +- Scan parquet (93)
 
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/12.txt
@@ -20,10 +20,10 @@ AdaptiveSparkPlan (44)
                                              :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     +- ColumnarBroadcastExchange (4)
                                              :        +- ^ FilterExecTransformer (2)
-                                             :           +- ^ Scan parquet (1)
+                                             :           +- ^ ScanTransformer parquet  (1)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (43)
    +- Exchange (42)
@@ -40,7 +40,7 @@ AdaptiveSparkPlan (44)
                            +- Scan parquet (34)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -69,7 +69,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (7) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/13.txt
@@ -24,13 +24,13 @@ AdaptiveSparkPlan (55)
                                                             +- ^ FlushableHashAggregateExecTransformer (12)
                                                                +- ^ ProjectExecTransformer (11)
                                                                   +- ^ BroadcastHashJoinExecTransformer LeftOuter BuildRight (10)
-                                                                     :- ^ Scan parquet (1)
+                                                                     :- ^ ScanTransformer parquet  (1)
                                                                      +- ^ InputIteratorTransformer (9)
                                                                         +- BroadcastQueryStage (7), Statistics(X)
                                                                            +- ColumnarBroadcastExchange (6)
                                                                               +- ^ ProjectExecTransformer (4)
                                                                                  +- ^ FilterExecTransformer (3)
-                                                                                    +- ^ Scan parquet (2)
+                                                                                    +- ^ ScanTransformer parquet  (2)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,13 +49,13 @@ AdaptiveSparkPlan (55)
                                        +- Scan parquet (41)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
 ReadSchema: struct<c_custkey:bigint>
 
-(2) Scan parquet
+(2) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/14.txt
@@ -13,12 +13,12 @@ AdaptiveSparkPlan (35)
                            +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                               :- ^ ProjectExecTransformer (3)
                               :  +- ^ FilterExecTransformer (2)
-                              :     +- ^ Scan parquet (1)
+                              :     +- ^ ScanTransformer parquet  (1)
                               +- ^ InputIteratorTransformer (10)
                                  +- BroadcastQueryStage (8), Statistics(X)
                                     +- ColumnarBroadcastExchange (7)
                                        +- ^ FilterExecTransformer (5)
-                                          +- ^ Scan parquet (4)
+                                          +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (34)
    +- Exchange (33)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (35)
                      +- Scan parquet (27)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -48,7 +48,7 @@ Arguments: (((isnotnull(l_shipdate#X) AND (l_shipdate#X >= 1995-09-01)) AND (l_s
 Output [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 Input [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/15.txt
@@ -12,7 +12,7 @@ AdaptiveSparkPlan (43)
                      :  +- BroadcastQueryStage (5), Statistics(X)
                      :     +- ColumnarBroadcastExchange (4)
                      :        +- ^ FilterExecTransformer (2)
-                     :           +- ^ Scan parquet (1)
+                     :           +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (20)
                         +- ^ RegularHashAggregateExecTransformer (19)
                            +- ^ InputIteratorTransformer (18)
@@ -23,7 +23,7 @@ AdaptiveSparkPlan (43)
                                           +- ^ FlushableHashAggregateExecTransformer (11)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (42)
    +- Exchange (41)
@@ -41,7 +41,7 @@ AdaptiveSparkPlan (43)
                               +- Scan parquet (32)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -70,7 +70,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (7) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -252,7 +252,7 @@ AdaptiveSparkPlan (69)
                               +- ^ FlushableHashAggregateExecTransformer (47)
                                  +- ^ ProjectExecTransformer (46)
                                     +- ^ FilterExecTransformer (45)
-                                       +- ^ Scan parquet (44)
+                                       +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    HashAggregate (68)
    +- HashAggregate (67)
@@ -264,7 +264,7 @@ AdaptiveSparkPlan (69)
                      +- Scan parquet (61)
 
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/16.txt
@@ -24,12 +24,12 @@ AdaptiveSparkPlan (59)
                                                             +- ^ ProjectExecTransformer (11)
                                                                +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                                   :- ^ FilterExecTransformer (2)
-                                                                  :  +- ^ Scan parquet (1)
+                                                                  :  +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (9)
                                                                      +- BroadcastQueryStage (7), Statistics(X)
                                                                         +- ColumnarBroadcastExchange (6)
                                                                            +- ^ FilterExecTransformer (4)
-                                                                              +- ^ Scan parquet (3)
+                                                                              +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (58)
    +- Exchange (57)
@@ -53,7 +53,7 @@ AdaptiveSparkPlan (59)
                                     +- Scan parquet (46)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -64,7 +64,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint>
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 Arguments: isnotnull(ps_partkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/18.txt
@@ -18,10 +18,10 @@ AdaptiveSparkPlan (88)
                                  :     :  +- BroadcastQueryStage (5), Statistics(X)
                                  :     :     +- ColumnarBroadcastExchange (4)
                                  :     :        +- ^ FilterExecTransformer (2)
-                                 :     :           +- ^ Scan parquet (1)
+                                 :     :           +- ^ ScanTransformer parquet  (1)
                                  :     +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (27)
                                  :        :- ^ FilterExecTransformer (9)
-                                 :        :  +- ^ Scan parquet (8)
+                                 :        :  +- ^ ScanTransformer parquet  (8)
                                  :        +- ^ InputIteratorTransformer (26)
                                  :           +- BroadcastQueryStage (24), Statistics(X)
                                  :              +- ColumnarBroadcastExchange (23)
@@ -34,13 +34,13 @@ AdaptiveSparkPlan (88)
                                  :                                   +- VeloxResizeBatches (14)
                                  :                                      +- ^ ProjectExecTransformer (12)
                                  :                                         +- ^ FlushableHashAggregateExecTransformer (11)
-                                 :                                            +- ^ Scan parquet (10)
+                                 :                                            +- ^ ScanTransformer parquet  (10)
                                  +- ^ InputIteratorTransformer (41)
                                     +- BroadcastQueryStage (39), Statistics(X)
                                        +- ColumnarBroadcastExchange (38)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (36)
                                              :- ^ FilterExecTransformer (31)
-                                             :  +- ^ Scan parquet (30)
+                                             :  +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (35)
                                                 +- BroadcastQueryStage (33), Statistics(X)
                                                    +- ReusedExchange (32)
@@ -79,7 +79,7 @@ AdaptiveSparkPlan (88)
                                           +- Scan parquet (73)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -108,7 +108,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ ReadSchema: struct<o_orderkey:bigint,o_custkey:bigint,o_totalprice:decimal(12,2)
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Arguments: (isnotnull(o_custkey#X) AND isnotnull(o_orderkey#X))
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -205,7 +205,7 @@ Join condition: None
 Output [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 Input [6]: [c_custkey#X, c_name#X, o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/19.txt
@@ -12,12 +12,12 @@ AdaptiveSparkPlan (34)
                         +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                            :- ^ ProjectExecTransformer (3)
                            :  +- ^ FilterExecTransformer (2)
-                           :     +- ^ Scan parquet (1)
+                           :     +- ^ ScanTransformer parquet  (1)
                            +- ^ InputIteratorTransformer (10)
                               +- BroadcastQueryStage (8), Statistics(X)
                                  +- ColumnarBroadcastExchange (7)
                                     +- ^ FilterExecTransformer (5)
-                                       +- ^ Scan parquet (4)
+                                       +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (33)
    +- Exchange (32)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (34)
                      +- Scan parquet (26)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ Arguments: ((((isnotnull(l_shipinstruct#X) AND l_shipmode#X IN (AIR,AIR REG)) AN
 Output [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/20.txt
@@ -17,7 +17,7 @@ AdaptiveSparkPlan (109)
                      :     :           +- VeloxResizeBatches (5)
                      :     :              +- ^ ProjectExecTransformer (3)
                      :     :                 +- ^ FilterExecTransformer (2)
-                     :     :                    +- ^ Scan parquet (1)
+                     :     :                    +- ^ ScanTransformer parquet  (1)
                      :     +- ^ InputIteratorTransformer (52)
                      :        +- BroadcastQueryStage (50), Statistics(X)
                      :           +- ColumnarBroadcastExchange (49)
@@ -28,13 +28,13 @@ AdaptiveSparkPlan (109)
                      :                    :     +- ColumnarBroadcastExchange (23)
                      :                    :        +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (21)
                      :                    :           :- ^ FilterExecTransformer (12)
-                     :                    :           :  +- ^ Scan parquet (11)
+                     :                    :           :  +- ^ ScanTransformer parquet  (11)
                      :                    :           +- ^ InputIteratorTransformer (20)
                      :                    :              +- BroadcastQueryStage (18), Statistics(X)
                      :                    :                 +- ColumnarBroadcastExchange (17)
                      :                    :                    +- ^ ProjectExecTransformer (15)
                      :                    :                       +- ^ FilterExecTransformer (14)
-                     :                    :                          +- ^ Scan parquet (13)
+                     :                    :                          +- ^ ScanTransformer parquet  (13)
                      :                    +- ^ FilterExecTransformer (45)
                      :                       +- ^ ProjectExecTransformer (44)
                      :                          +- ^ RegularHashAggregateExecTransformer (43)
@@ -47,7 +47,7 @@ AdaptiveSparkPlan (109)
                      :                                               +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (34)
                      :                                                  :- ^ ProjectExecTransformer (29)
                      :                                                  :  +- ^ FilterExecTransformer (28)
-                     :                                                  :     +- ^ Scan parquet (27)
+                     :                                                  :     +- ^ ScanTransformer parquet  (27)
                      :                                                  +- ^ InputIteratorTransformer (33)
                      :                                                     +- BroadcastQueryStage (31), Statistics(X)
                      :                                                        +- ReusedExchange (30)
@@ -56,7 +56,7 @@ AdaptiveSparkPlan (109)
                            +- ColumnarBroadcastExchange (59)
                               +- ^ ProjectExecTransformer (57)
                                  +- ^ FilterExecTransformer (56)
-                                    +- ^ Scan parquet (55)
+                                    +- ^ ScanTransformer parquet  (55)
 +- == Initial Plan ==
    Sort (108)
    +- Exchange (107)
@@ -98,7 +98,7 @@ AdaptiveSparkPlan (109)
                      +- Scan parquet (101)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -139,7 +139,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (10) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -150,7 +150,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int>
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Arguments: ((isnotnull(ps_availqty#X) AND isnotnull(ps_partkey#X)) AND isnotnull(ps_suppkey#X))
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -206,7 +206,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (26) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -323,7 +323,7 @@ Join condition: None
 Output [3]: [s_name#X, s_address#X, s_nationkey#X]
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(55) Scan parquet
+(55) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/21.txt
@@ -19,34 +19,34 @@ AdaptiveSparkPlan (92)
                               :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                               :     :     :     +- ColumnarBroadcastExchange (4)
                               :     :     :        +- ^ FilterExecTransformer (2)
-                              :     :     :           +- ^ Scan parquet (1)
+                              :     :     :           +- ^ ScanTransformer parquet  (1)
                               :     :     +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (26)
                               :     :        :- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (17)
                               :     :        :  :- ^ ProjectExecTransformer (10)
                               :     :        :  :  +- ^ FilterExecTransformer (9)
-                              :     :        :  :     +- ^ Scan parquet (8)
+                              :     :        :  :     +- ^ ScanTransformer parquet  (8)
                               :     :        :  +- ^ InputIteratorTransformer (16)
                               :     :        :     +- BroadcastQueryStage (14), Statistics(X)
                               :     :        :        +- ColumnarBroadcastExchange (13)
-                              :     :        :           +- ^ Scan parquet (11)
+                              :     :        :           +- ^ ScanTransformer parquet  (11)
                               :     :        +- ^ InputIteratorTransformer (25)
                               :     :           +- BroadcastQueryStage (23), Statistics(X)
                               :     :              +- ColumnarBroadcastExchange (22)
                               :     :                 +- ^ ProjectExecTransformer (20)
                               :     :                    +- ^ FilterExecTransformer (19)
-                              :     :                       +- ^ Scan parquet (18)
+                              :     :                       +- ^ ScanTransformer parquet  (18)
                               :     +- ^ InputIteratorTransformer (36)
                               :        +- BroadcastQueryStage (34), Statistics(X)
                               :           +- ColumnarBroadcastExchange (33)
                               :              +- ^ ProjectExecTransformer (31)
                               :                 +- ^ FilterExecTransformer (30)
-                              :                    +- ^ Scan parquet (29)
+                              :                    +- ^ ScanTransformer parquet  (29)
                               +- ^ InputIteratorTransformer (46)
                                  +- BroadcastQueryStage (44), Statistics(X)
                                     +- ColumnarBroadcastExchange (43)
                                        +- ^ ProjectExecTransformer (41)
                                           +- ^ FilterExecTransformer (40)
-                                             +- ^ Scan parquet (39)
+                                             +- ^ ScanTransformer parquet  (39)
 +- == Initial Plan ==
    TakeOrderedAndProject (91)
    +- HashAggregate (90)
@@ -82,7 +82,7 @@ AdaptiveSparkPlan (92)
                            +- Scan parquet (82)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -111,7 +111,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -126,7 +126,7 @@ Arguments: ((((isnotnull(l_receiptdate#X) AND isnotnull(l_commitdate#X)) AND (l_
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Input [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -155,7 +155,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(18) Scan parquet
+(18) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -202,7 +202,7 @@ Join condition: None
 Output [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 Input [5]: [s_suppkey#X, s_name#X, s_nationkey#X, l_orderkey#X, l_suppkey#X]
 
-(29) Scan parquet
+(29) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -244,7 +244,7 @@ Join condition: None
 Output [2]: [s_name#X, s_nationkey#X]
 Input [4]: [s_name#X, s_nationkey#X, l_orderkey#X, o_orderkey#X]
 
-(39) Scan parquet
+(39) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/22.txt
@@ -17,11 +17,11 @@ AdaptiveSparkPlan (40)
                                        +- ^ ProjectExecTransformer (10)
                                           +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (9)
                                              :- ^ FilterExecTransformer (2)
-                                             :  +- ^ Scan parquet (1)
+                                             :  +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (8)
                                                 +- BroadcastQueryStage (6), Statistics(X)
                                                    +- ColumnarBroadcastExchange (5)
-                                                      +- ^ Scan parquet (3)
+                                                      +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (39)
    +- Exchange (38)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (40)
                         +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ ReadSchema: struct<c_custkey:bigint,c_phone:string,c_acctbal:decimal(12,2)>
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Arguments: ((isnotnull(c_acctbal#X) AND substring(c_phone#X, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#X as decimal(16,6)) > Subquery subquery#X, [id=#X]))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -227,7 +227,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)
@@ -237,7 +237,7 @@ AdaptiveSparkPlan (60)
                +- Scan parquet (54)
 
 
-(41) Scan parquet
+(41) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -344,7 +344,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/3.txt
@@ -20,15 +20,15 @@ AdaptiveSparkPlan (54)
                                     :     :     +- ColumnarBroadcastExchange (5)
                                     :     :        +- ^ ProjectExecTransformer (3)
                                     :     :           +- ^ FilterExecTransformer (2)
-                                    :     :              +- ^ Scan parquet (1)
+                                    :     :              +- ^ ScanTransformer parquet  (1)
                                     :     +- ^ FilterExecTransformer (10)
-                                    :        +- ^ Scan parquet (9)
+                                    :        +- ^ ScanTransformer parquet  (9)
                                     +- ^ InputIteratorTransformer (20)
                                        +- BroadcastQueryStage (18), Statistics(X)
                                           +- ColumnarBroadcastExchange (17)
                                              +- ^ ProjectExecTransformer (15)
                                                 +- ^ FilterExecTransformer (14)
-                                                   +- ^ Scan parquet (13)
+                                                   +- ^ ScanTransformer parquet  (13)
 +- == Initial Plan ==
    TakeOrderedAndProject (53)
    +- HashAggregate (52)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (54)
                            +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -103,7 +103,7 @@ Join condition: None
 Output [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 Input [5]: [c_custkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/4.txt
@@ -18,13 +18,13 @@ AdaptiveSparkPlan (46)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (12)
                                              :- ^ ProjectExecTransformer (3)
                                              :  +- ^ FilterExecTransformer (2)
-                                             :     +- ^ Scan parquet (1)
+                                             :     +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (11)
                                                 +- BroadcastQueryStage (9), Statistics(X)
                                                    +- ColumnarBroadcastExchange (8)
                                                       +- ^ ProjectExecTransformer (6)
                                                          +- ^ FilterExecTransformer (5)
-                                                            +- ^ Scan parquet (4)
+                                                            +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -57,7 +57,7 @@ Arguments: ((isnotnull(o_orderdate#X) AND (o_orderdate#X >= 1993-07-01)) AND (o_
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Input [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/5.txt
@@ -28,31 +28,31 @@ AdaptiveSparkPlan (102)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ ProjectExecTransformer (10)
                                              :     :     :     :        +- ^ FilterExecTransformer (9)
-                                             :     :     :     :           +- ^ Scan parquet (8)
+                                             :     :     :     :           +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (47)
                                                 +- BroadcastQueryStage (45), Statistics(X)
                                                    +- ColumnarBroadcastExchange (44)
                                                       +- ^ ProjectExecTransformer (42)
                                                          +- ^ FilterExecTransformer (41)
-                                                            +- ^ Scan parquet (40)
+                                                            +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (101)
    +- Exchange (100)
@@ -90,7 +90,7 @@ AdaptiveSparkPlan (102)
                               +- Scan parquet (91)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -143,7 +143,7 @@ Join condition: None
 Output [2]: [c_nationkey#X, o_orderkey#X]
 Input [4]: [c_custkey#X, c_nationkey#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -181,7 +181,7 @@ Join condition: None
 Output [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [c_nationkey#X, o_orderkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -219,7 +219,7 @@ Join condition: None
 Output [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -257,7 +257,7 @@ Join condition: None
 Output [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 Input [6]: [l_extendedprice#X, l_discount#X, s_nationkey#X, n_nationkey#X, n_name#X, n_regionkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/7.txt
@@ -28,24 +28,24 @@ AdaptiveSparkPlan (95)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (9)
-                                             :     :     :     :        +- ^ Scan parquet (8)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (18)
                                              :     :     :        +- BroadcastQueryStage (16), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (15)
                                              :     :     :              +- ^ FilterExecTransformer (13)
-                                             :     :     :                 +- ^ Scan parquet (12)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (12)
                                              :     :     +- ^ InputIteratorTransformer (27)
                                              :     :        +- BroadcastQueryStage (25), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (24)
                                              :     :              +- ^ FilterExecTransformer (22)
-                                             :     :                 +- ^ Scan parquet (21)
+                                             :     :                 +- ^ ScanTransformer parquet  (21)
                                              :     +- ^ InputIteratorTransformer (36)
                                              :        +- BroadcastQueryStage (34), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (33)
                                              :              +- ^ FilterExecTransformer (31)
-                                             :                 +- ^ Scan parquet (30)
+                                             :                 +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (42)
                                                 +- BroadcastQueryStage (40), Statistics(X)
                                                    +- ReusedExchange (39)
@@ -84,7 +84,7 @@ AdaptiveSparkPlan (95)
                            +- Scan parquet (85)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -113,7 +113,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -133,7 +133,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Input [7]: [s_suppkey#X, s_nationkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 Input [7]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_orderkey#X, o_custkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -209,7 +209,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 Input [7]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X, c_custkey#X, c_nationkey#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/8.txt
@@ -34,40 +34,40 @@ AdaptiveSparkPlan (131)
                                                 :     :     :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                                 :     :     :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                                 :     :     :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                                :     :     :     :     :     :     :              +- ^ Scan parquet (1)
+                                                :     :     :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                                 :     :     :     :     :     :     +- ^ FilterExecTransformer (10)
-                                                :     :     :     :     :     :        +- ^ Scan parquet (9)
+                                                :     :     :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                                 :     :     :     :     :     +- ^ InputIteratorTransformer (19)
                                                 :     :     :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                                 :     :     :     :     :           +- ColumnarBroadcastExchange (16)
                                                 :     :     :     :     :              +- ^ FilterExecTransformer (14)
-                                                :     :     :     :     :                 +- ^ Scan parquet (13)
+                                                :     :     :     :     :                 +- ^ ScanTransformer parquet  (13)
                                                 :     :     :     :     +- ^ InputIteratorTransformer (28)
                                                 :     :     :     :        +- BroadcastQueryStage (26), Statistics(X)
                                                 :     :     :     :           +- ColumnarBroadcastExchange (25)
                                                 :     :     :     :              +- ^ FilterExecTransformer (23)
-                                                :     :     :     :                 +- ^ Scan parquet (22)
+                                                :     :     :     :                 +- ^ ScanTransformer parquet  (22)
                                                 :     :     :     +- ^ InputIteratorTransformer (37)
                                                 :     :     :        +- BroadcastQueryStage (35), Statistics(X)
                                                 :     :     :           +- ColumnarBroadcastExchange (34)
                                                 :     :     :              +- ^ FilterExecTransformer (32)
-                                                :     :     :                 +- ^ Scan parquet (31)
+                                                :     :     :                 +- ^ ScanTransformer parquet  (31)
                                                 :     :     +- ^ InputIteratorTransformer (46)
                                                 :     :        +- BroadcastQueryStage (44), Statistics(X)
                                                 :     :           +- ColumnarBroadcastExchange (43)
                                                 :     :              +- ^ FilterExecTransformer (41)
-                                                :     :                 +- ^ Scan parquet (40)
+                                                :     :                 +- ^ ScanTransformer parquet  (40)
                                                 :     +- ^ InputIteratorTransformer (55)
                                                 :        +- BroadcastQueryStage (53), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (52)
                                                 :              +- ^ FilterExecTransformer (50)
-                                                :                 +- ^ Scan parquet (49)
+                                                :                 +- ^ ScanTransformer parquet  (49)
                                                 +- ^ InputIteratorTransformer (65)
                                                    +- BroadcastQueryStage (63), Statistics(X)
                                                       +- ColumnarBroadcastExchange (62)
                                                          +- ^ ProjectExecTransformer (60)
                                                             +- ^ FilterExecTransformer (59)
-                                                               +- ^ Scan parquet (58)
+                                                               +- ^ ScanTransformer parquet  (58)
 +- == Initial Plan ==
    Sort (130)
    +- Exchange (129)
@@ -115,7 +115,7 @@ AdaptiveSparkPlan (131)
                               +- Scan parquet (120)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -148,7 +148,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -168,7 +168,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -206,7 +206,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -244,7 +244,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 Input [7]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X, c_custkey#X, c_nationkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -320,7 +320,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X, n_nationkey#X, n_regionkey#X]
 
-(49) Scan parquet
+(49) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -358,7 +358,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X, n_nationkey#X, n_name#X]
 
-(58) Scan parquet
+(58) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/9.txt
@@ -29,29 +29,29 @@ AdaptiveSparkPlan (100)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                              :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                              :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :              +- ^ Scan parquet (1)
+                                             :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (10)
-                                             :     :     :     :        +- ^ Scan parquet (9)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (46)
                                                 +- BroadcastQueryStage (44), Statistics(X)
                                                    +- ColumnarBroadcastExchange (43)
                                                       +- ^ FilterExecTransformer (41)
-                                                         +- ^ Scan parquet (40)
+                                                         +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (99)
    +- Exchange (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -121,7 +121,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -141,7 +141,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [7]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -179,7 +179,7 @@ Join condition: None
 Output [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [8]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -217,7 +217,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 Input [10]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -255,7 +255,7 @@ Join condition: None
 Output [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 Input [8]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderkey#X, o_orderdate#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/10.txt
@@ -18,24 +18,24 @@ AdaptiveSparkPlan (68)
                                     :     :- ^ ProjectExecTransformer (12)
                                     :     :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                                     :     :     :- ^ FilterExecTransformer (2)
-                                    :     :     :  +- ^ Scan parquet (1)
+                                    :     :     :  +- ^ ScanTransformer parquet  (1)
                                     :     :     +- ^ InputIteratorTransformer (10)
                                     :     :        +- BroadcastQueryStage (8), Statistics(X)
                                     :     :           +- ColumnarBroadcastExchange (7)
                                     :     :              +- ^ ProjectExecTransformer (5)
                                     :     :                 +- ^ FilterExecTransformer (4)
-                                    :     :                    +- ^ Scan parquet (3)
+                                    :     :                    +- ^ ScanTransformer parquet  (3)
                                     :     +- ^ InputIteratorTransformer (20)
                                     :        +- BroadcastQueryStage (18), Statistics(X)
                                     :           +- ColumnarBroadcastExchange (17)
                                     :              +- ^ ProjectExecTransformer (15)
                                     :                 +- ^ FilterExecTransformer (14)
-                                    :                    +- ^ Scan parquet (13)
+                                    :                    +- ^ ScanTransformer parquet  (13)
                                     +- ^ InputIteratorTransformer (29)
                                        +- BroadcastQueryStage (27), Statistics(X)
                                           +- ColumnarBroadcastExchange (26)
                                              +- ^ FilterExecTransformer (24)
-                                                +- ^ Scan parquet (23)
+                                                +- ^ ScanTransformer parquet  (23)
 +- == Initial Plan ==
    TakeOrderedAndProject (67)
    +- HashAggregate (66)
@@ -62,7 +62,7 @@ AdaptiveSparkPlan (68)
                         +- Scan parquet (59)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ ReadSchema: struct<c_custkey:bigint,c_name:string,c_address:string,c_nationkey:b
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Arguments: (isnotnull(c_custkey#X) AND isnotnull(c_nationkey#X))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -116,7 +116,7 @@ Join condition: None
 Output [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -159,7 +159,7 @@ Join condition: None
 Output [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 Input [11]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X]
 
-(23) Scan parquet
+(23) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/11.txt
@@ -20,18 +20,18 @@ AdaptiveSparkPlan (60)
                                                 :- ^ ProjectExecTransformer (11)
                                                 :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                 :     :- ^ FilterExecTransformer (2)
-                                                :     :  +- ^ Scan parquet (1)
+                                                :     :  +- ^ ScanTransformer parquet  (1)
                                                 :     +- ^ InputIteratorTransformer (9)
                                                 :        +- BroadcastQueryStage (7), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (6)
                                                 :              +- ^ FilterExecTransformer (4)
-                                                :                 +- ^ Scan parquet (3)
+                                                :                 +- ^ ScanTransformer parquet  (3)
                                                 +- ^ InputIteratorTransformer (19)
                                                    +- BroadcastQueryStage (17), Statistics(X)
                                                       +- ColumnarBroadcastExchange (16)
                                                          +- ^ ProjectExecTransformer (14)
                                                             +- ^ FilterExecTransformer (13)
-                                                               +- ^ Scan parquet (12)
+                                                               +- ^ ScanTransformer parquet  (12)
 +- == Initial Plan ==
    Sort (59)
    +- Exchange (58)
@@ -54,7 +54,7 @@ AdaptiveSparkPlan (60)
                                  +- Scan parquet (48)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -65,7 +65,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int,ps_supply
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Arguments: isnotnull(ps_suppkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -104,7 +104,7 @@ Join condition: None
 Output [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 Input [6]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X, s_suppkey#X, s_nationkey#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -341,7 +341,7 @@ AdaptiveSparkPlan (102)
                               :- ^ ProjectExecTransformer (68)
                               :  +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (67)
                               :     :- ^ FilterExecTransformer (62)
-                              :     :  +- ^ Scan parquet (61)
+                              :     :  +- ^ ScanTransformer parquet  (61)
                               :     +- ^ InputIteratorTransformer (66)
                               :        +- BroadcastQueryStage (64), Statistics(X)
                               :           +- ReusedExchange (63)
@@ -367,7 +367,7 @@ AdaptiveSparkPlan (102)
                         +- Scan parquet (93)
 
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/12.txt
@@ -20,10 +20,10 @@ AdaptiveSparkPlan (44)
                                              :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     +- ColumnarBroadcastExchange (4)
                                              :        +- ^ FilterExecTransformer (2)
-                                             :           +- ^ Scan parquet (1)
+                                             :           +- ^ ScanTransformer parquet  (1)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (43)
    +- Exchange (42)
@@ -40,7 +40,7 @@ AdaptiveSparkPlan (44)
                            +- Scan parquet (34)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -69,7 +69,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (7) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/13.txt
@@ -24,13 +24,13 @@ AdaptiveSparkPlan (55)
                                                             +- ^ FlushableHashAggregateExecTransformer (12)
                                                                +- ^ ProjectExecTransformer (11)
                                                                   +- ^ BroadcastHashJoinExecTransformer LeftOuter BuildRight (10)
-                                                                     :- ^ Scan parquet (1)
+                                                                     :- ^ ScanTransformer parquet  (1)
                                                                      +- ^ InputIteratorTransformer (9)
                                                                         +- BroadcastQueryStage (7), Statistics(X)
                                                                            +- ColumnarBroadcastExchange (6)
                                                                               +- ^ ProjectExecTransformer (4)
                                                                                  +- ^ FilterExecTransformer (3)
-                                                                                    +- ^ Scan parquet (2)
+                                                                                    +- ^ ScanTransformer parquet  (2)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,13 +49,13 @@ AdaptiveSparkPlan (55)
                                        +- Scan parquet (41)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
 ReadSchema: struct<c_custkey:bigint>
 
-(2) Scan parquet
+(2) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/14.txt
@@ -13,12 +13,12 @@ AdaptiveSparkPlan (35)
                            +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                               :- ^ ProjectExecTransformer (3)
                               :  +- ^ FilterExecTransformer (2)
-                              :     +- ^ Scan parquet (1)
+                              :     +- ^ ScanTransformer parquet  (1)
                               +- ^ InputIteratorTransformer (10)
                                  +- BroadcastQueryStage (8), Statistics(X)
                                     +- ColumnarBroadcastExchange (7)
                                        +- ^ FilterExecTransformer (5)
-                                          +- ^ Scan parquet (4)
+                                          +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (34)
    +- Exchange (33)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (35)
                      +- Scan parquet (27)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -48,7 +48,7 @@ Arguments: (((isnotnull(l_shipdate#X) AND (l_shipdate#X >= 1995-09-01)) AND (l_s
 Output [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 Input [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/15.txt
@@ -12,7 +12,7 @@ AdaptiveSparkPlan (43)
                      :  +- BroadcastQueryStage (5), Statistics(X)
                      :     +- ColumnarBroadcastExchange (4)
                      :        +- ^ FilterExecTransformer (2)
-                     :           +- ^ Scan parquet (1)
+                     :           +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (20)
                         +- ^ RegularHashAggregateExecTransformer (19)
                            +- ^ InputIteratorTransformer (18)
@@ -23,7 +23,7 @@ AdaptiveSparkPlan (43)
                                           +- ^ FlushableHashAggregateExecTransformer (11)
                                              +- ^ ProjectExecTransformer (10)
                                                 +- ^ FilterExecTransformer (9)
-                                                   +- ^ Scan parquet (8)
+                                                   +- ^ ScanTransformer parquet  (8)
 +- == Initial Plan ==
    Sort (42)
    +- Exchange (41)
@@ -41,7 +41,7 @@ AdaptiveSparkPlan (43)
                               +- Scan parquet (32)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -70,7 +70,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (7) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -254,7 +254,7 @@ AdaptiveSparkPlan (69)
                               +- ^ FlushableHashAggregateExecTransformer (47)
                                  +- ^ ProjectExecTransformer (46)
                                     +- ^ FilterExecTransformer (45)
-                                       +- ^ Scan parquet (44)
+                                       +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    HashAggregate (68)
    +- HashAggregate (67)
@@ -266,7 +266,7 @@ AdaptiveSparkPlan (69)
                      +- Scan parquet (61)
 
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/16.txt
@@ -24,12 +24,12 @@ AdaptiveSparkPlan (59)
                                                             +- ^ ProjectExecTransformer (11)
                                                                +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (10)
                                                                   :- ^ FilterExecTransformer (2)
-                                                                  :  +- ^ Scan parquet (1)
+                                                                  :  +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (9)
                                                                      +- BroadcastQueryStage (7), Statistics(X)
                                                                         +- ColumnarBroadcastExchange (6)
                                                                            +- ^ FilterExecTransformer (4)
-                                                                              +- ^ Scan parquet (3)
+                                                                              +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (58)
    +- Exchange (57)
@@ -53,7 +53,7 @@ AdaptiveSparkPlan (59)
                                     +- Scan parquet (46)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -64,7 +64,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint>
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 Arguments: isnotnull(ps_partkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/18.txt
@@ -18,10 +18,10 @@ AdaptiveSparkPlan (88)
                                  :     :  +- BroadcastQueryStage (5), Statistics(X)
                                  :     :     +- ColumnarBroadcastExchange (4)
                                  :     :        +- ^ FilterExecTransformer (2)
-                                 :     :           +- ^ Scan parquet (1)
+                                 :     :           +- ^ ScanTransformer parquet  (1)
                                  :     +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (27)
                                  :        :- ^ FilterExecTransformer (9)
-                                 :        :  +- ^ Scan parquet (8)
+                                 :        :  +- ^ ScanTransformer parquet  (8)
                                  :        +- ^ InputIteratorTransformer (26)
                                  :           +- BroadcastQueryStage (24), Statistics(X)
                                  :              +- ColumnarBroadcastExchange (23)
@@ -34,13 +34,13 @@ AdaptiveSparkPlan (88)
                                  :                                   +- VeloxResizeBatches (14)
                                  :                                      +- ^ ProjectExecTransformer (12)
                                  :                                         +- ^ FlushableHashAggregateExecTransformer (11)
-                                 :                                            +- ^ Scan parquet (10)
+                                 :                                            +- ^ ScanTransformer parquet  (10)
                                  +- ^ InputIteratorTransformer (41)
                                     +- BroadcastQueryStage (39), Statistics(X)
                                        +- ColumnarBroadcastExchange (38)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (36)
                                              :- ^ FilterExecTransformer (31)
-                                             :  +- ^ Scan parquet (30)
+                                             :  +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (35)
                                                 +- BroadcastQueryStage (33), Statistics(X)
                                                    +- ReusedExchange (32)
@@ -79,7 +79,7 @@ AdaptiveSparkPlan (88)
                                           +- Scan parquet (73)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -108,7 +108,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ ReadSchema: struct<o_orderkey:bigint,o_custkey:bigint,o_totalprice:decimal(12,2)
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Arguments: (isnotnull(o_custkey#X) AND isnotnull(o_orderkey#X))
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -207,7 +207,7 @@ Join condition: None
 Output [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 Input [6]: [c_custkey#X, c_name#X, o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/19.txt
@@ -12,12 +12,12 @@ AdaptiveSparkPlan (34)
                         +- ^ BroadcastHashJoinExecTransformer Inner BuildRight (11)
                            :- ^ ProjectExecTransformer (3)
                            :  +- ^ FilterExecTransformer (2)
-                           :     +- ^ Scan parquet (1)
+                           :     +- ^ ScanTransformer parquet  (1)
                            +- ^ InputIteratorTransformer (10)
                               +- BroadcastQueryStage (8), Statistics(X)
                                  +- ColumnarBroadcastExchange (7)
                                     +- ^ FilterExecTransformer (5)
-                                       +- ^ Scan parquet (4)
+                                       +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    HashAggregate (33)
    +- Exchange (32)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (34)
                      +- Scan parquet (26)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ Arguments: ((((isnotnull(l_shipinstruct#X) AND l_shipmode#X IN (AIR,AIR REG)) AN
 Output [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/20.txt
@@ -11,7 +11,7 @@ AdaptiveSparkPlan (98)
                      :- ^ ProjectExecTransformer (46)
                      :  +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (45)
                      :     :- ^ FilterExecTransformer (2)
-                     :     :  +- ^ Scan parquet (1)
+                     :     :  +- ^ ScanTransformer parquet  (1)
                      :     +- ^ InputIteratorTransformer (44)
                      :        +- BroadcastQueryStage (42), Statistics(X)
                      :           +- ColumnarBroadcastExchange (41)
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (98)
                      :                    :     +- ColumnarBroadcastExchange (15)
                      :                    :        +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (13)
                      :                    :           :- ^ FilterExecTransformer (4)
-                     :                    :           :  +- ^ Scan parquet (3)
+                     :                    :           :  +- ^ ScanTransformer parquet  (3)
                      :                    :           +- ^ InputIteratorTransformer (12)
                      :                    :              +- BroadcastQueryStage (10), Statistics(X)
                      :                    :                 +- ColumnarBroadcastExchange (9)
                      :                    :                    +- ^ ProjectExecTransformer (7)
                      :                    :                       +- ^ FilterExecTransformer (6)
-                     :                    :                          +- ^ Scan parquet (5)
+                     :                    :                          +- ^ ScanTransformer parquet  (5)
                      :                    +- ^ FilterExecTransformer (37)
                      :                       +- ^ ProjectExecTransformer (36)
                      :                          +- ^ RegularHashAggregateExecTransformer (35)
@@ -41,7 +41,7 @@ AdaptiveSparkPlan (98)
                      :                                               +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (26)
                      :                                                  :- ^ ProjectExecTransformer (21)
                      :                                                  :  +- ^ FilterExecTransformer (20)
-                     :                                                  :     +- ^ Scan parquet (19)
+                     :                                                  :     +- ^ ScanTransformer parquet  (19)
                      :                                                  +- ^ InputIteratorTransformer (25)
                      :                                                     +- BroadcastQueryStage (23), Statistics(X)
                      :                                                        +- ReusedExchange (22)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (98)
                            +- ColumnarBroadcastExchange (51)
                               +- ^ ProjectExecTransformer (49)
                                  +- ^ FilterExecTransformer (48)
-                                    +- ^ Scan parquet (47)
+                                    +- ^ ScanTransformer parquet  (47)
 +- == Initial Plan ==
    Sort (97)
    +- Exchange (96)
@@ -89,7 +89,7 @@ AdaptiveSparkPlan (98)
                      +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ ReadSchema: struct<s_suppkey:bigint,s_name:string,s_address:string,s_nationkey:b
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Arguments: isnotnull(s_nationkey#X)
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -111,7 +111,7 @@ ReadSchema: struct<ps_partkey:bigint,ps_suppkey:bigint,ps_availqty:int>
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Arguments: ((isnotnull(ps_availqty#X) AND isnotnull(ps_partkey#X)) AND isnotnull(ps_suppkey#X))
 
-(5) Scan parquet
+(5) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -168,7 +168,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -288,7 +288,7 @@ Join condition: None
 Output [3]: [s_name#X, s_address#X, s_nationkey#X]
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/21.txt
@@ -19,34 +19,34 @@ AdaptiveSparkPlan (92)
                               :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                               :     :     :     +- ColumnarBroadcastExchange (4)
                               :     :     :        +- ^ FilterExecTransformer (2)
-                              :     :     :           +- ^ Scan parquet (1)
+                              :     :     :           +- ^ ScanTransformer parquet  (1)
                               :     :     +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (26)
                               :     :        :- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (17)
                               :     :        :  :- ^ ProjectExecTransformer (10)
                               :     :        :  :  +- ^ FilterExecTransformer (9)
-                              :     :        :  :     +- ^ Scan parquet (8)
+                              :     :        :  :     +- ^ ScanTransformer parquet  (8)
                               :     :        :  +- ^ InputIteratorTransformer (16)
                               :     :        :     +- BroadcastQueryStage (14), Statistics(X)
                               :     :        :        +- ColumnarBroadcastExchange (13)
-                              :     :        :           +- ^ Scan parquet (11)
+                              :     :        :           +- ^ ScanTransformer parquet  (11)
                               :     :        +- ^ InputIteratorTransformer (25)
                               :     :           +- BroadcastQueryStage (23), Statistics(X)
                               :     :              +- ColumnarBroadcastExchange (22)
                               :     :                 +- ^ ProjectExecTransformer (20)
                               :     :                    +- ^ FilterExecTransformer (19)
-                              :     :                       +- ^ Scan parquet (18)
+                              :     :                       +- ^ ScanTransformer parquet  (18)
                               :     +- ^ InputIteratorTransformer (36)
                               :        +- BroadcastQueryStage (34), Statistics(X)
                               :           +- ColumnarBroadcastExchange (33)
                               :              +- ^ ProjectExecTransformer (31)
                               :                 +- ^ FilterExecTransformer (30)
-                              :                    +- ^ Scan parquet (29)
+                              :                    +- ^ ScanTransformer parquet  (29)
                               +- ^ InputIteratorTransformer (46)
                                  +- BroadcastQueryStage (44), Statistics(X)
                                     +- ColumnarBroadcastExchange (43)
                                        +- ^ ProjectExecTransformer (41)
                                           +- ^ FilterExecTransformer (40)
-                                             +- ^ Scan parquet (39)
+                                             +- ^ ScanTransformer parquet  (39)
 +- == Initial Plan ==
    TakeOrderedAndProject (91)
    +- HashAggregate (90)
@@ -82,7 +82,7 @@ AdaptiveSparkPlan (92)
                            +- Scan parquet (82)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -111,7 +111,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -126,7 +126,7 @@ Arguments: ((((isnotnull(l_receiptdate#X) AND isnotnull(l_commitdate#X)) AND (l_
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Input [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 
-(11) Scan parquet
+(11) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Right keys [1]: [l_orderkey#X]
 Join type: LeftSemi
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(18) Scan parquet
+(18) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -205,7 +205,7 @@ Join condition: None
 Output [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 Input [5]: [s_suppkey#X, s_name#X, s_nationkey#X, l_orderkey#X, l_suppkey#X]
 
-(29) Scan parquet
+(29) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -248,7 +248,7 @@ Join condition: None
 Output [2]: [s_name#X, s_nationkey#X]
 Input [4]: [s_name#X, s_nationkey#X, l_orderkey#X, o_orderkey#X]
 
-(39) Scan parquet
+(39) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/22.txt
@@ -17,11 +17,11 @@ AdaptiveSparkPlan (40)
                                        +- ^ ProjectExecTransformer (10)
                                           +- ^ BroadcastHashJoinExecTransformer LeftAnti BuildRight (9)
                                              :- ^ FilterExecTransformer (2)
-                                             :  +- ^ Scan parquet (1)
+                                             :  +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (8)
                                                 +- BroadcastQueryStage (6), Statistics(X)
                                                    +- ColumnarBroadcastExchange (5)
-                                                      +- ^ Scan parquet (3)
+                                                      +- ^ ScanTransformer parquet  (3)
 +- == Initial Plan ==
    Sort (39)
    +- Exchange (38)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (40)
                         +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -47,7 +47,7 @@ ReadSchema: struct<c_custkey:bigint,c_phone:string,c_acctbal:decimal(12,2)>
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Arguments: ((isnotnull(c_acctbal#X) AND substring(c_phone#X, 1, 2) IN (13,31,23,29,30,18,17)) AND (cast(c_acctbal#X as decimal(16,6)) > Subquery subquery#X, [id=#X]))
 
-(3) Scan parquet
+(3) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -229,7 +229,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)
@@ -239,7 +239,7 @@ AdaptiveSparkPlan (60)
                +- Scan parquet (54)
 
 
-(41) Scan parquet
+(41) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -346,7 +346,7 @@ AdaptiveSparkPlan (60)
                   +- ^ FlushableHashAggregateExecTransformer (44)
                      +- ^ ProjectExecTransformer (43)
                         +- ^ FilterExecTransformer (42)
-                           +- ^ Scan parquet (41)
+                           +- ^ ScanTransformer parquet  (41)
 +- == Initial Plan ==
    HashAggregate (59)
    +- Exchange (58)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/3.txt
@@ -20,15 +20,15 @@ AdaptiveSparkPlan (54)
                                     :     :     +- ColumnarBroadcastExchange (5)
                                     :     :        +- ^ ProjectExecTransformer (3)
                                     :     :           +- ^ FilterExecTransformer (2)
-                                    :     :              +- ^ Scan parquet (1)
+                                    :     :              +- ^ ScanTransformer parquet  (1)
                                     :     +- ^ FilterExecTransformer (10)
-                                    :        +- ^ Scan parquet (9)
+                                    :        +- ^ ScanTransformer parquet  (9)
                                     +- ^ InputIteratorTransformer (20)
                                        +- BroadcastQueryStage (18), Statistics(X)
                                           +- ColumnarBroadcastExchange (17)
                                              +- ^ ProjectExecTransformer (15)
                                                 +- ^ FilterExecTransformer (14)
-                                                   +- ^ Scan parquet (13)
+                                                   +- ^ ScanTransformer parquet  (13)
 +- == Initial Plan ==
    TakeOrderedAndProject (53)
    +- HashAggregate (52)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (54)
                            +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -104,7 +104,7 @@ Join condition: None
 Output [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 Input [5]: [c_custkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/4.txt
@@ -18,13 +18,13 @@ AdaptiveSparkPlan (46)
                                           +- ^ BroadcastHashJoinExecTransformer LeftSemi BuildRight (12)
                                              :- ^ ProjectExecTransformer (3)
                                              :  +- ^ FilterExecTransformer (2)
-                                             :     +- ^ Scan parquet (1)
+                                             :     +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (11)
                                                 +- BroadcastQueryStage (9), Statistics(X)
                                                    +- ColumnarBroadcastExchange (8)
                                                       +- ^ ProjectExecTransformer (6)
                                                          +- ^ FilterExecTransformer (5)
-                                                            +- ^ Scan parquet (4)
+                                                            +- ^ ScanTransformer parquet  (4)
 +- == Initial Plan ==
    Sort (45)
    +- Exchange (44)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (46)
                               +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -57,7 +57,7 @@ Arguments: ((isnotnull(o_orderdate#X) AND (o_orderdate#X >= 1993-07-01)) AND (o_
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Input [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 
-(4) Scan parquet
+(4) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/5.txt
@@ -28,31 +28,31 @@ AdaptiveSparkPlan (102)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ ProjectExecTransformer (10)
                                              :     :     :     :        +- ^ FilterExecTransformer (9)
-                                             :     :     :     :           +- ^ Scan parquet (8)
+                                             :     :     :     :           +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (47)
                                                 +- BroadcastQueryStage (45), Statistics(X)
                                                    +- ColumnarBroadcastExchange (44)
                                                       +- ^ ProjectExecTransformer (42)
                                                          +- ^ FilterExecTransformer (41)
-                                                            +- ^ Scan parquet (40)
+                                                            +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (101)
    +- Exchange (100)
@@ -90,7 +90,7 @@ AdaptiveSparkPlan (102)
                               +- Scan parquet (91)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -119,7 +119,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -144,7 +144,7 @@ Join condition: None
 Output [2]: [c_nationkey#X, o_orderkey#X]
 Input [4]: [c_custkey#X, c_nationkey#X, o_orderkey#X, o_custkey#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -183,7 +183,7 @@ Join condition: None
 Output [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [c_nationkey#X, o_orderkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -222,7 +222,7 @@ Join condition: None
 Output [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -261,7 +261,7 @@ Join condition: None
 Output [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 Input [6]: [l_extendedprice#X, l_discount#X, s_nationkey#X, n_nationkey#X, n_name#X, n_regionkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/7.txt
@@ -28,24 +28,24 @@ AdaptiveSparkPlan (95)
                                              :     :     :     :     :  +- BroadcastQueryStage (5), Statistics(X)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (4)
                                              :     :     :     :     :        +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :           +- ^ Scan parquet (1)
+                                             :     :     :     :     :           +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (9)
-                                             :     :     :     :        +- ^ Scan parquet (8)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (8)
                                              :     :     :     +- ^ InputIteratorTransformer (18)
                                              :     :     :        +- BroadcastQueryStage (16), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (15)
                                              :     :     :              +- ^ FilterExecTransformer (13)
-                                             :     :     :                 +- ^ Scan parquet (12)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (12)
                                              :     :     +- ^ InputIteratorTransformer (27)
                                              :     :        +- BroadcastQueryStage (25), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (24)
                                              :     :              +- ^ FilterExecTransformer (22)
-                                             :     :                 +- ^ Scan parquet (21)
+                                             :     :                 +- ^ ScanTransformer parquet  (21)
                                              :     +- ^ InputIteratorTransformer (36)
                                              :        +- BroadcastQueryStage (34), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (33)
                                              :              +- ^ FilterExecTransformer (31)
-                                             :                 +- ^ Scan parquet (30)
+                                             :                 +- ^ ScanTransformer parquet  (30)
                                              +- ^ InputIteratorTransformer (42)
                                                 +- BroadcastQueryStage (40), Statistics(X)
                                                    +- ReusedExchange (39)
@@ -84,7 +84,7 @@ AdaptiveSparkPlan (95)
                            +- Scan parquet (85)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -113,7 +113,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (7) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(8) Scan parquet
+(8) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -134,7 +134,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Input [7]: [s_suppkey#X, s_nationkey#X, l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(12) Scan parquet
+(12) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 Input [7]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_orderkey#X, o_custkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -212,7 +212,7 @@ Join condition: None
 Output [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 Input [7]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X, c_custkey#X, c_nationkey#X]
 
-(30) Scan parquet
+(30) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/8.txt
@@ -34,40 +34,40 @@ AdaptiveSparkPlan (131)
                                                 :     :     :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                                 :     :     :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                                 :     :     :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                                :     :     :     :     :     :     :              +- ^ Scan parquet (1)
+                                                :     :     :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                                 :     :     :     :     :     :     +- ^ FilterExecTransformer (10)
-                                                :     :     :     :     :     :        +- ^ Scan parquet (9)
+                                                :     :     :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                                 :     :     :     :     :     +- ^ InputIteratorTransformer (19)
                                                 :     :     :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                                 :     :     :     :     :           +- ColumnarBroadcastExchange (16)
                                                 :     :     :     :     :              +- ^ FilterExecTransformer (14)
-                                                :     :     :     :     :                 +- ^ Scan parquet (13)
+                                                :     :     :     :     :                 +- ^ ScanTransformer parquet  (13)
                                                 :     :     :     :     +- ^ InputIteratorTransformer (28)
                                                 :     :     :     :        +- BroadcastQueryStage (26), Statistics(X)
                                                 :     :     :     :           +- ColumnarBroadcastExchange (25)
                                                 :     :     :     :              +- ^ FilterExecTransformer (23)
-                                                :     :     :     :                 +- ^ Scan parquet (22)
+                                                :     :     :     :                 +- ^ ScanTransformer parquet  (22)
                                                 :     :     :     +- ^ InputIteratorTransformer (37)
                                                 :     :     :        +- BroadcastQueryStage (35), Statistics(X)
                                                 :     :     :           +- ColumnarBroadcastExchange (34)
                                                 :     :     :              +- ^ FilterExecTransformer (32)
-                                                :     :     :                 +- ^ Scan parquet (31)
+                                                :     :     :                 +- ^ ScanTransformer parquet  (31)
                                                 :     :     +- ^ InputIteratorTransformer (46)
                                                 :     :        +- BroadcastQueryStage (44), Statistics(X)
                                                 :     :           +- ColumnarBroadcastExchange (43)
                                                 :     :              +- ^ FilterExecTransformer (41)
-                                                :     :                 +- ^ Scan parquet (40)
+                                                :     :                 +- ^ ScanTransformer parquet  (40)
                                                 :     +- ^ InputIteratorTransformer (55)
                                                 :        +- BroadcastQueryStage (53), Statistics(X)
                                                 :           +- ColumnarBroadcastExchange (52)
                                                 :              +- ^ FilterExecTransformer (50)
-                                                :                 +- ^ Scan parquet (49)
+                                                :                 +- ^ ScanTransformer parquet  (49)
                                                 +- ^ InputIteratorTransformer (65)
                                                    +- BroadcastQueryStage (63), Statistics(X)
                                                       +- ColumnarBroadcastExchange (62)
                                                          +- ^ ProjectExecTransformer (60)
                                                             +- ^ FilterExecTransformer (59)
-                                                               +- ^ Scan parquet (58)
+                                                               +- ^ ScanTransformer parquet  (58)
 +- == Initial Plan ==
    Sort (130)
    +- Exchange (129)
@@ -115,7 +115,7 @@ AdaptiveSparkPlan (131)
                               +- Scan parquet (120)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -148,7 +148,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -169,7 +169,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Input [6]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -208,7 +208,7 @@ Join condition: None
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [6]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -247,7 +247,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 Input [7]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderkey#X, o_custkey#X, o_orderdate#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -286,7 +286,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X, c_custkey#X, c_nationkey#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -325,7 +325,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X, n_nationkey#X, n_regionkey#X]
 
-(49) Scan parquet
+(49) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -364,7 +364,7 @@ Join condition: None
 Output [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 Input [7]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X, n_nationkey#X, n_name#X]
 
-(58) Scan parquet
+(58) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/9.txt
@@ -29,29 +29,29 @@ AdaptiveSparkPlan (100)
                                              :     :     :     :     :     +- ColumnarBroadcastExchange (5)
                                              :     :     :     :     :        +- ^ ProjectExecTransformer (3)
                                              :     :     :     :     :           +- ^ FilterExecTransformer (2)
-                                             :     :     :     :     :              +- ^ Scan parquet (1)
+                                             :     :     :     :     :              +- ^ ScanTransformer parquet  (1)
                                              :     :     :     :     +- ^ FilterExecTransformer (10)
-                                             :     :     :     :        +- ^ Scan parquet (9)
+                                             :     :     :     :        +- ^ ScanTransformer parquet  (9)
                                              :     :     :     +- ^ InputIteratorTransformer (19)
                                              :     :     :        +- BroadcastQueryStage (17), Statistics(X)
                                              :     :     :           +- ColumnarBroadcastExchange (16)
                                              :     :     :              +- ^ FilterExecTransformer (14)
-                                             :     :     :                 +- ^ Scan parquet (13)
+                                             :     :     :                 +- ^ ScanTransformer parquet  (13)
                                              :     :     +- ^ InputIteratorTransformer (28)
                                              :     :        +- BroadcastQueryStage (26), Statistics(X)
                                              :     :           +- ColumnarBroadcastExchange (25)
                                              :     :              +- ^ FilterExecTransformer (23)
-                                             :     :                 +- ^ Scan parquet (22)
+                                             :     :                 +- ^ ScanTransformer parquet  (22)
                                              :     +- ^ InputIteratorTransformer (37)
                                              :        +- BroadcastQueryStage (35), Statistics(X)
                                              :           +- ColumnarBroadcastExchange (34)
                                              :              +- ^ FilterExecTransformer (32)
-                                             :                 +- ^ Scan parquet (31)
+                                             :                 +- ^ ScanTransformer parquet  (31)
                                              +- ^ InputIteratorTransformer (46)
                                                 +- BroadcastQueryStage (44), Statistics(X)
                                                    +- ColumnarBroadcastExchange (43)
                                                       +- ^ FilterExecTransformer (41)
-                                                         +- ^ Scan parquet (40)
+                                                         +- ^ ScanTransformer parquet  (40)
 +- == Initial Plan ==
    Sort (99)
    +- Exchange (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -121,7 +121,7 @@ Input [1]: [p_partkey#X]
 (8) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -142,7 +142,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Input [7]: [p_partkey#X, l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(13) Scan parquet
+(13) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -181,7 +181,7 @@ Join condition: None
 Output [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 Input [8]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_suppkey#X, s_nationkey#X]
 
-(22) Scan parquet
+(22) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -220,7 +220,7 @@ Join condition: None
 Output [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 Input [10]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 
-(31) Scan parquet
+(31) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -259,7 +259,7 @@ Join condition: None
 Output [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 Input [8]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderkey#X, o_orderdate#X]
 
-(40) Scan parquet
+(40) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/10.txt
@@ -31,28 +31,28 @@ AdaptiveSparkPlan (100)
                                     :                 :                 :        +- VeloxResizeBatches (5)
                                     :                 :                 :           +- ^ ProjectExecTransformer (3)
                                     :                 :                 :              +- ^ FilterExecTransformer (2)
-                                    :                 :                 :                 +- ^ Scan parquet (1)
+                                    :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                     :                 :                 +- ^ InputIteratorTransformer (18)
                                     :                 :                    +- ShuffleQueryStage (16)
                                     :                 :                       +- ColumnarExchange (15)
                                     :                 :                          +- VeloxResizeBatches (14)
                                     :                 :                             +- ^ ProjectExecTransformer (12)
                                     :                 :                                +- ^ FilterExecTransformer (11)
-                                    :                 :                                   +- ^ Scan parquet (10)
+                                    :                 :                                   +- ^ ScanTransformer parquet  (10)
                                     :                 +- ^ InputIteratorTransformer (35)
                                     :                    +- ShuffleQueryStage (33)
                                     :                       +- ColumnarExchange (32)
                                     :                          +- VeloxResizeBatches (31)
                                     :                             +- ^ ProjectExecTransformer (29)
                                     :                                +- ^ FilterExecTransformer (28)
-                                    :                                   +- ^ Scan parquet (27)
+                                    :                                   +- ^ ScanTransformer parquet  (27)
                                     +- ^ InputIteratorTransformer (52)
                                        +- ShuffleQueryStage (50)
                                           +- ColumnarExchange (49)
                                              +- VeloxResizeBatches (48)
                                                 +- ^ ProjectExecTransformer (46)
                                                    +- ^ FilterExecTransformer (45)
-                                                      +- ^ Scan parquet (44)
+                                                      +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    TakeOrderedAndProject (99)
    +- HashAggregate (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -125,7 +125,7 @@ Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (9) InputIteratorTransformer
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (26) InputIteratorTransformer
 Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -261,7 +261,7 @@ Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (43) InputIteratorTransformer
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/11.txt
@@ -29,21 +29,21 @@ AdaptiveSparkPlan (82)
                                                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                    +- ShuffleQueryStage (16)
                                                 :                       +- ColumnarExchange (15)
                                                 :                          +- VeloxResizeBatches (14)
                                                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                                +- ^ FilterExecTransformer (11)
-                                                :                                   +- ^ Scan parquet (10)
+                                                :                                   +- ^ ScanTransformer parquet  (10)
                                                 +- ^ InputIteratorTransformer (35)
                                                    +- ShuffleQueryStage (33)
                                                       +- ColumnarExchange (32)
                                                          +- VeloxResizeBatches (31)
                                                             +- ^ ProjectExecTransformer (29)
                                                                +- ^ FilterExecTransformer (28)
-                                                                  +- ^ Scan parquet (27)
+                                                                  +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    Sort (81)
    +- Exchange (80)
@@ -72,7 +72,7 @@ AdaptiveSparkPlan (82)
                                     +- Scan parquet (69)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -109,7 +109,7 @@ Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 (9) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -177,7 +177,7 @@ Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 (26) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/12.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (55)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,7 +49,7 @@ AdaptiveSparkPlan (55)
                                  +- Scan parquet (43)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -86,7 +86,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/13.txt
@@ -24,14 +24,14 @@ AdaptiveSparkPlan (58)
                                                       :     +- ColumnarExchange (5)
                                                       :        +- VeloxResizeBatches (4)
                                                       :           +- ^ ProjectExecTransformer (2)
-                                                      :              +- ^ Scan parquet (1)
+                                                      :              +- ^ ScanTransformer parquet  (1)
                                                       +- ^ InputIteratorTransformer (17)
                                                          +- ShuffleQueryStage (15)
                                                             +- ColumnarExchange (14)
                                                                +- VeloxResizeBatches (13)
                                                                   +- ^ ProjectExecTransformer (11)
                                                                      +- ^ FilterExecTransformer (10)
-                                                                        +- ^ Scan parquet (9)
+                                                                        +- ^ ScanTransformer parquet  (9)
 +- == Initial Plan ==
    Sort (57)
    +- Exchange (56)
@@ -52,7 +52,7 @@ AdaptiveSparkPlan (58)
                                        +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -84,7 +84,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/14.txt
@@ -13,14 +13,14 @@ AdaptiveSparkPlan (39)
                   :        +- VeloxResizeBatches (5)
                   :           +- ^ ProjectExecTransformer (3)
                   :              +- ^ FilterExecTransformer (2)
-                  :                 +- ^ Scan parquet (1)
+                  :                 +- ^ ScanTransformer parquet  (1)
                   +- ^ InputIteratorTransformer (18)
                      +- ShuffleQueryStage (16)
                         +- ColumnarExchange (15)
                            +- VeloxResizeBatches (14)
                               +- ^ ProjectExecTransformer (12)
                                  +- ^ FilterExecTransformer (11)
-                                    +- ^ Scan parquet (10)
+                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (38)
    +- HashAggregate (37)
@@ -37,7 +37,7 @@ AdaptiveSparkPlan (39)
                      +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -74,7 +74,7 @@ Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/15.txt
@@ -15,7 +15,7 @@ AdaptiveSparkPlan (50)
                         :        +- VeloxResizeBatches (5)
                         :           +- ^ ProjectExecTransformer (3)
                         :              +- ^ FilterExecTransformer (2)
-                        :                 +- ^ Scan parquet (1)
+                        :                 +- ^ ScanTransformer parquet  (1)
                         +- ^ FilterExecTransformer (22)
                            +- ^ RegularHashAggregateExecTransformer (21)
                               +- ^ InputIteratorTransformer (20)
@@ -26,7 +26,7 @@ AdaptiveSparkPlan (50)
                                              +- ^ FlushableHashAggregateExecTransformer (13)
                                                 +- ^ ProjectExecTransformer (12)
                                                    +- ^ FilterExecTransformer (11)
-                                                      +- ^ Scan parquet (10)
+                                                      +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (49)
    +- Exchange (48)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (50)
                                  +- Scan parquet (38)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/16.txt
@@ -29,14 +29,14 @@ AdaptiveSparkPlan (71)
                                                                   :        +- VeloxResizeBatches (5)
                                                                   :           +- ^ ProjectExecTransformer (3)
                                                                   :              +- ^ FilterExecTransformer (2)
-                                                                  :                 +- ^ Scan parquet (1)
+                                                                  :                 +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (18)
                                                                      +- ShuffleQueryStage (16)
                                                                         +- ColumnarExchange (15)
                                                                            +- VeloxResizeBatches (14)
                                                                               +- ^ ProjectExecTransformer (12)
                                                                                  +- ^ FilterExecTransformer (11)
-                                                                                    +- ^ Scan parquet (10)
+                                                                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (70)
    +- Exchange (69)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (71)
                                        +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ Input [2]: [ps_partkey#X, ps_suppkey#X]
 (9) InputIteratorTransformer
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/17.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/17.txt
@@ -15,14 +15,14 @@ AdaptiveSparkPlan (63)
                   :     :        +- VeloxResizeBatches (5)
                   :     :           +- ^ ProjectExecTransformer (3)
                   :     :              +- ^ FilterExecTransformer (2)
-                  :     :                 +- ^ Scan parquet (1)
+                  :     :                 +- ^ ScanTransformer parquet  (1)
                   :     +- ^ InputIteratorTransformer (18)
                   :        +- ShuffleQueryStage (16)
                   :           +- ColumnarExchange (15)
                   :              +- VeloxResizeBatches (14)
                   :                 +- ^ ProjectExecTransformer (12)
                   :                    +- ^ FilterExecTransformer (11)
-                  :                       +- ^ Scan parquet (10)
+                  :                       +- ^ ScanTransformer parquet  (10)
                   +- ^ FilterExecTransformer (33)
                      +- ^ ProjectExecTransformer (32)
                         +- ^ RegularHashAggregateExecTransformer (31)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (63)
                                        +- ^ ProjectExecTransformer (24)
                                           +- ^ FlushableHashAggregateExecTransformer (23)
                                              +- ^ FilterExecTransformer (22)
-                                                +- ^ Scan parquet (21)
+                                                +- ^ ScanTransformer parquet  (21)
 +- == Initial Plan ==
    HashAggregate (62)
    +- HashAggregate (61)
@@ -59,7 +59,7 @@ AdaptiveSparkPlan (63)
                               +- Scan parquet (52)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -96,7 +96,7 @@ Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [p_partkey#X, p_brand#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -142,7 +142,7 @@ Join condition: None
 Output [3]: [l_quantity#X, l_extendedprice#X, p_partkey#X]
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, p_partkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [l_partkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/18.txt
@@ -19,7 +19,7 @@ AdaptiveSparkPlan (110)
                   :                 :        +- VeloxResizeBatches (5)
                   :                 :           +- ^ ProjectExecTransformer (3)
                   :                 :              +- ^ FilterExecTransformer (2)
-                  :                 :                 +- ^ Scan parquet (1)
+                  :                 :                 +- ^ ScanTransformer parquet  (1)
                   :                 +- ^ InputIteratorTransformer (38)
                   :                    +- ShuffleQueryStage (36)
                   :                       +- ColumnarExchange (35)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (110)
                   :                                   :        +- VeloxResizeBatches (14)
                   :                                   :           +- ^ ProjectExecTransformer (12)
                   :                                   :              +- ^ FilterExecTransformer (11)
-                  :                                   :                 +- ^ Scan parquet (10)
+                  :                                   :                 +- ^ ScanTransformer parquet  (10)
                   :                                   +- ^ ProjectExecTransformer (30)
                   :                                      +- ^ FilterExecTransformer (29)
                   :                                         +- ^ RegularHashAggregateExecTransformer (28)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (110)
                   :                                                     +- VeloxResizeBatches (23)
                   :                                                        +- ^ ProjectExecTransformer (21)
                   :                                                           +- ^ FlushableHashAggregateExecTransformer (20)
-                  :                                                              +- ^ Scan parquet (19)
+                  :                                                              +- ^ ScanTransformer parquet  (19)
                   +- ^ ShuffledHashJoinExecTransformer LeftSemi BuildRight (63)
                      :- ^ InputIteratorTransformer (55)
                      :  +- ShuffleQueryStage (53)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (110)
                      :        +- VeloxResizeBatches (51)
                      :           +- ^ ProjectExecTransformer (49)
                      :              +- ^ FilterExecTransformer (48)
-                     :                 +- ^ Scan parquet (47)
+                     :                 +- ^ ScanTransformer parquet  (47)
                      +- ^ ProjectExecTransformer (62)
                         +- ^ FilterExecTransformer (61)
                            +- ^ RegularHashAggregateExecTransformer (60)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (110)
                                     +- Scan parquet (97)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -136,7 +136,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 (18) InputIteratorTransformer
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -289,7 +289,7 @@ Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 (46) InputIteratorTransformer
 Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/19.txt
@@ -12,14 +12,14 @@ AdaptiveSparkPlan (38)
                :        +- VeloxResizeBatches (5)
                :           +- ^ ProjectExecTransformer (3)
                :              +- ^ FilterExecTransformer (2)
-               :                 +- ^ Scan parquet (1)
+               :                 +- ^ ScanTransformer parquet  (1)
                +- ^ InputIteratorTransformer (18)
                   +- ShuffleQueryStage (16)
                      +- ColumnarExchange (15)
                         +- VeloxResizeBatches (14)
                            +- ^ ProjectExecTransformer (12)
                               +- ^ FilterExecTransformer (11)
-                                 +- ^ Scan parquet (10)
+                                 +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (37)
    +- HashAggregate (36)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (38)
                      +- Scan parquet (30)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/20.txt
@@ -21,7 +21,7 @@ AdaptiveSparkPlan (146)
                         :                 :        +- VeloxResizeBatches (5)
                         :                 :           +- ^ ProjectExecTransformer (3)
                         :                 :              +- ^ FilterExecTransformer (2)
-                        :                 :                 +- ^ Scan parquet (1)
+                        :                 :                 +- ^ ScanTransformer parquet  (1)
                         :                 +- ^ InputIteratorTransformer (68)
                         :                    +- ShuffleQueryStage (66)
                         :                       +- ColumnarExchange (65)
@@ -40,14 +40,14 @@ AdaptiveSparkPlan (146)
                         :                                   :                 :        +- VeloxResizeBatches (14)
                         :                                   :                 :           +- ^ ProjectExecTransformer (12)
                         :                                   :                 :              +- ^ FilterExecTransformer (11)
-                        :                                   :                 :                 +- ^ Scan parquet (10)
+                        :                                   :                 :                 +- ^ ScanTransformer parquet  (10)
                         :                                   :                 +- ^ InputIteratorTransformer (27)
                         :                                   :                    +- ShuffleQueryStage (25)
                         :                                   :                       +- ColumnarExchange (24)
                         :                                   :                          +- VeloxResizeBatches (23)
                         :                                   :                             +- ^ ProjectExecTransformer (21)
                         :                                   :                                +- ^ FilterExecTransformer (20)
-                        :                                   :                                   +- ^ Scan parquet (19)
+                        :                                   :                                   +- ^ ScanTransformer parquet  (19)
                         :                                   +- ^ InputIteratorTransformer (60)
                         :                                      +- ShuffleQueryStage (58)
                         :                                         +- ColumnarExchange (57)
@@ -64,7 +64,7 @@ AdaptiveSparkPlan (146)
                         :                                                                 :        +- VeloxResizeBatches (40)
                         :                                                                 :           +- ^ ProjectExecTransformer (38)
                         :                                                                 :              +- ^ FilterExecTransformer (37)
-                        :                                                                 :                 +- ^ Scan parquet (36)
+                        :                                                                 :                 +- ^ ScanTransformer parquet  (36)
                         :                                                                 +- ^ InputIteratorTransformer (48)
                         :                                                                    +- ShuffleQueryStage (46)
                         :                                                                       +- ReusedExchange (45)
@@ -74,7 +74,7 @@ AdaptiveSparkPlan (146)
                                  +- VeloxResizeBatches (81)
                                     +- ^ ProjectExecTransformer (79)
                                        +- ^ FilterExecTransformer (78)
-                                          +- ^ Scan parquet (77)
+                                          +- ^ ScanTransformer parquet  (77)
 +- == Initial Plan ==
    Sort (145)
    +- Exchange (144)
@@ -127,7 +127,7 @@ AdaptiveSparkPlan (146)
                         +- Scan parquet (137)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -164,7 +164,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -201,7 +201,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -269,7 +269,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (35) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(36) Scan parquet
+(36) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -434,7 +434,7 @@ Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 (76) InputIteratorTransformer
 Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 
-(77) Scan parquet
+(77) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/21.txt
@@ -30,7 +30,7 @@ AdaptiveSparkPlan (138)
                                  :                 :                 :        +- VeloxResizeBatches (5)
                                  :                 :                 :           +- ^ ProjectExecTransformer (3)
                                  :                 :                 :              +- ^ FilterExecTransformer (2)
-                                 :                 :                 :                 +- ^ Scan parquet (1)
+                                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                  :                 :                 +- ^ InputIteratorTransformer (44)
                                  :                 :                    +- ShuffleQueryStage (42)
                                  :                 :                       +- ColumnarExchange (41)
@@ -44,34 +44,34 @@ AdaptiveSparkPlan (138)
                                  :                 :                                   :  :        +- VeloxResizeBatches (14)
                                  :                 :                                   :  :           +- ^ ProjectExecTransformer (12)
                                  :                 :                                   :  :              +- ^ FilterExecTransformer (11)
-                                 :                 :                                   :  :                 +- ^ Scan parquet (10)
+                                 :                 :                                   :  :                 +- ^ ScanTransformer parquet  (10)
                                  :                 :                                   :  +- ^ InputIteratorTransformer (26)
                                  :                 :                                   :     +- ShuffleQueryStage (24)
                                  :                 :                                   :        +- ColumnarExchange (23)
                                  :                 :                                   :           +- VeloxResizeBatches (22)
                                  :                 :                                   :              +- ^ ProjectExecTransformer (20)
-                                 :                 :                                   :                 +- ^ Scan parquet (19)
+                                 :                 :                                   :                 +- ^ ScanTransformer parquet  (19)
                                  :                 :                                   +- ^ InputIteratorTransformer (36)
                                  :                 :                                      +- ShuffleQueryStage (34)
                                  :                 :                                         +- ColumnarExchange (33)
                                  :                 :                                            +- VeloxResizeBatches (32)
                                  :                 :                                               +- ^ ProjectExecTransformer (30)
                                  :                 :                                                  +- ^ FilterExecTransformer (29)
-                                 :                 :                                                     +- ^ Scan parquet (28)
+                                 :                 :                                                     +- ^ ScanTransformer parquet  (28)
                                  :                 +- ^ InputIteratorTransformer (61)
                                  :                    +- ShuffleQueryStage (59)
                                  :                       +- ColumnarExchange (58)
                                  :                          +- VeloxResizeBatches (57)
                                  :                             +- ^ ProjectExecTransformer (55)
                                  :                                +- ^ FilterExecTransformer (54)
-                                 :                                   +- ^ Scan parquet (53)
+                                 :                                   +- ^ ScanTransformer parquet  (53)
                                  +- ^ InputIteratorTransformer (78)
                                     +- ShuffleQueryStage (76)
                                        +- ColumnarExchange (75)
                                           +- VeloxResizeBatches (74)
                                              +- ^ ProjectExecTransformer (72)
                                                 +- ^ FilterExecTransformer (71)
-                                                   +- ^ Scan parquet (70)
+                                                   +- ^ ScanTransformer parquet  (70)
 +- == Initial Plan ==
    TakeOrderedAndProject (137)
    +- HashAggregate (136)
@@ -120,7 +120,7 @@ AdaptiveSparkPlan (138)
                               +- Scan parquet (127)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -157,7 +157,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -194,7 +194,7 @@ Input [2]: [l_orderkey#X, l_suppkey#X]
 (18) InputIteratorTransformer
 Input [2]: [l_orderkey#X, l_suppkey#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -231,7 +231,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(28) Scan parquet
+(28) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -330,7 +330,7 @@ Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 (52) InputIteratorTransformer
 Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -398,7 +398,7 @@ Input [2]: [s_name#X, s_nationkey#X]
 (69) InputIteratorTransformer
 Input [2]: [s_name#X, s_nationkey#X]
 
-(70) Scan parquet
+(70) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/22.txt
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (52)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (17)
                                                 +- ShuffleQueryStage (15)
                                                    +- ColumnarExchange (14)
                                                       +- VeloxResizeBatches (13)
                                                          +- ^ ProjectExecTransformer (11)
-                                                            +- ^ Scan parquet (10)
+                                                            +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (51)
    +- Exchange (50)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (52)
                            +- Scan parquet (42)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 (9) InputIteratorTransformer
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/3.txt
@@ -20,21 +20,21 @@ AdaptiveSparkPlan (67)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (18)
                      :                    +- ShuffleQueryStage (16)
                      :                       +- ColumnarExchange (15)
                      :                          +- VeloxResizeBatches (14)
                      :                             +- ^ ProjectExecTransformer (12)
                      :                                +- ^ FilterExecTransformer (11)
-                     :                                   +- ^ Scan parquet (10)
+                     :                                   +- ^ ScanTransformer parquet  (10)
                      +- ^ InputIteratorTransformer (35)
                         +- ShuffleQueryStage (33)
                            +- ColumnarExchange (32)
                               +- VeloxResizeBatches (31)
                                  +- ^ ProjectExecTransformer (29)
                                     +- ^ FilterExecTransformer (28)
-                                       +- ^ Scan parquet (27)
+                                       +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    TakeOrderedAndProject (66)
    +- HashAggregate (65)
@@ -61,7 +61,7 @@ AdaptiveSparkPlan (67)
                            +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -98,7 +98,7 @@ Input [1]: [c_custkey#X]
 (9) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -166,7 +166,7 @@ Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 (26) InputIteratorTransformer
 Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/4.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (56)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (55)
    +- Exchange (54)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (56)
                                  +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -87,7 +87,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/5.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (156)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (155)
    +- Exchange (154)
@@ -134,7 +134,7 @@ AdaptiveSparkPlan (156)
                                  +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -239,7 +239,7 @@ Input [2]: [c_nationkey#X, o_orderkey#X]
 (26) InputIteratorTransformer
 Input [2]: [c_nationkey#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -307,7 +307,7 @@ Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (43) InputIteratorTransformer
 Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -375,7 +375,7 @@ Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 (60) InputIteratorTransformer
 Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -443,7 +443,7 @@ Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 (77) InputIteratorTransformer
 Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/7.txt
@@ -46,35 +46,35 @@ AdaptiveSparkPlan (149)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (81)
                                                 +- ShuffleQueryStage (79)
                                                    +- ReusedExchange (78)
@@ -128,7 +128,7 @@ AdaptiveSparkPlan (149)
                               +- Scan parquet (138)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -165,7 +165,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -233,7 +233,7 @@ Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_ship
 (26) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -301,7 +301,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_cust
 (43) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -369,7 +369,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nati
 (60) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/8.txt
@@ -59,56 +59,56 @@ AdaptiveSparkPlan (207)
                                                 :                 :                 :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :                 :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :                 :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                                 :                 :                 :                 :                 :                 :                       +- ColumnarExchange (15)
                                                 :                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                                 :                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                                :                 :                 :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                                :                 :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (33)
                                                 :                 :                 :                 :                 :                       +- ColumnarExchange (32)
                                                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (31)
                                                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                                :                 :                 :                 :                 :                                   +- ^ Scan parquet (27)
+                                                :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (52)
                                                 :                 :                 :                 :                    +- ShuffleQueryStage (50)
                                                 :                 :                 :                 :                       +- ColumnarExchange (49)
                                                 :                 :                 :                 :                          +- VeloxResizeBatches (48)
                                                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (46)
                                                 :                 :                 :                 :                                +- ^ FilterExecTransformer (45)
-                                                :                 :                 :                 :                                   +- ^ Scan parquet (44)
+                                                :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (44)
                                                 :                 :                 :                 +- ^ InputIteratorTransformer (69)
                                                 :                 :                 :                    +- ShuffleQueryStage (67)
                                                 :                 :                 :                       +- ColumnarExchange (66)
                                                 :                 :                 :                          +- VeloxResizeBatches (65)
                                                 :                 :                 :                             +- ^ ProjectExecTransformer (63)
                                                 :                 :                 :                                +- ^ FilterExecTransformer (62)
-                                                :                 :                 :                                   +- ^ Scan parquet (61)
+                                                :                 :                 :                                   +- ^ ScanTransformer parquet  (61)
                                                 :                 :                 +- ^ InputIteratorTransformer (86)
                                                 :                 :                    +- ShuffleQueryStage (84)
                                                 :                 :                       +- ColumnarExchange (83)
                                                 :                 :                          +- VeloxResizeBatches (82)
                                                 :                 :                             +- ^ ProjectExecTransformer (80)
                                                 :                 :                                +- ^ FilterExecTransformer (79)
-                                                :                 :                                   +- ^ Scan parquet (78)
+                                                :                 :                                   +- ^ ScanTransformer parquet  (78)
                                                 :                 +- ^ InputIteratorTransformer (103)
                                                 :                    +- ShuffleQueryStage (101)
                                                 :                       +- ColumnarExchange (100)
                                                 :                          +- VeloxResizeBatches (99)
                                                 :                             +- ^ ProjectExecTransformer (97)
                                                 :                                +- ^ FilterExecTransformer (96)
-                                                :                                   +- ^ Scan parquet (95)
+                                                :                                   +- ^ ScanTransformer parquet  (95)
                                                 +- ^ InputIteratorTransformer (120)
                                                    +- ShuffleQueryStage (118)
                                                       +- ColumnarExchange (117)
                                                          +- VeloxResizeBatches (116)
                                                             +- ^ ProjectExecTransformer (114)
                                                                +- ^ FilterExecTransformer (113)
-                                                                  +- ^ Scan parquet (112)
+                                                                  +- ^ ScanTransformer parquet  (112)
 +- == Initial Plan ==
    Sort (206)
    +- Exchange (205)
@@ -177,7 +177,7 @@ AdaptiveSparkPlan (207)
                                  +- Scan parquet (195)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -214,7 +214,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (26) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -350,7 +350,7 @@ Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 (43) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -418,7 +418,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_order
 (60) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -486,7 +486,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nat
 (77) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -554,7 +554,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_reg
 (94) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 
-(95) Scan parquet
+(95) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -622,7 +622,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_nam
 (111) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 
-(112) Scan parquet
+(112) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/9.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (155)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (154)
    +- Exchange (153)
@@ -133,7 +133,7 @@ AdaptiveSparkPlan (155)
                               +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -170,7 +170,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -238,7 +238,7 @@ Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (26) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -306,7 +306,7 @@ Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (43) InputIteratorTransformer
 Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -374,7 +374,7 @@ Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_natio
 (60) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -442,7 +442,7 @@ Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_sup
 (77) InputIteratorTransformer
 Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/10.txt
@@ -31,28 +31,28 @@ AdaptiveSparkPlan (100)
                                     :                 :                 :        +- VeloxResizeBatches (5)
                                     :                 :                 :           +- ^ ProjectExecTransformer (3)
                                     :                 :                 :              +- ^ FilterExecTransformer (2)
-                                    :                 :                 :                 +- ^ Scan parquet (1)
+                                    :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                     :                 :                 +- ^ InputIteratorTransformer (18)
                                     :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                     :                 :                       +- ColumnarExchange (15)
                                     :                 :                          +- VeloxResizeBatches (14)
                                     :                 :                             +- ^ ProjectExecTransformer (12)
                                     :                 :                                +- ^ FilterExecTransformer (11)
-                                    :                 :                                   +- ^ Scan parquet (10)
+                                    :                 :                                   +- ^ ScanTransformer parquet  (10)
                                     :                 +- ^ InputIteratorTransformer (35)
                                     :                    +- ShuffleQueryStage (33), Statistics(X)
                                     :                       +- ColumnarExchange (32)
                                     :                          +- VeloxResizeBatches (31)
                                     :                             +- ^ ProjectExecTransformer (29)
                                     :                                +- ^ FilterExecTransformer (28)
-                                    :                                   +- ^ Scan parquet (27)
+                                    :                                   +- ^ ScanTransformer parquet  (27)
                                     +- ^ InputIteratorTransformer (52)
                                        +- ShuffleQueryStage (50), Statistics(X)
                                           +- ColumnarExchange (49)
                                              +- VeloxResizeBatches (48)
                                                 +- ^ ProjectExecTransformer (46)
                                                    +- ^ FilterExecTransformer (45)
-                                                      +- ^ Scan parquet (44)
+                                                      +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    TakeOrderedAndProject (99)
    +- HashAggregate (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -125,7 +125,7 @@ Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (9) InputIteratorTransformer
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (26) InputIteratorTransformer
 Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -261,7 +261,7 @@ Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (43) InputIteratorTransformer
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/11.txt
@@ -29,21 +29,21 @@ AdaptiveSparkPlan (82)
                                                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                       +- ColumnarExchange (15)
                                                 :                          +- VeloxResizeBatches (14)
                                                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                                +- ^ FilterExecTransformer (11)
-                                                :                                   +- ^ Scan parquet (10)
+                                                :                                   +- ^ ScanTransformer parquet  (10)
                                                 +- ^ InputIteratorTransformer (35)
                                                    +- ShuffleQueryStage (33), Statistics(X)
                                                       +- ColumnarExchange (32)
                                                          +- VeloxResizeBatches (31)
                                                             +- ^ ProjectExecTransformer (29)
                                                                +- ^ FilterExecTransformer (28)
-                                                                  +- ^ Scan parquet (27)
+                                                                  +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    Sort (81)
    +- Exchange (80)
@@ -72,7 +72,7 @@ AdaptiveSparkPlan (82)
                                     +- Scan parquet (69)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -109,7 +109,7 @@ Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 (9) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -177,7 +177,7 @@ Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 (26) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -444,7 +444,7 @@ AdaptiveSparkPlan (136)
                   :                 :        +- VeloxResizeBatches (87)
                   :                 :           +- ^ ProjectExecTransformer (85)
                   :                 :              +- ^ FilterExecTransformer (84)
-                  :                 :                 +- ^ Scan parquet (83)
+                  :                 :                 +- ^ ScanTransformer parquet  (83)
                   :                 +- ^ InputIteratorTransformer (95)
                   :                    +- ShuffleQueryStage (93), Statistics(X)
                   :                       +- ReusedExchange (92)
@@ -475,7 +475,7 @@ AdaptiveSparkPlan (136)
                         +- Scan parquet (127)
 
 
-(83) Scan parquet
+(83) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/12.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (55)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,7 +49,7 @@ AdaptiveSparkPlan (55)
                                  +- Scan parquet (43)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -86,7 +86,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/13.txt
@@ -24,14 +24,14 @@ AdaptiveSparkPlan (58)
                                                       :     +- ColumnarExchange (5)
                                                       :        +- VeloxResizeBatches (4)
                                                       :           +- ^ ProjectExecTransformer (2)
-                                                      :              +- ^ Scan parquet (1)
+                                                      :              +- ^ ScanTransformer parquet  (1)
                                                       +- ^ InputIteratorTransformer (17)
                                                          +- ShuffleQueryStage (15), Statistics(X)
                                                             +- ColumnarExchange (14)
                                                                +- VeloxResizeBatches (13)
                                                                   +- ^ ProjectExecTransformer (11)
                                                                      +- ^ FilterExecTransformer (10)
-                                                                        +- ^ Scan parquet (9)
+                                                                        +- ^ ScanTransformer parquet  (9)
 +- == Initial Plan ==
    Sort (57)
    +- Exchange (56)
@@ -52,7 +52,7 @@ AdaptiveSparkPlan (58)
                                        +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -84,7 +84,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/14.txt
@@ -13,14 +13,14 @@ AdaptiveSparkPlan (39)
                   :        +- VeloxResizeBatches (5)
                   :           +- ^ ProjectExecTransformer (3)
                   :              +- ^ FilterExecTransformer (2)
-                  :                 +- ^ Scan parquet (1)
+                  :                 +- ^ ScanTransformer parquet  (1)
                   +- ^ InputIteratorTransformer (18)
                      +- ShuffleQueryStage (16), Statistics(X)
                         +- ColumnarExchange (15)
                            +- VeloxResizeBatches (14)
                               +- ^ ProjectExecTransformer (12)
                                  +- ^ FilterExecTransformer (11)
-                                    +- ^ Scan parquet (10)
+                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (38)
    +- HashAggregate (37)
@@ -37,7 +37,7 @@ AdaptiveSparkPlan (39)
                      +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -74,7 +74,7 @@ Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/15.txt
@@ -14,7 +14,7 @@ AdaptiveSparkPlan (47)
                      :        +- VeloxResizeBatches (5)
                      :           +- ^ ProjectExecTransformer (3)
                      :              +- ^ FilterExecTransformer (2)
-                     :                 +- ^ Scan parquet (1)
+                     :                 +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (22)
                         +- ^ RegularHashAggregateExecTransformer (21)
                            +- ^ InputIteratorTransformer (20)
@@ -25,7 +25,7 @@ AdaptiveSparkPlan (47)
                                           +- ^ FlushableHashAggregateExecTransformer (13)
                                              +- ^ ProjectExecTransformer (12)
                                                 +- ^ FilterExecTransformer (11)
-                                                   +- ^ Scan parquet (10)
+                                                   +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (46)
    +- Exchange (45)
@@ -45,7 +45,7 @@ AdaptiveSparkPlan (47)
                                  +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -82,7 +82,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -272,7 +272,7 @@ AdaptiveSparkPlan (73)
                               +- ^ FlushableHashAggregateExecTransformer (51)
                                  +- ^ ProjectExecTransformer (50)
                                     +- ^ FilterExecTransformer (49)
-                                       +- ^ Scan parquet (48)
+                                       +- ^ ScanTransformer parquet  (48)
 +- == Initial Plan ==
    HashAggregate (72)
    +- HashAggregate (71)
@@ -284,7 +284,7 @@ AdaptiveSparkPlan (73)
                      +- Scan parquet (65)
 
 
-(48) Scan parquet
+(48) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/16.txt
@@ -29,14 +29,14 @@ AdaptiveSparkPlan (71)
                                                                   :        +- VeloxResizeBatches (5)
                                                                   :           +- ^ ProjectExecTransformer (3)
                                                                   :              +- ^ FilterExecTransformer (2)
-                                                                  :                 +- ^ Scan parquet (1)
+                                                                  :                 +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (18)
                                                                      +- ShuffleQueryStage (16), Statistics(X)
                                                                         +- ColumnarExchange (15)
                                                                            +- VeloxResizeBatches (14)
                                                                               +- ^ ProjectExecTransformer (12)
                                                                                  +- ^ FilterExecTransformer (11)
-                                                                                    +- ^ Scan parquet (10)
+                                                                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (70)
    +- Exchange (69)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (71)
                                        +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ Input [2]: [ps_partkey#X, ps_suppkey#X]
 (9) InputIteratorTransformer
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/17.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/17.txt
@@ -15,14 +15,14 @@ AdaptiveSparkPlan (63)
                   :     :        +- VeloxResizeBatches (5)
                   :     :           +- ^ ProjectExecTransformer (3)
                   :     :              +- ^ FilterExecTransformer (2)
-                  :     :                 +- ^ Scan parquet (1)
+                  :     :                 +- ^ ScanTransformer parquet  (1)
                   :     +- ^ InputIteratorTransformer (18)
                   :        +- ShuffleQueryStage (16), Statistics(X)
                   :           +- ColumnarExchange (15)
                   :              +- VeloxResizeBatches (14)
                   :                 +- ^ ProjectExecTransformer (12)
                   :                    +- ^ FilterExecTransformer (11)
-                  :                       +- ^ Scan parquet (10)
+                  :                       +- ^ ScanTransformer parquet  (10)
                   +- ^ FilterExecTransformer (33)
                      +- ^ ProjectExecTransformer (32)
                         +- ^ RegularHashAggregateExecTransformer (31)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (63)
                                        +- ^ ProjectExecTransformer (24)
                                           +- ^ FlushableHashAggregateExecTransformer (23)
                                              +- ^ FilterExecTransformer (22)
-                                                +- ^ Scan parquet (21)
+                                                +- ^ ScanTransformer parquet  (21)
 +- == Initial Plan ==
    HashAggregate (62)
    +- HashAggregate (61)
@@ -59,7 +59,7 @@ AdaptiveSparkPlan (63)
                               +- Scan parquet (52)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -96,7 +96,7 @@ Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [p_partkey#X, p_brand#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -142,7 +142,7 @@ Join condition: None
 Output [3]: [l_quantity#X, l_extendedprice#X, p_partkey#X]
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, p_partkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [l_partkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/18.txt
@@ -19,7 +19,7 @@ AdaptiveSparkPlan (110)
                   :                 :        +- VeloxResizeBatches (5)
                   :                 :           +- ^ ProjectExecTransformer (3)
                   :                 :              +- ^ FilterExecTransformer (2)
-                  :                 :                 +- ^ Scan parquet (1)
+                  :                 :                 +- ^ ScanTransformer parquet  (1)
                   :                 +- ^ InputIteratorTransformer (38)
                   :                    +- ShuffleQueryStage (36), Statistics(X)
                   :                       +- ColumnarExchange (35)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (110)
                   :                                   :        +- VeloxResizeBatches (14)
                   :                                   :           +- ^ ProjectExecTransformer (12)
                   :                                   :              +- ^ FilterExecTransformer (11)
-                  :                                   :                 +- ^ Scan parquet (10)
+                  :                                   :                 +- ^ ScanTransformer parquet  (10)
                   :                                   +- ^ ProjectExecTransformer (30)
                   :                                      +- ^ FilterExecTransformer (29)
                   :                                         +- ^ RegularHashAggregateExecTransformer (28)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (110)
                   :                                                     +- VeloxResizeBatches (23)
                   :                                                        +- ^ ProjectExecTransformer (21)
                   :                                                           +- ^ FlushableHashAggregateExecTransformer (20)
-                  :                                                              +- ^ Scan parquet (19)
+                  :                                                              +- ^ ScanTransformer parquet  (19)
                   +- ^ ShuffledHashJoinExecTransformer LeftSemi BuildRight (63)
                      :- ^ InputIteratorTransformer (55)
                      :  +- ShuffleQueryStage (53), Statistics(X)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (110)
                      :        +- VeloxResizeBatches (51)
                      :           +- ^ ProjectExecTransformer (49)
                      :              +- ^ FilterExecTransformer (48)
-                     :                 +- ^ Scan parquet (47)
+                     :                 +- ^ ScanTransformer parquet  (47)
                      +- ^ ProjectExecTransformer (62)
                         +- ^ FilterExecTransformer (61)
                            +- ^ RegularHashAggregateExecTransformer (60)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (110)
                                     +- Scan parquet (97)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -136,7 +136,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 (18) InputIteratorTransformer
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -289,7 +289,7 @@ Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 (46) InputIteratorTransformer
 Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/19.txt
@@ -12,14 +12,14 @@ AdaptiveSparkPlan (38)
                :        +- VeloxResizeBatches (5)
                :           +- ^ ProjectExecTransformer (3)
                :              +- ^ FilterExecTransformer (2)
-               :                 +- ^ Scan parquet (1)
+               :                 +- ^ ScanTransformer parquet  (1)
                +- ^ InputIteratorTransformer (18)
                   +- ShuffleQueryStage (16), Statistics(X)
                      +- ColumnarExchange (15)
                         +- VeloxResizeBatches (14)
                            +- ^ ProjectExecTransformer (12)
                               +- ^ FilterExecTransformer (11)
-                                 +- ^ Scan parquet (10)
+                                 +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (37)
    +- HashAggregate (36)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (38)
                      +- Scan parquet (30)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/20.txt
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (143)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (68)
                      :                    +- ShuffleQueryStage (66), Statistics(X)
                      :                       +- ColumnarExchange (65)
@@ -39,14 +39,14 @@ AdaptiveSparkPlan (143)
                      :                                   :                 :        +- VeloxResizeBatches (14)
                      :                                   :                 :           +- ^ ProjectExecTransformer (12)
                      :                                   :                 :              +- ^ FilterExecTransformer (11)
-                     :                                   :                 :                 +- ^ Scan parquet (10)
+                     :                                   :                 :                 +- ^ ScanTransformer parquet  (10)
                      :                                   :                 +- ^ InputIteratorTransformer (27)
                      :                                   :                    +- ShuffleQueryStage (25), Statistics(X)
                      :                                   :                       +- ColumnarExchange (24)
                      :                                   :                          +- VeloxResizeBatches (23)
                      :                                   :                             +- ^ ProjectExecTransformer (21)
                      :                                   :                                +- ^ FilterExecTransformer (20)
-                     :                                   :                                   +- ^ Scan parquet (19)
+                     :                                   :                                   +- ^ ScanTransformer parquet  (19)
                      :                                   +- ^ InputIteratorTransformer (60)
                      :                                      +- ShuffleQueryStage (58), Statistics(X)
                      :                                         +- ColumnarExchange (57)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (143)
                      :                                                                 :        +- VeloxResizeBatches (40)
                      :                                                                 :           +- ^ ProjectExecTransformer (38)
                      :                                                                 :              +- ^ FilterExecTransformer (37)
-                     :                                                                 :                 +- ^ Scan parquet (36)
+                     :                                                                 :                 +- ^ ScanTransformer parquet  (36)
                      :                                                                 +- ^ InputIteratorTransformer (48)
                      :                                                                    +- ShuffleQueryStage (46), Statistics(X)
                      :                                                                       +- ReusedExchange (45)
@@ -73,7 +73,7 @@ AdaptiveSparkPlan (143)
                               +- VeloxResizeBatches (81)
                                  +- ^ ProjectExecTransformer (79)
                                     +- ^ FilterExecTransformer (78)
-                                       +- ^ Scan parquet (77)
+                                       +- ^ ScanTransformer parquet  (77)
 +- == Initial Plan ==
    Sort (142)
    +- Exchange (141)
@@ -126,7 +126,7 @@ AdaptiveSparkPlan (143)
                         +- Scan parquet (134)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -163,7 +163,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -200,7 +200,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -268,7 +268,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (35) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(36) Scan parquet
+(36) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -433,7 +433,7 @@ Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 (76) InputIteratorTransformer
 Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 
-(77) Scan parquet
+(77) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/21.txt
@@ -29,7 +29,7 @@ AdaptiveSparkPlan (137)
                               :                 :                 :        +- VeloxResizeBatches (5)
                               :                 :                 :           +- ^ ProjectExecTransformer (3)
                               :                 :                 :              +- ^ FilterExecTransformer (2)
-                              :                 :                 :                 +- ^ Scan parquet (1)
+                              :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                               :                 :                 +- ^ InputIteratorTransformer (44)
                               :                 :                    +- ShuffleQueryStage (42), Statistics(X)
                               :                 :                       +- ColumnarExchange (41)
@@ -43,34 +43,34 @@ AdaptiveSparkPlan (137)
                               :                 :                                   :  :        +- VeloxResizeBatches (14)
                               :                 :                                   :  :           +- ^ ProjectExecTransformer (12)
                               :                 :                                   :  :              +- ^ FilterExecTransformer (11)
-                              :                 :                                   :  :                 +- ^ Scan parquet (10)
+                              :                 :                                   :  :                 +- ^ ScanTransformer parquet  (10)
                               :                 :                                   :  +- ^ InputIteratorTransformer (26)
                               :                 :                                   :     +- ShuffleQueryStage (24), Statistics(X)
                               :                 :                                   :        +- ColumnarExchange (23)
                               :                 :                                   :           +- VeloxResizeBatches (22)
                               :                 :                                   :              +- ^ ProjectExecTransformer (20)
-                              :                 :                                   :                 +- ^ Scan parquet (19)
+                              :                 :                                   :                 +- ^ ScanTransformer parquet  (19)
                               :                 :                                   +- ^ InputIteratorTransformer (36)
                               :                 :                                      +- ShuffleQueryStage (34), Statistics(X)
                               :                 :                                         +- ColumnarExchange (33)
                               :                 :                                            +- VeloxResizeBatches (32)
                               :                 :                                               +- ^ ProjectExecTransformer (30)
                               :                 :                                                  +- ^ FilterExecTransformer (29)
-                              :                 :                                                     +- ^ Scan parquet (28)
+                              :                 :                                                     +- ^ ScanTransformer parquet  (28)
                               :                 +- ^ InputIteratorTransformer (61)
                               :                    +- ShuffleQueryStage (59), Statistics(X)
                               :                       +- ColumnarExchange (58)
                               :                          +- VeloxResizeBatches (57)
                               :                             +- ^ ProjectExecTransformer (55)
                               :                                +- ^ FilterExecTransformer (54)
-                              :                                   +- ^ Scan parquet (53)
+                              :                                   +- ^ ScanTransformer parquet  (53)
                               +- ^ InputIteratorTransformer (78)
                                  +- ShuffleQueryStage (76), Statistics(X)
                                     +- ColumnarExchange (75)
                                        +- VeloxResizeBatches (74)
                                           +- ^ ProjectExecTransformer (72)
                                              +- ^ FilterExecTransformer (71)
-                                                +- ^ Scan parquet (70)
+                                                +- ^ ScanTransformer parquet  (70)
 +- == Initial Plan ==
    TakeOrderedAndProject (136)
    +- HashAggregate (135)
@@ -119,7 +119,7 @@ AdaptiveSparkPlan (137)
                               +- Scan parquet (126)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [2]: [l_orderkey#X, l_suppkey#X]
 (18) InputIteratorTransformer
 Input [2]: [l_orderkey#X, l_suppkey#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -230,7 +230,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(28) Scan parquet
+(28) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -329,7 +329,7 @@ Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 (52) InputIteratorTransformer
 Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -397,7 +397,7 @@ Input [2]: [s_name#X, s_nationkey#X]
 (69) InputIteratorTransformer
 Input [2]: [s_name#X, s_nationkey#X]
 
-(70) Scan parquet
+(70) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/22.txt
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (52)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (17)
                                                 +- ShuffleQueryStage (15), Statistics(X)
                                                    +- ColumnarExchange (14)
                                                       +- VeloxResizeBatches (13)
                                                          +- ^ ProjectExecTransformer (11)
-                                                            +- ^ Scan parquet (10)
+                                                            +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (51)
    +- Exchange (50)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (52)
                            +- Scan parquet (42)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 (9) InputIteratorTransformer
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -283,7 +283,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)
@@ -293,7 +293,7 @@ AdaptiveSparkPlan (72)
                +- Scan parquet (66)
 
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -400,7 +400,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/3.txt
@@ -20,21 +20,21 @@ AdaptiveSparkPlan (67)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (18)
                      :                    +- ShuffleQueryStage (16), Statistics(X)
                      :                       +- ColumnarExchange (15)
                      :                          +- VeloxResizeBatches (14)
                      :                             +- ^ ProjectExecTransformer (12)
                      :                                +- ^ FilterExecTransformer (11)
-                     :                                   +- ^ Scan parquet (10)
+                     :                                   +- ^ ScanTransformer parquet  (10)
                      +- ^ InputIteratorTransformer (35)
                         +- ShuffleQueryStage (33), Statistics(X)
                            +- ColumnarExchange (32)
                               +- VeloxResizeBatches (31)
                                  +- ^ ProjectExecTransformer (29)
                                     +- ^ FilterExecTransformer (28)
-                                       +- ^ Scan parquet (27)
+                                       +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    TakeOrderedAndProject (66)
    +- HashAggregate (65)
@@ -61,7 +61,7 @@ AdaptiveSparkPlan (67)
                            +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -98,7 +98,7 @@ Input [1]: [c_custkey#X]
 (9) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -166,7 +166,7 @@ Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 (26) InputIteratorTransformer
 Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/4.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (56)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (55)
    +- Exchange (54)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (56)
                                  +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -87,7 +87,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/5.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (156)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (155)
    +- Exchange (154)
@@ -134,7 +134,7 @@ AdaptiveSparkPlan (156)
                                  +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -239,7 +239,7 @@ Input [2]: [c_nationkey#X, o_orderkey#X]
 (26) InputIteratorTransformer
 Input [2]: [c_nationkey#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -307,7 +307,7 @@ Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (43) InputIteratorTransformer
 Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -375,7 +375,7 @@ Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 (60) InputIteratorTransformer
 Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -443,7 +443,7 @@ Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 (77) InputIteratorTransformer
 Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/7.txt
@@ -46,35 +46,35 @@ AdaptiveSparkPlan (149)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (81)
                                                 +- ShuffleQueryStage (79), Statistics(X)
                                                    +- ReusedExchange (78)
@@ -128,7 +128,7 @@ AdaptiveSparkPlan (149)
                               +- Scan parquet (138)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -165,7 +165,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -233,7 +233,7 @@ Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_ship
 (26) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -301,7 +301,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_cust
 (43) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -369,7 +369,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nati
 (60) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/8.txt
@@ -59,56 +59,56 @@ AdaptiveSparkPlan (207)
                                                 :                 :                 :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :                 :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :                 :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                 :                 :                 :                 :                 :                       +- ColumnarExchange (15)
                                                 :                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                                 :                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                                :                 :                 :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                                :                 :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                                 :                 :                 :                 :                 :                       +- ColumnarExchange (32)
                                                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (31)
                                                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                                :                 :                 :                 :                 :                                   +- ^ Scan parquet (27)
+                                                :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (52)
                                                 :                 :                 :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                                 :                 :                 :                 :                       +- ColumnarExchange (49)
                                                 :                 :                 :                 :                          +- VeloxResizeBatches (48)
                                                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (46)
                                                 :                 :                 :                 :                                +- ^ FilterExecTransformer (45)
-                                                :                 :                 :                 :                                   +- ^ Scan parquet (44)
+                                                :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (44)
                                                 :                 :                 :                 +- ^ InputIteratorTransformer (69)
                                                 :                 :                 :                    +- ShuffleQueryStage (67), Statistics(X)
                                                 :                 :                 :                       +- ColumnarExchange (66)
                                                 :                 :                 :                          +- VeloxResizeBatches (65)
                                                 :                 :                 :                             +- ^ ProjectExecTransformer (63)
                                                 :                 :                 :                                +- ^ FilterExecTransformer (62)
-                                                :                 :                 :                                   +- ^ Scan parquet (61)
+                                                :                 :                 :                                   +- ^ ScanTransformer parquet  (61)
                                                 :                 :                 +- ^ InputIteratorTransformer (86)
                                                 :                 :                    +- ShuffleQueryStage (84), Statistics(X)
                                                 :                 :                       +- ColumnarExchange (83)
                                                 :                 :                          +- VeloxResizeBatches (82)
                                                 :                 :                             +- ^ ProjectExecTransformer (80)
                                                 :                 :                                +- ^ FilterExecTransformer (79)
-                                                :                 :                                   +- ^ Scan parquet (78)
+                                                :                 :                                   +- ^ ScanTransformer parquet  (78)
                                                 :                 +- ^ InputIteratorTransformer (103)
                                                 :                    +- ShuffleQueryStage (101), Statistics(X)
                                                 :                       +- ColumnarExchange (100)
                                                 :                          +- VeloxResizeBatches (99)
                                                 :                             +- ^ ProjectExecTransformer (97)
                                                 :                                +- ^ FilterExecTransformer (96)
-                                                :                                   +- ^ Scan parquet (95)
+                                                :                                   +- ^ ScanTransformer parquet  (95)
                                                 +- ^ InputIteratorTransformer (120)
                                                    +- ShuffleQueryStage (118), Statistics(X)
                                                       +- ColumnarExchange (117)
                                                          +- VeloxResizeBatches (116)
                                                             +- ^ ProjectExecTransformer (114)
                                                                +- ^ FilterExecTransformer (113)
-                                                                  +- ^ Scan parquet (112)
+                                                                  +- ^ ScanTransformer parquet  (112)
 +- == Initial Plan ==
    Sort (206)
    +- Exchange (205)
@@ -177,7 +177,7 @@ AdaptiveSparkPlan (207)
                                  +- Scan parquet (195)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -214,7 +214,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (26) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -350,7 +350,7 @@ Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 (43) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -418,7 +418,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_order
 (60) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -486,7 +486,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nat
 (77) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -554,7 +554,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_reg
 (94) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 
-(95) Scan parquet
+(95) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -622,7 +622,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_nam
 (111) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 
-(112) Scan parquet
+(112) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/9.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (155)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (154)
    +- Exchange (153)
@@ -133,7 +133,7 @@ AdaptiveSparkPlan (155)
                               +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -170,7 +170,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -238,7 +238,7 @@ Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (26) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -306,7 +306,7 @@ Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (43) InputIteratorTransformer
 Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -374,7 +374,7 @@ Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_natio
 (60) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -442,7 +442,7 @@ Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_sup
 (77) InputIteratorTransformer
 Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/10.txt
@@ -31,28 +31,28 @@ AdaptiveSparkPlan (100)
                                     :                 :                 :        +- VeloxResizeBatches (5)
                                     :                 :                 :           +- ^ ProjectExecTransformer (3)
                                     :                 :                 :              +- ^ FilterExecTransformer (2)
-                                    :                 :                 :                 +- ^ Scan parquet (1)
+                                    :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                     :                 :                 +- ^ InputIteratorTransformer (18)
                                     :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                     :                 :                       +- ColumnarExchange (15)
                                     :                 :                          +- VeloxResizeBatches (14)
                                     :                 :                             +- ^ ProjectExecTransformer (12)
                                     :                 :                                +- ^ FilterExecTransformer (11)
-                                    :                 :                                   +- ^ Scan parquet (10)
+                                    :                 :                                   +- ^ ScanTransformer parquet  (10)
                                     :                 +- ^ InputIteratorTransformer (35)
                                     :                    +- ShuffleQueryStage (33), Statistics(X)
                                     :                       +- ColumnarExchange (32)
                                     :                          +- VeloxResizeBatches (31)
                                     :                             +- ^ ProjectExecTransformer (29)
                                     :                                +- ^ FilterExecTransformer (28)
-                                    :                                   +- ^ Scan parquet (27)
+                                    :                                   +- ^ ScanTransformer parquet  (27)
                                     +- ^ InputIteratorTransformer (52)
                                        +- ShuffleQueryStage (50), Statistics(X)
                                           +- ColumnarExchange (49)
                                              +- VeloxResizeBatches (48)
                                                 +- ^ ProjectExecTransformer (46)
                                                    +- ^ FilterExecTransformer (45)
-                                                      +- ^ Scan parquet (44)
+                                                      +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    TakeOrderedAndProject (99)
    +- HashAggregate (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -125,7 +125,7 @@ Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (9) InputIteratorTransformer
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -194,7 +194,7 @@ Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (26) InputIteratorTransformer
 Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -263,7 +263,7 @@ Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (43) InputIteratorTransformer
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/11.txt
@@ -29,21 +29,21 @@ AdaptiveSparkPlan (82)
                                                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                       +- ColumnarExchange (15)
                                                 :                          +- VeloxResizeBatches (14)
                                                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                                +- ^ FilterExecTransformer (11)
-                                                :                                   +- ^ Scan parquet (10)
+                                                :                                   +- ^ ScanTransformer parquet  (10)
                                                 +- ^ InputIteratorTransformer (35)
                                                    +- ShuffleQueryStage (33), Statistics(X)
                                                       +- ColumnarExchange (32)
                                                          +- VeloxResizeBatches (31)
                                                             +- ^ ProjectExecTransformer (29)
                                                                +- ^ FilterExecTransformer (28)
-                                                                  +- ^ Scan parquet (27)
+                                                                  +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    Sort (81)
    +- Exchange (80)
@@ -72,7 +72,7 @@ AdaptiveSparkPlan (82)
                                     +- Scan parquet (69)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -109,7 +109,7 @@ Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 (9) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -178,7 +178,7 @@ Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 (26) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -448,7 +448,7 @@ AdaptiveSparkPlan (136)
                   :                 :        +- VeloxResizeBatches (87)
                   :                 :           +- ^ ProjectExecTransformer (85)
                   :                 :              +- ^ FilterExecTransformer (84)
-                  :                 :                 +- ^ Scan parquet (83)
+                  :                 :                 +- ^ ScanTransformer parquet  (83)
                   :                 +- ^ InputIteratorTransformer (95)
                   :                    +- ShuffleQueryStage (93), Statistics(X)
                   :                       +- ReusedExchange (92)
@@ -479,7 +479,7 @@ AdaptiveSparkPlan (136)
                         +- Scan parquet (127)
 
 
-(83) Scan parquet
+(83) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/12.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (55)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,7 +49,7 @@ AdaptiveSparkPlan (55)
                                  +- Scan parquet (43)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -86,7 +86,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/13.txt
@@ -24,14 +24,14 @@ AdaptiveSparkPlan (58)
                                                       :     +- ColumnarExchange (5)
                                                       :        +- VeloxResizeBatches (4)
                                                       :           +- ^ ProjectExecTransformer (2)
-                                                      :              +- ^ Scan parquet (1)
+                                                      :              +- ^ ScanTransformer parquet  (1)
                                                       +- ^ InputIteratorTransformer (17)
                                                          +- ShuffleQueryStage (15), Statistics(X)
                                                             +- ColumnarExchange (14)
                                                                +- VeloxResizeBatches (13)
                                                                   +- ^ ProjectExecTransformer (11)
                                                                      +- ^ FilterExecTransformer (10)
-                                                                        +- ^ Scan parquet (9)
+                                                                        +- ^ ScanTransformer parquet  (9)
 +- == Initial Plan ==
    Sort (57)
    +- Exchange (56)
@@ -52,7 +52,7 @@ AdaptiveSparkPlan (58)
                                        +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -84,7 +84,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/14.txt
@@ -13,14 +13,14 @@ AdaptiveSparkPlan (39)
                   :        +- VeloxResizeBatches (5)
                   :           +- ^ ProjectExecTransformer (3)
                   :              +- ^ FilterExecTransformer (2)
-                  :                 +- ^ Scan parquet (1)
+                  :                 +- ^ ScanTransformer parquet  (1)
                   +- ^ InputIteratorTransformer (18)
                      +- ShuffleQueryStage (16), Statistics(X)
                         +- ColumnarExchange (15)
                            +- VeloxResizeBatches (14)
                               +- ^ ProjectExecTransformer (12)
                                  +- ^ FilterExecTransformer (11)
-                                    +- ^ Scan parquet (10)
+                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (38)
    +- HashAggregate (37)
@@ -37,7 +37,7 @@ AdaptiveSparkPlan (39)
                      +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -74,7 +74,7 @@ Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/15.txt
@@ -14,7 +14,7 @@ AdaptiveSparkPlan (47)
                      :        +- VeloxResizeBatches (5)
                      :           +- ^ ProjectExecTransformer (3)
                      :              +- ^ FilterExecTransformer (2)
-                     :                 +- ^ Scan parquet (1)
+                     :                 +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (22)
                         +- ^ RegularHashAggregateExecTransformer (21)
                            +- ^ InputIteratorTransformer (20)
@@ -25,7 +25,7 @@ AdaptiveSparkPlan (47)
                                           +- ^ FlushableHashAggregateExecTransformer (13)
                                              +- ^ ProjectExecTransformer (12)
                                                 +- ^ FilterExecTransformer (11)
-                                                   +- ^ Scan parquet (10)
+                                                   +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (46)
    +- Exchange (45)
@@ -45,7 +45,7 @@ AdaptiveSparkPlan (47)
                                  +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -82,7 +82,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -274,7 +274,7 @@ AdaptiveSparkPlan (73)
                               +- ^ FlushableHashAggregateExecTransformer (51)
                                  +- ^ ProjectExecTransformer (50)
                                     +- ^ FilterExecTransformer (49)
-                                       +- ^ Scan parquet (48)
+                                       +- ^ ScanTransformer parquet  (48)
 +- == Initial Plan ==
    HashAggregate (72)
    +- HashAggregate (71)
@@ -286,7 +286,7 @@ AdaptiveSparkPlan (73)
                      +- Scan parquet (65)
 
 
-(48) Scan parquet
+(48) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/16.txt
@@ -29,14 +29,14 @@ AdaptiveSparkPlan (71)
                                                                   :        +- VeloxResizeBatches (5)
                                                                   :           +- ^ ProjectExecTransformer (3)
                                                                   :              +- ^ FilterExecTransformer (2)
-                                                                  :                 +- ^ Scan parquet (1)
+                                                                  :                 +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (18)
                                                                      +- ShuffleQueryStage (16), Statistics(X)
                                                                         +- ColumnarExchange (15)
                                                                            +- VeloxResizeBatches (14)
                                                                               +- ^ ProjectExecTransformer (12)
                                                                                  +- ^ FilterExecTransformer (11)
-                                                                                    +- ^ Scan parquet (10)
+                                                                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (70)
    +- Exchange (69)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (71)
                                        +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ Input [2]: [ps_partkey#X, ps_suppkey#X]
 (9) InputIteratorTransformer
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/17.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/17.txt
@@ -15,14 +15,14 @@ AdaptiveSparkPlan (63)
                   :     :        +- VeloxResizeBatches (5)
                   :     :           +- ^ ProjectExecTransformer (3)
                   :     :              +- ^ FilterExecTransformer (2)
-                  :     :                 +- ^ Scan parquet (1)
+                  :     :                 +- ^ ScanTransformer parquet  (1)
                   :     +- ^ InputIteratorTransformer (18)
                   :        +- ShuffleQueryStage (16), Statistics(X)
                   :           +- ColumnarExchange (15)
                   :              +- VeloxResizeBatches (14)
                   :                 +- ^ ProjectExecTransformer (12)
                   :                    +- ^ FilterExecTransformer (11)
-                  :                       +- ^ Scan parquet (10)
+                  :                       +- ^ ScanTransformer parquet  (10)
                   +- ^ FilterExecTransformer (33)
                      +- ^ ProjectExecTransformer (32)
                         +- ^ RegularHashAggregateExecTransformer (31)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (63)
                                        +- ^ ProjectExecTransformer (24)
                                           +- ^ FlushableHashAggregateExecTransformer (23)
                                              +- ^ FilterExecTransformer (22)
-                                                +- ^ Scan parquet (21)
+                                                +- ^ ScanTransformer parquet  (21)
 +- == Initial Plan ==
    HashAggregate (62)
    +- HashAggregate (61)
@@ -59,7 +59,7 @@ AdaptiveSparkPlan (63)
                               +- Scan parquet (52)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -96,7 +96,7 @@ Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [p_partkey#X, p_brand#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -143,7 +143,7 @@ Join condition: None
 Output [3]: [l_quantity#X, l_extendedprice#X, p_partkey#X]
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, p_partkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [l_partkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/18.txt
@@ -19,7 +19,7 @@ AdaptiveSparkPlan (110)
                   :                 :        +- VeloxResizeBatches (5)
                   :                 :           +- ^ ProjectExecTransformer (3)
                   :                 :              +- ^ FilterExecTransformer (2)
-                  :                 :                 +- ^ Scan parquet (1)
+                  :                 :                 +- ^ ScanTransformer parquet  (1)
                   :                 +- ^ InputIteratorTransformer (38)
                   :                    +- ShuffleQueryStage (36), Statistics(X)
                   :                       +- ColumnarExchange (35)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (110)
                   :                                   :        +- VeloxResizeBatches (14)
                   :                                   :           +- ^ ProjectExecTransformer (12)
                   :                                   :              +- ^ FilterExecTransformer (11)
-                  :                                   :                 +- ^ Scan parquet (10)
+                  :                                   :                 +- ^ ScanTransformer parquet  (10)
                   :                                   +- ^ ProjectExecTransformer (30)
                   :                                      +- ^ FilterExecTransformer (29)
                   :                                         +- ^ RegularHashAggregateExecTransformer (28)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (110)
                   :                                                     +- VeloxResizeBatches (23)
                   :                                                        +- ^ ProjectExecTransformer (21)
                   :                                                           +- ^ FlushableHashAggregateExecTransformer (20)
-                  :                                                              +- ^ Scan parquet (19)
+                  :                                                              +- ^ ScanTransformer parquet  (19)
                   +- ^ ShuffledHashJoinExecTransformer LeftSemi BuildRight (63)
                      :- ^ InputIteratorTransformer (55)
                      :  +- ShuffleQueryStage (53), Statistics(X)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (110)
                      :        +- VeloxResizeBatches (51)
                      :           +- ^ ProjectExecTransformer (49)
                      :              +- ^ FilterExecTransformer (48)
-                     :                 +- ^ Scan parquet (47)
+                     :                 +- ^ ScanTransformer parquet  (47)
                      +- ^ ProjectExecTransformer (62)
                         +- ^ FilterExecTransformer (61)
                            +- ^ RegularHashAggregateExecTransformer (60)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (110)
                                     +- Scan parquet (97)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -136,7 +136,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 (18) InputIteratorTransformer
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -291,7 +291,7 @@ Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 (46) InputIteratorTransformer
 Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/19.txt
@@ -12,14 +12,14 @@ AdaptiveSparkPlan (38)
                :        +- VeloxResizeBatches (5)
                :           +- ^ ProjectExecTransformer (3)
                :              +- ^ FilterExecTransformer (2)
-               :                 +- ^ Scan parquet (1)
+               :                 +- ^ ScanTransformer parquet  (1)
                +- ^ InputIteratorTransformer (18)
                   +- ShuffleQueryStage (16), Statistics(X)
                      +- ColumnarExchange (15)
                         +- VeloxResizeBatches (14)
                            +- ^ ProjectExecTransformer (12)
                               +- ^ FilterExecTransformer (11)
-                                 +- ^ Scan parquet (10)
+                                 +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (37)
    +- HashAggregate (36)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (38)
                      +- Scan parquet (30)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/20.txt
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (143)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (68)
                      :                    +- ShuffleQueryStage (66), Statistics(X)
                      :                       +- ColumnarExchange (65)
@@ -39,14 +39,14 @@ AdaptiveSparkPlan (143)
                      :                                   :                 :        +- VeloxResizeBatches (14)
                      :                                   :                 :           +- ^ ProjectExecTransformer (12)
                      :                                   :                 :              +- ^ FilterExecTransformer (11)
-                     :                                   :                 :                 +- ^ Scan parquet (10)
+                     :                                   :                 :                 +- ^ ScanTransformer parquet  (10)
                      :                                   :                 +- ^ InputIteratorTransformer (27)
                      :                                   :                    +- ShuffleQueryStage (25), Statistics(X)
                      :                                   :                       +- ColumnarExchange (24)
                      :                                   :                          +- VeloxResizeBatches (23)
                      :                                   :                             +- ^ ProjectExecTransformer (21)
                      :                                   :                                +- ^ FilterExecTransformer (20)
-                     :                                   :                                   +- ^ Scan parquet (19)
+                     :                                   :                                   +- ^ ScanTransformer parquet  (19)
                      :                                   +- ^ InputIteratorTransformer (60)
                      :                                      +- ShuffleQueryStage (58), Statistics(X)
                      :                                         +- ColumnarExchange (57)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (143)
                      :                                                                 :        +- VeloxResizeBatches (40)
                      :                                                                 :           +- ^ ProjectExecTransformer (38)
                      :                                                                 :              +- ^ FilterExecTransformer (37)
-                     :                                                                 :                 +- ^ Scan parquet (36)
+                     :                                                                 :                 +- ^ ScanTransformer parquet  (36)
                      :                                                                 +- ^ InputIteratorTransformer (48)
                      :                                                                    +- ShuffleQueryStage (46), Statistics(X)
                      :                                                                       +- ReusedExchange (45)
@@ -73,7 +73,7 @@ AdaptiveSparkPlan (143)
                               +- VeloxResizeBatches (81)
                                  +- ^ ProjectExecTransformer (79)
                                     +- ^ FilterExecTransformer (78)
-                                       +- ^ Scan parquet (77)
+                                       +- ^ ScanTransformer parquet  (77)
 +- == Initial Plan ==
    Sort (142)
    +- Exchange (141)
@@ -126,7 +126,7 @@ AdaptiveSparkPlan (143)
                         +- Scan parquet (134)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -163,7 +163,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -200,7 +200,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -269,7 +269,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (35) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(36) Scan parquet
+(36) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -437,7 +437,7 @@ Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 (76) InputIteratorTransformer
 Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 
-(77) Scan parquet
+(77) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/21.txt
@@ -29,7 +29,7 @@ AdaptiveSparkPlan (137)
                               :                 :                 :        +- VeloxResizeBatches (5)
                               :                 :                 :           +- ^ ProjectExecTransformer (3)
                               :                 :                 :              +- ^ FilterExecTransformer (2)
-                              :                 :                 :                 +- ^ Scan parquet (1)
+                              :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                               :                 :                 +- ^ InputIteratorTransformer (44)
                               :                 :                    +- ShuffleQueryStage (42), Statistics(X)
                               :                 :                       +- ColumnarExchange (41)
@@ -43,34 +43,34 @@ AdaptiveSparkPlan (137)
                               :                 :                                   :  :        +- VeloxResizeBatches (14)
                               :                 :                                   :  :           +- ^ ProjectExecTransformer (12)
                               :                 :                                   :  :              +- ^ FilterExecTransformer (11)
-                              :                 :                                   :  :                 +- ^ Scan parquet (10)
+                              :                 :                                   :  :                 +- ^ ScanTransformer parquet  (10)
                               :                 :                                   :  +- ^ InputIteratorTransformer (26)
                               :                 :                                   :     +- ShuffleQueryStage (24), Statistics(X)
                               :                 :                                   :        +- ColumnarExchange (23)
                               :                 :                                   :           +- VeloxResizeBatches (22)
                               :                 :                                   :              +- ^ ProjectExecTransformer (20)
-                              :                 :                                   :                 +- ^ Scan parquet (19)
+                              :                 :                                   :                 +- ^ ScanTransformer parquet  (19)
                               :                 :                                   +- ^ InputIteratorTransformer (36)
                               :                 :                                      +- ShuffleQueryStage (34), Statistics(X)
                               :                 :                                         +- ColumnarExchange (33)
                               :                 :                                            +- VeloxResizeBatches (32)
                               :                 :                                               +- ^ ProjectExecTransformer (30)
                               :                 :                                                  +- ^ FilterExecTransformer (29)
-                              :                 :                                                     +- ^ Scan parquet (28)
+                              :                 :                                                     +- ^ ScanTransformer parquet  (28)
                               :                 +- ^ InputIteratorTransformer (61)
                               :                    +- ShuffleQueryStage (59), Statistics(X)
                               :                       +- ColumnarExchange (58)
                               :                          +- VeloxResizeBatches (57)
                               :                             +- ^ ProjectExecTransformer (55)
                               :                                +- ^ FilterExecTransformer (54)
-                              :                                   +- ^ Scan parquet (53)
+                              :                                   +- ^ ScanTransformer parquet  (53)
                               +- ^ InputIteratorTransformer (78)
                                  +- ShuffleQueryStage (76), Statistics(X)
                                     +- ColumnarExchange (75)
                                        +- VeloxResizeBatches (74)
                                           +- ^ ProjectExecTransformer (72)
                                              +- ^ FilterExecTransformer (71)
-                                                +- ^ Scan parquet (70)
+                                                +- ^ ScanTransformer parquet  (70)
 +- == Initial Plan ==
    TakeOrderedAndProject (136)
    +- HashAggregate (135)
@@ -119,7 +119,7 @@ AdaptiveSparkPlan (137)
                               +- Scan parquet (126)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [2]: [l_orderkey#X, l_suppkey#X]
 (18) InputIteratorTransformer
 Input [2]: [l_orderkey#X, l_suppkey#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -231,7 +231,7 @@ Right keys [1]: [l_orderkey#X]
 Join type: LeftSemi
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(28) Scan parquet
+(28) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -332,7 +332,7 @@ Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 (52) InputIteratorTransformer
 Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -401,7 +401,7 @@ Input [2]: [s_name#X, s_nationkey#X]
 (69) InputIteratorTransformer
 Input [2]: [s_name#X, s_nationkey#X]
 
-(70) Scan parquet
+(70) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/22.txt
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (52)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (17)
                                                 +- ShuffleQueryStage (15), Statistics(X)
                                                    +- ColumnarExchange (14)
                                                       +- VeloxResizeBatches (13)
                                                          +- ^ ProjectExecTransformer (11)
-                                                            +- ^ Scan parquet (10)
+                                                            +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (51)
    +- Exchange (50)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (52)
                            +- Scan parquet (42)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 (9) InputIteratorTransformer
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -285,7 +285,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)
@@ -295,7 +295,7 @@ AdaptiveSparkPlan (72)
                +- Scan parquet (66)
 
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -402,7 +402,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/3.txt
@@ -20,21 +20,21 @@ AdaptiveSparkPlan (67)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (18)
                      :                    +- ShuffleQueryStage (16), Statistics(X)
                      :                       +- ColumnarExchange (15)
                      :                          +- VeloxResizeBatches (14)
                      :                             +- ^ ProjectExecTransformer (12)
                      :                                +- ^ FilterExecTransformer (11)
-                     :                                   +- ^ Scan parquet (10)
+                     :                                   +- ^ ScanTransformer parquet  (10)
                      +- ^ InputIteratorTransformer (35)
                         +- ShuffleQueryStage (33), Statistics(X)
                            +- ColumnarExchange (32)
                               +- VeloxResizeBatches (31)
                                  +- ^ ProjectExecTransformer (29)
                                     +- ^ FilterExecTransformer (28)
-                                       +- ^ Scan parquet (27)
+                                       +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    TakeOrderedAndProject (66)
    +- HashAggregate (65)
@@ -61,7 +61,7 @@ AdaptiveSparkPlan (67)
                            +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -98,7 +98,7 @@ Input [1]: [c_custkey#X]
 (9) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -167,7 +167,7 @@ Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 (26) InputIteratorTransformer
 Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/4.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (56)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (55)
    +- Exchange (54)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (56)
                                  +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -87,7 +87,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/5.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (156)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (155)
    +- Exchange (154)
@@ -134,7 +134,7 @@ AdaptiveSparkPlan (156)
                                  +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -240,7 +240,7 @@ Input [2]: [c_nationkey#X, o_orderkey#X]
 (26) InputIteratorTransformer
 Input [2]: [c_nationkey#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -309,7 +309,7 @@ Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (43) InputIteratorTransformer
 Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -378,7 +378,7 @@ Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 (60) InputIteratorTransformer
 Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -447,7 +447,7 @@ Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 (77) InputIteratorTransformer
 Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/7.txt
@@ -46,35 +46,35 @@ AdaptiveSparkPlan (149)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (81)
                                                 +- ShuffleQueryStage (79), Statistics(X)
                                                    +- ReusedExchange (78)
@@ -128,7 +128,7 @@ AdaptiveSparkPlan (149)
                               +- Scan parquet (138)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -165,7 +165,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -234,7 +234,7 @@ Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_ship
 (26) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -303,7 +303,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_cust
 (43) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -372,7 +372,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nati
 (60) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/8.txt
@@ -59,56 +59,56 @@ AdaptiveSparkPlan (207)
                                                 :                 :                 :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :                 :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :                 :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                 :                 :                 :                 :                 :                       +- ColumnarExchange (15)
                                                 :                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                                 :                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                                :                 :                 :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                                :                 :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                                 :                 :                 :                 :                 :                       +- ColumnarExchange (32)
                                                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (31)
                                                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                                :                 :                 :                 :                 :                                   +- ^ Scan parquet (27)
+                                                :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (52)
                                                 :                 :                 :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                                 :                 :                 :                 :                       +- ColumnarExchange (49)
                                                 :                 :                 :                 :                          +- VeloxResizeBatches (48)
                                                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (46)
                                                 :                 :                 :                 :                                +- ^ FilterExecTransformer (45)
-                                                :                 :                 :                 :                                   +- ^ Scan parquet (44)
+                                                :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (44)
                                                 :                 :                 :                 +- ^ InputIteratorTransformer (69)
                                                 :                 :                 :                    +- ShuffleQueryStage (67), Statistics(X)
                                                 :                 :                 :                       +- ColumnarExchange (66)
                                                 :                 :                 :                          +- VeloxResizeBatches (65)
                                                 :                 :                 :                             +- ^ ProjectExecTransformer (63)
                                                 :                 :                 :                                +- ^ FilterExecTransformer (62)
-                                                :                 :                 :                                   +- ^ Scan parquet (61)
+                                                :                 :                 :                                   +- ^ ScanTransformer parquet  (61)
                                                 :                 :                 +- ^ InputIteratorTransformer (86)
                                                 :                 :                    +- ShuffleQueryStage (84), Statistics(X)
                                                 :                 :                       +- ColumnarExchange (83)
                                                 :                 :                          +- VeloxResizeBatches (82)
                                                 :                 :                             +- ^ ProjectExecTransformer (80)
                                                 :                 :                                +- ^ FilterExecTransformer (79)
-                                                :                 :                                   +- ^ Scan parquet (78)
+                                                :                 :                                   +- ^ ScanTransformer parquet  (78)
                                                 :                 +- ^ InputIteratorTransformer (103)
                                                 :                    +- ShuffleQueryStage (101), Statistics(X)
                                                 :                       +- ColumnarExchange (100)
                                                 :                          +- VeloxResizeBatches (99)
                                                 :                             +- ^ ProjectExecTransformer (97)
                                                 :                                +- ^ FilterExecTransformer (96)
-                                                :                                   +- ^ Scan parquet (95)
+                                                :                                   +- ^ ScanTransformer parquet  (95)
                                                 +- ^ InputIteratorTransformer (120)
                                                    +- ShuffleQueryStage (118), Statistics(X)
                                                       +- ColumnarExchange (117)
                                                          +- VeloxResizeBatches (116)
                                                             +- ^ ProjectExecTransformer (114)
                                                                +- ^ FilterExecTransformer (113)
-                                                                  +- ^ Scan parquet (112)
+                                                                  +- ^ ScanTransformer parquet  (112)
 +- == Initial Plan ==
    Sort (206)
    +- Exchange (205)
@@ -177,7 +177,7 @@ AdaptiveSparkPlan (207)
                                  +- Scan parquet (195)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -214,7 +214,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -283,7 +283,7 @@ Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (26) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -352,7 +352,7 @@ Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 (43) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -421,7 +421,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_order
 (60) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -490,7 +490,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nat
 (77) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -559,7 +559,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_reg
 (94) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 
-(95) Scan parquet
+(95) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -628,7 +628,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_nam
 (111) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 
-(112) Scan parquet
+(112) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/9.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (155)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (154)
    +- Exchange (153)
@@ -133,7 +133,7 @@ AdaptiveSparkPlan (155)
                               +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -170,7 +170,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -239,7 +239,7 @@ Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (26) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -308,7 +308,7 @@ Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (43) InputIteratorTransformer
 Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -377,7 +377,7 @@ Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_natio
 (60) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -446,7 +446,7 @@ Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_sup
 (77) InputIteratorTransformer
 Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/10.txt
@@ -31,28 +31,28 @@ AdaptiveSparkPlan (100)
                                     :                 :                 :        +- VeloxResizeBatches (5)
                                     :                 :                 :           +- ^ ProjectExecTransformer (3)
                                     :                 :                 :              +- ^ FilterExecTransformer (2)
-                                    :                 :                 :                 +- ^ Scan parquet (1)
+                                    :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                     :                 :                 +- ^ InputIteratorTransformer (18)
                                     :                 :                    +- ShuffleQueryStage (16)
                                     :                 :                       +- ColumnarExchange (15)
                                     :                 :                          +- VeloxResizeBatches (14)
                                     :                 :                             +- ^ ProjectExecTransformer (12)
                                     :                 :                                +- ^ FilterExecTransformer (11)
-                                    :                 :                                   +- ^ Scan parquet (10)
+                                    :                 :                                   +- ^ ScanTransformer parquet  (10)
                                     :                 +- ^ InputIteratorTransformer (35)
                                     :                    +- ShuffleQueryStage (33)
                                     :                       +- ColumnarExchange (32)
                                     :                          +- VeloxResizeBatches (31)
                                     :                             +- ^ ProjectExecTransformer (29)
                                     :                                +- ^ FilterExecTransformer (28)
-                                    :                                   +- ^ Scan parquet (27)
+                                    :                                   +- ^ ScanTransformer parquet  (27)
                                     +- ^ InputIteratorTransformer (52)
                                        +- ShuffleQueryStage (50)
                                           +- ColumnarExchange (49)
                                              +- VeloxResizeBatches (48)
                                                 +- ^ ProjectExecTransformer (46)
                                                    +- ^ FilterExecTransformer (45)
-                                                      +- ^ Scan parquet (44)
+                                                      +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    TakeOrderedAndProject (99)
    +- HashAggregate (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -125,7 +125,7 @@ Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (9) InputIteratorTransformer
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (26) InputIteratorTransformer
 Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -261,7 +261,7 @@ Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (43) InputIteratorTransformer
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/11.txt
@@ -29,21 +29,21 @@ AdaptiveSparkPlan (82)
                                                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                    +- ShuffleQueryStage (16)
                                                 :                       +- ColumnarExchange (15)
                                                 :                          +- VeloxResizeBatches (14)
                                                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                                +- ^ FilterExecTransformer (11)
-                                                :                                   +- ^ Scan parquet (10)
+                                                :                                   +- ^ ScanTransformer parquet  (10)
                                                 +- ^ InputIteratorTransformer (35)
                                                    +- ShuffleQueryStage (33)
                                                       +- ColumnarExchange (32)
                                                          +- VeloxResizeBatches (31)
                                                             +- ^ ProjectExecTransformer (29)
                                                                +- ^ FilterExecTransformer (28)
-                                                                  +- ^ Scan parquet (27)
+                                                                  +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    Sort (81)
    +- Exchange (80)
@@ -72,7 +72,7 @@ AdaptiveSparkPlan (82)
                                     +- Scan parquet (69)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -109,7 +109,7 @@ Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 (9) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -177,7 +177,7 @@ Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 (26) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/12.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (55)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,7 +49,7 @@ AdaptiveSparkPlan (55)
                                  +- Scan parquet (43)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -86,7 +86,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/13.txt
@@ -24,14 +24,14 @@ AdaptiveSparkPlan (58)
                                                       :     +- ColumnarExchange (5)
                                                       :        +- VeloxResizeBatches (4)
                                                       :           +- ^ ProjectExecTransformer (2)
-                                                      :              +- ^ Scan parquet (1)
+                                                      :              +- ^ ScanTransformer parquet  (1)
                                                       +- ^ InputIteratorTransformer (17)
                                                          +- ShuffleQueryStage (15)
                                                             +- ColumnarExchange (14)
                                                                +- VeloxResizeBatches (13)
                                                                   +- ^ ProjectExecTransformer (11)
                                                                      +- ^ FilterExecTransformer (10)
-                                                                        +- ^ Scan parquet (9)
+                                                                        +- ^ ScanTransformer parquet  (9)
 +- == Initial Plan ==
    Sort (57)
    +- Exchange (56)
@@ -52,7 +52,7 @@ AdaptiveSparkPlan (58)
                                        +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -84,7 +84,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/14.txt
@@ -13,14 +13,14 @@ AdaptiveSparkPlan (39)
                   :        +- VeloxResizeBatches (5)
                   :           +- ^ ProjectExecTransformer (3)
                   :              +- ^ FilterExecTransformer (2)
-                  :                 +- ^ Scan parquet (1)
+                  :                 +- ^ ScanTransformer parquet  (1)
                   +- ^ InputIteratorTransformer (18)
                      +- ShuffleQueryStage (16)
                         +- ColumnarExchange (15)
                            +- VeloxResizeBatches (14)
                               +- ^ ProjectExecTransformer (12)
                                  +- ^ FilterExecTransformer (11)
-                                    +- ^ Scan parquet (10)
+                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (38)
    +- HashAggregate (37)
@@ -37,7 +37,7 @@ AdaptiveSparkPlan (39)
                      +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -74,7 +74,7 @@ Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/15.txt
@@ -15,7 +15,7 @@ AdaptiveSparkPlan (50)
                         :        +- VeloxResizeBatches (5)
                         :           +- ^ ProjectExecTransformer (3)
                         :              +- ^ FilterExecTransformer (2)
-                        :                 +- ^ Scan parquet (1)
+                        :                 +- ^ ScanTransformer parquet  (1)
                         +- ^ FilterExecTransformer (22)
                            +- ^ RegularHashAggregateExecTransformer (21)
                               +- ^ InputIteratorTransformer (20)
@@ -26,7 +26,7 @@ AdaptiveSparkPlan (50)
                                              +- ^ FlushableHashAggregateExecTransformer (13)
                                                 +- ^ ProjectExecTransformer (12)
                                                    +- ^ FilterExecTransformer (11)
-                                                      +- ^ Scan parquet (10)
+                                                      +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (49)
    +- Exchange (48)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (50)
                                  +- Scan parquet (38)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/16.txt
@@ -29,14 +29,14 @@ AdaptiveSparkPlan (71)
                                                                   :        +- VeloxResizeBatches (5)
                                                                   :           +- ^ ProjectExecTransformer (3)
                                                                   :              +- ^ FilterExecTransformer (2)
-                                                                  :                 +- ^ Scan parquet (1)
+                                                                  :                 +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (18)
                                                                      +- ShuffleQueryStage (16)
                                                                         +- ColumnarExchange (15)
                                                                            +- VeloxResizeBatches (14)
                                                                               +- ^ ProjectExecTransformer (12)
                                                                                  +- ^ FilterExecTransformer (11)
-                                                                                    +- ^ Scan parquet (10)
+                                                                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (70)
    +- Exchange (69)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (71)
                                        +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ Input [2]: [ps_partkey#X, ps_suppkey#X]
 (9) InputIteratorTransformer
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/17.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/17.txt
@@ -15,14 +15,14 @@ AdaptiveSparkPlan (63)
                   :     :        +- VeloxResizeBatches (5)
                   :     :           +- ^ ProjectExecTransformer (3)
                   :     :              +- ^ FilterExecTransformer (2)
-                  :     :                 +- ^ Scan parquet (1)
+                  :     :                 +- ^ ScanTransformer parquet  (1)
                   :     +- ^ InputIteratorTransformer (18)
                   :        +- ShuffleQueryStage (16)
                   :           +- ColumnarExchange (15)
                   :              +- VeloxResizeBatches (14)
                   :                 +- ^ ProjectExecTransformer (12)
                   :                    +- ^ FilterExecTransformer (11)
-                  :                       +- ^ Scan parquet (10)
+                  :                       +- ^ ScanTransformer parquet  (10)
                   +- ^ FilterExecTransformer (33)
                      +- ^ ProjectExecTransformer (32)
                         +- ^ RegularHashAggregateExecTransformer (31)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (63)
                                        +- ^ ProjectExecTransformer (24)
                                           +- ^ FlushableHashAggregateExecTransformer (23)
                                              +- ^ FilterExecTransformer (22)
-                                                +- ^ Scan parquet (21)
+                                                +- ^ ScanTransformer parquet  (21)
 +- == Initial Plan ==
    HashAggregate (62)
    +- HashAggregate (61)
@@ -59,7 +59,7 @@ AdaptiveSparkPlan (63)
                               +- Scan parquet (52)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -96,7 +96,7 @@ Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [p_partkey#X, p_brand#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -142,7 +142,7 @@ Join condition: None
 Output [3]: [l_quantity#X, l_extendedprice#X, p_partkey#X]
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, p_partkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [l_partkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/18.txt
@@ -19,7 +19,7 @@ AdaptiveSparkPlan (110)
                   :                 :        +- VeloxResizeBatches (5)
                   :                 :           +- ^ ProjectExecTransformer (3)
                   :                 :              +- ^ FilterExecTransformer (2)
-                  :                 :                 +- ^ Scan parquet (1)
+                  :                 :                 +- ^ ScanTransformer parquet  (1)
                   :                 +- ^ InputIteratorTransformer (38)
                   :                    +- ShuffleQueryStage (36)
                   :                       +- ColumnarExchange (35)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (110)
                   :                                   :        +- VeloxResizeBatches (14)
                   :                                   :           +- ^ ProjectExecTransformer (12)
                   :                                   :              +- ^ FilterExecTransformer (11)
-                  :                                   :                 +- ^ Scan parquet (10)
+                  :                                   :                 +- ^ ScanTransformer parquet  (10)
                   :                                   +- ^ ProjectExecTransformer (30)
                   :                                      +- ^ FilterExecTransformer (29)
                   :                                         +- ^ RegularHashAggregateExecTransformer (28)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (110)
                   :                                                     +- VeloxResizeBatches (23)
                   :                                                        +- ^ ProjectExecTransformer (21)
                   :                                                           +- ^ FlushableHashAggregateExecTransformer (20)
-                  :                                                              +- ^ Scan parquet (19)
+                  :                                                              +- ^ ScanTransformer parquet  (19)
                   +- ^ ShuffledHashJoinExecTransformer LeftSemi BuildRight (63)
                      :- ^ InputIteratorTransformer (55)
                      :  +- ShuffleQueryStage (53)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (110)
                      :        +- VeloxResizeBatches (51)
                      :           +- ^ ProjectExecTransformer (49)
                      :              +- ^ FilterExecTransformer (48)
-                     :                 +- ^ Scan parquet (47)
+                     :                 +- ^ ScanTransformer parquet  (47)
                      +- ^ ProjectExecTransformer (62)
                         +- ^ FilterExecTransformer (61)
                            +- ^ RegularHashAggregateExecTransformer (60)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (110)
                                     +- Scan parquet (97)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -136,7 +136,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 (18) InputIteratorTransformer
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -289,7 +289,7 @@ Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 (46) InputIteratorTransformer
 Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/19.txt
@@ -12,14 +12,14 @@ AdaptiveSparkPlan (38)
                :        +- VeloxResizeBatches (5)
                :           +- ^ ProjectExecTransformer (3)
                :              +- ^ FilterExecTransformer (2)
-               :                 +- ^ Scan parquet (1)
+               :                 +- ^ ScanTransformer parquet  (1)
                +- ^ InputIteratorTransformer (18)
                   +- ShuffleQueryStage (16)
                      +- ColumnarExchange (15)
                         +- VeloxResizeBatches (14)
                            +- ^ ProjectExecTransformer (12)
                               +- ^ FilterExecTransformer (11)
-                                 +- ^ Scan parquet (10)
+                                 +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (37)
    +- HashAggregate (36)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (38)
                      +- Scan parquet (30)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/20.txt
@@ -21,7 +21,7 @@ AdaptiveSparkPlan (146)
                         :                 :        +- VeloxResizeBatches (5)
                         :                 :           +- ^ ProjectExecTransformer (3)
                         :                 :              +- ^ FilterExecTransformer (2)
-                        :                 :                 +- ^ Scan parquet (1)
+                        :                 :                 +- ^ ScanTransformer parquet  (1)
                         :                 +- ^ InputIteratorTransformer (68)
                         :                    +- ShuffleQueryStage (66)
                         :                       +- ColumnarExchange (65)
@@ -40,14 +40,14 @@ AdaptiveSparkPlan (146)
                         :                                   :                 :        +- VeloxResizeBatches (14)
                         :                                   :                 :           +- ^ ProjectExecTransformer (12)
                         :                                   :                 :              +- ^ FilterExecTransformer (11)
-                        :                                   :                 :                 +- ^ Scan parquet (10)
+                        :                                   :                 :                 +- ^ ScanTransformer parquet  (10)
                         :                                   :                 +- ^ InputIteratorTransformer (27)
                         :                                   :                    +- ShuffleQueryStage (25)
                         :                                   :                       +- ColumnarExchange (24)
                         :                                   :                          +- VeloxResizeBatches (23)
                         :                                   :                             +- ^ ProjectExecTransformer (21)
                         :                                   :                                +- ^ FilterExecTransformer (20)
-                        :                                   :                                   +- ^ Scan parquet (19)
+                        :                                   :                                   +- ^ ScanTransformer parquet  (19)
                         :                                   +- ^ InputIteratorTransformer (60)
                         :                                      +- ShuffleQueryStage (58)
                         :                                         +- ColumnarExchange (57)
@@ -64,7 +64,7 @@ AdaptiveSparkPlan (146)
                         :                                                                 :        +- VeloxResizeBatches (40)
                         :                                                                 :           +- ^ ProjectExecTransformer (38)
                         :                                                                 :              +- ^ FilterExecTransformer (37)
-                        :                                                                 :                 +- ^ Scan parquet (36)
+                        :                                                                 :                 +- ^ ScanTransformer parquet  (36)
                         :                                                                 +- ^ InputIteratorTransformer (48)
                         :                                                                    +- ShuffleQueryStage (46)
                         :                                                                       +- ReusedExchange (45)
@@ -74,7 +74,7 @@ AdaptiveSparkPlan (146)
                                  +- VeloxResizeBatches (81)
                                     +- ^ ProjectExecTransformer (79)
                                        +- ^ FilterExecTransformer (78)
-                                          +- ^ Scan parquet (77)
+                                          +- ^ ScanTransformer parquet  (77)
 +- == Initial Plan ==
    Sort (145)
    +- Exchange (144)
@@ -127,7 +127,7 @@ AdaptiveSparkPlan (146)
                         +- Scan parquet (137)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -164,7 +164,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -201,7 +201,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -269,7 +269,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (35) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(36) Scan parquet
+(36) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -434,7 +434,7 @@ Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 (76) InputIteratorTransformer
 Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 
-(77) Scan parquet
+(77) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/21.txt
@@ -30,7 +30,7 @@ AdaptiveSparkPlan (138)
                                  :                 :                 :        +- VeloxResizeBatches (5)
                                  :                 :                 :           +- ^ ProjectExecTransformer (3)
                                  :                 :                 :              +- ^ FilterExecTransformer (2)
-                                 :                 :                 :                 +- ^ Scan parquet (1)
+                                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                  :                 :                 +- ^ InputIteratorTransformer (44)
                                  :                 :                    +- ShuffleQueryStage (42)
                                  :                 :                       +- ColumnarExchange (41)
@@ -44,34 +44,34 @@ AdaptiveSparkPlan (138)
                                  :                 :                                   :  :        +- VeloxResizeBatches (14)
                                  :                 :                                   :  :           +- ^ ProjectExecTransformer (12)
                                  :                 :                                   :  :              +- ^ FilterExecTransformer (11)
-                                 :                 :                                   :  :                 +- ^ Scan parquet (10)
+                                 :                 :                                   :  :                 +- ^ ScanTransformer parquet  (10)
                                  :                 :                                   :  +- ^ InputIteratorTransformer (26)
                                  :                 :                                   :     +- ShuffleQueryStage (24)
                                  :                 :                                   :        +- ColumnarExchange (23)
                                  :                 :                                   :           +- VeloxResizeBatches (22)
                                  :                 :                                   :              +- ^ ProjectExecTransformer (20)
-                                 :                 :                                   :                 +- ^ Scan parquet (19)
+                                 :                 :                                   :                 +- ^ ScanTransformer parquet  (19)
                                  :                 :                                   +- ^ InputIteratorTransformer (36)
                                  :                 :                                      +- ShuffleQueryStage (34)
                                  :                 :                                         +- ColumnarExchange (33)
                                  :                 :                                            +- VeloxResizeBatches (32)
                                  :                 :                                               +- ^ ProjectExecTransformer (30)
                                  :                 :                                                  +- ^ FilterExecTransformer (29)
-                                 :                 :                                                     +- ^ Scan parquet (28)
+                                 :                 :                                                     +- ^ ScanTransformer parquet  (28)
                                  :                 +- ^ InputIteratorTransformer (61)
                                  :                    +- ShuffleQueryStage (59)
                                  :                       +- ColumnarExchange (58)
                                  :                          +- VeloxResizeBatches (57)
                                  :                             +- ^ ProjectExecTransformer (55)
                                  :                                +- ^ FilterExecTransformer (54)
-                                 :                                   +- ^ Scan parquet (53)
+                                 :                                   +- ^ ScanTransformer parquet  (53)
                                  +- ^ InputIteratorTransformer (78)
                                     +- ShuffleQueryStage (76)
                                        +- ColumnarExchange (75)
                                           +- VeloxResizeBatches (74)
                                              +- ^ ProjectExecTransformer (72)
                                                 +- ^ FilterExecTransformer (71)
-                                                   +- ^ Scan parquet (70)
+                                                   +- ^ ScanTransformer parquet  (70)
 +- == Initial Plan ==
    TakeOrderedAndProject (137)
    +- HashAggregate (136)
@@ -120,7 +120,7 @@ AdaptiveSparkPlan (138)
                               +- Scan parquet (127)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -157,7 +157,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -194,7 +194,7 @@ Input [2]: [l_orderkey#X, l_suppkey#X]
 (18) InputIteratorTransformer
 Input [2]: [l_orderkey#X, l_suppkey#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -231,7 +231,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(28) Scan parquet
+(28) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -330,7 +330,7 @@ Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 (52) InputIteratorTransformer
 Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -398,7 +398,7 @@ Input [2]: [s_name#X, s_nationkey#X]
 (69) InputIteratorTransformer
 Input [2]: [s_name#X, s_nationkey#X]
 
-(70) Scan parquet
+(70) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/22.txt
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (52)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (17)
                                                 +- ShuffleQueryStage (15)
                                                    +- ColumnarExchange (14)
                                                       +- VeloxResizeBatches (13)
                                                          +- ^ ProjectExecTransformer (11)
-                                                            +- ^ Scan parquet (10)
+                                                            +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (51)
    +- Exchange (50)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (52)
                            +- Scan parquet (42)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 (9) InputIteratorTransformer
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/3.txt
@@ -20,21 +20,21 @@ AdaptiveSparkPlan (67)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (18)
                      :                    +- ShuffleQueryStage (16)
                      :                       +- ColumnarExchange (15)
                      :                          +- VeloxResizeBatches (14)
                      :                             +- ^ ProjectExecTransformer (12)
                      :                                +- ^ FilterExecTransformer (11)
-                     :                                   +- ^ Scan parquet (10)
+                     :                                   +- ^ ScanTransformer parquet  (10)
                      +- ^ InputIteratorTransformer (35)
                         +- ShuffleQueryStage (33)
                            +- ColumnarExchange (32)
                               +- VeloxResizeBatches (31)
                                  +- ^ ProjectExecTransformer (29)
                                     +- ^ FilterExecTransformer (28)
-                                       +- ^ Scan parquet (27)
+                                       +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    TakeOrderedAndProject (66)
    +- HashAggregate (65)
@@ -61,7 +61,7 @@ AdaptiveSparkPlan (67)
                            +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -98,7 +98,7 @@ Input [1]: [c_custkey#X]
 (9) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -166,7 +166,7 @@ Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 (26) InputIteratorTransformer
 Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/4.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (56)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (55)
    +- Exchange (54)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (56)
                                  +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -87,7 +87,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/5.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (156)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (155)
    +- Exchange (154)
@@ -134,7 +134,7 @@ AdaptiveSparkPlan (156)
                                  +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -239,7 +239,7 @@ Input [2]: [c_nationkey#X, o_orderkey#X]
 (26) InputIteratorTransformer
 Input [2]: [c_nationkey#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -307,7 +307,7 @@ Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (43) InputIteratorTransformer
 Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -375,7 +375,7 @@ Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 (60) InputIteratorTransformer
 Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -443,7 +443,7 @@ Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 (77) InputIteratorTransformer
 Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/7.txt
@@ -46,35 +46,35 @@ AdaptiveSparkPlan (149)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (81)
                                                 +- ShuffleQueryStage (79)
                                                    +- ReusedExchange (78)
@@ -128,7 +128,7 @@ AdaptiveSparkPlan (149)
                               +- Scan parquet (138)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -165,7 +165,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -233,7 +233,7 @@ Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_ship
 (26) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -301,7 +301,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_cust
 (43) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -369,7 +369,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nati
 (60) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/8.txt
@@ -59,56 +59,56 @@ AdaptiveSparkPlan (207)
                                                 :                 :                 :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :                 :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :                 :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                                 :                 :                 :                 :                 :                 :                       +- ColumnarExchange (15)
                                                 :                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                                 :                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                                :                 :                 :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                                :                 :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (33)
                                                 :                 :                 :                 :                 :                       +- ColumnarExchange (32)
                                                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (31)
                                                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                                :                 :                 :                 :                 :                                   +- ^ Scan parquet (27)
+                                                :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (52)
                                                 :                 :                 :                 :                    +- ShuffleQueryStage (50)
                                                 :                 :                 :                 :                       +- ColumnarExchange (49)
                                                 :                 :                 :                 :                          +- VeloxResizeBatches (48)
                                                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (46)
                                                 :                 :                 :                 :                                +- ^ FilterExecTransformer (45)
-                                                :                 :                 :                 :                                   +- ^ Scan parquet (44)
+                                                :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (44)
                                                 :                 :                 :                 +- ^ InputIteratorTransformer (69)
                                                 :                 :                 :                    +- ShuffleQueryStage (67)
                                                 :                 :                 :                       +- ColumnarExchange (66)
                                                 :                 :                 :                          +- VeloxResizeBatches (65)
                                                 :                 :                 :                             +- ^ ProjectExecTransformer (63)
                                                 :                 :                 :                                +- ^ FilterExecTransformer (62)
-                                                :                 :                 :                                   +- ^ Scan parquet (61)
+                                                :                 :                 :                                   +- ^ ScanTransformer parquet  (61)
                                                 :                 :                 +- ^ InputIteratorTransformer (86)
                                                 :                 :                    +- ShuffleQueryStage (84)
                                                 :                 :                       +- ColumnarExchange (83)
                                                 :                 :                          +- VeloxResizeBatches (82)
                                                 :                 :                             +- ^ ProjectExecTransformer (80)
                                                 :                 :                                +- ^ FilterExecTransformer (79)
-                                                :                 :                                   +- ^ Scan parquet (78)
+                                                :                 :                                   +- ^ ScanTransformer parquet  (78)
                                                 :                 +- ^ InputIteratorTransformer (103)
                                                 :                    +- ShuffleQueryStage (101)
                                                 :                       +- ColumnarExchange (100)
                                                 :                          +- VeloxResizeBatches (99)
                                                 :                             +- ^ ProjectExecTransformer (97)
                                                 :                                +- ^ FilterExecTransformer (96)
-                                                :                                   +- ^ Scan parquet (95)
+                                                :                                   +- ^ ScanTransformer parquet  (95)
                                                 +- ^ InputIteratorTransformer (120)
                                                    +- ShuffleQueryStage (118)
                                                       +- ColumnarExchange (117)
                                                          +- VeloxResizeBatches (116)
                                                             +- ^ ProjectExecTransformer (114)
                                                                +- ^ FilterExecTransformer (113)
-                                                                  +- ^ Scan parquet (112)
+                                                                  +- ^ ScanTransformer parquet  (112)
 +- == Initial Plan ==
    Sort (206)
    +- Exchange (205)
@@ -177,7 +177,7 @@ AdaptiveSparkPlan (207)
                                  +- Scan parquet (195)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -214,7 +214,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (26) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -350,7 +350,7 @@ Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 (43) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -418,7 +418,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_order
 (60) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -486,7 +486,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nat
 (77) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -554,7 +554,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_reg
 (94) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 
-(95) Scan parquet
+(95) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -622,7 +622,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_nam
 (111) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 
-(112) Scan parquet
+(112) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/9.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (155)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (154)
    +- Exchange (153)
@@ -133,7 +133,7 @@ AdaptiveSparkPlan (155)
                               +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -170,7 +170,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -238,7 +238,7 @@ Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (26) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -306,7 +306,7 @@ Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (43) InputIteratorTransformer
 Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -374,7 +374,7 @@ Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_natio
 (60) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -442,7 +442,7 @@ Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_sup
 (77) InputIteratorTransformer
 Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/10.txt
@@ -31,28 +31,28 @@ AdaptiveSparkPlan (100)
                                     :                 :                 :        +- VeloxResizeBatches (5)
                                     :                 :                 :           +- ^ ProjectExecTransformer (3)
                                     :                 :                 :              +- ^ FilterExecTransformer (2)
-                                    :                 :                 :                 +- ^ Scan parquet (1)
+                                    :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                     :                 :                 +- ^ InputIteratorTransformer (18)
                                     :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                     :                 :                       +- ColumnarExchange (15)
                                     :                 :                          +- VeloxResizeBatches (14)
                                     :                 :                             +- ^ ProjectExecTransformer (12)
                                     :                 :                                +- ^ FilterExecTransformer (11)
-                                    :                 :                                   +- ^ Scan parquet (10)
+                                    :                 :                                   +- ^ ScanTransformer parquet  (10)
                                     :                 +- ^ InputIteratorTransformer (35)
                                     :                    +- ShuffleQueryStage (33), Statistics(X)
                                     :                       +- ColumnarExchange (32)
                                     :                          +- VeloxResizeBatches (31)
                                     :                             +- ^ ProjectExecTransformer (29)
                                     :                                +- ^ FilterExecTransformer (28)
-                                    :                                   +- ^ Scan parquet (27)
+                                    :                                   +- ^ ScanTransformer parquet  (27)
                                     +- ^ InputIteratorTransformer (52)
                                        +- ShuffleQueryStage (50), Statistics(X)
                                           +- ColumnarExchange (49)
                                              +- VeloxResizeBatches (48)
                                                 +- ^ ProjectExecTransformer (46)
                                                    +- ^ FilterExecTransformer (45)
-                                                      +- ^ Scan parquet (44)
+                                                      +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    TakeOrderedAndProject (99)
    +- HashAggregate (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -125,7 +125,7 @@ Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (9) InputIteratorTransformer
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (26) InputIteratorTransformer
 Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -261,7 +261,7 @@ Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (43) InputIteratorTransformer
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/11.txt
@@ -29,21 +29,21 @@ AdaptiveSparkPlan (82)
                                                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                       +- ColumnarExchange (15)
                                                 :                          +- VeloxResizeBatches (14)
                                                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                                +- ^ FilterExecTransformer (11)
-                                                :                                   +- ^ Scan parquet (10)
+                                                :                                   +- ^ ScanTransformer parquet  (10)
                                                 +- ^ InputIteratorTransformer (35)
                                                    +- ShuffleQueryStage (33), Statistics(X)
                                                       +- ColumnarExchange (32)
                                                          +- VeloxResizeBatches (31)
                                                             +- ^ ProjectExecTransformer (29)
                                                                +- ^ FilterExecTransformer (28)
-                                                                  +- ^ Scan parquet (27)
+                                                                  +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    Sort (81)
    +- Exchange (80)
@@ -72,7 +72,7 @@ AdaptiveSparkPlan (82)
                                     +- Scan parquet (69)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -109,7 +109,7 @@ Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 (9) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -177,7 +177,7 @@ Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 (26) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -444,7 +444,7 @@ AdaptiveSparkPlan (136)
                   :                 :        +- VeloxResizeBatches (87)
                   :                 :           +- ^ ProjectExecTransformer (85)
                   :                 :              +- ^ FilterExecTransformer (84)
-                  :                 :                 +- ^ Scan parquet (83)
+                  :                 :                 +- ^ ScanTransformer parquet  (83)
                   :                 +- ^ InputIteratorTransformer (95)
                   :                    +- ShuffleQueryStage (93), Statistics(X)
                   :                       +- ReusedExchange (92)
@@ -475,7 +475,7 @@ AdaptiveSparkPlan (136)
                         +- Scan parquet (127)
 
 
-(83) Scan parquet
+(83) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/12.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (55)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,7 +49,7 @@ AdaptiveSparkPlan (55)
                                  +- Scan parquet (43)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -86,7 +86,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/13.txt
@@ -24,14 +24,14 @@ AdaptiveSparkPlan (58)
                                                       :     +- ColumnarExchange (5)
                                                       :        +- VeloxResizeBatches (4)
                                                       :           +- ^ ProjectExecTransformer (2)
-                                                      :              +- ^ Scan parquet (1)
+                                                      :              +- ^ ScanTransformer parquet  (1)
                                                       +- ^ InputIteratorTransformer (17)
                                                          +- ShuffleQueryStage (15), Statistics(X)
                                                             +- ColumnarExchange (14)
                                                                +- VeloxResizeBatches (13)
                                                                   +- ^ ProjectExecTransformer (11)
                                                                      +- ^ FilterExecTransformer (10)
-                                                                        +- ^ Scan parquet (9)
+                                                                        +- ^ ScanTransformer parquet  (9)
 +- == Initial Plan ==
    Sort (57)
    +- Exchange (56)
@@ -52,7 +52,7 @@ AdaptiveSparkPlan (58)
                                        +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -84,7 +84,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/14.txt
@@ -13,14 +13,14 @@ AdaptiveSparkPlan (39)
                   :        +- VeloxResizeBatches (5)
                   :           +- ^ ProjectExecTransformer (3)
                   :              +- ^ FilterExecTransformer (2)
-                  :                 +- ^ Scan parquet (1)
+                  :                 +- ^ ScanTransformer parquet  (1)
                   +- ^ InputIteratorTransformer (18)
                      +- ShuffleQueryStage (16), Statistics(X)
                         +- ColumnarExchange (15)
                            +- VeloxResizeBatches (14)
                               +- ^ ProjectExecTransformer (12)
                                  +- ^ FilterExecTransformer (11)
-                                    +- ^ Scan parquet (10)
+                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (38)
    +- HashAggregate (37)
@@ -37,7 +37,7 @@ AdaptiveSparkPlan (39)
                      +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -74,7 +74,7 @@ Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/15.txt
@@ -14,7 +14,7 @@ AdaptiveSparkPlan (47)
                      :        +- VeloxResizeBatches (5)
                      :           +- ^ ProjectExecTransformer (3)
                      :              +- ^ FilterExecTransformer (2)
-                     :                 +- ^ Scan parquet (1)
+                     :                 +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (22)
                         +- ^ RegularHashAggregateExecTransformer (21)
                            +- ^ InputIteratorTransformer (20)
@@ -25,7 +25,7 @@ AdaptiveSparkPlan (47)
                                           +- ^ FlushableHashAggregateExecTransformer (13)
                                              +- ^ ProjectExecTransformer (12)
                                                 +- ^ FilterExecTransformer (11)
-                                                   +- ^ Scan parquet (10)
+                                                   +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (46)
    +- Exchange (45)
@@ -45,7 +45,7 @@ AdaptiveSparkPlan (47)
                                  +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -82,7 +82,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -272,7 +272,7 @@ AdaptiveSparkPlan (73)
                               +- ^ FlushableHashAggregateExecTransformer (51)
                                  +- ^ ProjectExecTransformer (50)
                                     +- ^ FilterExecTransformer (49)
-                                       +- ^ Scan parquet (48)
+                                       +- ^ ScanTransformer parquet  (48)
 +- == Initial Plan ==
    HashAggregate (72)
    +- HashAggregate (71)
@@ -284,7 +284,7 @@ AdaptiveSparkPlan (73)
                      +- Scan parquet (65)
 
 
-(48) Scan parquet
+(48) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/16.txt
@@ -29,14 +29,14 @@ AdaptiveSparkPlan (71)
                                                                   :        +- VeloxResizeBatches (5)
                                                                   :           +- ^ ProjectExecTransformer (3)
                                                                   :              +- ^ FilterExecTransformer (2)
-                                                                  :                 +- ^ Scan parquet (1)
+                                                                  :                 +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (18)
                                                                      +- ShuffleQueryStage (16), Statistics(X)
                                                                         +- ColumnarExchange (15)
                                                                            +- VeloxResizeBatches (14)
                                                                               +- ^ ProjectExecTransformer (12)
                                                                                  +- ^ FilterExecTransformer (11)
-                                                                                    +- ^ Scan parquet (10)
+                                                                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (70)
    +- Exchange (69)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (71)
                                        +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ Input [2]: [ps_partkey#X, ps_suppkey#X]
 (9) InputIteratorTransformer
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/17.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/17.txt
@@ -15,14 +15,14 @@ AdaptiveSparkPlan (63)
                   :     :        +- VeloxResizeBatches (5)
                   :     :           +- ^ ProjectExecTransformer (3)
                   :     :              +- ^ FilterExecTransformer (2)
-                  :     :                 +- ^ Scan parquet (1)
+                  :     :                 +- ^ ScanTransformer parquet  (1)
                   :     +- ^ InputIteratorTransformer (18)
                   :        +- ShuffleQueryStage (16), Statistics(X)
                   :           +- ColumnarExchange (15)
                   :              +- VeloxResizeBatches (14)
                   :                 +- ^ ProjectExecTransformer (12)
                   :                    +- ^ FilterExecTransformer (11)
-                  :                       +- ^ Scan parquet (10)
+                  :                       +- ^ ScanTransformer parquet  (10)
                   +- ^ FilterExecTransformer (33)
                      +- ^ ProjectExecTransformer (32)
                         +- ^ RegularHashAggregateExecTransformer (31)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (63)
                                        +- ^ ProjectExecTransformer (24)
                                           +- ^ FlushableHashAggregateExecTransformer (23)
                                              +- ^ FilterExecTransformer (22)
-                                                +- ^ Scan parquet (21)
+                                                +- ^ ScanTransformer parquet  (21)
 +- == Initial Plan ==
    HashAggregate (62)
    +- HashAggregate (61)
@@ -59,7 +59,7 @@ AdaptiveSparkPlan (63)
                               +- Scan parquet (52)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -96,7 +96,7 @@ Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [p_partkey#X, p_brand#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -142,7 +142,7 @@ Join condition: None
 Output [3]: [l_quantity#X, l_extendedprice#X, p_partkey#X]
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, p_partkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [l_partkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/18.txt
@@ -19,7 +19,7 @@ AdaptiveSparkPlan (110)
                   :                 :        +- VeloxResizeBatches (5)
                   :                 :           +- ^ ProjectExecTransformer (3)
                   :                 :              +- ^ FilterExecTransformer (2)
-                  :                 :                 +- ^ Scan parquet (1)
+                  :                 :                 +- ^ ScanTransformer parquet  (1)
                   :                 +- ^ InputIteratorTransformer (38)
                   :                    +- ShuffleQueryStage (36), Statistics(X)
                   :                       +- ColumnarExchange (35)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (110)
                   :                                   :        +- VeloxResizeBatches (14)
                   :                                   :           +- ^ ProjectExecTransformer (12)
                   :                                   :              +- ^ FilterExecTransformer (11)
-                  :                                   :                 +- ^ Scan parquet (10)
+                  :                                   :                 +- ^ ScanTransformer parquet  (10)
                   :                                   +- ^ ProjectExecTransformer (30)
                   :                                      +- ^ FilterExecTransformer (29)
                   :                                         +- ^ RegularHashAggregateExecTransformer (28)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (110)
                   :                                                     +- VeloxResizeBatches (23)
                   :                                                        +- ^ ProjectExecTransformer (21)
                   :                                                           +- ^ FlushableHashAggregateExecTransformer (20)
-                  :                                                              +- ^ Scan parquet (19)
+                  :                                                              +- ^ ScanTransformer parquet  (19)
                   +- ^ ShuffledHashJoinExecTransformer LeftSemi BuildRight (63)
                      :- ^ InputIteratorTransformer (55)
                      :  +- ShuffleQueryStage (53), Statistics(X)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (110)
                      :        +- VeloxResizeBatches (51)
                      :           +- ^ ProjectExecTransformer (49)
                      :              +- ^ FilterExecTransformer (48)
-                     :                 +- ^ Scan parquet (47)
+                     :                 +- ^ ScanTransformer parquet  (47)
                      +- ^ ProjectExecTransformer (62)
                         +- ^ FilterExecTransformer (61)
                            +- ^ RegularHashAggregateExecTransformer (60)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (110)
                                     +- Scan parquet (97)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -136,7 +136,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 (18) InputIteratorTransformer
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -289,7 +289,7 @@ Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 (46) InputIteratorTransformer
 Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/19.txt
@@ -12,14 +12,14 @@ AdaptiveSparkPlan (38)
                :        +- VeloxResizeBatches (5)
                :           +- ^ ProjectExecTransformer (3)
                :              +- ^ FilterExecTransformer (2)
-               :                 +- ^ Scan parquet (1)
+               :                 +- ^ ScanTransformer parquet  (1)
                +- ^ InputIteratorTransformer (18)
                   +- ShuffleQueryStage (16), Statistics(X)
                      +- ColumnarExchange (15)
                         +- VeloxResizeBatches (14)
                            +- ^ ProjectExecTransformer (12)
                               +- ^ FilterExecTransformer (11)
-                                 +- ^ Scan parquet (10)
+                                 +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (37)
    +- HashAggregate (36)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (38)
                      +- Scan parquet (30)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/20.txt
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (143)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (68)
                      :                    +- ShuffleQueryStage (66), Statistics(X)
                      :                       +- ColumnarExchange (65)
@@ -39,14 +39,14 @@ AdaptiveSparkPlan (143)
                      :                                   :                 :        +- VeloxResizeBatches (14)
                      :                                   :                 :           +- ^ ProjectExecTransformer (12)
                      :                                   :                 :              +- ^ FilterExecTransformer (11)
-                     :                                   :                 :                 +- ^ Scan parquet (10)
+                     :                                   :                 :                 +- ^ ScanTransformer parquet  (10)
                      :                                   :                 +- ^ InputIteratorTransformer (27)
                      :                                   :                    +- ShuffleQueryStage (25), Statistics(X)
                      :                                   :                       +- ColumnarExchange (24)
                      :                                   :                          +- VeloxResizeBatches (23)
                      :                                   :                             +- ^ ProjectExecTransformer (21)
                      :                                   :                                +- ^ FilterExecTransformer (20)
-                     :                                   :                                   +- ^ Scan parquet (19)
+                     :                                   :                                   +- ^ ScanTransformer parquet  (19)
                      :                                   +- ^ InputIteratorTransformer (60)
                      :                                      +- ShuffleQueryStage (58), Statistics(X)
                      :                                         +- ColumnarExchange (57)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (143)
                      :                                                                 :        +- VeloxResizeBatches (40)
                      :                                                                 :           +- ^ ProjectExecTransformer (38)
                      :                                                                 :              +- ^ FilterExecTransformer (37)
-                     :                                                                 :                 +- ^ Scan parquet (36)
+                     :                                                                 :                 +- ^ ScanTransformer parquet  (36)
                      :                                                                 +- ^ InputIteratorTransformer (48)
                      :                                                                    +- ShuffleQueryStage (46), Statistics(X)
                      :                                                                       +- ReusedExchange (45)
@@ -73,7 +73,7 @@ AdaptiveSparkPlan (143)
                               +- VeloxResizeBatches (81)
                                  +- ^ ProjectExecTransformer (79)
                                     +- ^ FilterExecTransformer (78)
-                                       +- ^ Scan parquet (77)
+                                       +- ^ ScanTransformer parquet  (77)
 +- == Initial Plan ==
    Sort (142)
    +- Exchange (141)
@@ -126,7 +126,7 @@ AdaptiveSparkPlan (143)
                         +- Scan parquet (134)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -163,7 +163,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -200,7 +200,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -268,7 +268,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (35) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(36) Scan parquet
+(36) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -433,7 +433,7 @@ Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 (76) InputIteratorTransformer
 Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 
-(77) Scan parquet
+(77) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/21.txt
@@ -29,7 +29,7 @@ AdaptiveSparkPlan (137)
                               :                 :                 :        +- VeloxResizeBatches (5)
                               :                 :                 :           +- ^ ProjectExecTransformer (3)
                               :                 :                 :              +- ^ FilterExecTransformer (2)
-                              :                 :                 :                 +- ^ Scan parquet (1)
+                              :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                               :                 :                 +- ^ InputIteratorTransformer (44)
                               :                 :                    +- ShuffleQueryStage (42), Statistics(X)
                               :                 :                       +- ColumnarExchange (41)
@@ -43,34 +43,34 @@ AdaptiveSparkPlan (137)
                               :                 :                                   :  :        +- VeloxResizeBatches (14)
                               :                 :                                   :  :           +- ^ ProjectExecTransformer (12)
                               :                 :                                   :  :              +- ^ FilterExecTransformer (11)
-                              :                 :                                   :  :                 +- ^ Scan parquet (10)
+                              :                 :                                   :  :                 +- ^ ScanTransformer parquet  (10)
                               :                 :                                   :  +- ^ InputIteratorTransformer (26)
                               :                 :                                   :     +- ShuffleQueryStage (24), Statistics(X)
                               :                 :                                   :        +- ColumnarExchange (23)
                               :                 :                                   :           +- VeloxResizeBatches (22)
                               :                 :                                   :              +- ^ ProjectExecTransformer (20)
-                              :                 :                                   :                 +- ^ Scan parquet (19)
+                              :                 :                                   :                 +- ^ ScanTransformer parquet  (19)
                               :                 :                                   +- ^ InputIteratorTransformer (36)
                               :                 :                                      +- ShuffleQueryStage (34), Statistics(X)
                               :                 :                                         +- ColumnarExchange (33)
                               :                 :                                            +- VeloxResizeBatches (32)
                               :                 :                                               +- ^ ProjectExecTransformer (30)
                               :                 :                                                  +- ^ FilterExecTransformer (29)
-                              :                 :                                                     +- ^ Scan parquet (28)
+                              :                 :                                                     +- ^ ScanTransformer parquet  (28)
                               :                 +- ^ InputIteratorTransformer (61)
                               :                    +- ShuffleQueryStage (59), Statistics(X)
                               :                       +- ColumnarExchange (58)
                               :                          +- VeloxResizeBatches (57)
                               :                             +- ^ ProjectExecTransformer (55)
                               :                                +- ^ FilterExecTransformer (54)
-                              :                                   +- ^ Scan parquet (53)
+                              :                                   +- ^ ScanTransformer parquet  (53)
                               +- ^ InputIteratorTransformer (78)
                                  +- ShuffleQueryStage (76), Statistics(X)
                                     +- ColumnarExchange (75)
                                        +- VeloxResizeBatches (74)
                                           +- ^ ProjectExecTransformer (72)
                                              +- ^ FilterExecTransformer (71)
-                                                +- ^ Scan parquet (70)
+                                                +- ^ ScanTransformer parquet  (70)
 +- == Initial Plan ==
    TakeOrderedAndProject (136)
    +- HashAggregate (135)
@@ -119,7 +119,7 @@ AdaptiveSparkPlan (137)
                               +- Scan parquet (126)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [2]: [l_orderkey#X, l_suppkey#X]
 (18) InputIteratorTransformer
 Input [2]: [l_orderkey#X, l_suppkey#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -230,7 +230,7 @@ Left keys [1]: [l_orderkey#X]
 Right keys [1]: [l_orderkey#X]
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(28) Scan parquet
+(28) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -329,7 +329,7 @@ Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 (52) InputIteratorTransformer
 Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -397,7 +397,7 @@ Input [2]: [s_name#X, s_nationkey#X]
 (69) InputIteratorTransformer
 Input [2]: [s_name#X, s_nationkey#X]
 
-(70) Scan parquet
+(70) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/22.txt
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (52)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (17)
                                                 +- ShuffleQueryStage (15), Statistics(X)
                                                    +- ColumnarExchange (14)
                                                       +- VeloxResizeBatches (13)
                                                          +- ^ ProjectExecTransformer (11)
-                                                            +- ^ Scan parquet (10)
+                                                            +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (51)
    +- Exchange (50)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (52)
                            +- Scan parquet (42)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 (9) InputIteratorTransformer
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -283,7 +283,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)
@@ -293,7 +293,7 @@ AdaptiveSparkPlan (72)
                +- Scan parquet (66)
 
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -400,7 +400,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/3.txt
@@ -20,21 +20,21 @@ AdaptiveSparkPlan (67)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (18)
                      :                    +- ShuffleQueryStage (16), Statistics(X)
                      :                       +- ColumnarExchange (15)
                      :                          +- VeloxResizeBatches (14)
                      :                             +- ^ ProjectExecTransformer (12)
                      :                                +- ^ FilterExecTransformer (11)
-                     :                                   +- ^ Scan parquet (10)
+                     :                                   +- ^ ScanTransformer parquet  (10)
                      +- ^ InputIteratorTransformer (35)
                         +- ShuffleQueryStage (33), Statistics(X)
                            +- ColumnarExchange (32)
                               +- VeloxResizeBatches (31)
                                  +- ^ ProjectExecTransformer (29)
                                     +- ^ FilterExecTransformer (28)
-                                       +- ^ Scan parquet (27)
+                                       +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    TakeOrderedAndProject (66)
    +- HashAggregate (65)
@@ -61,7 +61,7 @@ AdaptiveSparkPlan (67)
                            +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -98,7 +98,7 @@ Input [1]: [c_custkey#X]
 (9) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -166,7 +166,7 @@ Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 (26) InputIteratorTransformer
 Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/4.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (56)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (55)
    +- Exchange (54)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (56)
                                  +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -87,7 +87,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/5.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (156)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (155)
    +- Exchange (154)
@@ -134,7 +134,7 @@ AdaptiveSparkPlan (156)
                                  +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -239,7 +239,7 @@ Input [2]: [c_nationkey#X, o_orderkey#X]
 (26) InputIteratorTransformer
 Input [2]: [c_nationkey#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -307,7 +307,7 @@ Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (43) InputIteratorTransformer
 Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -375,7 +375,7 @@ Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 (60) InputIteratorTransformer
 Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -443,7 +443,7 @@ Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 (77) InputIteratorTransformer
 Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/7.txt
@@ -46,35 +46,35 @@ AdaptiveSparkPlan (149)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (81)
                                                 +- ShuffleQueryStage (79), Statistics(X)
                                                    +- ReusedExchange (78)
@@ -128,7 +128,7 @@ AdaptiveSparkPlan (149)
                               +- Scan parquet (138)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -165,7 +165,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -233,7 +233,7 @@ Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_ship
 (26) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -301,7 +301,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_cust
 (43) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -369,7 +369,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nati
 (60) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/8.txt
@@ -59,56 +59,56 @@ AdaptiveSparkPlan (207)
                                                 :                 :                 :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :                 :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :                 :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                 :                 :                 :                 :                 :                       +- ColumnarExchange (15)
                                                 :                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                                 :                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                                :                 :                 :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                                :                 :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                                 :                 :                 :                 :                 :                       +- ColumnarExchange (32)
                                                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (31)
                                                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                                :                 :                 :                 :                 :                                   +- ^ Scan parquet (27)
+                                                :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (52)
                                                 :                 :                 :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                                 :                 :                 :                 :                       +- ColumnarExchange (49)
                                                 :                 :                 :                 :                          +- VeloxResizeBatches (48)
                                                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (46)
                                                 :                 :                 :                 :                                +- ^ FilterExecTransformer (45)
-                                                :                 :                 :                 :                                   +- ^ Scan parquet (44)
+                                                :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (44)
                                                 :                 :                 :                 +- ^ InputIteratorTransformer (69)
                                                 :                 :                 :                    +- ShuffleQueryStage (67), Statistics(X)
                                                 :                 :                 :                       +- ColumnarExchange (66)
                                                 :                 :                 :                          +- VeloxResizeBatches (65)
                                                 :                 :                 :                             +- ^ ProjectExecTransformer (63)
                                                 :                 :                 :                                +- ^ FilterExecTransformer (62)
-                                                :                 :                 :                                   +- ^ Scan parquet (61)
+                                                :                 :                 :                                   +- ^ ScanTransformer parquet  (61)
                                                 :                 :                 +- ^ InputIteratorTransformer (86)
                                                 :                 :                    +- ShuffleQueryStage (84), Statistics(X)
                                                 :                 :                       +- ColumnarExchange (83)
                                                 :                 :                          +- VeloxResizeBatches (82)
                                                 :                 :                             +- ^ ProjectExecTransformer (80)
                                                 :                 :                                +- ^ FilterExecTransformer (79)
-                                                :                 :                                   +- ^ Scan parquet (78)
+                                                :                 :                                   +- ^ ScanTransformer parquet  (78)
                                                 :                 +- ^ InputIteratorTransformer (103)
                                                 :                    +- ShuffleQueryStage (101), Statistics(X)
                                                 :                       +- ColumnarExchange (100)
                                                 :                          +- VeloxResizeBatches (99)
                                                 :                             +- ^ ProjectExecTransformer (97)
                                                 :                                +- ^ FilterExecTransformer (96)
-                                                :                                   +- ^ Scan parquet (95)
+                                                :                                   +- ^ ScanTransformer parquet  (95)
                                                 +- ^ InputIteratorTransformer (120)
                                                    +- ShuffleQueryStage (118), Statistics(X)
                                                       +- ColumnarExchange (117)
                                                          +- VeloxResizeBatches (116)
                                                             +- ^ ProjectExecTransformer (114)
                                                                +- ^ FilterExecTransformer (113)
-                                                                  +- ^ Scan parquet (112)
+                                                                  +- ^ ScanTransformer parquet  (112)
 +- == Initial Plan ==
    Sort (206)
    +- Exchange (205)
@@ -177,7 +177,7 @@ AdaptiveSparkPlan (207)
                                  +- Scan parquet (195)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -214,7 +214,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -282,7 +282,7 @@ Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (26) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -350,7 +350,7 @@ Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 (43) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -418,7 +418,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_order
 (60) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -486,7 +486,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nat
 (77) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -554,7 +554,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_reg
 (94) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 
-(95) Scan parquet
+(95) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -622,7 +622,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_nam
 (111) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 
-(112) Scan parquet
+(112) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/9.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (155)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (154)
    +- Exchange (153)
@@ -133,7 +133,7 @@ AdaptiveSparkPlan (155)
                               +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -170,7 +170,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -238,7 +238,7 @@ Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (26) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -306,7 +306,7 @@ Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (43) InputIteratorTransformer
 Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -374,7 +374,7 @@ Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_natio
 (60) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -442,7 +442,7 @@ Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_sup
 (77) InputIteratorTransformer
 Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/1.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/1.txt
@@ -16,7 +16,7 @@ AdaptiveSparkPlan (30)
                                     +- ^ FlushableHashAggregateExecTransformer (4)
                                        +- ^ ProjectExecTransformer (3)
                                           +- ^ FilterExecTransformer (2)
-                                             +- ^ Scan parquet (1)
+                                             +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    Sort (29)
    +- Exchange (28)
@@ -28,7 +28,7 @@ AdaptiveSparkPlan (30)
                      +- Scan parquet (22)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_tax#X, l_returnflag#X, l_linestatus#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/10.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/10.txt
@@ -31,28 +31,28 @@ AdaptiveSparkPlan (100)
                                     :                 :                 :        +- VeloxResizeBatches (5)
                                     :                 :                 :           +- ^ ProjectExecTransformer (3)
                                     :                 :                 :              +- ^ FilterExecTransformer (2)
-                                    :                 :                 :                 +- ^ Scan parquet (1)
+                                    :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                     :                 :                 +- ^ InputIteratorTransformer (18)
                                     :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                     :                 :                       +- ColumnarExchange (15)
                                     :                 :                          +- VeloxResizeBatches (14)
                                     :                 :                             +- ^ ProjectExecTransformer (12)
                                     :                 :                                +- ^ FilterExecTransformer (11)
-                                    :                 :                                   +- ^ Scan parquet (10)
+                                    :                 :                                   +- ^ ScanTransformer parquet  (10)
                                     :                 +- ^ InputIteratorTransformer (35)
                                     :                    +- ShuffleQueryStage (33), Statistics(X)
                                     :                       +- ColumnarExchange (32)
                                     :                          +- VeloxResizeBatches (31)
                                     :                             +- ^ ProjectExecTransformer (29)
                                     :                                +- ^ FilterExecTransformer (28)
-                                    :                                   +- ^ Scan parquet (27)
+                                    :                                   +- ^ ScanTransformer parquet  (27)
                                     +- ^ InputIteratorTransformer (52)
                                        +- ShuffleQueryStage (50), Statistics(X)
                                           +- ColumnarExchange (49)
                                              +- VeloxResizeBatches (48)
                                                 +- ^ ProjectExecTransformer (46)
                                                    +- ^ FilterExecTransformer (45)
-                                                      +- ^ Scan parquet (44)
+                                                      +- ^ ScanTransformer parquet  (44)
 +- == Initial Plan ==
    TakeOrderedAndProject (99)
    +- HashAggregate (98)
@@ -88,7 +88,7 @@ AdaptiveSparkPlan (100)
                            +- Scan parquet (90)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -125,7 +125,7 @@ Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (9) InputIteratorTransformer
 Input [7]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -194,7 +194,7 @@ Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (26) InputIteratorTransformer
 Input [8]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_returnflag#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -263,7 +263,7 @@ Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acct
 (43) InputIteratorTransformer
 Input [9]: [c_custkey#X, c_name#X, c_address#X, c_nationkey#X, c_phone#X, c_acctbal#X, c_comment#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/11.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/11.txt
@@ -29,21 +29,21 @@ AdaptiveSparkPlan (82)
                                                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                       +- ColumnarExchange (15)
                                                 :                          +- VeloxResizeBatches (14)
                                                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                                +- ^ FilterExecTransformer (11)
-                                                :                                   +- ^ Scan parquet (10)
+                                                :                                   +- ^ ScanTransformer parquet  (10)
                                                 +- ^ InputIteratorTransformer (35)
                                                    +- ShuffleQueryStage (33), Statistics(X)
                                                       +- ColumnarExchange (32)
                                                          +- VeloxResizeBatches (31)
                                                             +- ^ ProjectExecTransformer (29)
                                                                +- ^ FilterExecTransformer (28)
-                                                                  +- ^ Scan parquet (27)
+                                                                  +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    Sort (81)
    +- Exchange (80)
@@ -72,7 +72,7 @@ AdaptiveSparkPlan (82)
                                     +- Scan parquet (69)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -109,7 +109,7 @@ Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 (9) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -178,7 +178,7 @@ Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 (26) InputIteratorTransformer
 Input [4]: [ps_partkey#X, ps_availqty#X, ps_supplycost#X, s_nationkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -448,7 +448,7 @@ AdaptiveSparkPlan (136)
                   :                 :        +- VeloxResizeBatches (87)
                   :                 :           +- ^ ProjectExecTransformer (85)
                   :                 :              +- ^ FilterExecTransformer (84)
-                  :                 :                 +- ^ Scan parquet (83)
+                  :                 :                 +- ^ ScanTransformer parquet  (83)
                   :                 +- ^ InputIteratorTransformer (95)
                   :                    +- ShuffleQueryStage (93), Statistics(X)
                   :                       +- ReusedExchange (92)
@@ -479,7 +479,7 @@ AdaptiveSparkPlan (136)
                         +- Scan parquet (127)
 
 
-(83) Scan parquet
+(83) ScanTransformer parquet 
 Output [3]: [ps_suppkey#X, ps_availqty#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/12.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/12.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (55)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (54)
    +- Exchange (53)
@@ -49,7 +49,7 @@ AdaptiveSparkPlan (55)
                                  +- Scan parquet (43)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -86,7 +86,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_shipdate#X, l_commitdate#X, l_receiptdate#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/13.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/13.txt
@@ -24,14 +24,14 @@ AdaptiveSparkPlan (58)
                                                       :     +- ColumnarExchange (5)
                                                       :        +- VeloxResizeBatches (4)
                                                       :           +- ^ ProjectExecTransformer (2)
-                                                      :              +- ^ Scan parquet (1)
+                                                      :              +- ^ ScanTransformer parquet  (1)
                                                       +- ^ InputIteratorTransformer (17)
                                                          +- ShuffleQueryStage (15), Statistics(X)
                                                             +- ColumnarExchange (14)
                                                                +- VeloxResizeBatches (13)
                                                                   +- ^ ProjectExecTransformer (11)
                                                                      +- ^ FilterExecTransformer (10)
-                                                                        +- ^ Scan parquet (9)
+                                                                        +- ^ ScanTransformer parquet  (9)
 +- == Initial Plan ==
    Sort (57)
    +- Exchange (56)
@@ -52,7 +52,7 @@ AdaptiveSparkPlan (58)
                                        +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [1]: [c_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -84,7 +84,7 @@ Input [1]: [c_custkey#X]
 (8) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(9) Scan parquet
+(9) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_comment#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/14.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/14.txt
@@ -13,14 +13,14 @@ AdaptiveSparkPlan (39)
                   :        +- VeloxResizeBatches (5)
                   :           +- ^ ProjectExecTransformer (3)
                   :              +- ^ FilterExecTransformer (2)
-                  :                 +- ^ Scan parquet (1)
+                  :                 +- ^ ScanTransformer parquet  (1)
                   +- ^ InputIteratorTransformer (18)
                      +- ShuffleQueryStage (16), Statistics(X)
                         +- ColumnarExchange (15)
                            +- VeloxResizeBatches (14)
                               +- ^ ProjectExecTransformer (12)
                                  +- ^ FilterExecTransformer (11)
-                                    +- ^ Scan parquet (10)
+                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (38)
    +- HashAggregate (37)
@@ -37,7 +37,7 @@ AdaptiveSparkPlan (39)
                      +- Scan parquet (31)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -74,7 +74,7 @@ Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/15.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/15.txt
@@ -14,7 +14,7 @@ AdaptiveSparkPlan (47)
                      :        +- VeloxResizeBatches (5)
                      :           +- ^ ProjectExecTransformer (3)
                      :              +- ^ FilterExecTransformer (2)
-                     :                 +- ^ Scan parquet (1)
+                     :                 +- ^ ScanTransformer parquet  (1)
                      +- ^ FilterExecTransformer (22)
                         +- ^ RegularHashAggregateExecTransformer (21)
                            +- ^ InputIteratorTransformer (20)
@@ -25,7 +25,7 @@ AdaptiveSparkPlan (47)
                                           +- ^ FlushableHashAggregateExecTransformer (13)
                                              +- ^ ProjectExecTransformer (12)
                                                 +- ^ FilterExecTransformer (11)
-                                                   +- ^ Scan parquet (10)
+                                                   +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (46)
    +- Exchange (45)
@@ -45,7 +45,7 @@ AdaptiveSparkPlan (47)
                                  +- Scan parquet (35)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -82,7 +82,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_phone#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -274,7 +274,7 @@ AdaptiveSparkPlan (73)
                               +- ^ FlushableHashAggregateExecTransformer (51)
                                  +- ^ ProjectExecTransformer (50)
                                     +- ^ FilterExecTransformer (49)
-                                       +- ^ Scan parquet (48)
+                                       +- ^ ScanTransformer parquet  (48)
 +- == Initial Plan ==
    HashAggregate (72)
    +- HashAggregate (71)
@@ -286,7 +286,7 @@ AdaptiveSparkPlan (73)
                      +- Scan parquet (65)
 
 
-(48) Scan parquet
+(48) ScanTransformer parquet 
 Output [4]: [l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/16.txt
@@ -29,14 +29,14 @@ AdaptiveSparkPlan (71)
                                                                   :        +- VeloxResizeBatches (5)
                                                                   :           +- ^ ProjectExecTransformer (3)
                                                                   :              +- ^ FilterExecTransformer (2)
-                                                                  :                 +- ^ Scan parquet (1)
+                                                                  :                 +- ^ ScanTransformer parquet  (1)
                                                                   +- ^ InputIteratorTransformer (18)
                                                                      +- ShuffleQueryStage (16), Statistics(X)
                                                                         +- ColumnarExchange (15)
                                                                            +- VeloxResizeBatches (14)
                                                                               +- ^ ProjectExecTransformer (12)
                                                                                  +- ^ FilterExecTransformer (11)
-                                                                                    +- ^ Scan parquet (10)
+                                                                                    +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (70)
    +- Exchange (69)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (71)
                                        +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [ps_partkey#X, ps_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -100,7 +100,7 @@ Input [2]: [ps_partkey#X, ps_suppkey#X]
 (9) InputIteratorTransformer
 Input [2]: [ps_partkey#X, ps_suppkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_type#X, p_size#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/17.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/17.txt
@@ -15,14 +15,14 @@ AdaptiveSparkPlan (63)
                   :     :        +- VeloxResizeBatches (5)
                   :     :           +- ^ ProjectExecTransformer (3)
                   :     :              +- ^ FilterExecTransformer (2)
-                  :     :                 +- ^ Scan parquet (1)
+                  :     :                 +- ^ ScanTransformer parquet  (1)
                   :     +- ^ InputIteratorTransformer (18)
                   :        +- ShuffleQueryStage (16), Statistics(X)
                   :           +- ColumnarExchange (15)
                   :              +- VeloxResizeBatches (14)
                   :                 +- ^ ProjectExecTransformer (12)
                   :                    +- ^ FilterExecTransformer (11)
-                  :                       +- ^ Scan parquet (10)
+                  :                       +- ^ ScanTransformer parquet  (10)
                   +- ^ FilterExecTransformer (33)
                      +- ^ ProjectExecTransformer (32)
                         +- ^ RegularHashAggregateExecTransformer (31)
@@ -33,7 +33,7 @@ AdaptiveSparkPlan (63)
                                        +- ^ ProjectExecTransformer (24)
                                           +- ^ FlushableHashAggregateExecTransformer (23)
                                              +- ^ FilterExecTransformer (22)
-                                                +- ^ Scan parquet (21)
+                                                +- ^ ScanTransformer parquet  (21)
 +- == Initial Plan ==
    HashAggregate (62)
    +- HashAggregate (61)
@@ -59,7 +59,7 @@ AdaptiveSparkPlan (63)
                               +- Scan parquet (52)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -96,7 +96,7 @@ Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 (9) InputIteratorTransformer
 Input [3]: [l_partkey#X, l_quantity#X, l_extendedprice#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [p_partkey#X, p_brand#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -143,7 +143,7 @@ Join condition: None
 Output [3]: [l_quantity#X, l_extendedprice#X, p_partkey#X]
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, p_partkey#X]
 
-(21) Scan parquet
+(21) ScanTransformer parquet 
 Output [2]: [l_partkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/18.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/18.txt
@@ -19,7 +19,7 @@ AdaptiveSparkPlan (110)
                   :                 :        +- VeloxResizeBatches (5)
                   :                 :           +- ^ ProjectExecTransformer (3)
                   :                 :              +- ^ FilterExecTransformer (2)
-                  :                 :                 +- ^ Scan parquet (1)
+                  :                 :                 +- ^ ScanTransformer parquet  (1)
                   :                 +- ^ InputIteratorTransformer (38)
                   :                    +- ShuffleQueryStage (36), Statistics(X)
                   :                       +- ColumnarExchange (35)
@@ -32,7 +32,7 @@ AdaptiveSparkPlan (110)
                   :                                   :        +- VeloxResizeBatches (14)
                   :                                   :           +- ^ ProjectExecTransformer (12)
                   :                                   :              +- ^ FilterExecTransformer (11)
-                  :                                   :                 +- ^ Scan parquet (10)
+                  :                                   :                 +- ^ ScanTransformer parquet  (10)
                   :                                   +- ^ ProjectExecTransformer (30)
                   :                                      +- ^ FilterExecTransformer (29)
                   :                                         +- ^ RegularHashAggregateExecTransformer (28)
@@ -42,7 +42,7 @@ AdaptiveSparkPlan (110)
                   :                                                     +- VeloxResizeBatches (23)
                   :                                                        +- ^ ProjectExecTransformer (21)
                   :                                                           +- ^ FlushableHashAggregateExecTransformer (20)
-                  :                                                              +- ^ Scan parquet (19)
+                  :                                                              +- ^ ScanTransformer parquet  (19)
                   +- ^ ShuffledHashJoinExecTransformer LeftSemi BuildRight (63)
                      :- ^ InputIteratorTransformer (55)
                      :  +- ShuffleQueryStage (53), Statistics(X)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (110)
                      :        +- VeloxResizeBatches (51)
                      :           +- ^ ProjectExecTransformer (49)
                      :              +- ^ FilterExecTransformer (48)
-                     :                 +- ^ Scan parquet (47)
+                     :                 +- ^ ScanTransformer parquet  (47)
                      +- ^ ProjectExecTransformer (62)
                         +- ^ FilterExecTransformer (61)
                            +- ^ RegularHashAggregateExecTransformer (60)
@@ -99,7 +99,7 @@ AdaptiveSparkPlan (110)
                                     +- Scan parquet (97)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -136,7 +136,7 @@ Input [2]: [c_custkey#X, c_name#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_name#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -173,7 +173,7 @@ Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 (18) InputIteratorTransformer
 Input [4]: [o_orderkey#X, o_custkey#X, o_totalprice#X, o_orderdate#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -291,7 +291,7 @@ Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 (46) InputIteratorTransformer
 Input [5]: [c_custkey#X, c_name#X, o_orderkey#X, o_totalprice#X, o_orderdate#X]
 
-(47) Scan parquet
+(47) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_quantity#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/19.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/19.txt
@@ -12,14 +12,14 @@ AdaptiveSparkPlan (38)
                :        +- VeloxResizeBatches (5)
                :           +- ^ ProjectExecTransformer (3)
                :              +- ^ FilterExecTransformer (2)
-               :                 +- ^ Scan parquet (1)
+               :                 +- ^ ScanTransformer parquet  (1)
                +- ^ InputIteratorTransformer (18)
                   +- ShuffleQueryStage (16), Statistics(X)
                      +- ColumnarExchange (15)
                         +- VeloxResizeBatches (14)
                            +- ^ ProjectExecTransformer (12)
                               +- ^ FilterExecTransformer (11)
-                                 +- ^ Scan parquet (10)
+                                 +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    HashAggregate (37)
    +- HashAggregate (36)
@@ -36,7 +36,7 @@ AdaptiveSparkPlan (38)
                      +- Scan parquet (30)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [6]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, l_shipinstruct#X, l_shipmode#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -73,7 +73,7 @@ Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 (9) InputIteratorTransformer
 Input [4]: [l_partkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [p_partkey#X, p_brand#X, p_size#X, p_container#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/20.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/20.txt
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (143)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (68)
                      :                    +- ShuffleQueryStage (66), Statistics(X)
                      :                       +- ColumnarExchange (65)
@@ -39,14 +39,14 @@ AdaptiveSparkPlan (143)
                      :                                   :                 :        +- VeloxResizeBatches (14)
                      :                                   :                 :           +- ^ ProjectExecTransformer (12)
                      :                                   :                 :              +- ^ FilterExecTransformer (11)
-                     :                                   :                 :                 +- ^ Scan parquet (10)
+                     :                                   :                 :                 +- ^ ScanTransformer parquet  (10)
                      :                                   :                 +- ^ InputIteratorTransformer (27)
                      :                                   :                    +- ShuffleQueryStage (25), Statistics(X)
                      :                                   :                       +- ColumnarExchange (24)
                      :                                   :                          +- VeloxResizeBatches (23)
                      :                                   :                             +- ^ ProjectExecTransformer (21)
                      :                                   :                                +- ^ FilterExecTransformer (20)
-                     :                                   :                                   +- ^ Scan parquet (19)
+                     :                                   :                                   +- ^ ScanTransformer parquet  (19)
                      :                                   +- ^ InputIteratorTransformer (60)
                      :                                      +- ShuffleQueryStage (58), Statistics(X)
                      :                                         +- ColumnarExchange (57)
@@ -63,7 +63,7 @@ AdaptiveSparkPlan (143)
                      :                                                                 :        +- VeloxResizeBatches (40)
                      :                                                                 :           +- ^ ProjectExecTransformer (38)
                      :                                                                 :              +- ^ FilterExecTransformer (37)
-                     :                                                                 :                 +- ^ Scan parquet (36)
+                     :                                                                 :                 +- ^ ScanTransformer parquet  (36)
                      :                                                                 +- ^ InputIteratorTransformer (48)
                      :                                                                    +- ShuffleQueryStage (46), Statistics(X)
                      :                                                                       +- ReusedExchange (45)
@@ -73,7 +73,7 @@ AdaptiveSparkPlan (143)
                               +- VeloxResizeBatches (81)
                                  +- ^ ProjectExecTransformer (79)
                                     +- ^ FilterExecTransformer (78)
-                                       +- ^ Scan parquet (77)
+                                       +- ^ ScanTransformer parquet  (77)
 +- == Initial Plan ==
    Sort (142)
    +- Exchange (141)
@@ -126,7 +126,7 @@ AdaptiveSparkPlan (143)
                         +- Scan parquet (134)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -163,7 +163,7 @@ Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [4]: [s_suppkey#X, s_name#X, s_address#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -200,7 +200,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (18) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -269,7 +269,7 @@ Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 (35) InputIteratorTransformer
 Input [3]: [ps_partkey#X, ps_suppkey#X, ps_availqty#X]
 
-(36) Scan parquet
+(36) ScanTransformer parquet 
 Output [4]: [l_partkey#X, l_suppkey#X, l_quantity#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -437,7 +437,7 @@ Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 (76) InputIteratorTransformer
 Input [3]: [s_name#X, s_address#X, s_nationkey#X]
 
-(77) Scan parquet
+(77) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/21.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/21.txt
@@ -29,7 +29,7 @@ AdaptiveSparkPlan (137)
                               :                 :                 :        +- VeloxResizeBatches (5)
                               :                 :                 :           +- ^ ProjectExecTransformer (3)
                               :                 :                 :              +- ^ FilterExecTransformer (2)
-                              :                 :                 :                 +- ^ Scan parquet (1)
+                              :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                               :                 :                 +- ^ InputIteratorTransformer (44)
                               :                 :                    +- ShuffleQueryStage (42), Statistics(X)
                               :                 :                       +- ColumnarExchange (41)
@@ -43,34 +43,34 @@ AdaptiveSparkPlan (137)
                               :                 :                                   :  :        +- VeloxResizeBatches (14)
                               :                 :                                   :  :           +- ^ ProjectExecTransformer (12)
                               :                 :                                   :  :              +- ^ FilterExecTransformer (11)
-                              :                 :                                   :  :                 +- ^ Scan parquet (10)
+                              :                 :                                   :  :                 +- ^ ScanTransformer parquet  (10)
                               :                 :                                   :  +- ^ InputIteratorTransformer (26)
                               :                 :                                   :     +- ShuffleQueryStage (24), Statistics(X)
                               :                 :                                   :        +- ColumnarExchange (23)
                               :                 :                                   :           +- VeloxResizeBatches (22)
                               :                 :                                   :              +- ^ ProjectExecTransformer (20)
-                              :                 :                                   :                 +- ^ Scan parquet (19)
+                              :                 :                                   :                 +- ^ ScanTransformer parquet  (19)
                               :                 :                                   +- ^ InputIteratorTransformer (36)
                               :                 :                                      +- ShuffleQueryStage (34), Statistics(X)
                               :                 :                                         +- ColumnarExchange (33)
                               :                 :                                            +- VeloxResizeBatches (32)
                               :                 :                                               +- ^ ProjectExecTransformer (30)
                               :                 :                                                  +- ^ FilterExecTransformer (29)
-                              :                 :                                                     +- ^ Scan parquet (28)
+                              :                 :                                                     +- ^ ScanTransformer parquet  (28)
                               :                 +- ^ InputIteratorTransformer (61)
                               :                    +- ShuffleQueryStage (59), Statistics(X)
                               :                       +- ColumnarExchange (58)
                               :                          +- VeloxResizeBatches (57)
                               :                             +- ^ ProjectExecTransformer (55)
                               :                                +- ^ FilterExecTransformer (54)
-                              :                                   +- ^ Scan parquet (53)
+                              :                                   +- ^ ScanTransformer parquet  (53)
                               +- ^ InputIteratorTransformer (78)
                                  +- ShuffleQueryStage (76), Statistics(X)
                                     +- ColumnarExchange (75)
                                        +- VeloxResizeBatches (74)
                                           +- ^ ProjectExecTransformer (72)
                                              +- ^ FilterExecTransformer (71)
-                                                +- ^ Scan parquet (70)
+                                                +- ^ ScanTransformer parquet  (70)
 +- == Initial Plan ==
    TakeOrderedAndProject (136)
    +- HashAggregate (135)
@@ -119,7 +119,7 @@ AdaptiveSparkPlan (137)
                               +- Scan parquet (126)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -156,7 +156,7 @@ Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [3]: [s_suppkey#X, s_name#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -193,7 +193,7 @@ Input [2]: [l_orderkey#X, l_suppkey#X]
 (18) InputIteratorTransformer
 Input [2]: [l_orderkey#X, l_suppkey#X]
 
-(19) Scan parquet
+(19) ScanTransformer parquet 
 Output [2]: [l_orderkey#X, l_suppkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -231,7 +231,7 @@ Right keys [1]: [l_orderkey#X]
 Join type: LeftSemi
 Join condition: NOT (l_suppkey#X = l_suppkey#X)
 
-(28) Scan parquet
+(28) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -332,7 +332,7 @@ Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 (52) InputIteratorTransformer
 Input [3]: [s_name#X, s_nationkey#X, l_orderkey#X]
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderstatus#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -401,7 +401,7 @@ Input [2]: [s_name#X, s_nationkey#X]
 (69) InputIteratorTransformer
 Input [2]: [s_name#X, s_nationkey#X]
 
-(70) Scan parquet
+(70) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/22.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/22.txt
@@ -22,13 +22,13 @@ AdaptiveSparkPlan (52)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (17)
                                                 +- ShuffleQueryStage (15), Statistics(X)
                                                    +- ColumnarExchange (14)
                                                       +- VeloxResizeBatches (13)
                                                          +- ^ ProjectExecTransformer (11)
-                                                            +- ^ Scan parquet (10)
+                                                            +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (51)
    +- Exchange (50)
@@ -46,7 +46,7 @@ AdaptiveSparkPlan (52)
                            +- Scan parquet (42)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -83,7 +83,7 @@ Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 (9) InputIteratorTransformer
 Input [3]: [c_custkey#X, c_phone#X, c_acctbal#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [1]: [o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -285,7 +285,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)
@@ -295,7 +295,7 @@ AdaptiveSparkPlan (72)
                +- Scan parquet (66)
 
 
-(53) Scan parquet
+(53) ScanTransformer parquet 
 Output [2]: [c_phone#X, c_acctbal#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -402,7 +402,7 @@ AdaptiveSparkPlan (72)
                   +- ^ FlushableHashAggregateExecTransformer (56)
                      +- ^ ProjectExecTransformer (55)
                         +- ^ FilterExecTransformer (54)
-                           +- ^ Scan parquet (53)
+                           +- ^ ScanTransformer parquet  (53)
 +- == Initial Plan ==
    HashAggregate (71)
    +- Exchange (70)

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/3.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/3.txt
@@ -20,21 +20,21 @@ AdaptiveSparkPlan (67)
                      :                 :        +- VeloxResizeBatches (5)
                      :                 :           +- ^ ProjectExecTransformer (3)
                      :                 :              +- ^ FilterExecTransformer (2)
-                     :                 :                 +- ^ Scan parquet (1)
+                     :                 :                 +- ^ ScanTransformer parquet  (1)
                      :                 +- ^ InputIteratorTransformer (18)
                      :                    +- ShuffleQueryStage (16), Statistics(X)
                      :                       +- ColumnarExchange (15)
                      :                          +- VeloxResizeBatches (14)
                      :                             +- ^ ProjectExecTransformer (12)
                      :                                +- ^ FilterExecTransformer (11)
-                     :                                   +- ^ Scan parquet (10)
+                     :                                   +- ^ ScanTransformer parquet  (10)
                      +- ^ InputIteratorTransformer (35)
                         +- ShuffleQueryStage (33), Statistics(X)
                            +- ColumnarExchange (32)
                               +- VeloxResizeBatches (31)
                                  +- ^ ProjectExecTransformer (29)
                                     +- ^ FilterExecTransformer (28)
-                                       +- ^ Scan parquet (27)
+                                       +- ^ ScanTransformer parquet  (27)
 +- == Initial Plan ==
    TakeOrderedAndProject (66)
    +- HashAggregate (65)
@@ -61,7 +61,7 @@ AdaptiveSparkPlan (67)
                            +- Scan parquet (57)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_mktsegment#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -98,7 +98,7 @@ Input [1]: [c_custkey#X]
 (9) InputIteratorTransformer
 Input [1]: [c_custkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [4]: [o_orderkey#X, o_custkey#X, o_orderdate#X, o_shippriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -167,7 +167,7 @@ Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 (26) InputIteratorTransformer
 Input [3]: [o_orderkey#X, o_orderdate#X, o_shippriority#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/4.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/4.txt
@@ -22,14 +22,14 @@ AdaptiveSparkPlan (56)
                                              :        +- VeloxResizeBatches (5)
                                              :           +- ^ ProjectExecTransformer (3)
                                              :              +- ^ FilterExecTransformer (2)
-                                             :                 +- ^ Scan parquet (1)
+                                             :                 +- ^ ScanTransformer parquet  (1)
                                              +- ^ InputIteratorTransformer (18)
                                                 +- ShuffleQueryStage (16), Statistics(X)
                                                    +- ColumnarExchange (15)
                                                       +- VeloxResizeBatches (14)
                                                          +- ^ ProjectExecTransformer (12)
                                                             +- ^ FilterExecTransformer (11)
-                                                               +- ^ Scan parquet (10)
+                                                               +- ^ ScanTransformer parquet  (10)
 +- == Initial Plan ==
    Sort (55)
    +- Exchange (54)
@@ -50,7 +50,7 @@ AdaptiveSparkPlan (56)
                                  +- Scan parquet (44)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_orderdate#X, o_orderpriority#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -87,7 +87,7 @@ Input [2]: [o_orderkey#X, o_orderpriority#X]
 (9) InputIteratorTransformer
 Input [2]: [o_orderkey#X, o_orderpriority#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [l_orderkey#X, l_commitdate#X, l_receiptdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/5.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/5.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (156)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (155)
    +- Exchange (154)
@@ -134,7 +134,7 @@ AdaptiveSparkPlan (156)
                                  +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -171,7 +171,7 @@ Input [2]: [c_custkey#X, c_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [c_custkey#X, c_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -240,7 +240,7 @@ Input [2]: [c_nationkey#X, o_orderkey#X]
 (26) InputIteratorTransformer
 Input [2]: [c_nationkey#X, o_orderkey#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -309,7 +309,7 @@ Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (43) InputIteratorTransformer
 Input [4]: [c_nationkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -378,7 +378,7 @@ Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 (60) InputIteratorTransformer
 Input [3]: [l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [3]: [n_nationkey#X, n_name#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -447,7 +447,7 @@ Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 (77) InputIteratorTransformer
 Input [4]: [l_extendedprice#X, l_discount#X, n_name#X, n_regionkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/6.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/6.txt
@@ -10,7 +10,7 @@ AdaptiveSparkPlan (20)
                   +- ^ FlushableHashAggregateExecTransformer (4)
                      +- ^ ProjectExecTransformer (3)
                         +- ^ FilterExecTransformer (2)
-                           +- ^ Scan parquet (1)
+                           +- ^ ScanTransformer parquet  (1)
 +- == Initial Plan ==
    HashAggregate (19)
    +- Exchange (18)
@@ -20,7 +20,7 @@ AdaptiveSparkPlan (20)
                +- Scan parquet (14)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [4]: [l_quantity#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/7.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/7.txt
@@ -46,35 +46,35 @@ AdaptiveSparkPlan (149)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (81)
                                                 +- ShuffleQueryStage (79), Statistics(X)
                                                    +- ReusedExchange (78)
@@ -128,7 +128,7 @@ AdaptiveSparkPlan (149)
                               +- Scan parquet (138)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -165,7 +165,7 @@ Input [2]: [s_suppkey#X, s_nationkey#X]
 (9) InputIteratorTransformer
 Input [2]: [s_suppkey#X, s_nationkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -234,7 +234,7 @@ Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_ship
 (26) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_orderkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_custkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -303,7 +303,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_cust
 (43) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, o_custkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -372,7 +372,7 @@ Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nati
 (60) InputIteratorTransformer
 Input [5]: [s_nationkey#X, l_extendedprice#X, l_discount#X, l_shipdate#X, c_nationkey#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/8.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/8.txt
@@ -59,56 +59,56 @@ AdaptiveSparkPlan (207)
                                                 :                 :                 :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                                 :                 :                 :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                                 :                 :                 :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                                :                 :                 :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                                :                 :                 :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                                 :                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                                 :                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                                 :                 :                 :                 :                 :                 :                       +- ColumnarExchange (15)
                                                 :                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                                 :                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                                 :                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                                :                 :                 :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                                :                 :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                                 :                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                                 :                 :                 :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                                 :                 :                 :                 :                 :                       +- ColumnarExchange (32)
                                                 :                 :                 :                 :                 :                          +- VeloxResizeBatches (31)
                                                 :                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                                 :                 :                 :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                                :                 :                 :                 :                 :                                   +- ^ Scan parquet (27)
+                                                :                 :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                                 :                 :                 :                 :                 +- ^ InputIteratorTransformer (52)
                                                 :                 :                 :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                                 :                 :                 :                 :                       +- ColumnarExchange (49)
                                                 :                 :                 :                 :                          +- VeloxResizeBatches (48)
                                                 :                 :                 :                 :                             +- ^ ProjectExecTransformer (46)
                                                 :                 :                 :                 :                                +- ^ FilterExecTransformer (45)
-                                                :                 :                 :                 :                                   +- ^ Scan parquet (44)
+                                                :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (44)
                                                 :                 :                 :                 +- ^ InputIteratorTransformer (69)
                                                 :                 :                 :                    +- ShuffleQueryStage (67), Statistics(X)
                                                 :                 :                 :                       +- ColumnarExchange (66)
                                                 :                 :                 :                          +- VeloxResizeBatches (65)
                                                 :                 :                 :                             +- ^ ProjectExecTransformer (63)
                                                 :                 :                 :                                +- ^ FilterExecTransformer (62)
-                                                :                 :                 :                                   +- ^ Scan parquet (61)
+                                                :                 :                 :                                   +- ^ ScanTransformer parquet  (61)
                                                 :                 :                 +- ^ InputIteratorTransformer (86)
                                                 :                 :                    +- ShuffleQueryStage (84), Statistics(X)
                                                 :                 :                       +- ColumnarExchange (83)
                                                 :                 :                          +- VeloxResizeBatches (82)
                                                 :                 :                             +- ^ ProjectExecTransformer (80)
                                                 :                 :                                +- ^ FilterExecTransformer (79)
-                                                :                 :                                   +- ^ Scan parquet (78)
+                                                :                 :                                   +- ^ ScanTransformer parquet  (78)
                                                 :                 +- ^ InputIteratorTransformer (103)
                                                 :                    +- ShuffleQueryStage (101), Statistics(X)
                                                 :                       +- ColumnarExchange (100)
                                                 :                          +- VeloxResizeBatches (99)
                                                 :                             +- ^ ProjectExecTransformer (97)
                                                 :                                +- ^ FilterExecTransformer (96)
-                                                :                                   +- ^ Scan parquet (95)
+                                                :                                   +- ^ ScanTransformer parquet  (95)
                                                 +- ^ InputIteratorTransformer (120)
                                                    +- ShuffleQueryStage (118), Statistics(X)
                                                       +- ColumnarExchange (117)
                                                          +- VeloxResizeBatches (116)
                                                             +- ^ ProjectExecTransformer (114)
                                                                +- ^ FilterExecTransformer (113)
-                                                                  +- ^ Scan parquet (112)
+                                                                  +- ^ ScanTransformer parquet  (112)
 +- == Initial Plan ==
    Sort (206)
    +- Exchange (205)
@@ -177,7 +177,7 @@ AdaptiveSparkPlan (207)
                                  +- Scan parquet (195)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_type#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -214,7 +214,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [5]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -283,7 +283,7 @@ Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 (26) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_suppkey#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -352,7 +352,7 @@ Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 (43) InputIteratorTransformer
 Input [4]: [l_orderkey#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [o_orderkey#X, o_custkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -421,7 +421,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_order
 (60) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_custkey#X, o_orderdate#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [c_custkey#X, c_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -490,7 +490,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nat
 (77) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, c_nationkey#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_regionkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -559,7 +559,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_reg
 (94) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, s_nationkey#X, o_orderdate#X, n_regionkey#X]
 
-(95) Scan parquet
+(95) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -628,7 +628,7 @@ Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_nam
 (111) InputIteratorTransformer
 Input [5]: [l_extendedprice#X, l_discount#X, o_orderdate#X, n_regionkey#X, n_name#X]
 
-(112) Scan parquet
+(112) ScanTransformer parquet 
 Output [2]: [r_regionkey#X, r_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/9.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/9.txt
@@ -46,42 +46,42 @@ AdaptiveSparkPlan (155)
                                              :                 :                 :                 :                 :        +- VeloxResizeBatches (5)
                                              :                 :                 :                 :                 :           +- ^ ProjectExecTransformer (3)
                                              :                 :                 :                 :                 :              +- ^ FilterExecTransformer (2)
-                                             :                 :                 :                 :                 :                 +- ^ Scan parquet (1)
+                                             :                 :                 :                 :                 :                 +- ^ ScanTransformer parquet  (1)
                                              :                 :                 :                 :                 +- ^ InputIteratorTransformer (18)
                                              :                 :                 :                 :                    +- ShuffleQueryStage (16), Statistics(X)
                                              :                 :                 :                 :                       +- ColumnarExchange (15)
                                              :                 :                 :                 :                          +- VeloxResizeBatches (14)
                                              :                 :                 :                 :                             +- ^ ProjectExecTransformer (12)
                                              :                 :                 :                 :                                +- ^ FilterExecTransformer (11)
-                                             :                 :                 :                 :                                   +- ^ Scan parquet (10)
+                                             :                 :                 :                 :                                   +- ^ ScanTransformer parquet  (10)
                                              :                 :                 :                 +- ^ InputIteratorTransformer (35)
                                              :                 :                 :                    +- ShuffleQueryStage (33), Statistics(X)
                                              :                 :                 :                       +- ColumnarExchange (32)
                                              :                 :                 :                          +- VeloxResizeBatches (31)
                                              :                 :                 :                             +- ^ ProjectExecTransformer (29)
                                              :                 :                 :                                +- ^ FilterExecTransformer (28)
-                                             :                 :                 :                                   +- ^ Scan parquet (27)
+                                             :                 :                 :                                   +- ^ ScanTransformer parquet  (27)
                                              :                 :                 +- ^ InputIteratorTransformer (52)
                                              :                 :                    +- ShuffleQueryStage (50), Statistics(X)
                                              :                 :                       +- ColumnarExchange (49)
                                              :                 :                          +- VeloxResizeBatches (48)
                                              :                 :                             +- ^ ProjectExecTransformer (46)
                                              :                 :                                +- ^ FilterExecTransformer (45)
-                                             :                 :                                   +- ^ Scan parquet (44)
+                                             :                 :                                   +- ^ ScanTransformer parquet  (44)
                                              :                 +- ^ InputIteratorTransformer (69)
                                              :                    +- ShuffleQueryStage (67), Statistics(X)
                                              :                       +- ColumnarExchange (66)
                                              :                          +- VeloxResizeBatches (65)
                                              :                             +- ^ ProjectExecTransformer (63)
                                              :                                +- ^ FilterExecTransformer (62)
-                                             :                                   +- ^ Scan parquet (61)
+                                             :                                   +- ^ ScanTransformer parquet  (61)
                                              +- ^ InputIteratorTransformer (86)
                                                 +- ShuffleQueryStage (84), Statistics(X)
                                                    +- ColumnarExchange (83)
                                                       +- VeloxResizeBatches (82)
                                                          +- ^ ProjectExecTransformer (80)
                                                             +- ^ FilterExecTransformer (79)
-                                                               +- ^ Scan parquet (78)
+                                                               +- ^ ScanTransformer parquet  (78)
 +- == Initial Plan ==
    Sort (154)
    +- Exchange (153)
@@ -133,7 +133,7 @@ AdaptiveSparkPlan (155)
                               +- Scan parquet (144)
 
 
-(1) Scan parquet
+(1) ScanTransformer parquet 
 Output [2]: [p_partkey#X, p_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -170,7 +170,7 @@ Input [1]: [p_partkey#X]
 (9) InputIteratorTransformer
 Input [1]: [p_partkey#X]
 
-(10) Scan parquet
+(10) ScanTransformer parquet 
 Output [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -239,7 +239,7 @@ Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (26) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X]
 
-(27) Scan parquet
+(27) ScanTransformer parquet 
 Output [2]: [s_suppkey#X, s_nationkey#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -308,7 +308,7 @@ Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedpric
 (43) InputIteratorTransformer
 Input [7]: [l_orderkey#X, l_partkey#X, l_suppkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X]
 
-(44) Scan parquet
+(44) ScanTransformer parquet 
 Output [3]: [ps_partkey#X, ps_suppkey#X, ps_supplycost#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -377,7 +377,7 @@ Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_natio
 (60) InputIteratorTransformer
 Input [6]: [l_orderkey#X, l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X]
 
-(61) Scan parquet
+(61) ScanTransformer parquet 
 Output [2]: [o_orderkey#X, o_orderdate#X]
 Batched: true
 Location: InMemoryFileIndex [*]
@@ -446,7 +446,7 @@ Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_sup
 (77) InputIteratorTransformer
 Input [6]: [l_quantity#X, l_extendedprice#X, l_discount#X, s_nationkey#X, ps_supplycost#X, o_orderdate#X]
 
-(78) Scan parquet
+(78) ScanTransformer parquet 
 Output [2]: [n_nationkey#X, n_name#X]
 Batched: true
 Location: InMemoryFileIndex [*]

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -157,10 +157,8 @@ abstract class FileSourceScanExecTransformerBase(
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genFileSourceScanTransformerMetricsUpdater(metrics)
 
-  override val nodeNamePrefix: String = "NativeFile"
-
   override val nodeName: String = {
-    s"Scan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
+    s"ScanTransformer $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
   }
 
   override def getProperties: Map[String, String] = {

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
@@ -45,7 +45,7 @@ class GlutenCustomerExtensionSuite extends GlutenSQLTestsTrait {
         case f: TestFileSourceScanExecTransformer => f
       }
       assert(!testFileSourceScanExecTransformer.isEmpty)
-      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestNativeFile"))
+      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestFile"))
     }
   }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -60,7 +60,7 @@ case class TestFileSourceScanExecTransformer(
       optionalNumCoalescedBuckets,
       disableBucketedScan)
 
-  override val nodeNamePrefix: String = "TestNativeFile"
+  override val nodeNamePrefix: String = "TestFile"
 
   override def doCanonicalize(): TestFileSourceScanExecTransformer = {
     TestFileSourceScanExecTransformer(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
@@ -45,7 +45,7 @@ class GlutenCustomerExtensionSuite extends GlutenSQLTestsTrait {
         case f: TestFileSourceScanExecTransformer => f
       }
       assert(!testFileSourceScanExecTransformer.isEmpty)
-      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestNativeFile"))
+      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestFile"))
     }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -58,5 +58,5 @@ case class TestFileSourceScanExecTransformer(
       optionalNumCoalescedBuckets,
       disableBucketedScan)
 
-  override val nodeNamePrefix: String = "TestNativeFile"
+  override val nodeNamePrefix: String = "TestFile"
 }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
@@ -45,7 +45,7 @@ class GlutenCustomerExtensionSuite extends GlutenSQLTestsTrait {
         case f: TestFileSourceScanExecTransformer => f
       }
       assert(!testFileSourceScanExecTransformer.isEmpty)
-      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestNativeFile"))
+      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestFile"))
     }
   }
 }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -58,5 +58,5 @@ case class TestFileSourceScanExecTransformer(
       optionalNumCoalescedBuckets,
       disableBucketedScan)
 
-  override val nodeNamePrefix: String = "TestNativeFile"
+  override val nodeNamePrefix: String = "TestFile"
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
@@ -45,7 +45,7 @@ class GlutenCustomerExtensionSuite extends GlutenSQLTestsTrait {
         case f: TestFileSourceScanExecTransformer => f
       }
       assert(!testFileSourceScanExecTransformer.isEmpty)
-      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestNativeFile"))
+      assert(testFileSourceScanExecTransformer(0).nodeNamePrefix.equals("TestFile"))
     }
   }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -58,5 +58,5 @@ case class TestFileSourceScanExecTransformer(
       optionalNumCoalescedBuckets,
       disableBucketedScan)
 
-  override val nodeNamePrefix: String = "TestNativeFile"
+  override val nodeNamePrefix: String = "TestFile"
 }

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AbstractBatchScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AbstractBatchScanExec.scala
@@ -260,6 +260,6 @@ abstract class AbstractBatchScanExec(
   }
 
   override def nodeName: String = {
-    s"BatchScan ${table.name()}".trim
+    s"BatchScanTransformer ${table.name()}".trim
   }
 }

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AbstractBatchScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AbstractBatchScanExec.scala
@@ -260,6 +260,6 @@ abstract class AbstractBatchScanExec(
   }
 
   override def nodeName: String = {
-    s"BatchScan ${table.name()}".trim
+    s"BatchScanTransformer ${table.name()}".trim
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Keep consistent with other transformers.
For V1 FileScan native, update nameNode from "Scan **" to "ScanTransformer **", update nodeNamePrefix from "NativeFile" to "File".
For V2 BatchScan native, update nameNode from "BatchScan **" to "BatchScanTransformer **".


## How was this patch tested?

Pass CI.

