### PR TITLE
[GLUTEN-7900][VL] Enable prefix sort config in spill

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -487,7 +487,7 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
     configs[velox::core::QueryConfig::kSpillCompressionKind] =
         veloxCfg_->get<std::string>(kSpillCompressionKind, "lz4");
     configs[velox::core::QueryConfig::kSpillPrefixSortEnabled] =
-        veloxCfg_->get<std::string>(kSpillPrefixSortEnabled, "true");
+        veloxCfg_->get<std::string>(kSpillPrefixSortEnabled, "false");
     configs[velox::core::QueryConfig::kSparkBloomFilterExpectedNumItems] =
         std::to_string(veloxCfg_->get<int64_t>(kBloomFilterExpectedNumItems, 1000000));
     configs[velox::core::QueryConfig::kSparkBloomFilterNumBits] =

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -486,8 +486,8 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
         std::to_string(veloxCfg_->get<uint8_t>(kSpillableReservationGrowthPct, 25));
     configs[velox::core::QueryConfig::kSpillCompressionKind] =
         veloxCfg_->get<std::string>(kSpillCompressionKind, "lz4");
-    configs[velox::core::QueryConfig::kSpillEnablePrefixSort] =
-        veloxCfg_->get<std::string>(kSpillEnablePrefixSort, "true");
+    configs[velox::core::QueryConfig::kSpillPrefixSortEnabled] =
+        veloxCfg_->get<std::string>(kSpillPrefixSortEnabled, "true");
     configs[velox::core::QueryConfig::kSparkBloomFilterExpectedNumItems] =
         std::to_string(veloxCfg_->get<int64_t>(kBloomFilterExpectedNumItems, 1000000));
     configs[velox::core::QueryConfig::kSparkBloomFilterNumBits] =

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -486,6 +486,8 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
         std::to_string(veloxCfg_->get<uint8_t>(kSpillableReservationGrowthPct, 25));
     configs[velox::core::QueryConfig::kSpillCompressionKind] =
         veloxCfg_->get<std::string>(kSpillCompressionKind, "lz4");
+    configs[velox::core::QueryConfig::kSpillEnablePrefixSort] =
+        veloxCfg_->get<std::string>(kSpillEnablePrefixSort, "true");
     configs[velox::core::QueryConfig::kSparkBloomFilterExpectedNumItems] =
         std::to_string(veloxCfg_->get<int64_t>(kBloomFilterExpectedNumItems, 1000000));
     configs[velox::core::QueryConfig::kSparkBloomFilterNumBits] =

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -44,6 +44,7 @@ const uint64_t kMaxSpillFileSizeDefault = 1L * 1024 * 1024 * 1024;
 const std::string kSpillableReservationGrowthPct =
     "spark.gluten.sql.columnar.backend.velox.spillableReservationGrowthPct";
 const std::string kSpillCompressionKind = "spark.io.compression.codec";
+const std::string kSpillEnablePrefixSort = "spark.gluten.sql.columnar.backend.velox.spillEnablePrefixSort";
 const std::string kMaxPartialAggregationMemoryRatio =
     "spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio";
 const std::string kMaxExtendedPartialAggregationMemoryRatio =

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -44,7 +44,7 @@ const uint64_t kMaxSpillFileSizeDefault = 1L * 1024 * 1024 * 1024;
 const std::string kSpillableReservationGrowthPct =
     "spark.gluten.sql.columnar.backend.velox.spillableReservationGrowthPct";
 const std::string kSpillCompressionKind = "spark.io.compression.codec";
-const std::string kSpillEnablePrefixSort = "spark.gluten.sql.columnar.backend.velox.spillEnablePrefixSort";
+const std::string kSpillPrefixSortEnabled = "spark.gluten.sql.columnar.backend.velox.spillPrefixsortEnabled";
 const std::string kMaxPartialAggregationMemoryRatio =
     "spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio";
 const std::string kMaxExtendedPartialAggregationMemoryRatio =

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_11_14
+VELOX_REPO=https://github.com/jinchengchenghh/velox.git
+VELOX_BRANCH=prefixsort
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/jinchengchenghh/velox.git
-VELOX_BRANCH=prefixsort
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=2024_11_14
 VELOX_HOME=""
 
 OS=`uname -s`


### PR DESCRIPTION
Prefix sort can reduce the spill sort time by 3x with the sampled Meta production query but timsort increase the sort time by 20%.  So timsort performance seems depends on the actual data pattern.
After pick this PR  https://github.com/facebookincubator/velox/pull/11527, a query in jenkins spill with string is 41s prefixsort vs 37s timsort vs 63s stdsort.

Config `spark.gluten.sql.columnar.backend.velox.spillPrefixsortEnabled` disable in this PR, enable it as default after test.

Relevant Velox PR: https://github.com/facebookincubator/velox/pull/11384
Resolves https://github.com/apache/incubator-gluten/issues/7900
