### PR TITLE
[GLUTEN-8025][VL] set default kSpillWriteBufferSize to the same as velox

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -471,13 +471,13 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
         std::to_string(veloxCfg_->get<bool>(kOrderBySpillEnabled, true));
     configs[velox::core::QueryConfig::kMaxSpillLevel] = std::to_string(veloxCfg_->get<int32_t>(kMaxSpillLevel, 4));
     configs[velox::core::QueryConfig::kMaxSpillFileSize] =
-        std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillFileSize, 1L * 1024 * 1024 * 1024));
+        std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillFileSize, 1L * 1024 * 1024 * 1024)); 
     configs[velox::core::QueryConfig::kMaxSpillRunRows] =
         std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillRunRows, 3L * 1024 * 1024));
     configs[velox::core::QueryConfig::kMaxSpillBytes] =
         std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillBytes, 107374182400LL));
     configs[velox::core::QueryConfig::kSpillWriteBufferSize] =
-        std::to_string(veloxCfg_->get<uint64_t>(kSpillWriteBufferSize, 4L * 1024 * 1024));
+        std::to_string(veloxCfg_->get<uint64_t>(kSpillWriteBufferSize, 1L * 1024 * 1024));
     configs[velox::core::QueryConfig::kSpillStartPartitionBit] =
         std::to_string(veloxCfg_->get<uint8_t>(kSpillStartPartitionBit, 29));
     configs[velox::core::QueryConfig::kSpillNumPartitionBits] =

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -471,7 +471,7 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
         std::to_string(veloxCfg_->get<bool>(kOrderBySpillEnabled, true));
     configs[velox::core::QueryConfig::kMaxSpillLevel] = std::to_string(veloxCfg_->get<int32_t>(kMaxSpillLevel, 4));
     configs[velox::core::QueryConfig::kMaxSpillFileSize] =
-        std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillFileSize, 1L * 1024 * 1024 * 1024)); 
+        std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillFileSize, 1L * 1024 * 1024 * 1024));
     configs[velox::core::QueryConfig::kMaxSpillRunRows] =
         std::to_string(veloxCfg_->get<uint64_t>(kMaxSpillRunRows, 3L * 1024 * 1024));
     configs[velox::core::QueryConfig::kMaxSpillBytes] =

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -34,12 +34,13 @@ const std::string kOrderBySpillEnabled = "spark.gluten.sql.columnar.backend.velo
 // https://github.com/facebookincubator/velox/blob/95f3e80e77d046c12fbc79dc529366be402e9c2b/velox/docs/configs.rst#spilling
 const std::string kMaxSpillLevel = "spark.gluten.sql.columnar.backend.velox.maxSpillLevel";
 const std::string kMaxSpillFileSize = "spark.gluten.sql.columnar.backend.velox.maxSpillFileSize";
+const uint64_t kMaxSpillFileSizeDefault = 1L * 1024 * 1024 * 1024;
 const std::string kSpillStartPartitionBit = "spark.gluten.sql.columnar.backend.velox.spillStartPartitionBit";
 const std::string kSpillPartitionBits = "spark.gluten.sql.columnar.backend.velox.spillPartitionBits";
 const std::string kMaxSpillRunRows = "spark.gluten.sql.columnar.backend.velox.MaxSpillRunRows";
 const std::string kMaxSpillBytes = "spark.gluten.sql.columnar.backend.velox.MaxSpillBytes";
 const std::string kSpillWriteBufferSize = "spark.gluten.sql.columnar.backend.velox.spillWriteBufferSize";
-const uint64_t kMaxSpillFileSizeDefault = 1L * 1024 * 1024 * 1024;
+const std::string kSpillReadBufferSize = "spark.gluten.sql.columnar.backend.velox.spillReadBufferSize";
 
 const std::string kSpillableReservationGrowthPct =
     "spark.gluten.sql.columnar.backend.velox.spillableReservationGrowthPct";

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -1589,7 +1589,7 @@ object GlutenConfig {
       .internal()
       .doc("The maximum write buffer size")
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("4M")
+      .createWithDefaultString("1M")
 
   val MAX_PARTITION_PER_WRITERS_SESSION =
     buildConf("spark.gluten.sql.columnar.backend.velox.maxPartitionsPerWritersSession")

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -321,6 +321,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def veloxMaxWriteBufferSize: Long = conf.getConf(COLUMNAR_VELOX_MAX_SPILL_WRITE_BUFFER_SIZE)
 
+  def veloxMaxReadBufferSize: Long = conf.getConf(COLUMNAR_VELOX_MAX_SPILL_READ_BUFFER_SIZE)
+
   def veloxBloomFilterExpectedNumItems: Long =
     conf.getConf(COLUMNAR_VELOX_BLOOM_FILTER_EXPECTED_NUM_ITEMS)
 
@@ -1587,7 +1589,14 @@ object GlutenConfig {
   val COLUMNAR_VELOX_MAX_SPILL_WRITE_BUFFER_SIZE =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillWriteBufferSize")
       .internal()
-      .doc("The maximum write buffer size")
+      .doc("The maximum write buffer size during spilling")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1M")
+
+  val COLUMNAR_VELOX_MAX_SPILL_READ_BUFFER_SIZE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.spillReadBufferSize")
+      .internal()
+      .doc("The maximum read buffer size during merging spill files")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1M")
 


### PR DESCRIPTION
The kSpillWriteBufferSize is set to 4M by typo. correct it to 1M. The value control the buffer size when spill write data to disk. 

Add config kSpillReadBufferSize. it controls the read buffer size when spill data is fetch back. The memory will be allocated as offheap memory. So if there are to many spill files, the memory will exceed offheap size and trigger the OOM issue by operator::getOutput.

The spill files number is impacted by MaxSpillFileSize and MaxSpillRunRows, both are the smaller the more spill files.  