### PR TITLE
[GLUTEN-7243][VL] A follow-up fix for #7748

### DIFF
--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -46,7 +46,7 @@ class RowVectorStream {
       // As of now, non-zero running threads usually happens when:
       // 1. Task A spills task B;
       // 2. Task A trys to grow buffers created by task B, during which spill is requested on task A again.
-      facebook::velox::exec::SuspendedSection(driverCtx_->driver);
+      facebook::velox::exec::SuspendedSection ss(driverCtx_->driver);
       hasNext = iterator_->hasNext();
     }
     if (!hasNext) {
@@ -64,7 +64,7 @@ class RowVectorStream {
     {
       // We are leaving Velox task execution and are probably entering Spark code through JNI. Suspend the current
       // driver to make the current task open to spilling.
-      facebook::velox::exec::SuspendedSection(driverCtx_->driver);
+      facebook::velox::exec::SuspendedSection ss(driverCtx_->driver);
       cb = iterator_->next();
     }
     const std::shared_ptr<VeloxColumnarBatch>& vb = VeloxColumnarBatch::from(pool_, cb);


### PR DESCRIPTION
#7748 missed a local object name to make RAII work with correct scope.

Without the change, the suspend state will be cleared immediately since the local object will be destroyed right after it's created. So `hasNext()` call will not consider the current driver as suspended. As a result #7748 will not work and spill may still cause hanging.

The patch fixes the issue.