### PR TITLE
[VL] Fix weekly scheduled GHA job

### DIFF
--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -73,7 +73,7 @@ jobs:
           export MAVEN_HOME=/usr/lib/maven && \
           export PATH=${PATH}:${MAVEN_HOME}/bin && \
           cd $GITHUB_WORKSPACE/ && \
-          ./dev/package.sh
+          ./dev/package.sh && echo "test"
 
   build-on-ubuntu:
     strategy:

--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -93,8 +93,8 @@ jobs:
             sudo apt install -y software-properties-common
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test
             sudo apt update && sudo apt install -y gcc-11 g++-11
-            sudo ln -sf /usr/bin/gcc-11 /usr/bin/gcc
-            sudo ln -sf /usr/bin/g++-11 /usr/bin/g++
+            export CC=/usr/bin/gcc-11
+            export CXX=/usr/bin/g++-11
           fi
           sudo apt-get install -y openjdk-8-jdk
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -73,7 +73,7 @@ jobs:
           export MAVEN_HOME=/usr/lib/maven && \
           export PATH=${PATH}:${MAVEN_HOME}/bin && \
           cd $GITHUB_WORKSPACE/ && \
-          ./dev/package.sh && echo "test"
+          ./dev/package.sh
 
   build-on-ubuntu:
     strategy:

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -239,9 +239,6 @@ if [ -z "${GLUTEN_VCPKG_ENABLED:-}" ] && [ $RUN_SETUP_SCRIPT == "ON" ]; then
   pushd $VELOX_HOME
   if [ $OS == 'Linux' ]; then
     setup_linux
-    echo "CC: $CC"
-    echo "CXX: $CXX"
-    exit 0
   elif [ $OS == 'Darwin' ]; then
     setup_macos
   else

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -239,6 +239,9 @@ if [ -z "${GLUTEN_VCPKG_ENABLED:-}" ] && [ $RUN_SETUP_SCRIPT == "ON" ]; then
   pushd $VELOX_HOME
   if [ $OS == 'Linux' ]; then
     setup_linux
+    echo "CC: $CC"
+    echo "CXX: $CXX"
+    exit 0
   elif [ $OS == 'Darwin' ]; then
     setup_macos
   else


### PR DESCRIPTION
## What changes were proposed in this pull request?

The dynamic build path on Ubuntu-20.04 is broken.
https://github.com/apache/incubator-gluten/actions/runs/11768073834/job/32777486610

The root cause is, we pre-install gcc-11, then create a symbolic link: `sudo ln -sf /usr/bin/gcc-11 /usr/bin/gcc` before executing Gluten script to build. But Velox also installs gcc-11 which overwrites the pre-installed one and then makes symbolic link invalid.

## How was this patch tested?

CI.

