### PR TITLE
[GLUTEN-7267][CORE][CH] Move schema pruning optimization of HiveTableScan to an individual post-transform rule

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -396,8 +396,4 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   }
 
   override def supportWindowGroupLimitExec(rankLikeFunction: Expression): Boolean = true
-
-  override def supportHiveTableScanNestedColumnPruning: Boolean =
-    GlutenConfig.getConf.enableColumnarHiveTableScanNestedColumnPruning
-
 }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -98,6 +98,7 @@ object CHRuleApi {
       c => intercept(HeuristicTransform.Single(validatorBuilder(c.glutenConf), rewrites, offloads)))
 
     // Legacy: Post-transform rules.
+    injector.injectPostTransform(_ => PruneNestedColumnsInHiveTableScan)
     injector.injectPostTransform(_ => RemoveNativeWriteFilesSortAndProject())
     injector.injectPostTransform(c => intercept(RewriteTransformer.apply(c.session)))
     injector.injectPostTransform(_ => PushDownFilterToScan)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -131,6 +131,4 @@ trait BackendSettingsApi {
   def supportColumnarArrowUdf(): Boolean = false
 
   def needPreComputeRangeFrameBoundary(): Boolean = false
-
-  def supportHiveTableScanNestedColumnPruning(): Boolean = false
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PruneNestedColumnsInHiveTableScan.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PruneNestedColumnsInHiveTableScan.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar
+
+import org.apache.gluten.execution.ProjectExecTransformer
+
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.hive.HiveTableScanNestedColumnPruning
+
+// Since https://github.com/apache/incubator-gluten/pull/7268.
+// Used only by CH backend as of now.
+object PruneNestedColumnsInHiveTableScan extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = plan.transformUp {
+    case p: ProjectExecTransformer
+        if HiveTableScanNestedColumnPruning.supportNestedColumnPruning(p) =>
+      HiveTableScanNestedColumnPruning.apply(p)
+  }
+}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -188,7 +188,7 @@ object OffloadOthers {
   // Utility to replace single node within transformed Gluten node.
   // Children will be preserved as they are as children of the output node.
   //
-  // Do not look-up on children on the input node in this rule. Otherwise
+  // Do not look up on children on the input node in this rule. Otherwise
   // it may break RAS which would group all the possible input nodes to
   // search for validate candidates.
   private class ReplaceSingleNode() extends LogLevelUtil with Logging {
@@ -215,11 +215,7 @@ object OffloadOthers {
         case plan: ProjectExec =>
           val columnarChild = plan.child
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-          if (HiveTableScanNestedColumnPruning.supportNestedColumnPruning(plan)) {
-            HiveTableScanNestedColumnPruning.apply(plan)
-          } else {
-            ProjectExecTransformer(plan.projectList, columnarChild)
-          }
+          ProjectExecTransformer(plan.projectList, columnarChild)
         case plan: HashAggregateExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           HashAggregateExecBaseTransformer.from(plan)
@@ -247,7 +243,6 @@ object OffloadOthers {
             plan.bucketSpec,
             plan.options,
             plan.staticPartitions)
-
           ColumnarWriteFilesExec(
             writeTransformer,
             plan.fileFormat,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleEx
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.{ArrowEvalPythonExec, BatchEvalPythonExec}
 import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecShim}
-import org.apache.spark.sql.hive.{HiveTableScanExecTransformer, HiveTableScanNestedColumnPruning}
+import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 // Exchange transformation.
 case class OffloadExchange() extends OffloadSingleNode with LogLevelUtil {


### PR DESCRIPTION
Following https://github.com/apache/incubator-gluten/pull/7268, move the new code to an individual rule `PruneNestedColumnsInHiveTableScan`.

The reason is `HiveTableScanNestedColumnPruning` actually matches on a `project + hive scan` pattern so is not simply offloading a project. Move the code out from `OffloadSingleNode` which targets to handle one single query plan node. 