### PR TITLE
[GLUTEN-7910][CORE][VL] Flip dependency direction for gluten-iceberg

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -29,6 +29,74 @@
         <tagsToExclude>org.apache.gluten.tags.UDFTest</tagsToExclude>
       </properties>
     </profile>
+    <profile>
+      <id>iceberg</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-iceberg</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-iceberg</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-spark-${sparkbundle.version}_${scala.binary.version}</artifactId>
+          <version>${iceberg.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-spark-runtime-${sparkbundle.version}_${scala.binary.version}</artifactId>
+          <version>${iceberg.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-iceberg-sources</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${project.basedir}/src/main-iceberg/scala</source>
+                    <source>${project.basedir}/src/main-iceberg/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-iceberg-test-sources</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${project.basedir}/src/test-iceberg/scala</source>
+                    <source>${project.basedir}/src/test-iceberg/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/backends-velox/src/test-iceberg/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/backends-velox/src/test-iceberg/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gluten.execution
+
+class VeloxIcebergSuite extends IcebergSuite

--- a/backends-velox/src/test-iceberg/scala/org/apache/gluten/execution/VeloxTPCHIcebergSuite.scala
+++ b/backends-velox/src/test-iceberg/scala/org/apache/gluten/execution/VeloxTPCHIcebergSuite.scala
@@ -24,9 +24,8 @@ import org.apache.iceberg.spark.SparkWriteOptions
 import java.io.File
 
 class VeloxTPCHIcebergSuite extends VeloxTPCHSuite {
-
   protected val tpchBasePath: String = new File(
-    "../backends-velox/src/test/resources").getAbsolutePath
+    "backends-velox/src/test/resources").getAbsolutePath
 
   override protected val resourcePath: String =
     new File(tpchBasePath, "tpch-data-parquet").getCanonicalPath

--- a/backends-velox/src/test-iceberg/scala/org/apache/gluten/execution/VeloxTPCHIcebergSuite.scala
+++ b/backends-velox/src/test-iceberg/scala/org/apache/gluten/execution/VeloxTPCHIcebergSuite.scala
@@ -24,12 +24,13 @@ import org.apache.iceberg.spark.SparkWriteOptions
 import java.io.File
 
 class VeloxTPCHIcebergSuite extends VeloxTPCHSuite {
-  protected val tpchBasePath: String = new File(
-    "backends-velox/src/test/resources").getAbsolutePath
+  protected val tpchBasePath: String =
+    getClass.getResource("/").getPath + "../../../src/test/resources"
 
   override protected val resourcePath: String =
     new File(tpchBasePath, "tpch-data-parquet").getCanonicalPath
 
+  // FIXME: Unused.
   override protected val queriesResults: String =
     new File(tpchBasePath, "queries-output").getCanonicalPath
 

--- a/gluten-iceberg/pom.xml
+++ b/gluten-iceberg/pom.xml
@@ -51,19 +51,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.gluten</groupId>
-            <artifactId>backends-velox</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.gluten</groupId>
-            <artifactId>backends-velox</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <type>test-jar</type>

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -21,9 +21,10 @@ import org.apache.gluten.GlutenConfig
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 
-class VeloxIcebergSuite extends WholeStageTransformerSuite {
-
+abstract class IcebergSuite extends WholeStageTransformerSuite {
   protected val rootPath: String = getClass.getResource("/").getPath
+  // FIXME: This folder is in module backends-velox so is not accessible if profile backends-velox
+  //  is not enabled during Maven build.
   override protected val resourcePath: String = "/tpch-data-parquet"
   override protected val fileFormat: String = "parquet"
 


### PR DESCRIPTION
#7910 

Make Maven module `backends-velox` depend on `gluten-iceberg` than the opposite, to make sure the common source code and UT code (particularly `IcebergSuite` at the moment) to be accessible from other backend modules (particularly `backends-clickhouse` at the moment).

The new source/test folder `backends-velox/src/main-iceberg` / `backends-velox/src/test-iceberg` are added for placing code that relate to Velox+Iceberg support.

TODO in subsequent PRs: 
1. Enable Maven code linters for `backends-velox/src/main-iceberg` / `backends-velox/src/test-iceberg`