### PR TITLE
[GLUTEN-7499][VL][CI] Print ccache statistics for tracking its efficacy

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -71,6 +71,7 @@ jobs:
           df -a
           cd $GITHUB_WORKSPACE/
           bash dev/ci-velox-buildstatic-centos-7.sh
+          ccache -s
       - name: "Save ccache"
         uses: actions/cache/save@v3
         id: ccache
@@ -954,6 +955,7 @@ jobs:
         run: |
           df -a
           bash dev/ci-velox-buildshared-centos-8.sh
+          ccache -s
       - name: "Save ccache"
         uses: actions/cache/save@v3
         id: ccache


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just a minor change in case of ccache loses its efficacy for some reason.

P.S.

For the current pr, we got the below statistics printed.

```
cache directory                     /__w/incubator-gluten/incubator-gluten/.ccache
primary config                      /__w/incubator-gluten/incubator-gluten/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
stats updated                       Fri Nov 15 03:03:00 2024
cache hit (direct)                112337
cache hit (preprocessed)             899
cache miss                         10042
cache hit rate                     91.85 %
called for link                      368
cleanups performed                    59
files in cache                     11473
cache size                           4.3 GB
max cache size                       5.0 GB
```


## How was this patch tested?

N/A

