### PR TITLE
[VL] CI: Fix out-of-date module name in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -60,7 +60,7 @@ CORE:
 VELOX:
   - changed-files:
     - any-glob-to-any-file: [
-      'gluten-data/**/*',
+      'gluten-arrow/**/*',
       'backends-velox/**/*',
       'ep/build-velox/**/*',
       'cpp/**/*'


### PR DESCRIPTION
`gluten-data` was renamed to `gluten-arow`. Update the name in labeler.yml.