### PR TITLE
[GLUTEN-7979][CH] Fix exception cause by one child of UnionExec outputs Array(Nothing) while the other outputs Array(String)

### DIFF
--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -480,21 +480,7 @@ std::optional<DB::ColumnWithTypeAndName> NestedColumnExtractHelper::extractColum
 
 const DB::ColumnWithTypeAndName * NestedColumnExtractHelper::findColumn(const DB::Block & in_block, const std::string & name) const
 {
-    if (case_insentive)
-    {
-        std::string final_name = name;
-        boost::to_lower(final_name);
-        const auto & cols = in_block.getColumnsWithTypeAndName();
-        auto found = std::find_if(cols.begin(), cols.end(), [&](const auto & column) { return boost::iequals(column.name, name); });
-        if (found == cols.end())
-            return nullptr;
-        return &*found;
-    }
-
-    const auto * col = in_block.findByName(name);
-    if (col)
-        return col;
-    return nullptr;
+    return in_block.findByName(name, case_insentive);
 }
 
 const DB::ActionsDAG::Node * ActionsDAGUtil::convertNodeType(

--- a/cpp-ch/local-engine/Common/GlutenStringUtils.h
+++ b/cpp-ch/local-engine/Common/GlutenStringUtils.h
@@ -21,9 +21,6 @@
 
 namespace local_engine
 {
-using PartitionValue = std::pair<std::string, std::string>;
-using PartitionValues = std::vector<PartitionValue>;
-
 class GlutenStringUtils
 {
 public:

--- a/cpp-ch/local-engine/Operator/PartitionColumnFillingTransform.cpp
+++ b/cpp-ch/local-engine/Operator/PartitionColumnFillingTransform.cpp
@@ -57,16 +57,11 @@ ColumnPtr createFloatPartitionColumn(DataTypePtr column_type, const std::string 
     return column_type->createColumnConst(1, value);
 }
 
-//template <>
-//ColumnPtr createFloatPartitionColumn<Float32>(DataTypePtr column_type, std::string partition_value);
-//template <>
-//ColumnPtr createFloatPartitionColumn<Float64>(DataTypePtr column_type, std::string partition_value);
-
 PartitionColumnFillingTransform::PartitionColumnFillingTransform(
     const DB::Block & input_, const DB::Block & output_, const String & partition_col_name_, const String & partition_col_value_)
     : ISimpleTransform(input_, output_, true), partition_col_name(partition_col_name_), partition_col_value(partition_col_value_)
 {
-    partition_col_type = output_.getByName(partition_col_name_).type;
+    partition_col_type = output_.getByName(partition_col_name_, true).type;
     partition_column = createPartitionColumn();
 }
 

--- a/cpp-ch/local-engine/Parser/FunctionExecutor.cpp
+++ b/cpp-ch/local-engine/Parser/FunctionExecutor.cpp
@@ -79,8 +79,6 @@ void FunctionExecutor::parseExpression()
     /// Notice keep_result must be true, because result_node of current function must be output node in actions_dag
     const auto * node = expression_parser->parseFunction(expression.scalar_function(), actions_dag, true);
     result_name = node->result_name;
-    // std::cout << "actions_dag:" << std::endl;
-    // std::cout << actions_dag->dumpDAG() << std::endl;
 
     expression_actions = std::make_unique<ExpressionActions>(std::move(actions_dag));
 }
@@ -115,9 +113,7 @@ bool FunctionExecutor::executeAndCompare(const std::vector<FunctionExecutor::Tes
     }
     block.setColumns(std::move(columns));
 
-    // std::cout << "input block:" << block.dumpStructure() << std::endl;
     execute(block);
-    // std::cout << "output block:" << block.dumpStructure() << std::endl;
 
     const auto & result_column = block.getByName(result_name).column;
     for (size_t i = 0; i < cases.size(); ++i)

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -130,49 +130,49 @@ void SerializedPlanParser::adjustOutput(const DB::QueryPlanPtr & query_plan, con
     const auto & output_schema = root_rel.root().output_schema();
     if (output_schema.types_size())
     {
-        auto original_header = query_plan->getCurrentHeader();
-        const auto & original_cols = original_header.getColumnsWithTypeAndName();
-        if (static_cast<size_t>(output_schema.types_size()) != original_cols.size())
+        auto origin_header = query_plan->getCurrentHeader();
+        const auto & origin_columns = origin_header.getColumnsWithTypeAndName();
+
+        if (static_cast<size_t>(output_schema.types_size()) != origin_columns.size())
         {
             debug::dumpPlan(*query_plan, true);
             debug::dumpMessage(root_rel, "substrait::PlanRel", true);
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Missmatch result columns size. plan column size {}, subtrait plan output schema size {}, subtrait plan name size {}.",
-                original_cols.size(),
+                origin_columns.size(),
                 output_schema.types_size(),
                 root_rel.root().names_size());
         }
+
         bool need_final_project = false;
-        ColumnsWithTypeAndName final_cols;
+        ColumnsWithTypeAndName final_columns;
         for (int i = 0; i < output_schema.types_size(); ++i)
         {
-            const auto & col = original_cols[i];
-            auto type = TypeParser::parseType(output_schema.types(i));
-            // At present, we only check nullable mismatch.
-            // intermediate aggregate data is special, no check here.
-            if (type->isNullable() != col.type->isNullable() && !typeid_cast<const DataTypeAggregateFunction *>(col.type.get()))
-            {
-                if (type->isNullable())
-                {
-                    auto wrapped = wrapNullableType(true, col.type);
-                    final_cols.emplace_back(type->createColumn(), wrapped, col.name);
-                    need_final_project = !wrapped->equals(*col.type);
-                }
-                else
-                {
-                    final_cols.emplace_back(type->createColumn(), removeNullable(col.type), col.name);
-                    need_final_project = true;
-                }
-            }
+            const auto & origin_column = origin_columns[i];
+            const auto & origin_type = origin_column.type;
+            auto final_type = TypeParser::parseType(output_schema.types(i));
+
+            /// Intermediate aggregate data is special, no check here.
+            if (typeid_cast<const DataTypeAggregateFunction *>(origin_column.type.get()) || origin_type->equals(*final_type))
+                final_columns.push_back(origin_column);
             else
             {
-                final_cols.push_back(col);
+                need_final_project = true;
+
+                bool need_const = origin_column.column && isColumnConst(*origin_column.column);
+                ColumnWithTypeAndName final_column(
+                    need_const ? final_type->createColumnConst(0, assert_cast<const ColumnConst &>(*origin_column.column).getField())
+                               : final_type->createColumn(),
+                    final_type,
+                    origin_column.name);
+                final_columns.emplace_back(std::move(final_column));
             }
         }
+
         if (need_final_project)
         {
-            ActionsDAG final_project = ActionsDAG::makeConvertingActions(original_cols, final_cols, ActionsDAG::MatchColumnsMode::Position);
+            ActionsDAG final_project = ActionsDAG::makeConvertingActions(origin_columns, final_columns, ActionsDAG::MatchColumnsMode::Position);
             QueryPlanStepPtr final_project_step
                 = std::make_unique<ExpressionStep>(query_plan->getCurrentHeader(), std::move(final_project));
             final_project_step->setStepDescription("Project for output schema");

--- a/cpp-ch/local-engine/Storages/IO/NativeReader.cpp
+++ b/cpp-ch/local-engine/Storages/IO/NativeReader.cpp
@@ -54,6 +54,7 @@ DB::Block NativeReader::read()
     DB::Block result_block;
     if (istr.eof())
         return result_block;
+
     if (columns_parse_util.empty())
     {
         result_block = prepareByFirstBlock();
@@ -154,6 +155,7 @@ DB::Block NativeReader::prepareByFirstBlock()
 {
     if (istr.eof())
         return {};
+
     const DataTypeFactory & data_type_factory = DataTypeFactory::instance();
     DB::Block result_block;
 
@@ -246,10 +248,12 @@ bool NativeReader::appendNextBlock(DB::Block & result_block)
 {
     if (istr.eof())
         return false;
+
     size_t columns = 0;
     size_t rows = 0;
     readVarUInt(columns, istr);
     readVarUInt(rows, istr);
+
     for (size_t i = 0; i < columns; ++i)
     {
         // Not actually read type name.
@@ -259,6 +263,7 @@ bool NativeReader::appendNextBlock(DB::Block & result_block)
 
         if (!rows) [[unlikely]]
             continue;
+
         auto & column_parse_util = columns_parse_util[i];
         auto & column = result_block.getByPosition(i);
         column_parse_util.parse(istr, column.column, rows, column_parse_util);

--- a/cpp-ch/local-engine/Storages/IO/NativeWriter.cpp
+++ b/cpp-ch/local-engine/Storages/IO/NativeWriter.cpp
@@ -32,6 +32,7 @@ namespace local_engine
 {
 
 const String NativeWriter::AGG_STATE_SUFFIX= "#optagg";
+
 void NativeWriter::flush()
 {
     ostr.next();

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.cpp
@@ -19,9 +19,11 @@
 #include <Core/Settings.h>
 #include <IO/ReadBufferFromFile.h>
 #include <Storages/SubstraitSource/JSONFormatFile.h>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <Common/GlutenConfig.h>
 #include <Common/GlutenStringUtils.h>
 #include <Common/logger_useful.h>
+
 
 #if USE_PARQUET
 #include <Storages/SubstraitSource/ParquetFormatFile.h>
@@ -56,13 +58,18 @@ FormatFile::FormatFile(
         for (size_t i = 0; i < file_info.partition_columns_size(); ++i)
         {
             const auto & partition_column = file_info.partition_columns(i);
+
             std::string unescaped_key;
             std::string unescaped_value;
             Poco::URI::decode(partition_column.key(), unescaped_key);
             Poco::URI::decode(partition_column.value(), unescaped_value);
-            auto key = std::move(unescaped_key);
-            partition_keys.push_back(key);
-            partition_values[key] = std::move(unescaped_value);
+
+            partition_keys.push_back(unescaped_key);
+            partition_values[unescaped_key] = unescaped_value;
+
+            std::string normalized_key = unescaped_key;
+            boost::to_lower(normalized_key);
+            normalized_partition_values[normalized_key] = unescaped_value;
         }
     }
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
@@ -65,9 +65,11 @@ public:
     virtual std::optional<size_t> getTotalRows() { return {}; }
 
     /// Get partition keys from file path
-    inline const std::vector<String> & getFilePartitionKeys() const { return partition_keys; }
+    const std::vector<String> & getFilePartitionKeys() const { return partition_keys; }
 
-    inline const std::map<String, String> & getFilePartitionValues() const { return partition_values; }
+    const std::map<String, String> & getFilePartitionValues() const { return partition_values; }
+
+    const std::map<String, String> & getFileNormalizedPartitionValues() const { return normalized_partition_values; }
 
     virtual String getURIPath() const { return file_info.uri_file(); }
 
@@ -81,6 +83,8 @@ protected:
     ReadBufferBuilderPtr read_buffer_builder;
     std::vector<String> partition_keys;
     std::map<String, String> partition_values;
+    /// partition keys are normalized to lower cases for partition column case-insensitive matching
+    std::map<String, String> normalized_partition_values;
     std::shared_ptr<const DB::KeyCondition> key_condition;
 };
 using FormatFilePtr = std::shared_ptr<FormatFile>;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
@@ -87,8 +87,8 @@ SubstraitFileSource::SubstraitFileSource(
         /// File partition keys are read from the file path
         const auto partition_keys = files[0]->getFilePartitionKeys();
         for (const auto & key : partition_keys)
-            if (to_read_header.findByName(key))
-                to_read_header.erase(key);
+            if (const auto * col = to_read_header.findByName(key, true))
+                to_read_header.erase(col->name);
     }
 }
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -203,6 +203,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude(
       "SPARK-32376: Make unionByName null-filling behavior work with struct columns - deep expr")
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
+    .exclude("SPARK-36673: Only merge nullability for Unions of struct") // disabled due to case-insensitive not supported in CH tuple
     .exclude("except all")
     .exclude("exceptAll - nullability")
     .exclude("intersectAll")

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -203,7 +203,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude(
       "SPARK-32376: Make unionByName null-filling behavior work with struct columns - deep expr")
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
-    .exclude("SPARK-36673: Only merge nullability for Unions of struct") // disabled due to case-insensitive not supported in CH tuple
+    .exclude(
+      "SPARK-36673: Only merge nullability for Unions of struct"
+    ) // disabled due to case-insensitive not supported in CH tuple
     .exclude("except all")
     .exclude("exceptAll - nullability")
     .exclude("intersectAll")

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -225,6 +225,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
     .exclude("SPARK-36797: Union should resolve nested columns as top-level columns")
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar")
+    .exclude(
+      "SPARK-36673: Only merge nullability for Unions of struct"
+    ) // disabled due to case-insensitive not supported in CH tuple
     .exclude("except all")
     .exclude("exceptAll - nullability")
     .exclude("intersectAll")

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -227,6 +227,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
     .exclude("SPARK-36797: Union should resolve nested columns as top-level columns")
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar")
+    .exclude("SPARK-36673: Only merge nullability for Unions of struct") // disabled due to case-insensitive not supported in CH tuple
   enableSuite[GlutenDataFrameStatSuite]
   enableSuite[GlutenDataFrameSuite]
     .exclude("Uuid expressions should produce same results at retries in the same DataFrame")

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -227,7 +227,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
     .exclude("SPARK-36797: Union should resolve nested columns as top-level columns")
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar")
-    .exclude("SPARK-36673: Only merge nullability for Unions of struct") // disabled due to case-insensitive not supported in CH tuple
+    .exclude(
+      "SPARK-36673: Only merge nullability for Unions of struct"
+    ) // disabled due to case-insensitive not supported in CH tuple
   enableSuite[GlutenDataFrameStatSuite]
   enableSuite[GlutenDataFrameSuite]
     .exclude("Uuid expressions should produce same results at retries in the same DataFrame")

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -227,6 +227,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
     .exclude("SPARK-36797: Union should resolve nested columns as top-level columns")
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar")
+    .exclude("SPARK-36673: Only merge nullability for Unions of struct") // disabled due to case-insensitive not supported in CH tuple
   enableSuite[GlutenDataFrameStatSuite]
   enableSuite[GlutenDataFrameSuite]
     .exclude("Uuid expressions should produce same results at retries in the same DataFrame")

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -227,7 +227,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("SPARK-35756: unionByName support struct having same col names but different sequence")
     .exclude("SPARK-36797: Union should resolve nested columns as top-level columns")
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar")
-    .exclude("SPARK-36673: Only merge nullability for Unions of struct") // disabled due to case-insensitive not supported in CH tuple
+    .exclude(
+      "SPARK-36673: Only merge nullability for Unions of struct"
+    ) // disabled due to case-insensitive not supported in CH tuple
   enableSuite[GlutenDataFrameStatSuite]
   enableSuite[GlutenDataFrameSuite]
     .exclude("Uuid expressions should produce same results at retries in the same DataFrame")


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#7979)

## How was this patch tested?

"SPARK-36673: Only merge nullability for Unions of struct" was excluded because of https://github.com/apache/incubator-gluten/issues/7985

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

