### PR TITLE
[VL] Fix wrong lib suffix for google_cloud_cpp_storage

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -138,8 +138,8 @@ endmacro()
 
 macro(find_gcssdk)
   set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".so")
-  find_package(google_cloud_cpp_storage REQUIRED)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  find_package(google_cloud_cpp_storage CONFIG 2.22.0 REQUIRED)
   set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
 endmacro()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, static google_cloud_cpp_storage lib is used in both static build and dynamic build. The lib suffix was wrongly set for CMake to find the lib.

## How was this patch tested?

Local verification.

