### PR TITLE
[GLUTEN-7028][CH][Part-10] Collecting Delta stats for MergeTree

### DIFF
--- a/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
+++ b/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
@@ -26,9 +26,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Projection, UnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, DeclarativeAggregate}
 import org.apache.spark.sql.delta.files.{FileDelayedCommitProtocol, MergeTreeDelayedCommitProtocol2}
-import org.apache.spark.sql.delta.stats.DeltaFileStatistics
+import org.apache.spark.sql.delta.stats.{DeltaFileStatistics, DeltaJobStatisticsTracker}
 import org.apache.spark.sql.execution.datasources.{ExecutedWriteSummary, WriteJobDescription, WriteTaskResult}
-import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.Utils
 
 import scala.collection.mutable.ArrayBuffer
@@ -61,14 +60,15 @@ case class NativeDeltaStats(projection: Projection) extends (InternalRow => Unit
 
   def result: DeltaFileStatistics = DeltaFileStatistics(results.toMap)
 }
-case class FileDeltaColumnarWrite(
-    override val jobTrackerID: String,
-    override val description: WriteJobDescription,
-    override val committer: FileDelayedCommitProtocol)
-  extends CHColumnarWrite[FileDelayedCommitProtocol]
-  with Logging {
 
-  private lazy val nativeDeltaStats: Option[NativeDeltaStats] = {
+trait SupportNativeDeltaStats[T <: FileCommitProtocol] extends CHColumnarWrite[T] {
+
+  private lazy val deltaWriteJobStatsTracker: Option[DeltaJobStatisticsTracker] =
+    description.statsTrackers
+      .find(_.isInstanceOf[DeltaJobStatisticsTracker])
+      .map(_.asInstanceOf[DeltaJobStatisticsTracker])
+
+  lazy val nativeDeltaStats: Option[NativeDeltaStats] = {
     deltaWriteJobStatsTracker
       .map(
         delta => {
@@ -77,10 +77,7 @@ case class FileDeltaColumnarWrite(
                 if ae.aggregateFunction.isInstanceOf[DeclarativeAggregate] =>
               ae.aggregateFunction.asInstanceOf[DeclarativeAggregate].evaluateExpression
           }
-          val z = Seq(
-            AttributeReference("filename", StringType, nullable = false)(),
-            AttributeReference("partition_id", StringType, nullable = false)())
-          val s =
+          val vanillaSchema =
             delta.statsColExpr
               .collect {
                 case ae: AggregateExpression
@@ -92,10 +89,24 @@ case class FileDeltaColumnarWrite(
           NativeDeltaStats(
             UnsafeProjection.create(
               exprs = Seq(r),
-              inputSchema = z :++ s
+              inputSchema = nativeStatsSchema(vanillaSchema)
             ))
         })
   }
+
+  def nativeStatsSchema(vanilla: Seq[AttributeReference]): Seq[AttributeReference]
+}
+
+case class FileDeltaColumnarWrite(
+    override val jobTrackerID: String,
+    override val description: WriteJobDescription,
+    override val committer: FileDelayedCommitProtocol)
+  extends SupportNativeDeltaStats[FileDelayedCommitProtocol]
+  with Logging {
+
+  override def nativeStatsSchema(vanilla: Seq[AttributeReference]): Seq[AttributeReference] =
+    NativeFileWriteResult.nativeStatsSchema(vanilla)
+
   override def doSetupNativeTask(): Unit = {
     assert(description.path == committer.outputPath)
     val nameSpec = CreateFileNameSpec(taskAttemptContext, description)

--- a/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
+++ b/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
@@ -38,7 +38,7 @@ case class DeltaFileCommitInfo(committer: FileDelayedCommitProtocol)
   val addedFiles: ArrayBuffer[(Map[String, String], String)] =
     new ArrayBuffer[(Map[String, String], String)]
   override def apply(stat: NativeFileWriteResult): Unit = {
-    if (stat.partition_id == "__NO_PARTITION_ID__") {
+    if (stat.partition_id == CHColumnarWrite.EMPTY_PARTITION_ID) {
       addedFiles.append((Map.empty[String, String], stat.filename))
     } else {
       val partitionValues = committer.parsePartitions(stat.partition_id)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeConfig.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeConfig.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.backendsapi.clickhouse
 import org.apache.spark.sql.internal.SQLConf
 
 object RuntimeConfig {
-  import CHConf._
+  import CHConf.runtimeConfig
   import SQLConf._
 
   /** Clickhouse Configuration */

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
@@ -20,9 +20,19 @@ import org.apache.spark.sql.internal.SQLConf
 
 object RuntimeSettings {
 
-  import CHConf._
+  import CHConf.runtimeSettings
   import SQLConf._
 
+  /** Clickhouse settings */
+  // scalastyle:off line.size.limit
+  val MIN_INSERT_BLOCK_SIZE_ROWS =
+    buildConf(runtimeSettings("min_insert_block_size_rows"))
+      .doc("https://clickhouse.com/docs/en/operations/settings/settings#min_insert_block_size_rows")
+      .longConf
+      .createWithDefault(1048449)
+  // scalastyle:on line.size.limit
+
+  /** Gluten Configuration */
   val NATIVE_WRITE_RESERVE_PARTITION_COLUMNS =
     buildConf(runtimeSettings("gluten.write.reserve_partition_columns"))
       .doc("Whether reserve partition columns for Native write or not, default is false")

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/MergeTreeConf.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/MergeTreeConf.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.gluten.backendsapi.clickhouse.CHConf
+
+import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.sql.internal.SQLConf
+
+/** [[CHConf]] entries for MergeTree features. */
+trait MergeTreeConfBase {
+
+  private val CH_PREFIX: String = CHConf.runtimeSettings("merge_tree")
+  private val GLUTEN_PREFIX: String = CHConf.runtimeSettings("mergetree")
+
+  private def buildCHConf(key: String): ConfigBuilder = SQLConf.buildConf(s"$CH_PREFIX.$key")
+  private def buildGLUTENConf(key: String): ConfigBuilder =
+    SQLConf.buildConf(s"$GLUTEN_PREFIX.$key")
+
+  // scalastyle:off line.size.limit
+  val ASSIGN_PART_UUIDS =
+    buildCHConf("assign_part_uuids")
+      .doc(s""" Used in UT for compatibility with old compaction algorithm.
+              | https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#virtual-columns
+              |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
+  val MIN_ROWS_FOR_WIDE_PART =
+    buildCHConf("min_rows_for_wide_part")
+      .doc(s""" Used in UT for compatibility with old compaction algorithm.
+              | https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#min_bytes_for_wide_part
+              |""".stripMargin)
+      .longConf
+      .createWithDefault(0)
+  // scalastyle:on line.size.limit
+
+  val OPTIMIZE_TASK =
+    buildGLUTENConf("optimize_task")
+      .doc(s""" Used in UT for compatibility with old compaction algorithm.
+              | This flag is used to notify pipeline that the current running task
+              | is an MergeTree optimize task.
+              | """.stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+}
+
+object MergeTreeConf extends MergeTreeConfBase

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -158,6 +158,7 @@ object CHExecUtil extends Logging {
       columns: Int,
       rows: Int): Iterator[InternalRow] = {
     val rowInfo = CHBlockConverterJniWrapper.convertColumnarToRow(blockAddress, null)
+    assert(rowInfo.fieldsNum == columns)
     getRowIterFromSparkRowInfo(rowInfo, columns, rows)
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/RunTPCHTest.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/RunTPCHTest.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.RuntimeConfig
 import org.apache.gluten.benchmarks.GenTPCHTableScripts
 
 import org.apache.spark.sql.SparkSession
@@ -101,7 +101,7 @@ object RunTPCHTest {
       .config("spark.sql.columnVector.offheap.enabled", "true")
       .config("spark.memory.offHeap.enabled", "true")
       .config("spark.memory.offHeap.size", offHeapSize)
-      .config(CHConf.runtimeConfig("logger.level"), "error")
+      .config(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .config("spark.sql.warehouse.dir", warehouse)
       .config(
         "javax.jdo.option.ConnectionURL",

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
@@ -1025,12 +1025,11 @@ class GlutenClickHouseDeltaParquetWriteSuite
     }
   }
 
-  // FIXME: optimize
-  testSparkVersionLE33("test parquet optimize with the path based table") {
+  test("test parquet optimize with the path based table") {
     val dataPath = s"$basePath/lineitem_delta_parquet_optimize_path_based"
     clearDataPath(dataPath)
     withSQLConf(
-      "spark.databricks.delta.optimize.maxFileSize" -> "1000000",
+      "spark.databricks.delta.optimize.maxFileSize" -> "1100000",
       "spark.databricks.delta.optimize.minFileSize" -> "838000") {
 
       val sourceDF = spark.sql(s"""
@@ -1047,10 +1046,14 @@ class GlutenClickHouseDeltaParquetWriteSuite
       val clickhouseTable = DeltaTable.forPath(spark, dataPath)
       clickhouseTable.optimize().executeCompaction()
 
+      // There are 75 parquet files + 2 json files after compaction
+      assert(countFiles(new File(dataPath)) === 77)
+
       clickhouseTable.vacuum(0.0)
       if (spark32) {
         assert(countFiles(new File(dataPath)) === 27)
       } else {
+        // There are 25 parquet files + 4 json files after vacuum
         assert(countFiles(new File(dataPath)) === 29)
       }
 
@@ -1060,7 +1063,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
 
     withSQLConf(
       "spark.databricks.delta.optimize.maxFileSize" -> "10000000",
-      "spark.databricks.delta.optimize.minFileSize" -> "1000000") {
+      "spark.databricks.delta.optimize.minFileSize" -> "1100000") {
 
       val clickhouseTable = DeltaTable.forPath(spark, dataPath)
       clickhouseTable.optimize().executeCompaction()
@@ -1069,6 +1072,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
       if (spark32) {
         assert(countFiles(new File(dataPath)) === 6)
       } else {
+        // There are 3 parquet files + 7 json files + 2 check point files after vacuum
         assert(countFiles(new File(dataPath)) === 12)
       }
 
@@ -1084,6 +1088,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
     if (spark32) {
       assert(countFiles(new File(dataPath)) === 5)
     } else {
+      // There are 1 parquet file + 10 json files + 2 check point files after vacuum
       assert(countFiles(new File(dataPath)) === 13)
     }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseNativeWriteTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseNativeWriteTableSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.execution.hive
 
 import org.apache.gluten.GlutenConfig
+import org.apache.gluten.backendsapi.clickhouse.RuntimeConfig
 import org.apache.gluten.execution.GlutenClickHouseWholeStageTransformerSuite
 import org.apache.gluten.test.AllDataTypesWithComplexType.genTestData
 import org.apache.gluten.utils.UTSystemParameters
@@ -37,8 +38,6 @@ class GlutenClickHouseNativeWriteTableSuite
   with NativeWriteChecker {
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
-
     var sessionTimeZone = "GMT"
     if (isSparkVersionGE("3.5")) {
       sessionTimeZone = java.util.TimeZone.getDefault.getID
@@ -67,7 +66,7 @@ class GlutenClickHouseNativeWriteTableSuite
       .set("spark.sql.storeAssignmentPolicy", "legacy")
       .set("spark.sql.warehouse.dir", getWarehouseDir)
       .set("spark.sql.session.timeZone", sessionTimeZone)
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .setMaster("local[1]")
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseTableAfterRestart.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseTableAfterRestart.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.hive
 
+import org.apache.gluten.backendsapi.clickhouse.{RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
 import org.apache.spark.SparkConf
@@ -54,11 +55,11 @@ class GlutenClickHouseTableAfterRestart
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .setCHConfig("user_defined_path", "/tmp/user_defined")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.ui.enabled", "true")
-      .setCHSettings("min_insert_block_size_rows", 100000)
+      .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)
       .setMaster("local[2]")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseTableAfterRestart.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseTableAfterRestart.scala
@@ -16,7 +16,8 @@
  */
 package org.apache.gluten.execution.hive
 
-import org.apache.gluten.backendsapi.clickhouse.{RuntimeConfig, RuntimeSettings}
+import org.apache.gluten.GlutenConfig
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
 import org.apache.spark.SparkConf
@@ -59,6 +60,8 @@ class GlutenClickHouseTableAfterRestart
       .setCHConfig("user_defined_path", "/tmp/user_defined")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.ui.enabled", "true")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf
@@ -55,7 +55,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set("spark.gluten.soft-affinity.enabled", "true")
       .setCHSettings("mergetree.merge_after_insert", false)
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -57,6 +58,8 @@ class GlutenClickHouseMergeTreeCacheDataSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set("spark.gluten.soft-affinity.enabled", "true")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -398,7 +401,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
     spark.sql("drop table lineitem_mergetree_hdfs purge")
   }
 
-  test("test cache mergetree data no partition columns") {
+  testSparkVersionLE33("test cache mergetree data no partition columns") {
 
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_mergetree_hdfs;
@@ -487,7 +490,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
     spark.sql("drop table lineitem_mergetree_hdfs purge")
   }
 
-  test("test cache mergetree data with upper case column name") {
+  testSparkVersionLE33("test cache mergetree data with upper case column name") {
 
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_mergetree_hdfs;

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeOptimizeSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeOptimizeSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -50,6 +51,8 @@ class GlutenClickHouseMergeTreeOptimizeSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "10000")
       .set(
         "spark.databricks.delta.retentionDurationCheck.enabled",
@@ -327,7 +330,7 @@ class GlutenClickHouseMergeTreeOptimizeSuite
     assertResult(600572)(ret.apply(0).get(0))
   }
 
-  test("test mergetree optimize table with partition and bucket") {
+  testSparkVersionLE33("test mergetree optimize table with partition and bucket") {
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_mergetree_optimize_p6;
                  |""".stripMargin)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeOptimizeSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeOptimizeSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf
@@ -49,8 +49,8 @@ class GlutenClickHouseMergeTreeOptimizeSuite
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .setCHConfig("logger.level", "error")
-      .setCHSettings("min_insert_block_size_rows", 10000)
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
+      .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "10000")
       .set(
         "spark.databricks.delta.retentionDurationCheck.enabled",
         "false"

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.backendsapi.clickhouse.RuntimeSettings
 import org.apache.gluten.execution._
 import org.apache.gluten.utils.Arm
 
@@ -58,7 +59,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.ui.enabled", "true")
-      .setCHSettings("min_insert_block_size_rows", 100000)
+      .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -58,6 +59,8 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -359,7 +362,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
     spark.sql("drop table lineitem_mergetree_partition_hdfs")
   }
 
-  test("test mergetree write with bucket table") {
+  testSparkVersionLE33("test mergetree write with bucket table") {
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_mergetree_bucket_hdfs;
                  |""".stripMargin)
@@ -435,7 +438,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
     spark.sql("drop table lineitem_mergetree_bucket_hdfs")
   }
 
-  test("test mergetree write with the path based") {
+  testSparkVersionLE33("test mergetree write with the path based") {
     val dataPath = s"$HDFS_URL/test/lineitem_mergetree_bucket_hdfs"
 
     val sourceDF = spark.sql(s"""

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf
@@ -57,7 +57,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -500,7 +500,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
       CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true",
       CHConf.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
-      CHConf.runtimeSettings("min_insert_block_size_rows") -> "10000"
+      RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key -> "10000"
     ) {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS $tableName;

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf
@@ -57,7 +57,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -500,7 +500,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
       CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true",
       CHConf.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
-      CHConf.runtimeSettings("min_insert_block_size_rows") -> "10000"
+      RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key -> "10000"
     ) {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS $tableName;

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -58,6 +59,8 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -359,7 +362,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
     spark.sql("drop table lineitem_mergetree_partition_hdfs")
   }
 
-  test("test mergetree write with bucket table") {
+  testSparkVersionLE33("test mergetree write with bucket table") {
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_mergetree_bucket_hdfs;
                  |""".stripMargin)
@@ -435,7 +438,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
     spark.sql("drop table lineitem_mergetree_bucket_hdfs purge")
   }
 
-  test("test mergetree write with the path based") {
+  testSparkVersionLE33("test mergetree write with the path based") {
     val dataPath = s"$HDFS_URL/test/lineitem_mergetree_bucket_hdfs"
 
     val sourceDF = spark.sql(s"""

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.execution.mergetree
 
 import org.apache.gluten.backendsapi.clickhouse.CHConf._
+import org.apache.gluten.backendsapi.clickhouse.RuntimeConfig
 import org.apache.gluten.execution.{BasicScanExecTransformer, FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf
@@ -62,7 +63,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
   }
 
   override protected def beforeEach(): Unit = {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf._
-import org.apache.gluten.backendsapi.clickhouse.RuntimeConfig
+import org.apache.gluten.GlutenConfig
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig}
 import org.apache.gluten.execution.{BasicScanExecTransformer, FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf
@@ -64,6 +64,8 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
   }
 
   override protected def beforeEach(): Unit = {
@@ -421,7 +423,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
 
   }
 
-  test("test mergetree write with bucket table") {
+  testSparkVersionLE33("test mergetree write with bucket table") {
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_mergetree_bucket_s3;
                  |""".stripMargin)
@@ -497,7 +499,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
     spark.sql("drop table lineitem_mergetree_bucket_s3")
   }
 
-  test("test mergetree write with the path based") {
+  testSparkVersionLE33("test mergetree write with the path based") {
     val dataPath = s"s3a://$BUCKET_NAME/lineitem_mergetree_bucket_s3"
 
     val sourceDF = spark.sql(s"""
@@ -560,8 +562,8 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
 
     withSQLConf(
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
-      runtimeSettings("mergetree.insert_without_local_storage") -> "true",
-      runtimeSettings("mergetree.merge_after_insert") -> "true"
+      CHConf.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
+      CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true"
     ) {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS $tableName;
@@ -620,7 +622,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
 
     FileUtils.forceDelete(new File(S3_METADATA_PATH))
 
-    withSQLConf(runtimeSettings("enabled_driver_filter_mergetree_index") -> "true") {
+    withSQLConf(CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> "true") {
       runTPCHQueryBySQL(6, q6(tableName)) {
         df =>
           val scanExec = collect(df.queryExecution.executedPlan) {
@@ -635,7 +637,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
             case scanExec: BasicScanExecTransformer => scanExec
           }
           assertResult(1)(plans.size)
-          assertResult(1)(plans.head.getSplitInfos.size)
+          assertResult(1)(plans.head.getSplitInfos().size)
       }
     }
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.execution.mergetree
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeSettings}
 import org.apache.gluten.execution._
 import org.apache.gluten.utils.Arm
 
@@ -58,7 +58,7 @@ class GlutenClickHouseMergeTreeWriteSuite
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
       .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
-      .setCHSettings("min_insert_block_size_rows", 100000)
+      .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
+import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.CHConf
 import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
@@ -42,6 +43,8 @@ class GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.memory.offHeap.size", "4G")
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
   }
 
   override protected def createTPCHNotNullTables(): Unit = {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.metrics
 
+import org.apache.gluten.backendsapi.clickhouse.RuntimeConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.execution.GlutenPlan
 
@@ -49,7 +50,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
       .set("spark.io.compression.codec", "LZ4")
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
-      .setCHConfig("logger.level", "error")
+      .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .setCHSettings("input_format_parquet_max_block_size", parquetMaxBlockSize)
       .setCHConfig("enable_pre_projection_for_join_conditions", "false")
       .setCHConfig("enable_streaming_aggregating", true)

--- a/cpp-ch/local-engine/Common/DebugUtils.h
+++ b/cpp-ch/local-engine/Common/DebugUtils.h
@@ -29,11 +29,13 @@ class QueryPlan;
 namespace debug
 {
 
+void dumpMemoryUsage(const char * type);
 void dumpPlan(DB::QueryPlan & plan, const char * type = "clickhouse plan", bool force = false, LoggerPtr = nullptr);
 void dumpMessage(const google::protobuf::Message & message, const char * type, bool force = false, LoggerPtr = nullptr);
 
 void headBlock(const DB::Block & block, size_t count = 10);
 void headColumn(const DB::ColumnPtr & column, size_t count = 10);
+void printBlockHeader(const DB::Block & block, const std::string & prefix = "");
 std::string showString(const DB::Block & block, size_t numRows = 20, size_t truncate = 20, bool vertical = false);
 inline std::string verticalShowString(const DB::Block & block, size_t numRows = 20, size_t truncate = 20)
 {

--- a/cpp-ch/local-engine/Parser/CHColumnToSparkRow.h
+++ b/cpp-ch/local-engine/Parser/CHColumnToSparkRow.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 #include <vector>
+#include <jni.h>
 #include <Core/Block.h>
 #include <Core/Field.h>
 #include <Common/Allocator.h>
@@ -84,7 +85,7 @@ private:
 
 using SparkRowInfoPtr = std::unique_ptr<local_engine::SparkRowInfo>;
 
-class CHColumnToSparkRow : private Allocator<false/* clear_memory */>
+class CHColumnToSparkRow : private Allocator<false /* clear_memory */>
 // class CHColumnToSparkRow : public DB::Arena
 {
 public:
@@ -197,5 +198,12 @@ private:
     const DB::DataTypePtr type_without_nullable;
     const DB::WhichDataType which;
 };
+
+namespace SparkRowInfoJNI
+{
+void init(JNIEnv *);
+void destroy(JNIEnv *);
+jobject create(JNIEnv * env, const SparkRowInfo & spark_row_info);
+}
 
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.cpp
@@ -155,11 +155,9 @@ void addMergeTreeSinkTransform(
     //
 
     SparkMergeTreeWriteSettings write_settings{context};
-    if (partition_by.empty())
-        write_settings.partition_settings.partition_dir = SubstraitFileSink::NO_PARTITION_ID;
 
     auto sink = partition_by.empty()
-        ? SparkMergeTreeSink::create(merge_tree_table, write_settings, context->getGlobalContext(), {stats})
+        ? SparkMergeTreeSink::create(merge_tree_table, write_settings, context->getQueryContext(), {stats})
         : std::make_shared<SparkMergeTreePartitionedFileSink>(header, partition_by, merge_tree_table, write_settings, context, stats);
 
     chain.addSource(sink);

--- a/cpp-ch/local-engine/Storages/MergeTree/MergeSparkMergeTreeTask.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/MergeSparkMergeTreeTask.h
@@ -116,11 +116,4 @@ private:
 
 using MergeSparkMergeTreeTaskPtr = std::shared_ptr<MergeSparkMergeTreeTask>;
 
-
-[[maybe_unused]] static void executeHere(MergeSparkMergeTreeTaskPtr task)
-{
-    while (task->executeStep()) {}
-}
-
-
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.cpp
@@ -69,19 +69,21 @@ std::unordered_map<String, String> extractPartMetaData(ReadBuffer & in)
 
 enum SupportedMetaDataStorageType
 {
-    UNKNOWN =0,
+    UNKNOWN = 0,
     ROCKSDB,
     LOCAL
 };
 
 template <SupportedMetaDataStorageType type>
-static void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const Context & context)
+static void
+restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const Context & context)
 {
     UNREACHABLE();
 }
 
 template <>
-void restoreMetaData<ROCKSDB>(const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const Context & context)
+void restoreMetaData<ROCKSDB>(
+    const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const Context & context)
 {
     auto data_disk = storage->getStoragePolicy()->getAnyDisk();
     std::unordered_set<String> not_exists_part;
@@ -109,23 +111,23 @@ void restoreMetaData<ROCKSDB>(const SparkStorageMergeTreePtr & storage, const Me
 
         for (const auto & part : not_exists_part)
         {
-                auto part_path = table_path / part;
-                auto metadata_file_path = part_path / METADATA_FILE_NAME;
+            auto part_path = table_path / part;
+            auto metadata_file_path = part_path / METADATA_FILE_NAME;
 
-                if (metadata_storage->existsDirectory(part_path))
-                    return;
-                else
-                    transaction->createDirectoryRecursive(part_path);
-                auto key = s3->generateObjectKeyForPath(metadata_file_path.generic_string(), std::nullopt);
-                StoredObject metadata_object(key.serialize());
-                auto read_settings = ReadSettings{};
-                read_settings.enable_filesystem_cache = false;
-                auto part_metadata = extractPartMetaData(*s3->readObject(metadata_object, read_settings));
-                for (const auto & item : part_metadata)
-                {
-                    auto item_path = part_path / item.first;
-                    transaction->writeStringToFile(item_path, item.second);
-                }
+            if (metadata_storage->existsDirectory(part_path))
+                return;
+            else
+                transaction->createDirectoryRecursive(part_path);
+            auto key = s3->generateObjectKeyForPath(metadata_file_path.generic_string(), std::nullopt);
+            StoredObject metadata_object(key.serialize());
+            auto read_settings = ReadSettings{};
+            read_settings.enable_filesystem_cache = false;
+            auto part_metadata = extractPartMetaData(*s3->readObject(metadata_object, read_settings));
+            for (const auto & item : part_metadata)
+            {
+                auto item_path = part_path / item.first;
+                transaction->writeStringToFile(item_path, item.second);
+            }
         }
         transaction->commit();
     }
@@ -212,25 +214,16 @@ void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTa
         return;
     auto metadata_storage = data_disk->getMetadataStorage();
     if (metadata_storage->getType() == MetadataStorageType::Local)
-    {
         restoreMetaData<LOCAL>(storage, mergeTreeTable, context);
-    }
     // None is RocksDB
     else if (metadata_storage->getType() == MetadataStorageType::None)
-    {
         restoreMetaData<ROCKSDB>(storage, mergeTreeTable, context);
-    }
     else
-    {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported metadata storage type {}.", metadata_storage->getType());
-    }
 }
 
 void saveFileStatus(
-    const DB::MergeTreeData & storage,
-    const DB::ContextPtr& context,
-    const String & part_name,
-    IDataPartStorage & data_part_storage)
+    const DB::MergeTreeData & storage, const DB::ContextPtr & context, const String & part_name, IDataPartStorage & data_part_storage)
 {
     const DiskPtr disk = storage.getStoragePolicy()->getAnyDisk();
     if (!disk->isRemote())
@@ -252,11 +245,11 @@ void saveFileStatus(
 }
 
 
-std::vector<MergeTreeDataPartPtr> mergeParts(
+MergeTreeDataPartPtr mergeParts(
     std::vector<DB::DataPartPtr> selected_parts,
     const String & new_part_uuid,
     SparkStorageMergeTree & storage,
-    const String  & partition_dir,
+    const String & partition_dir,
     const String & bucket_dir)
 {
     auto future_part = std::make_shared<DB::FutureMergedMutatedPart>();
@@ -264,41 +257,30 @@ std::vector<MergeTreeDataPartPtr> mergeParts(
 
     future_part->assign(std::move(selected_parts));
     future_part->part_info = MergeListElement::FAKE_RESULT_PART_FOR_PROJECTION;
+
+    //TODO: name
     future_part->name = partition_dir.empty() ? "" : partition_dir + "/";
-
-    if(!bucket_dir.empty())
-    {
+    if (!bucket_dir.empty())
         future_part->name = future_part->name + bucket_dir + "/";
-    }
-    future_part->name = future_part->name +  new_part_uuid + "-merged";
+    future_part->name = future_part->name + new_part_uuid + "-merged";
 
-    auto entry = std::make_shared<DB::MergeMutateSelectedEntry>(future_part, DB::CurrentlyMergingPartsTaggerPtr{}, std::make_shared<DB::MutationCommands>());
+    auto entry = std::make_shared<DB::MergeMutateSelectedEntry>(
+        future_part, DB::CurrentlyMergingPartsTaggerPtr{}, std::make_shared<DB::MutationCommands>());
 
     // Copying a vector of columns `deduplicate by columns.
     DB::IExecutableTask::TaskResultCallback f = [](bool) {};
-    auto task = std::make_shared<local_engine::MergeSparkMergeTreeTask>(
-        storage, storage.getInMemoryMetadataPtr(), false,  std::vector<std::string>{}, false, entry,
-        DB::TableLockHolder{}, f);
+    const auto task = std::make_shared<MergeSparkMergeTreeTask>(
+        storage, storage.getInMemoryMetadataPtr(), false, std::vector<std::string>{}, false, entry, DB::TableLockHolder{}, f);
 
     task->setCurrentTransaction(DB::MergeTreeTransactionHolder{}, DB::MergeTreeTransactionPtr{});
 
-    executeHere(task);
-
-    std::unordered_set<std::string> to_load{future_part->name};
-    std::vector<MergeTreeDataPartPtr> merged = storage.loadDataPartsWithNames(to_load);
-    return merged;
-}
-
-/** TODO: Remove it.
- * Extract partition values from partition directory, we implement it in the java */
-void extractPartitionValues(const String & partition_dir, std::unordered_map<String, String> & partition_values)
-{
-    Poco::StringTokenizer partitions(partition_dir, "/");
-    for (const auto & partition : partitions)
+    while (task->executeStep())
     {
-        Poco::StringTokenizer key_value(partition, "=");
-        chassert(key_value.count() == 2);
-        partition_values.emplace(key_value[0], key_value[1]);
     }
+
+    std::vector<MergeTreeDataPartPtr> merged = storage.loadDataPartsWithNames({future_part->name});
+    assert(merged.size() == 1);
+    return merged[0];
 }
+
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.h
@@ -24,7 +24,6 @@ namespace local_engine
 {
 
 
-
 bool isMergeTreePartMetaDataFile(const String & file_name);
 
 void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const Context & context);
@@ -32,7 +31,7 @@ void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTa
 void saveFileStatus(
     const DB::MergeTreeData & storage, const DB::ContextPtr & context, const String & part_name, IDataPartStorage & data_part_storage);
 
-std::vector<MergeTreeDataPartPtr> mergeParts(
+MergeTreeDataPartPtr mergeParts(
     std::vector<DB::DataPartPtr> selected_parts,
     const String & new_part_uuid,
     SparkStorageMergeTree & storage,

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeMeta.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeMeta.cpp
@@ -262,15 +262,6 @@ MergeTreeTable::MergeTreeTable(const local_engine::Write & write, const substrai
     table_configs.storage_policy = merge_tree_write.storage_policy();
 }
 
-std::unique_ptr<MergeTreeSettings> buildMergeTreeSettings(const MergeTreeTableSettings & config)
-{
-    auto settings = std::make_unique<DB::MergeTreeSettings>();
-    settings->set("allow_nullable_key", Field(1));
-    if (!config.storage_policy.empty())
-        settings->set("storage_policy", Field(config.storage_policy));
-    return settings;
-}
-
 std::unique_ptr<SelectQueryInfo> buildQueryInfo(NamesAndTypesList & names_and_types_list)
 {
     std::unique_ptr<SelectQueryInfo> query_info = std::make_unique<SelectQueryInfo>();

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeMeta.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeMeta.h
@@ -16,11 +16,9 @@
  */
 #pragma once
 
+#include <Interpreters/MergeTreeTransaction.h>
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/TreeRewriter.h>
-
-#include <Interpreters/MergeTreeTransaction.h>
-#include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageInMemoryMetadata.h>
@@ -95,8 +93,6 @@ struct MergeTreeTableInstance : MergeTreeTable
     explicit MergeTreeTableInstance(const substrait::ReadRel::ExtensionTable & extension_table);
     explicit MergeTreeTableInstance(const std::string & info);
 };
-
-std::unique_ptr<MergeTreeSettings> buildMergeTreeSettings(const MergeTreeTableSettings & config);
 
 std::unique_ptr<SelectQueryInfo> buildQueryInfo(NamesAndTypesList & names_and_types_list);
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.cpp
@@ -224,8 +224,12 @@ void SinkHelper::writeTempPart(
 {
     assert(!metadata_snapshot->hasPartitionKey());
     const std::string & part_name_prefix = write_settings.partition_settings.part_name_prefix;
-    std::string part_dir = fmt::format("{}_{:03d}", part_name_prefix, part_num);
-    auto tmp = dataRef().getWriter().writeTempPart(block_with_partition, metadata_snapshot, context, part_dir);
+    std::string part_dir;
+    if (write_settings.is_optimize_task)
+        part_dir = fmt::format("{}-merged", part_name_prefix);
+    else
+        part_dir = fmt::format("{}_{:03d}", part_name_prefix, part_num);
+    const auto tmp = dataRef().getWriter().writeTempPart(block_with_partition, metadata_snapshot, context, part_dir);
     part_with_stats.data_part = tmp.part;
     new_parts.emplace_back(std::move(part_with_stats));
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
@@ -230,7 +230,9 @@ public:
 
         for (const auto & part : parts)
         {
-            columns_[part_name]->insertData(part.data_part->name.c_str(), part.data_part->name.size());
+            std::string part_name_without_partition
+                = partition_dir.empty() ? part.data_part->name : part.data_part->name.substr(partition_dir.size() + 1);
+            columns_[part_name]->insertData(part_name_without_partition.c_str(), part_name_without_partition.size());
             columns_[partition_id]->insertData(partition.c_str(), partition.size());
 
             countColData.emplace_back(part.data_part->rows_count);
@@ -321,8 +323,8 @@ public:
 
         assert(write_settings.partition_settings.partition_dir.empty());
         assert(write_settings.partition_settings.bucket_dir.empty());
-        write_settings.partition_settings.part_name_prefix
-            = fmt::format("{}/{}", partition_id, write_settings.partition_settings.part_name_prefix);
+        write_settings.partition_settings.part_name_prefix = fmt::format(
+            "{}/{}{}", partition_id, toString(DB::UUIDHelpers::generateV4()), write_settings.partition_settings.part_name_prefix);
         write_settings.partition_settings.partition_dir = partition_id;
 
         return SparkMergeTreeSink::create(

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriteSettings.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriteSettings.cpp
@@ -38,6 +38,9 @@ SparkMergeTreeWriteSettings::SparkMergeTreeWriteSettings(const DB::ContextPtr & 
 
     if (DB::Field limit_cnt_field; settings.tryGet("mergetree.max_num_part_per_merge_task", limit_cnt_field))
         merge_limit_parts = limit_cnt_field.safeGet<Int64>() <= 0 ? merge_limit_parts : limit_cnt_field.safeGet<Int64>();
+
+    if (settingsEqual(context->getSettingsRef(), MergeTreeConf::OPTIMIZE_TASK, "true"))
+        is_optimize_task = true;
 }
 
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriteSettings.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriteSettings.h
@@ -32,9 +32,19 @@ struct SparkMergeTreeWriteSettings
     SparkMergeTreeWritePartitionSettings partition_settings;
     bool merge_after_insert{true};
     bool insert_without_local_storage{false};
-    size_t merge_min_size = 1024 * 1024 * 1024;  // 1GB
+    bool is_optimize_task{false};
+    size_t merge_min_size = 1024 * 1024 * 1024; // 1GB
     size_t merge_limit_parts = 10;
 
     explicit SparkMergeTreeWriteSettings(const DB::ContextPtr & context);
+};
+
+struct MergeTreeConf
+{
+    inline static const String CH_CONF{"merge_tree"};
+    inline static const String GLUTEN_CONF{"mergetree"};
+
+    inline static const String OPTIMIZE_TASK{GLUTEN_CONF + ".optimize_task"};
+    // inline static const String MAX_NUM_PART_PER_MERGE_TASK{GLUTEN_CONF + ".max_num_part_per_merge_task"};
 };
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriteSettings.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriteSettings.h
@@ -32,7 +32,7 @@ struct SparkMergeTreeWriteSettings
     SparkMergeTreeWritePartitionSettings partition_settings;
     bool merge_after_insert{true};
     bool insert_without_local_storage{false};
-    size_t merge_min_size = 1024 * 1024 * 1024;
+    size_t merge_min_size = 1024 * 1024 * 1024;  // 1GB
     size_t merge_limit_parts = 10;
 
     explicit SparkMergeTreeWriteSettings(const DB::ContextPtr & context);

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriter.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriter.cpp
@@ -154,10 +154,10 @@ std::vector<PartInfo> SparkMergeTreeWriter::getAllPartInfo() const
     for (const auto & part : parts)
     {
         res.emplace_back(PartInfo{
-            part->name,
-            part->getMarksCount(),
-            part->getBytesOnDisk(),
-            part->rows_count,
+            part.data_part->name,
+            part.data_part->getMarksCount(),
+            part.data_part->getBytesOnDisk(),
+            part.data_part->rows_count,
             sink_helper.write_settings.partition_settings.partition_dir,
             sink_helper.write_settings.partition_settings.bucket_dir});
     }

--- a/cpp-ch/local-engine/Storages/Output/NormalFileWriter.cpp
+++ b/cpp-ch/local-engine/Storages/Output/NormalFileWriter.cpp
@@ -16,19 +16,19 @@
  */
 #include "NormalFileWriter.h"
 
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnMap.h>
 #include <QueryPipeline/QueryPipeline.h>
 #include <Poco/URI.h>
 #include <Common/DebugUtils.h>
-#include <Columns/ColumnConst.h>
-#include <Columns/ColumnArray.h>
-#include <Columns/ColumnMap.h>
 
 namespace local_engine
 {
 
 using namespace DB;
 
-const std::string SubstraitFileSink::NO_PARTITION_ID{"__NO_PARTITION_ID__"};
+const std::string WriteStatsBase::NO_PARTITION_ID{"__NO_PARTITION_ID__"};
 const std::string SparkPartitionedBaseSink::DEFAULT_PARTITION_NAME{"__HIVE_DEFAULT_PARTITION__"};
 const std::string SparkPartitionedBaseSink::BUCKET_COLUMN_NAME{"__bucket_value__"};
 const std::vector<std::string> FileNameGenerator::SUPPORT_PLACEHOLDERS{"{id}", "{bucket}"};

--- a/cpp-ch/local-engine/tests/gluten_test_util.h
+++ b/cpp-ch/local-engine/tests/gluten_test_util.h
@@ -83,6 +83,8 @@ std::pair<substrait::Plan, std::unique_ptr<LocalExecutor>> create_plan_and_execu
 
 }
 
+using TestSettings = std::map<std::string, DB::Field>;
+
 inline std::string replaceLocalFilesWildcards(const std::string_view haystack, const std::string_view replaced)
 {
     static constexpr auto wildcard = "{replace_local_files}";

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline.cpp
@@ -157,7 +157,7 @@ TEST(WritePipeline, SubstraitFileSink)
     const auto & col_a = *(x.getColumns()[0]);
     EXPECT_EQ(settings.task_write_filename_pattern, col_a.getDataAt(0));
     const auto & col_b = *(x.getColumns()[1]);
-    EXPECT_EQ(SubstraitFileSink::NO_PARTITION_ID, col_b.getDataAt(0));
+    EXPECT_EQ(WriteStatsBase::NO_PARTITION_ID, col_b.getDataAt(0));
     const auto & col_c = *(x.getColumns()[2]);
     EXPECT_EQ(10000, col_c.getInt(0));
 }

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
@@ -285,6 +285,8 @@ void writeMerge(
 }
 INCBIN(_3_mergetree_plan_, SOURCE_DIR "/utils/extern-local-engine/tests/json/mergetree/3_one_pipeline.json");
 INCBIN(_4_mergetree_plan_, SOURCE_DIR "/utils/extern-local-engine/tests/json/mergetree/4_one_pipeline.json");
+INCBIN(_lowcard_plan_, SOURCE_DIR "/utils/extern-local-engine/tests/json/mergetree/lowcard.json");
+INCBIN(_case_sensitive_plan_, SOURCE_DIR "/utils/extern-local-engine/tests/json/mergetree/case_sensitive.json");
 TEST(MergeTree, Pipeline)
 {
     // context->setSetting("mergetree.max_num_part_per_merge_task", 1);
@@ -309,5 +311,33 @@ TEST(MergeTree, PipelineWithPartition)
         {
             EXPECT_EQ(3815, block.rows());
             debug::headBlock(block);
+        });
+}
+
+TEST(MergeTree, lowcard)
+{
+    writeMerge(
+        EMBEDDED_PLAN(_lowcard_plan_),
+        "tmp/lineitem_mergetre_lowcard",
+        {},
+        [&](const DB::Block & block)
+        {
+            EXPECT_EQ(1, block.rows());
+            std::cerr << debug::verticalShowString(block, 10, 50) << std::endl;
+        });
+}
+
+TEST(MergeTree, case_sensitive)
+{
+    //TODO: case_sensitive
+    GTEST_SKIP();
+    writeMerge(
+        EMBEDDED_PLAN(_case_sensitive_plan_),
+        "tmp/LINEITEM_MERGETREE_CASE_SENSITIVE",
+        {},
+        [&](const DB::Block & block)
+        {
+            EXPECT_EQ(1, block.rows());
+            std::cerr << debug::showString(block, 20, 50) << std::endl;
         });
 }

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
@@ -261,15 +261,10 @@ namespace
 void writeMerge(
     std::string_view json_plan,
     const std::string & outputPath,
+    ContextMutablePtr context,
     const std::function<void(const DB::Block &)> & callback,
     std::optional<std::string> input = std::nullopt)
 {
-    const auto context = DB::Context::createCopy(QueryContext::globalContext());
-
-    auto queryid = QueryContext::instance().initializeQuery("gtest_mergetree");
-    SCOPE_EXIT({ QueryContext::instance().finalizeQuery(queryid); });
-
-
     GlutenWriteSettings settings{.task_write_tmp_dir = outputPath};
     settings.set(context);
     SparkMergeTreeWritePartitionSettings partition_settings{.part_name_prefix = "pipline_prefix"};
@@ -286,21 +281,31 @@ INCBIN(_3_mergetree_plan_, SOURCE_DIR "/utils/extern-local-engine/tests/json/mer
 INCBIN(_4_mergetree_plan_, SOURCE_DIR "/utils/extern-local-engine/tests/json/mergetree/4_one_pipeline.json");
 TEST(MergeTree, Pipeline)
 {
+    auto query_id = QueryContext::instance().initializeQuery("gtest_mergetree");
+    SCOPE_EXIT({ QueryContext::instance().finalizeQuery(query_id); });
+
+    const auto context = QueryContext::instance().currentQueryContext();
+    context->setSetting("min_insert_block_size_rows", 100000);
+    context->setSetting("optimize.minFileSize", 1024 * 1024 * 10);
+    // context->setSetting("mergetree.max_num_part_per_merge_task", 1);
     writeMerge(
         EMBEDDED_PLAN(_3_mergetree_plan_),
         "tmp/lineitem_mergetree",
+        context,
         [&](const DB::Block & block)
         {
-            EXPECT_EQ(1, block.rows());
+            EXPECT_EQ(3, block.rows());
             debug::headBlock(block);
         });
 }
 
 TEST(MergeTree, PipelineWithPartition)
 {
+    const auto context = DB::Context::createCopy(QueryContext::globalContext());
     writeMerge(
         EMBEDDED_PLAN(_4_mergetree_plan_),
         "tmp/lineitem_mergetree_p",
+        context,
         [&](const DB::Block & block)
         {
             EXPECT_EQ(3815, block.rows());

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
@@ -273,7 +273,7 @@ void writeMerge(
         context->setSetting(x.first, x.second);
     GlutenWriteSettings settings{.task_write_tmp_dir = outputPath};
     settings.set(context);
-    SparkMergeTreeWritePartitionSettings partition_settings{.part_name_prefix = "pipline_prefix"};
+    SparkMergeTreeWritePartitionSettings partition_settings{.part_name_prefix = "_1"};
     partition_settings.set(context);
 
     auto input_json = input.value_or(replaceLocalFilesWithTPCH(EMBEDDED_PLAN(_3_mergetree_plan_input_)));
@@ -311,7 +311,7 @@ TEST(MergeTree, PipelineWithPartition)
         [&](const DB::Block & block)
         {
             EXPECT_EQ(3815, block.rows());
-            debug::headBlock(block);
+            std::cerr << debug::showString(block, 50, 50) << std::endl;
         });
 }
 

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline_mergetree.cpp
@@ -293,11 +293,12 @@ TEST(MergeTree, Pipeline)
     writeMerge(
         EMBEDDED_PLAN(_3_mergetree_plan_),
         "tmp/lineitem_mergetree",
-        {{"min_insert_block_size_rows", 100000}, {"optimize.minFileSize", 1024 * 1024 * 10}},
+        {{"min_insert_block_size_rows", 100000}
+         /*, {"optimize.minFileSize", 1024 * 1024 * 10}*/},
         [&](const DB::Block & block)
         {
-            EXPECT_EQ(3, block.rows());
-            debug::headBlock(block);
+            EXPECT_EQ(1, block.rows());
+            std::cerr << debug::verticalShowString(block, 10, 50) << std::endl;
         });
 }
 

--- a/cpp-ch/local-engine/tests/json/mergetree/case_sensitive.json
+++ b/cpp-ch/local-engine/tests/json/mergetree/case_sensitive.json
@@ -1,0 +1,792 @@
+{
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 3,
+        "name": "alias:date"
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "alias:str"
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "alias:fp64"
+      }
+    },
+    {
+      "extensionFunction": {
+        "name": "alias:i64"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "write": {
+            "namedTable": {
+              "advancedExtension": {
+                "optimization": {
+                  "@type": "type.googleapis.com/local_engine.Write",
+                  "common": {
+                    "format": "mergetree"
+                  },
+                  "mergetree": {
+                    "database": "default",
+                    "table": "lineitem_mergetree_case_sensitive",
+                    "snapshotId": "1733308441225_0",
+                    "orderByKey": "l_discount",
+                    "storagePolicy": "default"
+                  }
+                },
+                "enhancement": {
+                  "@type": "type.googleapis.com/substrait.Type",
+                  "struct": {
+                    "types": [
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                }
+              }
+            },
+            "tableSchema": {
+              "names": [
+                "L_ORDERKEY",
+                "L_PARTKEY",
+                "L_SUPPKEY",
+                "L_LINENUMBER",
+                "L_QUANTITY",
+                "L_EXTENDEDPRICE",
+                "L_DISCOUNT",
+                "L_TAX",
+                "L_RETURNFLAG",
+                "L_LINESTATUS",
+                "L_SHIPDATE",
+                "L_COMMITDATE",
+                "L_RECEIPTDATE",
+                "L_SHIPINSTRUCT",
+                "L_SHIPMODE",
+                "L_COMMENT"
+              ],
+              "struct": {
+                "types": [
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "date": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "date": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "date": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }
+                ]
+              },
+              "columnTypes": [
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "PARTITION_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL"
+              ]
+            },
+            "input": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      21,
+                      22,
+                      23,
+                      24,
+                      25,
+                      26,
+                      27,
+                      28,
+                      29,
+                      30,
+                      31
+                    ]
+                  }
+                },
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "l_orderkey",
+                        "l_partkey",
+                        "l_suppkey",
+                        "l_linenumber",
+                        "l_quantity",
+                        "l_extendedprice",
+                        "l_discount",
+                        "l_tax",
+                        "l_returnflag",
+                        "l_linestatus",
+                        "l_shipdate",
+                        "l_commitdate",
+                        "l_receiptdate",
+                        "l_shipinstruct",
+                        "l_shipmode",
+                        "l_comment"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "date": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "date": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "date": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ]
+                      },
+                      "columnTypes": [
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL"
+                      ]
+                    },
+                    "advancedExtension": {
+                      "optimization": {
+                        "@type": "type.googleapis.com/google.protobuf.StringValue",
+                        "value": "isMergeTree=0\n"
+                      }
+                    }
+                  }
+                },
+                "expressions": [
+                  {
+                    "scalarFunction": {
+                      "outputType": {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "outputType": {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "outputType": {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "outputType": {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 1,
+                      "outputType": {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 1,
+                      "outputType": {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 1,
+                      "outputType": {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 1,
+                      "outputType": {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 2,
+                      "outputType": {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 2,
+                      "outputType": {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 3,
+                      "outputType": {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 3,
+                      "outputType": {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 3,
+                      "outputType": {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 2,
+                      "outputType": {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 2,
+                      "outputType": {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 14
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "scalarFunction": {
+                      "functionReference": 2,
+                      "outputType": {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 15
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "outputSchema": {
+          "nullability": "NULLABILITY_REQUIRED"
+        }
+      }
+    }
+  ]
+}

--- a/cpp-ch/local-engine/tests/json/mergetree/lowcard.json
+++ b/cpp-ch/local-engine/tests/json/mergetree/lowcard.json
@@ -1,0 +1,378 @@
+{
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "write": {
+            "namedTable": {
+              "advancedExtension": {
+                "optimization": {
+                  "@type": "type.googleapis.com/local_engine.Write",
+                  "common": {
+                    "format": "mergetree"
+                  },
+                  "mergetree": {
+                    "database": "default",
+                    "table": "lineitem_mergetree_lowcard",
+                    "snapshotId": "1733306791131_0",
+                    "orderByKey": "tuple()",
+                    "lowCardKey": "l_returnflag,l_linestatus,l_quantity",
+                    "storagePolicy": "default"
+                  }
+                },
+                "enhancement": {
+                  "@type": "type.googleapis.com/substrait.Type",
+                  "struct": {
+                    "types": [
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                }
+              }
+            },
+            "tableSchema": {
+              "names": [
+                "l_orderkey",
+                "l_partkey",
+                "l_suppkey",
+                "l_linenumber",
+                "l_quantity",
+                "l_extendedprice",
+                "l_discount",
+                "l_tax",
+                "l_returnflag",
+                "l_linestatus",
+                "l_shipdate",
+                "l_commitdate",
+                "l_receiptdate",
+                "l_shipinstruct",
+                "l_shipmode",
+                "l_comment"
+              ],
+              "struct": {
+                "types": [
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "i64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "fp64": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "date": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "date": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "date": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  {
+                    "string": {
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }
+                ]
+              },
+              "columnTypes": [
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL",
+                "NORMAL_COL"
+              ]
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "l_orderkey",
+                    "l_partkey",
+                    "l_suppkey",
+                    "l_linenumber",
+                    "l_quantity",
+                    "l_extendedprice",
+                    "l_discount",
+                    "l_tax",
+                    "l_returnflag",
+                    "l_linestatus",
+                    "l_shipdate",
+                    "l_commitdate",
+                    "l_receiptdate",
+                    "l_shipinstruct",
+                    "l_shipmode",
+                    "l_comment"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "date": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "string": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ]
+                  },
+                  "columnTypes": [
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL",
+                    "NORMAL_COL"
+                  ]
+                },
+                "advancedExtension": {
+                  "optimization": {
+                    "@type": "type.googleapis.com/google.protobuf.StringValue",
+                    "value": "isMergeTree=0\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "outputSchema": {
+          "nullability": "NULLABILITY_REQUIRED"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
(Fixes: #7028)

Similar with #7993, this PR supports collecting stats for mergetree.  I **remove** the old compaction algorithm and replaced it with delta's implementaion for two reasons:
1.  After https://delta.io/blog/delta-lake-3-2/, delta optimazie command. supports  **Liquid clustering**.
2. It's impossible to collect stats with old compaction.

> Notes
> Since we conside droping support `Bucket` table, we can use delta's `OptimizeTableCommand `instead of gluen's version

There are some tests failed with one pipeline write, recored in #7028, we can fix it in the next PRs

## How was this patch tested?

Uisng existed UTs

