### PR TITLE
[GLUTEN-7028][CH][Part-9] Collecting Delta stats for parquet

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -426,6 +426,18 @@
               </sources>
             </configuration>
           </execution>
+          <execution>
+          <id>add-test-sources</id>
+          <phase>generate-test-sources</phase>
+          <goals>
+            <goal>add-test-source</goal>
+          </goals>
+          <configuration>
+            <sources>
+              <source>src/test/delta-${delta.binary.version}</source>
+            </sources>
+          </configuration>
+        </execution>
         </executions>
       </plugin>
       <plugin>

--- a/backends-clickhouse/src/main/delta-32/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
+++ b/backends-clickhouse/src/main/delta-32/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
@@ -102,10 +102,17 @@ case class FileDeltaColumnarWrite(
     val writePath = description.path
     val writeFileName = committer.getFileName(taskAttemptContext, nameSpec.suffix, Map.empty)
 
-    /// CDC files (CDC_PARTITION_COL = true) are named with "cdc-..." instead of "part-...".
-    /// So, using pattern match to replace guid to {}.
+    /**
+     * CDC files (CDC_PARTITION_COL = true) are named with "cdc-..." instead of "part-...".So, using
+     * pattern match to replace guid to {}.See the following example:
+     * {{{
+     *   part-00000-7d672b28-c079-4b00-bb0a-196c15112918-c000.snappy.parquet
+     *     =>
+     *   part-00000-{}.snappy.parquet
+     * }}}
+     */
     val guidPattern =
-      """.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:\..*)?$""".r
+      """.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:-c(\d+)\..*)?$""".r
     val fileNamePattern =
       guidPattern.replaceAllIn(writeFileName, m => writeFileName.replace(m.group(1), "{}"))
 

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
@@ -41,6 +41,12 @@ object RuntimeSettings {
       .stringConf
       .createWithDefault("")
 
+  val TASK_WRITE_FILENAME_PATTERN =
+    buildConf(runtimeSettings("gluten.task_write_filename_pattern"))
+      .doc("The pattern to generate file name for writing delta parquet in spark 3.5")
+      .stringConf
+      .createWithDefault("")
+
   val PART_NAME_PREFIX =
     buildConf(runtimeSettings("gluten.part_name_prefix"))
       .doc("The part name prefix for writing data")

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWrite.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWrite.scala
@@ -96,7 +96,7 @@ trait CHColumnarWrite[T <: FileCommitProtocol] {
 object CreateFileNameSpec {
   def apply(taskContext: TaskAttemptContext, description: WriteJobDescription): FileNameSpec = {
     val fileCounter = 0
-    val suffix = f".c$fileCounter%03d" +
+    val suffix = f"-c$fileCounter%03d" +
       description.outputWriterFactory.getFileExtension(taskContext)
     FileNameSpec("", suffix)
   }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWrite.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWrite.scala
@@ -22,10 +22,10 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.{FileCommitProtocol, FileNameSpec, HadoopMapReduceCommitProtocol}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GenericInternalRow}
+import org.apache.spark.sql.delta.stats.DeltaJobStatisticsTracker
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, BasicWriteTaskStats, ExecutedWriteSummary, PartitioningUtils, WriteJobDescription, WriteTaskResult, WriteTaskStatsTracker}
-import org.apache.spark.sql.execution.utils.CHExecUtil
-import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 
 import org.apache.hadoop.fs.Path
@@ -36,6 +36,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import java.lang.reflect.Field
 
 import scala.collection.mutable
+import scala.language.implicitConversions
 
 trait CHColumnarWrite[T <: FileCommitProtocol] {
 
@@ -52,17 +53,18 @@ trait CHColumnarWrite[T <: FileCommitProtocol] {
   def abortTask(): Unit = {
     committer.abortTask(taskAttemptContext)
   }
-  def commitTask(batch: ColumnarBatch): Option[WriteTaskResult]
+  def commitTask(writeResults: Seq[InternalRow]): Option[WriteTaskResult]
 
   lazy val basicWriteJobStatsTracker: WriteTaskStatsTracker = description.statsTrackers
     .find(_.isInstanceOf[BasicWriteJobStatsTracker])
     .map(_.newTaskInstance())
     .get
 
-  // TODO: task commit time
-  def finalStats: BasicWriteTaskStats = basicWriteJobStatsTracker
-    .getFinalStats(0)
-    .asInstanceOf[BasicWriteTaskStats]
+  lazy val deltaWriteJobStatsTracker: Option[(Seq[Attribute], Expression)] =
+    description.statsTrackers
+      .find(_.isInstanceOf[DeltaJobStatisticsTracker])
+      .map(_.asInstanceOf[DeltaJobStatisticsTracker])
+      .map(tracker => (tracker.dataCols, tracker.statsColExpr))
 
   lazy val (taskAttemptContext: TaskAttemptContext, jobId: String) = {
     // Copied from `SparkHadoopWriterUtils.createJobID` to be compatible with multi-version
@@ -149,31 +151,72 @@ case class HadoopMapReduceAdapter(sparkCommitter: HadoopMapReduceCommitProtocol)
  *     StructField("record_count", LongType, false) :: Nil)
  * }}}
  */
-case class BasicNativeStat(filename: String, partition_id: String, record_count: Long) {
-
+case class NativeFileWriteResult(filename: String, partition_id: String, record_count: Long) {
   lazy val relativePath: String = if (partition_id == "__NO_PARTITION_ID__") {
     filename
   } else {
     s"$partition_id/$filename"
   }
 }
-object BasicNativeStats {
 
-  /**
-   * we assume the number of records is less than 10,000.So the memory overhead is acceptable.
-   * otherwise, we need to access ColumnarBatch row by row, which is not efficient.
-   */
-  def apply(cb: ColumnarBatch): Seq[BasicNativeStat] =
-    CHExecUtil
-      .c2r(cb)
-      .map(
-        row =>
-          BasicNativeStat(
-            row.getUTF8String(0).toString,
-            row.getUTF8String(1).toString,
-            row.getLong(2)
-          ))
-      .toSeq
+object NativeFileWriteResult {
+  implicit def apply(row: InternalRow): NativeFileWriteResult = {
+    NativeFileWriteResult(row.getString(0), row.getString(1), row.getLong(2))
+  }
+}
+
+case class NativeStatCompute(rows: Seq[InternalRow]) {
+  def apply[T](stats: Seq[T => Unit])(implicit creator: InternalRow => T): Unit = {
+    rows.foreach {
+      row =>
+        val stat = creator(row)
+        stats.foreach(agg => agg(stat))
+    }
+  }
+}
+
+case class NativeBasicWriteTaskStatsTracker(
+    description: WriteJobDescription,
+    basicWriteJobStatsTracker: WriteTaskStatsTracker)
+  extends (NativeFileWriteResult => Unit) {
+  private var numWrittenRows: Long = 0
+  override def apply(stat: NativeFileWriteResult): Unit = {
+    val absolutePath = s"${description.path}/${stat.relativePath}"
+    if (stat.partition_id != "__NO_PARTITION_ID__") {
+      basicWriteJobStatsTracker.newPartition(new GenericInternalRow(Array[Any](stat.partition_id)))
+    }
+    basicWriteJobStatsTracker.newFile(absolutePath)
+    basicWriteJobStatsTracker.closeFile(absolutePath)
+    numWrittenRows += stat.record_count
+  }
+  private def finalStats: BasicWriteTaskStats = basicWriteJobStatsTracker
+    .getFinalStats(0)
+    .asInstanceOf[BasicWriteTaskStats]
+
+  def result: BasicWriteTaskStats = finalStats.copy(numRows = numWrittenRows)
+}
+
+case class FileCommitInfo(description: WriteJobDescription)
+  extends (NativeFileWriteResult => Unit) {
+  private val partitions: mutable.Set[String] = mutable.Set[String]()
+  private val addedAbsPathFiles: mutable.Map[String, String] = mutable.Map[String, String]()
+
+  def apply(stat: NativeFileWriteResult): Unit = {
+    val tmpAbsolutePath = s"${description.path}/${stat.relativePath}"
+    if (stat.partition_id != "__NO_PARTITION_ID__") {
+      partitions += stat.partition_id
+      val customOutputPath =
+        description.customPartitionLocations.get(
+          PartitioningUtils.parsePathFragment(stat.partition_id))
+      if (customOutputPath.isDefined) {
+        addedAbsPathFiles(tmpAbsolutePath) = customOutputPath.get + "/" + stat.filename
+      }
+    }
+  }
+
+  def result: (Set[String], Map[String, String]) = {
+    (partitions.toSet, addedAbsPathFiles.toMap)
+  }
 }
 
 case class HadoopMapReduceCommitProtocolWrite(
@@ -196,50 +239,29 @@ case class HadoopMapReduceCommitProtocolWrite(
     BackendsApiManager.getIteratorApiInstance.injectWriteFilesTempPath(writePath, writeFileName)
   }
 
-  def doCollectNativeResult(cb: ColumnarBatch): Option[WriteTaskResult] = {
-    val basicNativeStats = BasicNativeStats(cb)
-
-    // TODO: we need close iterator here before processing the result.
+  def doCollectNativeResult(stats: Seq[InternalRow]): Option[WriteTaskResult] = {
     // Write an empty iterator
-    if (basicNativeStats.isEmpty) {
+    if (stats.isEmpty) {
       None
     } else {
-      val partitions: mutable.Set[String] = mutable.Set[String]()
-      val addedAbsPathFiles: mutable.Map[String, String] = mutable.Map[String, String]()
-
-      var numWrittenRows: Long = 0
-      basicNativeStats.foreach {
-        stat =>
-          val tmpAbsolutePath = s"${description.path}/${stat.relativePath}"
-          if (stat.partition_id != "__NO_PARTITION_ID__") {
-            partitions += stat.partition_id
-            val customOutputPath =
-              description.customPartitionLocations.get(
-                PartitioningUtils.parsePathFragment(stat.partition_id))
-            if (customOutputPath.isDefined) {
-              addedAbsPathFiles(tmpAbsolutePath) = customOutputPath.get + "/" + stat.filename
-            }
-            basicWriteJobStatsTracker.newPartition(
-              new GenericInternalRow(Array[Any](stat.partition_id)))
-          }
-          basicWriteJobStatsTracker.newFile(tmpAbsolutePath)
-          basicWriteJobStatsTracker.closeFile(tmpAbsolutePath)
-          numWrittenRows += stat.record_count
-      }
-
-      val updatedPartitions = partitions.toSet
+      val commitInfo = FileCommitInfo(description)
+      val basicNativeStat = NativeBasicWriteTaskStatsTracker(description, basicWriteJobStatsTracker)
+      val basicNativeStats = Seq(commitInfo, basicNativeStat)
+      NativeStatCompute(stats)(basicNativeStats)
+      val (partitions, addedAbsPathFiles) = commitInfo.result
+      val updatedPartitions = partitions
       Some(
         WriteTaskResult(
-          new TaskCommitMessage(addedAbsPathFiles.toMap -> updatedPartitions),
+          new TaskCommitMessage(addedAbsPathFiles -> updatedPartitions),
           ExecutedWriteSummary(
             updatedPartitions = updatedPartitions,
-            stats = Seq(finalStats.copy(numRows = numWrittenRows)))
+            stats = Seq(basicNativeStat.result))
         ))
     }
   }
 
-  override def commitTask(batch: ColumnarBatch): Option[WriteTaskResult] = {
-    doCollectNativeResult(batch).map(
+  override def commitTask(writeResults: Seq[InternalRow]): Option[WriteTaskResult] = {
+    doCollectNativeResult(writeResults).map(
       nativeWriteTaskResult => {
         val (_, taskCommitTime) = Utils.timeTakenMs {
           committer.commitTask(taskAttemptContext)

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
@@ -49,8 +49,9 @@ class CHColumnarWriteFilesRDD(
   extends RDD[WriterCommitMessage](prev) {
 
   private def reportTaskMetrics(writeTaskResult: WriteTaskResult): Unit = {
-    writeTaskResult.summary.stats.headOption.map(_.asInstanceOf[BasicWriteTaskStats]).foreach {
-      stats =>
+    writeTaskResult.summary.stats.find(_.isInstanceOf[BasicWriteTaskStats]).foreach {
+      s =>
+        val stats = s.asInstanceOf[BasicWriteTaskStats]
         // Reports bytesWritten and recordsWritten to the Spark output metrics.
         // We should update it after calling `commitTask` to overwrite the metrics.
         Option(TaskContext.get()).map(_.taskMetrics().outputMetrics).foreach {
@@ -103,6 +104,7 @@ class CHColumnarWriteFilesRDD(
         val writeResults = CHExecUtil.c2r(resultColumnarBatch).map(_.copy()).toSeq
         // TODO: we need close iterator here before processing the result.
         // TODO: task commit time
+        // TODO: get the schema from result ColumnarBatch and verify it.
         assert(!iter.hasNext)
 
         val writeTaskResult = commitProtocol

--- a/backends-clickhouse/src/test/delta-20/org/apache/spark/gluten/delta/DeltaStatsUtils.scala
+++ b/backends-clickhouse/src/test/delta-20/org/apache/spark/gluten/delta/DeltaStatsUtils.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.gluten.delta
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+object DeltaStatsUtils {
+
+  def statsDF(
+      sparkSession: SparkSession,
+      deltaJson: String,
+      schema: String
+  ): DataFrame = {
+    throw new IllegalAccessException("Method not used below spark 3.5")
+  }
+}

--- a/backends-clickhouse/src/test/delta-23/org/apache/spark/gluten/delta/DeltaStatsUtils.scala
+++ b/backends-clickhouse/src/test/delta-23/org/apache/spark/gluten/delta/DeltaStatsUtils.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.gluten.delta
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+object DeltaStatsUtils {
+
+  def statsDF(
+      sparkSession: SparkSession,
+      deltaJson: String,
+      schema: String
+  ): DataFrame = {
+    throw new IllegalAccessException("Method not used below spark 3.5")
+  }
+}

--- a/backends-clickhouse/src/test/delta-32/org/apache/spark/gluten/delta/DeltaStatsUtils.scala
+++ b/backends-clickhouse/src/test/delta-32/org/apache/spark/gluten/delta/DeltaStatsUtils.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.gluten.delta
+
+import org.apache.spark.sql.{wrapper, DataFrame, SparkSession}
+import org.apache.spark.sql.delta.{DeltaColumnMappingMode, DeltaLog, DeltaLogFileIndex, NoMapping}
+import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
+import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, StatisticsCollection}
+import org.apache.spark.sql.functions.{col, from_json, regexp_replace}
+import org.apache.spark.sql.types._
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import java.util.Locale
+
+case class Statistics(override val tableSchema: StructType) extends StatisticsCollection {
+  override val outputAttributeSchema: StructType = tableSchema
+  // [[outputTableStatsSchema]] is the candidate schema to find statistics columns.
+  override val outputTableStatsSchema: StructType = tableSchema
+  override val statsColumnSpec = DeltaStatsColumnSpec(None, Some(32))
+  override val columnMappingMode: DeltaColumnMappingMode = NoMapping
+  override val protocol: Protocol = Protocol(
+    minReaderVersion = 1,
+    minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+    readerFeatures = None,
+    writerFeatures = Some(Set()))
+
+  override def spark: SparkSession = {
+    throw new Exception("Method not used in statisticsCollectionFromMetadata")
+  }
+}
+
+object DeltaStatsUtils {
+
+  private def stringToDataType(dataType: String): DataType =
+    dataType.toLowerCase(Locale.ROOT) match {
+      case "bigint" => LongType
+      case "double" => DoubleType
+      case "string" => StringType
+      case "date" => DateType
+      case _ => throw new IllegalArgumentException(s"Unsupported data type: $dataType")
+    }
+
+  /**
+   * Parse a schema string as follows into a [[StructType]].
+   * {{{
+   *  l_orderkey      bigint,
+   *  l_partkey       bigint,
+   *  l_suppkey       bigint,
+   *  l_linenumber    bigint
+   * }}}
+   */
+  private def stringToSchema(schemaString: String): StructType = {
+    val fields = schemaString.trim.split(",\\s*").map {
+      fieldString =>
+        val parts = fieldString.trim.split("\\s+")
+        require(parts.length == 2, s"Invalid field definition: $fieldString")
+        val fieldName = parts(0).trim
+        val fieldType = stringToDataType(parts(1).trim)
+        StructField(fieldName, fieldType, nullable = true)
+    }
+    StructType(fields)
+  }
+
+  def statsDF(
+      sparkSession: SparkSession,
+      deltaJson: String,
+      schema: String
+  ): DataFrame = {
+
+    val statistics = Statistics(stringToSchema(schema))
+
+    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(Map.empty)
+    wrapper
+      .ofRows(
+        sparkSession,
+        DeltaLog.indexToRelation(
+          sparkSession,
+          DeltaLogFileIndex(
+            DeltaLogFileIndex.COMMIT_FILE_FORMAT,
+            FileSystem.get(hadoopConf),
+            Seq(new Path(deltaJson))),
+          Map.empty)
+      )
+      .select("add")
+      .filter("add is not null")
+      .withColumns(Map(
+        "path" -> regexp_replace(
+          col("add.path"),
+          "-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}",
+          ""
+        ), // normalize file name
+        "stats" -> from_json(col("add.stats"), statistics.statsSchema)
+      ))
+      .select(
+        "path",
+        "stats.numRecords",
+        "stats.minValues.*",
+        "stats.maxValues.*",
+        "stats.nullCount.*")
+  }
+
+}

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
@@ -94,32 +94,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
                  | select /*+ REPARTITION(5) */ * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_delta_parquet
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_delta_parquet")) {
       df =>
         val plans = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -635,32 +610,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
          |  l_comment from lineitem
          |  where l_shipdate BETWEEN date'1993-02-01' AND date'1993-02-10'
          |""".stripMargin)
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_delta_parquet_partition
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+    runTPCHQueryBySQL(1, q1("lineitem_delta_parquet_partition"), compareResult = false) {
       df =>
         val result = df.collect()
         assert(result.length === 2)
@@ -703,32 +653,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
                  | as select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_delta_parquet_ctas1
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_delta_parquet_ctas1")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -756,34 +681,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
                  |LOCATION '$basePath/lineitem_mergetree_ctas2'
                  | as select * from lineitem
                  |""".stripMargin)
-
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_delta_parquet_ctas2
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) { _ => {} }
-
+    runTPCHQueryBySQL(1, q1("lineitem_delta_parquet_ctas2")) { _ => {} }
   }
 
   test("test path based parquet write with the delta") {
@@ -829,32 +727,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       .mode(SaveMode.Overwrite)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    delta.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"delta.`$dataPath`")) {
       df =>
         val plans = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -1149,32 +1022,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       .mode(SaveMode.Append)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    delta.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+    runTPCHQueryBySQL(1, q1(s"delta.`$dataPath`"), compareResult = false) {
       df =>
         val result = df.collect()
         assert(result.length === 2)
@@ -1215,32 +1063,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
                  | as select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    delta.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) { _ => {} }
+    runTPCHQueryBySQL(1, q1(s"delta.`$dataPath`")) { _ => {} }
   }
 
   testSparkVersionLE33("test parquet optimize basic") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.spark.SparkConf
+import org.apache.spark.gluten.delta.DeltaStatsUtils
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.delta.files.TahoeFileIndex
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -49,7 +50,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
-      .set("spark.gluten.sql.native.writer.enabled", "true")
+      .set("spark.gluten.sql.native.writer.enabled", spark35.toString)
       .set("spark.sql.storeAssignmentPolicy", "legacy")
       .setCHSettings("mergetree.merge_after_insert", false)
       .set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
@@ -59,42 +60,45 @@ class GlutenClickHouseDeltaParquetWriteSuite
     createNotNullTPCHTablesInParquet(tablesPath)
   }
 
+  private val q1SchemaString: String =
+    s""" l_orderkey      bigint,
+       | l_partkey       bigint,
+       | l_suppkey       bigint,
+       | l_linenumber    bigint,
+       | l_quantity      double,
+       | l_extendedprice double,
+       | l_discount      double,
+       | l_tax           double,
+       | l_returnflag    string,
+       | l_linestatus    string,
+       | l_shipdate      date,
+       | l_commitdate    date,
+       | l_receiptdate   date,
+       | l_shipinstruct  string,
+       | l_shipmode      string,
+       | l_comment       string""".stripMargin
+
+  private def doInsert(drop: String, create: String, insert: String): Unit = {
+    spark.sql(drop)
+    spark.sql(create)
+    spark.sql(insert)
+  }
+  private def drop(table: String): String = s"DROP TABLE IF EXISTS $table"
+  private def createLineitem(table: String): String =
+    s"""CREATE TABLE IF NOT EXISTS $table ($q1SchemaString) USING delta
+       |TBLPROPERTIES (write.format.default = 'parquet')
+       |LOCATION '$basePath/$table'
+       |""".stripMargin
+
   test("test parquet table write with the delta") {
-    spark.sql(s"""
-                 |DROP TABLE IF EXISTS lineitem_delta_parquet;
-                 |""".stripMargin)
 
-    spark.sql(s"""
-                 |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
-                 |USING delta
-                 |TBLPROPERTIES (write.format.default = 'parquet')
-                 |LOCATION '$basePath/lineitem_delta_parquet'
-                 |""".stripMargin)
+    def insert(table: String): String =
+      s"insert into table $table select /*+ REPARTITION(5) */ * from lineitem"
 
-    spark.sql(s"""
-                 | insert into table lineitem_delta_parquet
-                 | select /*+ REPARTITION(5) */ * from lineitem
-                 |""".stripMargin)
+    val table = "lineitem_delta_parquet"
+    doInsert(drop(table), createLineitem(table), insert(table))
 
-    runTPCHQueryBySQL(1, q1("lineitem_delta_parquet")) {
+    runTPCHQueryBySQL(1, q1(table)) {
       df =>
         val plans = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -109,106 +113,64 @@ class GlutenClickHouseDeltaParquetWriteSuite
         val addFiles = fileIndex.matchingFiles(Nil, Nil)
         assert(addFiles.size === 5)
     }
+
+    if (spark35) {
+      val vanillaTable = "lineitem_delta_parquet_vanilla"
+      withSQLConf(("spark.gluten.sql.native.writer.enabled", "false")) {
+        doInsert(drop(vanillaTable), createLineitem(vanillaTable), insert(vanillaTable))
+      }
+      val expected = DeltaStatsUtils
+        .statsDF(
+          spark,
+          s"$basePath/$vanillaTable/_delta_log/00000000000000000001.json",
+          q1SchemaString)
+        .collect()
+
+      checkAnswer(
+        DeltaStatsUtils.statsDF(
+          spark,
+          s"$basePath/$table/_delta_log/00000000000000000001.json",
+          q1SchemaString),
+        expected
+      )
+    }
   }
 
   test("test parquet insert overwrite with the delta") {
-    spark.sql(s"""
-                 |DROP TABLE IF EXISTS lineitem_delta_parquet_insertoverwrite;
-                 |""".stripMargin)
+    def insert(table: String): String =
+      s"insert into table $table select  * from lineitem"
 
+    val table = "lineitem_delta_parquet_insertoverwrite"
+    doInsert(drop(table), createLineitem(table), insert(table))
     spark.sql(s"""
-                 |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_insertoverwrite
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
-                 |USING delta
-                 |LOCATION '$basePath/lineitem_delta_parquet_insertoverwrite'
-                 |""".stripMargin)
-
-    spark.sql(s"""
-                 | insert into table lineitem_delta_parquet_insertoverwrite
-                 | select * from lineitem
-                 |""".stripMargin)
-
-    spark.sql(s"""
-                 | insert overwrite table lineitem_delta_parquet_insertoverwrite
+                 | insert overwrite table $table
                  | select * from lineitem where mod(l_orderkey,2) = 1
                  |""".stripMargin)
-    val sql2 =
-      s"""
-         | select count(*) from lineitem_delta_parquet_insertoverwrite
-         |""".stripMargin
-    assert(
-      // total rows should remain unchanged
-      spark.sql(sql2).collect().apply(0).get(0) === 300001
-    )
+
+    // total rows should remain unchanged
+    assert(spark.sql(s"select count(*) from $table").collect().apply(0).get(0) === 300001)
   }
 
   test("test parquet insert overwrite partitioned table with small table, static with delta") {
-    spark.sql(s"""
-                 |DROP TABLE IF EXISTS lineitem_delta_parquet_insertoverwrite2;
-                 |""".stripMargin)
-
-    spark.sql(s"""
-                 |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_insertoverwrite2
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
-                 |USING delta
-                 |PARTITIONED BY (l_shipdate)
-                 |LOCATION '$basePath/lineitem_delta_parquet_insertoverwrite2'
-                 |""".stripMargin)
-
-    spark.sql(s"""
-                 | insert into table lineitem_delta_parquet_insertoverwrite2
-                 | select * from lineitem
-                 | where l_shipdate BETWEEN date'1993-01-01' AND date'1993-03-31'
-                 |""".stripMargin)
-
-    spark.sql(
+    val table = "lineitem_delta_parquet_insertoverwrite2"
+    doInsert(
+      drop(table),
       s"""
-         | insert overwrite table lineitem_delta_parquet_insertoverwrite2
-         | select * from lineitem where l_shipdate BETWEEN date'1993-02-01' AND date'1993-02-10'
-         |""".stripMargin)
-    val sql2 =
+         |CREATE TABLE IF NOT EXISTS $table ($q1SchemaString) USING delta
+         |PARTITIONED BY (l_shipdate)
+         |LOCATION '$basePath/$table'
+         |""".stripMargin,
       s"""
-         | select count(*) from lineitem_delta_parquet_insertoverwrite2
-         |
+         | insert into table $table select * from lineitem
+         | where l_shipdate BETWEEN date'1993-01-01' AND date'1993-03-31'
          |""".stripMargin
-    assert(
-      // total rows should remain unchanged
-      spark.sql(sql2).collect().apply(0).get(0) === 2418
     )
+    spark.sql(s"""
+                 | insert overwrite table $table select * from lineitem
+                 | where l_shipdate BETWEEN date'1993-02-01' AND date'1993-02-10'
+                 |""".stripMargin)
+    // total rows should remain unchanged
+    assert(spark.sql(s"select count(*) from $table").collect().apply(0).get(0) === 2418)
   }
 
   test("test parquet insert overwrite partitioned table with small table, dynamic with delta") {
@@ -219,24 +181,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
 
       spark.sql(s"""
                    |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_insertoverwrite3
-                   |(
-                   | l_orderkey      bigint,
-                   | l_partkey       bigint,
-                   | l_suppkey       bigint,
-                   | l_linenumber    bigint,
-                   | l_quantity      double,
-                   | l_extendedprice double,
-                   | l_discount      double,
-                   | l_tax           double,
-                   | l_returnflag    string,
-                   | l_linestatus    string,
-                   | l_shipdate      date,
-                   | l_commitdate    date,
-                   | l_receiptdate   date,
-                   | l_shipinstruct  string,
-                   | l_shipmode      string,
-                   | l_comment       string
-                   |)
+                   |($q1SchemaString)
                    |USING delta
                    |PARTITIONED BY (l_shipdate)
                    |LOCATION '$basePath/lineitem_delta_parquet_insertoverwrite3'
@@ -272,24 +217,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
 
     spark.sql(s"""
                  |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_update
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
+                 |($q1SchemaString)
                  |USING delta
                  |LOCATION '$basePath/lineitem_delta_parquet_update'
                  |""".stripMargin)
@@ -335,10 +263,9 @@ class GlutenClickHouseDeltaParquetWriteSuite
          | select count(*) from lineitem_delta_parquet_update
          |
          |""".stripMargin
-    assert(
-      // total rows should remain unchanged
-      spark.sql(sql2).collect().apply(0).get(0) === 600572
-    )
+
+    // total rows should remain unchanged
+    assert(spark.sql(sql2).collect().apply(0).get(0) === 600572)
   }
 
   test("test parquet table delete with the delta") {
@@ -348,24 +275,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
 
     spark.sql(s"""
                  |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_delete
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
+                 |($q1SchemaString)
                  |USING delta
                  |LOCATION '$basePath/lineitem_delta_parquet_delete'
                  |""".stripMargin)
@@ -415,24 +325,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
 
     spark.sql(s"""
                  |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_upsert
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
+                 |($q1SchemaString)
                  |USING delta
                  |LOCATION '$basePath/lineitem_delta_parquet_upsert'
                  |""".stripMargin)
@@ -517,24 +410,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
 
     spark.sql(s"""
                  |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_partition
-                 |(
-                 | l_orderkey      bigint,
-                 | l_partkey       bigint,
-                 | l_suppkey       bigint,
-                 | l_linenumber    bigint,
-                 | l_quantity      double,
-                 | l_extendedprice double,
-                 | l_discount      double,
-                 | l_tax           double,
-                 | l_returnflag    string,
-                 | l_linestatus    string,
-                 | l_shipdate      date,
-                 | l_commitdate    date,
-                 | l_receiptdate   date,
-                 | l_shipinstruct  string,
-                 | l_shipmode      string,
-                 | l_comment       string
-                 |)
+                 |($q1SchemaString)
                  |USING delta
                  |PARTITIONED BY (l_shipdate, l_returnflag)
                  |LOCATION '$basePath/lineitem_delta_parquet_partition'
@@ -1066,7 +942,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
     runTPCHQueryBySQL(1, q1(s"delta.`$dataPath`")) { _ => {} }
   }
 
-  testSparkVersionLE33("test parquet optimize basic") {
+  test("test parquet optimize basic") {
     withSQLConf("spark.databricks.delta.optimize.maxFileSize" -> "20000000") {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS lineitem_delta_parquet_optimize;
@@ -1101,7 +977,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
     }
   }
 
-  testSparkVersionLE33("test parquet optimize partitioned by one low card column") {
+  test("test parquet optimize partitioned by one low card column") {
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_delta_parquet_optimize_p2;
                  |""".stripMargin)
@@ -1140,7 +1016,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
     assert(ret2.apply(0).get(0) === 600572)
   }
 
-  testSparkVersionLE33("test parquet optimize parallel delete") {
+  test("test parquet optimize parallel delete") {
     withSQLConf("spark.databricks.delta.vacuum.parallelDelete.enabled" -> "true") {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS lineitem_delta_parquet_optimize_p4;

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseExcelFormatSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseExcelFormatSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.CHConf
 
 import org.apache.spark.SparkConf
@@ -76,7 +77,7 @@ class GlutenClickHouseExcelFormatSuite
 
   // in this case, FakeRowAdaptor does R2C
   test("parquet native writer writing a in memory DF") {
-    withSQLConf(("spark.gluten.sql.native.writer.enabled", "true")) {
+    withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")) {
       val filePath = basePath + "/native_parquet_test"
       val format = "parquet"
 
@@ -99,7 +100,7 @@ class GlutenClickHouseExcelFormatSuite
 
   // in this case, FakeRowAdaptor only wrap&transfer
   test("parquet native writer writing a DF from file") {
-    withSQLConf(("spark.gluten.sql.native.writer.enabled", "true")) {
+    withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")) {
 
       val filePath = basePath + "/native_parquet_test"
       val format = "parquet"
@@ -123,7 +124,7 @@ class GlutenClickHouseExcelFormatSuite
 
   // in this case, FakeRowAdaptor only wrap&transfer
   test("parquet native writer writing a DF from an aggregate") {
-    withSQLConf(("spark.gluten.sql.native.writer.enabled", "true")) {
+    withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")) {
 
       val filePath = basePath + "/native_parquet_test_agg"
       val format = "parquet"
@@ -1480,7 +1481,7 @@ class GlutenClickHouseExcelFormatSuite
          | from $format.`$tablePath`
          | where long_field > 30
          |""".stripMargin
-    withSQLConf(("spark.gluten.sql.native.writer.enabled", "true")) {
+    withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")) {
       testFileFormatBase(tablePath, format, sql, df => {})
     }
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHAbstractSuite.scala
@@ -621,4 +621,42 @@ abstract class GlutenClickHouseTPCHAbstractSuite
       checkDataFrame(noFallBack, customCheck, df)
   }
 
+  def q1(tableName: String): String =
+    s"""
+       |SELECT
+       |    l_returnflag,
+       |    l_linestatus,
+       |    sum(l_quantity) AS sum_qty,
+       |    sum(l_extendedprice) AS sum_base_price,
+       |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+       |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+       |    avg(l_quantity) AS avg_qty,
+       |    avg(l_extendedprice) AS avg_price,
+       |    avg(l_discount) AS avg_disc,
+       |    count(*) AS count_order
+       |FROM
+       |    $tableName
+       |WHERE
+       |    l_shipdate <= date'1998-09-02' - interval 1 day
+       |GROUP BY
+       |    l_returnflag,
+       |    l_linestatus
+       |ORDER BY
+       |    l_returnflag,
+       |    l_linestatus;
+       |
+       |""".stripMargin
+
+  def q6(tableName: String): String =
+    s"""
+       |SELECT
+       |    sum(l_extendedprice * l_discount) AS revenue
+       |FROM
+       |    $tableName
+       |WHERE
+       |    l_shipdate >= date'1994-01-01'
+       |    AND l_shipdate < date'1994-01-01' + interval 1 year
+       |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+       |    AND l_quantity < 24
+       |""".stripMargin
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
@@ -64,7 +64,7 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
 
   test("test uuid - write and read") {
     withSQLConf(
-      ("spark.gluten.sql.native.writer.enabled", "true"),
+      (GlutenConfig.NATIVE_WRITER_ENABLED.key, "true"),
       (GlutenConfig.GLUTEN_ENABLED.key, "true")) {
       withTable("uuid_test") {
         spark.sql("create table if not exists uuid_test (id string) using parquet")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseNativeWriteTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseNativeWriteTableSuite.scala
@@ -610,7 +610,7 @@ class GlutenClickHouseNativeWriteTableSuite
           }
           val table_name_vanilla = table_name_vanilla_template.format(format)
           spark.sql(s"drop table IF EXISTS $table_name_vanilla")
-          withSQLConf(("spark.gluten.sql.native.writer.enabled", "false")) {
+          withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "false")) {
             withNativeWriteCheck(checkNative = false) {
               spark
                 .table("origin_table")
@@ -672,7 +672,7 @@ class GlutenClickHouseNativeWriteTableSuite
 
           val table_name_vanilla = table_name_vanilla_template.format(format)
           spark.sql(s"drop table IF EXISTS $table_name_vanilla")
-          withSQLConf(("spark.gluten.sql.native.writer.enabled", "false")) {
+          withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "false")) {
             withNativeWriteCheck(checkNative = false) {
               spark
                 .table("origin_table")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
@@ -114,32 +114,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .mode(SaveMode.Overwrite)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val plans = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -205,32 +180,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .option("clickhouse.lowCardKey", "l_returnflag,l_linestatus")
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val plans = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -575,32 +525,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .mode(SaveMode.Append)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -672,32 +597,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .mode(SaveMode.Append)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`"), compareResult = false) {
       df =>
         val result = df.collect()
         assertResult(4)(result.length)
@@ -771,32 +671,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .mode(SaveMode.Append)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -875,32 +750,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
                  | as select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -935,32 +785,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
                  | as select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) { _ => {} }
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) { _ => {} }
 
   }
 
@@ -978,32 +803,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .mode(SaveMode.Append)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) { _ => {} }
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) { _ => {} }
     val directory = new File(dataPath)
     // find a folder whose name is like 48b70783-b3b8-4bf8-9c52-5261aead8e3e_0_006
     val partDir = directory.listFiles().filter(f => f.getName.length > 20).head
@@ -1057,19 +857,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .mode(SaveMode.Append)
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    sum(l_extendedprice * l_discount) AS revenue
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate >= date'1994-01-01'
-         |    AND l_shipdate < date'1994-01-01' + interval 1 year
-         |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
-         |    AND l_quantity < 24
-         |""".stripMargin
-    runTPCHQueryBySQL(6, sqlStr) {
+    runTPCHQueryBySQL(6, q6(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -1218,32 +1006,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
 
   test("GLUTEN-5219: Fix the table metadata sync issue for the CH backend") {
     def checkQueryResult(tableName: String): Unit = {
-      val sqlStr =
-        s"""
-           |SELECT
-           |    l_returnflag,
-           |    l_linestatus,
-           |    sum(l_quantity) AS sum_qty,
-           |    sum(l_extendedprice) AS sum_base_price,
-           |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-           |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-           |    avg(l_quantity) AS avg_qty,
-           |    avg(l_extendedprice) AS avg_price,
-           |    avg(l_discount) AS avg_disc,
-           |    count(*) AS count_order
-           |FROM
-           |    clickhouse.`$tableName`
-           |WHERE
-           |    l_shipdate <= date'1998-09-02' - interval 1 day
-           |GROUP BY
-           |    l_returnflag,
-           |    l_linestatus
-           |ORDER BY
-           |    l_returnflag,
-           |    l_linestatus;
-           |
-           |""".stripMargin
-      runTPCHQueryBySQL(1, sqlStr) {
+      runTPCHQueryBySQL(1, q1(s"clickhouse.`$tableName`")) {
         df =>
           val scanExec = collect(df.queryExecution.executedPlan) {
             case f: FileSourceScanExecTransformer => f

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
@@ -111,32 +111,8 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
                  | select * from lineitem
                  |""".stripMargin)
     FileUtils.deleteDirectory(new File(HDFS_METADATA_PATH))
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_hdfs")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -196,32 +172,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_orderbykey_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_orderbykey_hdfs")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -358,32 +309,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
                  |  where l_returnflag = 'A'
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_partition_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_partition_hdfs"), compareResult = false) {
       df =>
         val result = df.collect()
         assertResult(4)(result.length)
@@ -471,32 +397,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_bucket_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_bucket_hdfs")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -552,32 +453,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
       .option("clickhouse.storage_policy", "__hdfs_main")
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
@@ -111,32 +111,8 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
                  | select * from lineitem
                  |""".stripMargin)
     FileUtils.deleteDirectory(new File(HDFS_METADATA_PATH))
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_hdfs")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -196,32 +172,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_orderbykey_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_orderbykey_hdfs")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -358,32 +309,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
                  |  where l_returnflag = 'A'
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_partition_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_partition_hdfs"), compareResult = false) {
       df =>
         val result = df.collect()
         assertResult(4)(result.length)
@@ -471,32 +397,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_bucket_hdfs
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_bucket_hdfs")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -552,32 +453,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
       .option("clickhouse.storage_policy", "__hdfs_main_rocksdb")
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
@@ -125,32 +125,8 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
                  | select * from lineitem
                  |""".stripMargin)
     FileUtils.deleteDirectory(new File(S3_METADATA_PATH))
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_s3
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_s3")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -256,32 +232,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_orderbykey_s3
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_orderbykey_s3")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -418,32 +369,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
                  |  where l_returnflag = 'A'
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_partition_s3
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_partition_s3"), compareResult = false) {
       df =>
         val result = df.collect()
         assertResult(4)(result.length)
@@ -532,32 +458,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_bucket_s3
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_bucket_s3")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -613,32 +514,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
       .option("clickhouse.storage_policy", "__s3_main")
       .save(dataPath)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    clickhouse.`$dataPath`
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1(s"clickhouse.`$dataPath`")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -743,21 +619,8 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
 
     FileUtils.forceDelete(new File(S3_METADATA_PATH))
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    sum(l_extendedprice * l_discount) AS revenue
-         |FROM
-         |    $tableName
-         |WHERE
-         |    l_shipdate >= date'1994-01-01'
-         |    AND l_shipdate < date'1994-01-01' + interval 1 year
-         |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
-         |    AND l_quantity < 24
-         |""".stripMargin
-
     withSQLConf(runtimeSettings("enabled_driver_filter_mergetree_index") -> "true") {
-      runTPCHQueryBySQL(6, sqlStr) {
+      runTPCHQueryBySQL(6, q6(tableName)) {
         df =>
           val scanExec = collect(df.queryExecution.executedPlan) {
             case f: FileSourceScanExecTransformer => f

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -213,7 +213,7 @@ class GlutenClickHouseMergeTreeWriteSuite
   }
 
   test("test mergetree insert overwrite partitioned table with small table, static") {
-    withSQLConf((CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, "false")) {
+    withSQLConf((CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)) {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS lineitem_mergetree_insertoverwrite2;
                    |""".stripMargin)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -102,32 +102,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                    | select * from lineitem
                    |""".stripMargin)
 
-      val sqlStr =
-        s"""
-           |SELECT
-           |    l_returnflag,
-           |    l_linestatus,
-           |    sum(l_quantity) AS sum_qty,
-           |    sum(l_extendedprice) AS sum_base_price,
-           |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-           |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-           |    avg(l_quantity) AS avg_qty,
-           |    avg(l_extendedprice) AS avg_price,
-           |    avg(l_discount) AS avg_disc,
-           |    count(*) AS count_order
-           |FROM
-           |    lineitem_mergetree
-           |WHERE
-           |    l_shipdate <= date'1998-09-02' - interval 1 day
-           |GROUP BY
-           |    l_returnflag,
-           |    l_linestatus
-           |ORDER BY
-           |    l_returnflag,
-           |    l_linestatus;
-           |
-           |""".stripMargin
-      runTPCHQueryBySQL(1, sqlStr) {
+      runTPCHQueryBySQL(1, q1("lineitem_mergetree")) {
         df =>
           val plans = collect(df.queryExecution.executedPlan) {
             case f: FileSourceScanExecTransformer => f
@@ -573,32 +548,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_orderbykey
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_orderbykey")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -731,32 +681,8 @@ class GlutenClickHouseMergeTreeWriteSuite
                  |  l_comment from lineitem
                  |  where l_shipdate BETWEEN date'1993-02-01' AND date'1993-02-10'
                  |""".stripMargin)
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_partition
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr, compareResult = false) {
+
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_partition"), compareResult = false) {
       df =>
         val result = df.collect()
         assertResult(4)(result.length)
@@ -849,32 +775,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_bucket
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_bucket")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -1055,32 +956,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | as select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_ctas1
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) {
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_ctas1")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -1117,32 +993,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | as select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_ctas2
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) { _ => {} }
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_ctas2")) { _ => {} }
 
   }
 
@@ -1181,32 +1032,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_mergetree_lowcard
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr) { _ => {} }
+    runTPCHQueryBySQL(1, q1("lineitem_mergetree_lowcard")) { _ => {} }
     val directory = new File(s"$basePath/lineitem_mergetree_lowcard")
     // find a folder whose name is like 48b70783-b3b8-4bf8-9c52-5261aead8e3e_0_006
     val partDir = directory.listFiles().filter(f => f.getName.length > 20).head
@@ -1281,19 +1107,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    sum(l_extendedprice * l_discount) AS revenue
-         |FROM
-         |    lineitem_mergetree_orderbykey2
-         |WHERE
-         |    l_shipdate >= date'1994-01-01'
-         |    AND l_shipdate < date'1994-01-01' + interval 1 year
-         |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
-         |    AND l_quantity < 24
-         |""".stripMargin
-    runTPCHQueryBySQL(6, sqlStr) {
+    runTPCHQueryBySQL(6, q6("lineitem_mergetree_orderbykey2")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -1368,18 +1182,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr = s"""
-                    |SELECT
-                    |    sum(l_extendedprice * l_discount) AS revenue
-                    |FROM
-                    |    lineitem_mergetree_orderbykey3
-                    |WHERE
-                    |    l_shipdate >= date'1994-01-01'
-                    |    AND l_shipdate < date'1994-01-01' + interval 1 year
-                    |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
-                    |    AND l_quantity < 24
-                    |""".stripMargin
-    runTPCHQueryBySQL(6, sqlStr) {
+    runTPCHQueryBySQL(6, q6("lineitem_mergetree_orderbykey3")) {
       df =>
         val scanExec = collect(df.queryExecution.executedPlan) {
           case f: FileSourceScanExecTransformer => f
@@ -1584,7 +1387,7 @@ class GlutenClickHouseMergeTreeWriteSuite
            |    l_linestatus;
            |
            |""".stripMargin
-      runTPCHQueryBySQL(1, sqlStr) {
+      runTPCHQueryBySQL(1, q1(tableName)) {
         df =>
           val scanExec = collect(df.queryExecution.executedPlan) {
             case f: FileSourceScanExecTransformer => f
@@ -1777,23 +1580,10 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    sum(l_extendedprice * l_discount) AS revenue
-         |FROM
-         |    lineitem_mergetree_pk_pruning_by_driver
-         |WHERE
-         |    l_shipdate >= date'1994-01-01'
-         |    AND l_shipdate < date'1994-01-01' + interval 1 year
-         |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
-         |    AND l_quantity < 24
-         |""".stripMargin
-
     Seq(("true", 2), ("false", 3)).foreach(
       conf => {
         withSQLConf(CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> conf._1) {
-          runTPCHQueryBySQL(6, sqlStr) {
+          runTPCHQueryBySQL(6, q6("lineitem_mergetree_pk_pruning_by_driver")) {
             df =>
               val scanExec = collect(df.queryExecution.executedPlan) {
                 case f: FileSourceScanExecTransformer => f
@@ -1817,7 +1607,7 @@ class GlutenClickHouseMergeTreeWriteSuite
       CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> "true",
       CHConf.prefixOf("files.per.partition.threshold") -> "10"
     ) {
-      runTPCHQueryBySQL(6, sqlStr) {
+      runTPCHQueryBySQL(6, q6("lineitem_mergetree_pk_pruning_by_driver")) {
         df =>
           val scanExec = collect(df.queryExecution.executedPlan) {
             case f: FileSourceScanExecTransformer => f
@@ -2044,19 +1834,7 @@ class GlutenClickHouseMergeTreeWriteSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    sum(l_extendedprice * l_discount) AS revenue
-         |FROM
-         |    lineitem_mergetree_case_sensitive
-         |WHERE
-         |    l_shipdate >= date'1994-01-01'
-         |    AND l_shipdate < date'1994-01-01' + interval 1 year
-         |    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
-         |    AND l_quantity < 24
-         |""".stripMargin
-    runTPCHQueryBySQL(6, sqlStr) { _ => }
+    runTPCHQueryBySQL(6, q6("lineitem_mergetree_case_sensitive")) { _ => }
   }
 
   test("test mergetree with partition with whitespace") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.CHConf
 import org.apache.gluten.execution._
 import org.apache.gluten.utils.Arm
@@ -55,7 +56,7 @@ class GlutenClickHouseMergeTreeWriteSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
-      .set("spark.gluten.sql.native.writer.enabled", "true")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
       .setCHSettings("min_insert_block_size_rows", 100000)
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite.scala
@@ -86,31 +86,6 @@ class GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite
                  | select * from lineitem
                  |""".stripMargin)
 
-    val sqlStr =
-      s"""
-         |SELECT
-         |    l_returnflag,
-         |    l_linestatus,
-         |    sum(l_quantity) AS sum_qty,
-         |    sum(l_extendedprice) AS sum_base_price,
-         |    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
-         |    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
-         |    avg(l_quantity) AS avg_qty,
-         |    avg(l_extendedprice) AS avg_price,
-         |    avg(l_discount) AS avg_disc,
-         |    count(*) AS count_order
-         |FROM
-         |    lineitem_task_not_serializable
-         |WHERE
-         |    l_shipdate <= date'1998-09-02' - interval 1 day
-         |GROUP BY
-         |    l_returnflag,
-         |    l_linestatus
-         |ORDER BY
-         |    l_returnflag,
-         |    l_linestatus;
-         |
-         |""".stripMargin
-    runTPCHQueryBySQL(1, sqlStr)(_ => {})
+    runTPCHQueryBySQL(1, q1("lineitem_task_not_serializable"))(_ => {})
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/gluten/NativeWriteChecker.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/gluten/NativeWriteChecker.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.gluten
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.execution.GlutenClickHouseWholeStageTransformerSuite
 
 import org.apache.spark.sql.{Dataset, Row}
@@ -70,13 +71,13 @@ trait NativeWriteChecker
   }
 
   def nativeWrite(f: String => Unit): Unit = {
-    withSQLConf(("spark.gluten.sql.native.writer.enabled", "true")) {
+    withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")) {
       formats.foreach(f(_))
     }
   }
 
   def vanillaWrite(block: => Unit): Unit = {
-    withSQLConf(("spark.gluten.sql.native.writer.enabled", "false")) {
+    withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "false")) {
       block
     }
   }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/wrapper/package.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/wrapper/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+package object wrapper {
+  def ofRows(sparkSession: SparkSession, logicalPlan: LogicalPlan): DataFrame =
+    Dataset.ofRows(sparkSession, logicalPlan)
+}

--- a/cpp-ch/local-engine/Common/BlockTypeUtils.cpp
+++ b/cpp-ch/local-engine/Common/BlockTypeUtils.cpp
@@ -39,18 +39,12 @@ DB::DataTypePtr wrapNullableType(bool nullable, DB::DataTypePtr nested_type)
     {
         if (nested_type->isLowCardinalityNullable())
             return nested_type;
-        else if (!nested_type->lowCardinality())
-            return std::make_shared<DB::DataTypeNullable>(nested_type);
-        else
+        if (nested_type->lowCardinality())
             return std::make_shared<DB::DataTypeLowCardinality>(
                 std::make_shared<DB::DataTypeNullable>(dynamic_cast<const DB::DataTypeLowCardinality &>(*nested_type).getDictionaryType()));
-    }
-
-
-    if (nullable && !nested_type->isNullable())
         return std::make_shared<DB::DataTypeNullable>(nested_type);
-    else
-        return nested_type;
+    }
+    return nested_type;
 }
 
 }

--- a/cpp-ch/local-engine/Common/BlockTypeUtils.h
+++ b/cpp-ch/local-engine/Common/BlockTypeUtils.h
@@ -73,14 +73,18 @@ inline DB::DataTypePtr DATE()
     return std::make_shared<DB::DataTypeDate32>();
 }
 
-inline DB::Block makeBlockHeader(const DB::ColumnsWithTypeAndName & data_)
+inline DB::Block makeBlockHeader(const DB::ColumnsWithTypeAndName & data)
 {
-    return DB::Block(data_);
+    return DB::Block(data);
 }
 
 DB::NamesAndTypesList blockToNameAndTypeList(const DB::Block & header);
 DB::DataTypePtr wrapNullableType(bool nullable, DB::DataTypePtr nested_type);
 
+inline DB::DataTypePtr wrapNullableType(DB::DataTypePtr nested_type)
+{
+    return wrapNullableType(true, nested_type);
+}
 inline DB::DataTypePtr wrapNullableType(const substrait::Type_Nullability nullable, const DB::DataTypePtr & nested_type)
 {
     return wrapNullableType(nullable == substrait::Type_Nullability_NULLABILITY_NULLABLE, nested_type);

--- a/cpp-ch/local-engine/Common/DebugUtils.cpp
+++ b/cpp-ch/local-engine/Common/DebugUtils.cpp
@@ -280,7 +280,7 @@ static std::string showString(const NameAndColumns & block, size_t numRows, size
     {
         // For Data that has more than "numRows" records
         const char * rowsString = (numRows == 1) ? "row" : "rows";
-        sb << "only showing top" << numRows << rowsString << std::endl;
+        sb << "only showing top " << numRows << " " << rowsString << std::endl;
     }
     return sb.str();
 }

--- a/cpp-ch/local-engine/Common/DebugUtils.cpp
+++ b/cpp-ch/local-engine/Common/DebugUtils.cpp
@@ -19,10 +19,7 @@
 #include <sstream>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
-#include <DataTypes/DataTypeDate.h>
-#include <DataTypes/DataTypeDate32.h>
 #include <DataTypes/DataTypeDateTime64.h>
-#include <Formats/FormatSettings.h>
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Processors/QueryPlan/QueryPlan.h>
@@ -37,6 +34,260 @@ namespace pb_util = google::protobuf::util;
 
 namespace debug
 {
+namespace Utils
+{
+
+/**
+ * Return the number of half widths in a given string. Note that a full width character
+ * occupies two half widths.
+ *
+ * For a string consisting of 1 million characters, the execution of this method requires
+ * about 50ms.
+ */
+static size_t stringHalfWidth(const std::string & str)
+{
+    //TODO: Implement this method
+    return str.size();
+}
+
+/**
+ * <p>Left pad a String with spaces (' ').</p>
+ *
+ * <p>The String is padded to the size of {@code size}.</p>
+ *
+ * <pre>
+ * StringUtils.leftPad(null, *)   = null
+ * StringUtils.leftPad("", 3)     = "   "
+ * StringUtils.leftPad("bat", 3)  = "bat"
+ * StringUtils.leftPad("bat", 5)  = "  bat"
+ * StringUtils.leftPad("bat", 1)  = "bat"
+ * StringUtils.leftPad("bat", -1) = "bat"
+ * </pre>
+ *
+ * @param str  the String to pad out, may be null
+ * @param size  the size to pad to
+ * @return left padded String or original String if no padding is necessary,
+ *  {@code null} if null String input
+ */
+static std::string leftPad(const std::string & str, int totalWidth)
+{
+    std::stringstream ss;
+    ss << std::setw(totalWidth) << std::setfill(' ') << str;
+    return ss.str();
+}
+
+/**
+ * <p>Right pad a String with spaces (' ').</p>
+ *
+ * <p>The String is padded to the size of {@code size}.</p>
+ *
+ * <pre>
+ * StringUtils.rightPad(null, *)   = null
+ * StringUtils.rightPad("", 3)     = "   "
+ * StringUtils.rightPad("bat", 3)  = "bat"
+ * StringUtils.rightPad("bat", 5)  = "bat  "
+ * StringUtils.rightPad("bat", 1)  = "bat"
+ * StringUtils.rightPad("bat", -1) = "bat"
+ * </pre>
+ *
+ * @param str  the String to pad out, may be null
+ * @param totalWidth the size to pad to
+ * @param padChar  the character to pad with
+ * @param size  the size to pad to
+ * @return right padded String or original String if no padding is necessary,
+ *  {@code null} if null String input
+ */
+static std::string rightPad(const std::string & str, int totalWidth, char padChar = ' ')
+{
+    std::stringstream ss;
+    ss << str << std::setw(totalWidth - str.size()) << std::setfill(padChar) << "";
+    return ss.str();
+}
+
+static std::string truncate(const std::string & str, size_t width)
+{
+    if (str.size() <= width)
+        return str;
+    return str.substr(0, width - 3) + "...";
+}
+
+using NameAndColumn = std::pair<std::string, DB::ColumnPtr>;
+using NameAndColumns = std::vector<NameAndColumn>;
+
+/**
+ * Get rows represented in Sequence by specific truncate and vertical requirement.
+ *
+ * @param block Columns to show
+ * @param numRows Number of rows to return
+ * @param truncate If set to more than 0, truncates strings to `truncate` characters and
+ *                   all cells will be aligned right.
+ */
+static std::vector<std::vector<std::string>> getRows(const NameAndColumns & block, size_t numRows, size_t truncate)
+{
+    std::vector<std::vector<std::string>> results;
+    results.reserve(numRows);
+    results.emplace_back(std::vector<std::string>());
+    auto & headRow = results.back();
+
+    for (const auto & column : block)
+    {
+        const auto & name = column.first;
+        headRow.emplace_back(debug::Utils::truncate(name, truncate));
+    }
+
+    auto getDataType = [](const DB::IColumn * col)
+    {
+        if (const auto * column_nullable = DB::checkAndGetColumn<DB::ColumnNullable>(col))
+            return column_nullable->getNestedColumn().getDataType();
+        return col->getDataType();
+    };
+
+    for (size_t row = 0; row < numRows - 1; ++row)
+    {
+        results.emplace_back(std::vector<std::string>());
+        auto & currentRow = results.back();
+        currentRow.reserve(block.size());
+
+        for (const auto & column : block)
+        {
+            const auto * const col = column.second.get();
+            DB::WhichDataType which(getDataType(col));
+            if (which.isAggregateFunction())
+                currentRow.emplace_back("Nan");
+            else
+            {
+                if (col->isNullAt(row))
+                    currentRow.emplace_back("null");
+                else
+                {
+                    std::string str = DB::toString((*col)[row]);
+                    currentRow.emplace_back(Utils::truncate(str, truncate));
+                }
+            }
+        }
+    }
+    return results;
+}
+
+static std::string showString(const NameAndColumns & block, size_t numRows, size_t truncate, bool vertical)
+{
+    numRows = std::min(numRows, block[0].second->size());
+    bool hasMoreData = block[0].second->size() > numRows;
+    // Get rows represented by vector[vector[String]], we may get one more line if it has more data.
+    std::vector<std::vector<std::string>> rows = getRows(block, numRows + 1, truncate);
+
+    size_t numCols = block.size();
+    // We set a minimum column width at '3'
+    constexpr size_t minimumColWidth = 3;
+
+    std::stringstream sb;
+
+    if (!vertical)
+    {
+        // Initialise the width of each column to a minimum value
+        std::vector<size_t> colWidths(numCols, minimumColWidth);
+
+        // Compute the width of each column
+        for (const auto & row : rows)
+            for (size_t i = 0; i < row.size(); ++i)
+                colWidths[i] = std::max(colWidths[i], stringHalfWidth(row[i]));
+
+        std::vector<std::vector<std::string>> paddedRows;
+        for (const auto & row : rows)
+        {
+            std::vector<std::string> paddedRow;
+            for (size_t i = 0; i < row.size(); ++i)
+                if (truncate > 0)
+                    paddedRow.push_back(leftPad(row[i], colWidths[i] - stringHalfWidth(row[i]) + row[i].size()));
+                else
+                    paddedRow.push_back(rightPad(row[i], colWidths[i] - stringHalfWidth(row[i]) + row[i].size()));
+            paddedRows.push_back(paddedRow);
+        }
+
+        // Create SeparateLine
+        std::stringstream sep;
+        for (int width : colWidths)
+            sep << "+" << std::string(width, '-');
+        sep << "+\n";
+
+        // column names
+        sb << sep.str();
+        for (const auto & cell : paddedRows[0])
+            sb << "|" << cell;
+        sb << "|\n" << sep.str();
+
+        // data
+        for (size_t i = 1; i < paddedRows.size(); ++i)
+        {
+            for (const auto & cell : paddedRows[i])
+                sb << "|" << cell;
+            sb << "|\n";
+        }
+        sb << sep.str();
+    }
+    else
+    {
+        // Extended display mode enabled
+        const std::vector<std::string> & fieldNames = rows[0];
+        auto dataRowsBegin = [&]() { return rows.begin() + 1; };
+
+        // Compute the width of field name and data columns
+        size_t fieldNameColWidth = minimumColWidth;
+        for (const auto & fieldName : fieldNames)
+            fieldNameColWidth = std::max(fieldNameColWidth, Utils::stringHalfWidth(fieldName));
+
+        size_t dataColWidth = minimumColWidth;
+
+
+        for (auto dataRowIter = dataRowsBegin(); dataRowIter != rows.end(); ++dataRowIter)
+        {
+            const auto & row = *dataRowIter;
+            size_t maxWidth = 0;
+            for (const auto & cell : row)
+                maxWidth = std::max(maxWidth, stringHalfWidth(cell));
+            dataColWidth = std::max(dataColWidth, maxWidth);
+        }
+
+        //
+        for (auto dataRowIter = dataRowsBegin(); dataRowIter != rows.end(); ++dataRowIter)
+        {
+            // create row header
+            std::string rowHeader = "-RECORD " + std::to_string(rows.end() - dataRowIter);
+            rowHeader = rightPad(rowHeader, fieldNameColWidth + dataColWidth + 5, '-');
+            sb << rowHeader << "\n";
+
+            // process each cell in the row
+            const auto & row = *dataRowIter;
+            for (size_t j = 0; j < row.size(); j++)
+            {
+                const std::string & cell = row[j];
+                const std::string & fieldName = fieldNames[j];
+                std::string paddedFieldName = rightPad(fieldName, fieldNameColWidth - stringHalfWidth(fieldName) + fieldName.length());
+                std::string paddedData = rightPad(cell, dataColWidth - stringHalfWidth(cell) + cell.length());
+                sb << " " << paddedFieldName << " | " << paddedData << " \n";
+            }
+            sb << "\n";
+        }
+    }
+
+    // Print a footer
+    if (vertical && block[0].second->empty())
+    {
+        // In a vertical mode, print an empty row set explicitly
+        sb << "(0 rows)" << std::endl;
+    }
+    else if (hasMoreData)
+    {
+        // For Data that has more than "numRows" records
+        const char * rowsString = (numRows == 1) ? "row" : "rows";
+        sb << "only showing top" << numRows << rowsString << std::endl;
+    }
+    return sb.str();
+}
+} // namespace Utils
+
+
+///
 
 void dumpPlan(DB::QueryPlan & plan, const char * type, bool force, LoggerPtr logger)
 {
@@ -85,80 +336,33 @@ void dumpMessage(const google::protobuf::Message & message, const char * type, b
 
 void headBlock(const DB::Block & block, size_t count)
 {
-    std::cout << "============Block============" << std::endl;
-    std::cout << block.dumpStructure() << std::endl;
-    // print header
-    for (const auto & name : block.getNames())
-        std::cout << name << "\t";
-    std::cout << std::endl;
-
-    // print rows
-    for (size_t row = 0; row < std::min(count, block.rows()); ++row)
-    {
-        for (size_t column = 0; column < block.columns(); ++column)
-        {
-            const auto type = block.getByPosition(column).type;
-            auto col = block.getByPosition(column).column;
-
-            if (column > 0)
-                std::cout << "\t";
-            DB::WhichDataType which(type);
-            if (which.isAggregateFunction())
-                std::cout << "Nan";
-            else if (col->isNullAt(row))
-                std::cout << "null";
-            else
-                std::cout << toString((*col)[row]);
-        }
-        std::cout << std::endl;
-    }
+    std::cerr << showString(block, count) << std::endl;
 }
-
-String printBlock(const DB::Block & block, size_t count)
-{
-    std::ostringstream ss;
-    ss << std::string("============Block============\n");
-    ss << block.dumpStructure() << String("\n");
-    // print header
-    for (const auto & name : block.getNames())
-        ss << name << std::string("\t");
-    ss << std::string("\n");
-
-    // print rows
-    for (size_t row = 0; row < std::min(count, block.rows()); ++row)
-    {
-        for (size_t column = 0; column < block.columns(); ++column)
-        {
-            const auto type = block.getByPosition(column).type;
-            auto col = block.getByPosition(column).column;
-
-            if (column > 0)
-                ss << std::string("\t");
-            DB::WhichDataType which(type);
-            if (which.isAggregateFunction())
-                ss << std::string("Nan");
-            else if (col->isNullAt(row))
-                ss << std::string("null");
-            else
-                ss << toString((*col)[row]);
-        }
-        ss << std::string("\n");
-    }
-    return ss.str();
-}
-
 
 void headColumn(const DB::ColumnPtr & column, size_t count)
 {
-    std::cout << "============Column============" << std::endl;
-
-    // print header
-    std::cout << column->getName() << "\t";
-    std::cout << std::endl;
-
-    // print rows
-    for (size_t row = 0; row < std::min(count, column->size()); ++row)
-        std::cout << toString((*column)[row]) << std::endl;
+    std::cerr << Utils::showString({{"Column", column}}, count, 20, false) << std::endl;
 }
 
+/**
+ * Compose the string representing rows for output
+ *
+ * @param block Block to show
+ * @param numRows Number of rows to show
+ * @param truncate If set to more than 0, truncates strings to `truncate` characters and
+ *                   all cells will be aligned right.
+ * @param vertical If set to true, prints output rows vertically (one line per column value).
+ */
+
+std::string showString(const DB::Block & block, size_t numRows, size_t truncate, bool vertical)
+{
+    std::vector<DB::ColumnWithTypeAndName> columns = block.getColumnsWithTypeAndName();
+    Utils::NameAndColumns name_and_columns;
+    name_and_columns.reserve(columns.size());
+    std::ranges::transform(
+        columns,
+        std::back_inserter(name_and_columns),
+        [](const DB::ColumnWithTypeAndName & col) { return std::make_pair(col.name, col.column); });
+    return Utils::showString(name_and_columns, numRows, truncate, vertical);
+}
 }

--- a/cpp-ch/local-engine/Common/DebugUtils.h
+++ b/cpp-ch/local-engine/Common/DebugUtils.h
@@ -33,7 +33,11 @@ void dumpPlan(DB::QueryPlan & plan, const char * type = "clickhouse plan", bool 
 void dumpMessage(const google::protobuf::Message & message, const char * type, bool force = false, LoggerPtr = nullptr);
 
 void headBlock(const DB::Block & block, size_t count = 10);
-String printBlock(const DB::Block & block, size_t count = 10);
-
 void headColumn(const DB::ColumnPtr & column, size_t count = 10);
+std::string showString(const DB::Block & block, size_t numRows = 20, size_t truncate = 20, bool vertical = false);
+inline std::string verticalShowString(const DB::Block & block, size_t numRows = 20, size_t truncate = 20)
+{
+    return showString(block, numRows, truncate, true);
+}
+
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.h
@@ -44,7 +44,8 @@ DB::Names collect_partition_cols(const DB::Block & header, const substrait::Name
 
 #define WRITE_RELATED_SETTINGS(M, ALIAS) \
     M(String, task_write_tmp_dir, , "The temporary directory for writing data") \
-    M(String, task_write_filename, , "The filename for writing data")
+    M(String, task_write_filename, , "The filename for writing data") \
+    M(String, task_write_filename_pattern, , "The pattern to generate file name for writing delta parquet in spark 3.5")
 
 DECLARE_GLUTEN_SETTINGS(GlutenWriteSettings, WRITE_RELATED_SETTINGS)
 

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.cpp
@@ -89,7 +89,8 @@ SinkToStoragePtr SparkMergeTreeSink::create(
             temp->getStorageID().getFullNameNotQuoted());
         sink_helper = std::make_shared<CopyToRemoteSinkHelper>(temp, dest_storage, write_settings_);
     }
-    sink_helper = std::make_shared<DirectSinkHelper>(dest_storage, write_settings_, isRemoteStorage);
+    else
+        sink_helper = std::make_shared<DirectSinkHelper>(dest_storage, write_settings_, isRemoteStorage);
     return std::make_shared<SparkMergeTreeSink>(sink_helper, context, stats);
 }
 
@@ -130,7 +131,7 @@ void SinkHelper::doMergePartsAsync(const std::vector<DB::MergeTreeDataPartPtr> &
     for (const auto & selected_part : prepare_merge_parts)
         tmp_parts.emplace(selected_part->name);
 
-    // check thread group initialized in task thread
+    // check a thread group initialized in task thread
     currentThreadGroupMemoryUsage();
     thread_pool.scheduleOrThrow(
         [this, prepare_merge_parts, thread_group = CurrentThread::getGroup()]() -> void

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
@@ -193,7 +193,6 @@ public:
     void collectStats(const std::deque<DB::MergeTreeDataPartPtr> & parts, const std::string & partition) const
     {
         const size_t size = parts.size() + columns_[part_name]->size();
-
         columns_[part_name]->reserve(size);
         columns_[partition_id]->reserve(size);
 

--- a/cpp-ch/local-engine/Storages/Output/NormalFileWriter.h
+++ b/cpp-ch/local-engine/Storages/Output/NormalFileWriter.h
@@ -61,6 +61,85 @@ private:
 OutputFormatFilePtr createOutputFormatFile(
     const DB::ContextPtr & context, const std::string & file_uri, const DB::Block & preferred_schema, const std::string & format_hint);
 
+struct DeltaStats
+{
+    size_t row_count;
+    std::vector<DB::Field> min;
+    std::vector<DB::Field> max;
+    std::vector<Int64> null_count;
+    std::set<size_t> partition_index;
+
+    static DeltaStats create(const DB::Block & output, const DB::Names & partition)
+    {
+        size_t size = output.columns() - partition.size();
+        std::set<size_t> partition_index;
+        std::ranges::transform(
+            partition,
+            std::inserter(partition_index, partition_index.end()),
+            [&](const auto & name) { return output.getPositionByName(name); });
+        assert(partition_index.size() == partition.size());
+        return DeltaStats(size, partition_index);
+    }
+    static DB::Block statsHeader(const DB::Block & output, const DB::Names & partition, DB::ColumnsWithTypeAndName && statsHeaderBase)
+    {
+        std::set<std::string> partition_index;
+        std::ranges::transform(partition, std::inserter(partition_index, partition_index.end()), [&](const auto & name) { return name; });
+
+        assert(partition_index.size() == partition.size());
+
+        auto appendBase = [&](const std::string & prefix)
+        {
+            for (const auto & column : output.getColumnsWithTypeAndName())
+                if (!partition_index.contains(column.name))
+                    statsHeaderBase.emplace_back(wrapNullableType(column.type), prefix + column.name);
+        };
+        appendBase("min_");
+        appendBase("max_");
+        for (const auto & column : output.getColumnsWithTypeAndName())
+            if (!partition_index.contains(column.name))
+                statsHeaderBase.emplace_back(BIGINT(), "null_count_" + column.name);
+
+        return makeBlockHeader(statsHeaderBase);
+    }
+
+    explicit DeltaStats(size_t size, const std::set<size_t> & partition_index_ = {})
+        : row_count(0), min(size), max(size), null_count(size, 0), partition_index(partition_index_)
+    {
+    }
+
+    void update(const DB::Chunk & chunk)
+    {
+        row_count += chunk.getNumRows();
+        const auto & columns = chunk.getColumns();
+        assert(columns.size() == min.size() + partition_index.size());
+        for (size_t i = 0, col = 0; col < columns.size(); ++col)
+        {
+            if (partition_index.contains(col))
+                continue;
+
+            const auto & column = columns[col];
+            Int64 null_count = 0;
+            if (const auto * nullable_column = typeid_cast<const DB::ColumnNullable *>(column.get()))
+            {
+                const auto & null_map = nullable_column->getNullMapData();
+                null_count = std::ranges::count_if(null_map, [](UInt8 value) { return value != 0; });
+            }
+            this->null_count[i] += null_count;
+
+            DB::Field min_value, max_value;
+            column->getExtremes(min_value, max_value);
+            assert(min[i].isNull() || min_value.getType() == min[i].getType());
+            assert(max[i].isNull() || max_value.getType() == max[i].getType());
+            if (min[i].isNull() || min_value < min[i])
+                min[i] = min_value;
+            if (max[i].isNull() || max_value > max[i])
+                max[i] = max_value;
+
+            ++i;
+        }
+    }
+};
+
 class WriteStatsBase : public DB::ISimpleTransform
 {
 protected:
@@ -96,67 +175,56 @@ public:
 
 class WriteStats : public WriteStatsBase
 {
-    static DB::Block statsHeader()
+    DB::MutableColumns columns_;
+
+    enum ColumnIndex
     {
-        return makeBlockHeader({{STRING(), "filename"}, {STRING(), "partition_id"}, {BIGINT(), "record_count"}});
-    }
-    DB::Arena partition_keys_arena_;
-    std::string filename_;
-    absl::flat_hash_map<StringRef, size_t> file_to_count_;
+        filename,
+        partition_id,
+        record_count
+    };
 
 protected:
     DB::Chunk final_result() override
     {
-        const size_t size = file_to_count_.size();
-
-        auto file_col = STRING()->createColumn();
-        file_col->reserve(size);
-        auto partition_col = STRING()->createColumn();
-        partition_col->reserve(size);
-        auto countCol = BIGINT()->createColumn();
-        countCol->reserve(size);
-        auto & countColData = static_cast<DB::ColumnVector<Int64> &>(*countCol).getData();
-
-        UInt64 num_rows = 0;
-        for (const auto & [relative_path, rows] : file_to_count_)
-        {
-            if (rows == 0)
-                continue;
-            file_col->insertData(filename_.c_str(), filename_.size());
-            partition_col->insertData(relative_path.data, relative_path.size);
-            countColData.emplace_back(rows);
-            num_rows++;
-        }
-
-        const DB::Columns res_columns{std::move(file_col), std::move(partition_col), std::move(countCol)};
-        return DB::Chunk(res_columns, num_rows);
+        size_t rows = columns_[filename]->size();
+        return DB::Chunk(std::move(columns_), rows);
     }
 
 public:
-    explicit WriteStats(const DB::Block & input_header_) : WriteStatsBase(input_header_, statsHeader()) { }
-    String getName() const override { return "WriteStats"; }
-    void addFilePath(const String & partition_id, const String & filename)
+    WriteStats(const DB::Block & input_header_, const DB::Block & output_header_)
+        : WriteStatsBase(input_header_, output_header_), columns_(output_header_.cloneEmptyColumns())
     {
-        assert(!filename.empty());
-
-        if (filename_.empty())
-            filename_ = filename;
-
-        assert(filename_ == filename);
-
-        if (partition_id.empty())
-            return;
-        file_to_count_.emplace(copyStringInArena(partition_keys_arena_, partition_id), 0);
     }
 
-    void collectStats(const String & file_path, size_t rows)
+    static std::shared_ptr<WriteStats> create(const DB::Block & input_header_, const DB::Names & partition)
     {
-        if (const auto it = file_to_count_.find(file_path); it != file_to_count_.end())
+        return std::make_shared<WriteStats>(
+            input_header_,
+            DeltaStats::statsHeader(
+                input_header_, partition, {{STRING(), "filename"}, {STRING(), "partition_id"}, {BIGINT(), "record_count"}}));
+    }
+
+    String getName() const override { return "WriteStats"; }
+
+    void collectStats(const String & filename, const String & partition, const DeltaStats & stats) const
+    {
+        // 3 => filename, partition_id, record_count
+        constexpr size_t baseOffset = 3;
+        assert(columns_.size() == baseOffset + stats.min.size() + stats.max.size() + stats.null_count.size());
+        columns_[ColumnIndex::filename]->insertData(filename.c_str(), filename.size());
+        columns_[partition_id]->insertData(partition.c_str(), partition.size());
+        auto & countColData = static_cast<DB::ColumnVector<Int64> &>(*columns_[record_count]).getData();
+        countColData.emplace_back(stats.row_count);
+        size_t columnSize = stats.min.size();
+        for (int i = 0; i < columnSize; ++i)
         {
-            it->second += rows;
-            return;
+            size_t offset = baseOffset + i;
+            columns_[offset]->insert(stats.min[i]);
+            columns_[columnSize + offset]->insert(stats.max[i]);
+            auto & nullCountData = static_cast<DB::ColumnVector<Int64> &>(*columns_[(columnSize * 2) + offset]).getData();
+            nullCountData.emplace_back(stats.null_count[i]);
         }
-        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "File path {} not found in the stats map", file_path);
     }
 };
 
@@ -166,6 +234,7 @@ class SubstraitFileSink final : public DB::SinkToStorage
     const std::string relative_path_;
     OutputFormatFile::OutputFormatPtr output_format_;
     std::shared_ptr<WriteStats> stats_;
+    DeltaStats delta_stats_;
 
     static std::string makeFilename(const std::string & base_path, const std::string & partition_id, const std::string & relative)
     {
@@ -185,32 +254,33 @@ public:
         const std::string & relative,
         const std::string & format_hint,
         const DB::Block & header,
-        const std::shared_ptr<WriteStatsBase> & stats)
+        const std::shared_ptr<WriteStatsBase> & stats,
+        const DeltaStats & delta_stats)
         : SinkToStorage(header)
         , partition_id_(partition_id.empty() ? NO_PARTITION_ID : partition_id)
         , relative_path_(relative)
         , output_format_(createOutputFormatFile(context, makeFilename(base_path, partition_id, relative), header, format_hint)
                              ->createOutputFormat(header))
         , stats_(std::dynamic_pointer_cast<WriteStats>(stats))
+        , delta_stats_(delta_stats)
     {
-        stats_->addFilePath(partition_id_, relative_path_);
     }
+
     String getName() const override { return "SubstraitFileSink"; }
 
 protected:
     void consume(DB::Chunk & chunk) override
     {
-        const size_t row_count = chunk.getNumRows();
+        delta_stats_.update(chunk);
         output_format_->output->write(materializeBlock(getHeader().cloneWithColumns(chunk.detachColumns())));
-
-        if (stats_)
-            stats_->collectStats(partition_id_, row_count);
     }
     void onFinish() override
     {
         output_format_->output->finalize();
         output_format_->output->flush();
         output_format_->write_buffer->finalize();
+        if (stats_ && delta_stats_.row_count > 0)
+            stats_->collectStats(relative_path_, partition_id_, delta_stats_);
     }
 };
 
@@ -246,6 +316,7 @@ public:
 protected:
     DB::ContextPtr context_;
     std::shared_ptr<WriteStatsBase> stats_;
+    DeltaStats empty_delta_stats_;
 
 public:
     SparkPartitionedBaseSink(
@@ -253,7 +324,10 @@ public:
         const DB::Names & partition_by,
         const DB::Block & input_header,
         const std::shared_ptr<WriteStatsBase> & stats)
-        : PartitionedSink(make_partition_expression(partition_by), context, input_header), context_(context), stats_(stats)
+        : PartitionedSink(make_partition_expression(partition_by), context, input_header)
+        , context_(context)
+        , stats_(stats)
+        , empty_delta_stats_(DeltaStats::create(input_header, partition_by))
     {
     }
 };
@@ -288,7 +362,8 @@ public:
         assert(stats_);
         const auto partition_path = fmt::format("{}/{}", partition_id, filename_);
         validatePartitionKey(partition_path, true);
-        return std::make_shared<SubstraitFileSink>(context_, base_path_, partition_id, filename_, format_hint_, sample_block_, stats_);
+        return std::make_shared<SubstraitFileSink>(
+            context_, base_path_, partition_id, filename_, format_hint_, sample_block_, stats_, empty_delta_stats_);
     }
     String getName() const override { return "SubstraitPartitionedFileSink"; }
 };

--- a/cpp-ch/local-engine/Storages/Output/ORCOutputFormatFile.h
+++ b/cpp-ch/local-engine/Storages/Output/ORCOutputFormatFile.h
@@ -20,8 +20,8 @@
 #include "config.h"
 
 #if USE_ORC
-#    include <IO/WriteBuffer.h>
-#    include <Storages/Output/OutputFormatFile.h>
+#include <IO/WriteBuffer.h>
+#include <Storages/Output/OutputFormatFile.h>
 
 namespace local_engine
 {
@@ -33,7 +33,6 @@ public:
         const std::string & file_uri_,
         WriteBufferBuilderPtr write_buffer_builder_,
         const DB::Block & preferred_schema_);
-    ~ORCOutputFormatFile() override = default;
 
     OutputFormatFile::OutputFormatPtr createOutputFormat(const DB::Block & header) override;
 };

--- a/cpp-ch/local-engine/Storages/Output/OutputFormatFile.h
+++ b/cpp-ch/local-engine/Storages/Output/OutputFormatFile.h
@@ -16,10 +16,6 @@
  */
 #pragma once
 
-#include <memory>
-#include <optional>
-#include <vector>
-
 #include <Core/Block.h>
 #include <IO/WriteBuffer.h>
 #include <Interpreters/Context.h>
@@ -48,8 +44,8 @@ public:
     virtual ~OutputFormatFile() = default;
 
     virtual OutputFormatPtr createOutputFormat(const DB::Block & header_) = 0;
-
-    virtual const DB::Block getPreferredSchema() const { return preferred_schema; }
+    OutputFormatPtr createOutputFormat() { return createOutputFormat(preferred_schema); }
+    DB::Block getPreferredSchema() const { return preferred_schema; }
 
 protected:
     DB::Block createHeaderWithPreferredSchema(const DB::Block & header);

--- a/cpp-ch/local-engine/Storages/Output/ParquetOutputFormatFile.h
+++ b/cpp-ch/local-engine/Storages/Output/ParquetOutputFormatFile.h
@@ -33,7 +33,6 @@ public:
         const std::string & file_uri_,
         const WriteBufferBuilderPtr & write_buffer_builder_,
         const DB::Block & preferred_schema_);
-    ~ParquetOutputFormatFile() override = default;
 
     OutputFormatFile::OutputFormatPtr createOutputFormat(const DB::Block & header) override;
 };

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline.cpp
@@ -152,7 +152,7 @@ TEST(WritePipeline, SubstraitFileSink)
 
     EXPECT_TRUE(local_executor->hasNext());
     const Block & x = *local_executor->nextColumnar();
-    debug::headBlock(x);
+    std::cerr << debug::verticalShowString(x, 10, 50) << std::endl;
     EXPECT_EQ(1, x.rows());
     const auto & col_a = *(x.getColumns()[0]);
     EXPECT_EQ(settings.task_write_filename, col_a.getDataAt(0));
@@ -186,7 +186,6 @@ TEST(WritePipeline, SubstraitPartitionedFileSink)
     const substrait::WriteRel & write_rel = root_rel.root().input().write();
     EXPECT_TRUE(write_rel.has_named_table());
 
-    const substrait::NamedObjectWrite & named_table = write_rel.named_table();
     EXPECT_TRUE(write_rel.has_table_schema());
     const substrait::NamedStruct & table_schema = write_rel.table_schema();
     auto block = TypeParser::buildBlockFromNamedStruct(table_schema);
@@ -202,16 +201,7 @@ TEST(WritePipeline, SubstraitPartitionedFileSink)
     const Block & x = *local_executor->nextColumnar();
     debug::headBlock(x, 25);
     EXPECT_EQ(25, x.rows());
-    // const auto & col_b = *(x.getColumns()[1]);
-    // EXPECT_EQ(16, col_b.getInt(0));
 }
-
-/*DB::ASTPtr printColumn(const std::string& column)
-{
-    //  printf('%05d',col)
-    DB::ASTs arguments {std::make_shared<DB::ASTLiteral>("%05d"), std::make_shared<DB::ASTIdentifier>(column)};
-    return DB::makeASTFunction("printf", std::move(arguments));
-}*/
 
 TEST(WritePipeline, ComputePartitionedExpression)
 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introducing `DeltaStats` to collect stats as delta does.

(Fixes: \#7028)

## How was this patch tested?

Using Existed Uts

In `test("test parquet table write with the delta")`, adding logic to verify delta stats
``` scala
    if (spark35) {
      val vanillaTable = "lineitem_delta_parquet_vanilla"
      withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "false")) {
        doInsert(drop(vanillaTable), createLineitem(vanillaTable), insert(vanillaTable))
      }
      val expected = DeltaStatsUtils
        .statsDF(
          spark,
          s"$basePath/$vanillaTable/_delta_log/00000000000000000001.json",
          q1SchemaString)
        .collect()

      checkAnswer(
        DeltaStatsUtils.statsDF(
          spark,
          s"$basePath/$table/_delta_log/00000000000000000001.json",
          q1SchemaString),
        expected
      )
    }
```
