### PR TITLE
[GLUTEN-7907][CH] Fixed data race in `ExpresionParser::getUniqueName`

### DIFF
--- a/cpp-ch/local-engine/Parser/ExpressionParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpressionParser.cpp
@@ -624,7 +624,7 @@ const DB::ActionsDAG::Node * ExpressionParser::toFunctionNode(
     return &actions_dag.addFunction(function_builder, args, result_name);
 }
 
-UInt64 ExpressionParser::unique_name_counter = 0;
+std::atomic<UInt64> ExpressionParser::unique_name_counter = 0;
 String ExpressionParser::getUniqueName(const String & name) const
 {
     return name + "_" + std::to_string(unique_name_counter++);

--- a/cpp-ch/local-engine/Parser/ExpressionParser.h
+++ b/cpp-ch/local-engine/Parser/ExpressionParser.h
@@ -20,6 +20,7 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context_fwd.h>
 #include <substrait/plan.pb.h>
+#include <atomic>
 #include "SerializedPlanParser.h"
 
 
@@ -74,7 +75,7 @@ public:
     String safeGetFunctionName(const substrait::Expression_ScalarFunction & func_) const;
 
 private:
-    static UInt64 unique_name_counter;
+    static std::atomic<UInt64> unique_name_counter;
     std::shared_ptr<const ParserContext> context;
 
     DB::ActionsDAG::NodeRawConstPtrs


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #7907

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

