### PR TITLE
[VL] Clean up duplicate CMake code for setting CMAKE_CXX_FLAGS

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -136,12 +136,15 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       -Wno-nullability-completeness \
       -Wno-pessimizing-move \
       -Wno-mismatched-tags \
-      -Wno-class-memaccess \
       ${KNOWN_WARNINGS}")
   # Specific definition for an issue with boost/stacktrace when building on
   # macOS. See https://github.com/boostorg/stacktrace/issues/88 and comments
   # therein.
   add_compile_definitions(_GNU_SOURCE)
+endif()
+
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-memaccess")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -98,7 +98,9 @@ set(KNOWN_WARNINGS
        -Wno-error=unused-function \
        -Wno-error=unused-variable \
        -Wno-strict-aliasing \
-       -Wno-ignored-qualifiers")
+       -Wno-ignored-qualifiers \
+       -Wno-deprecated-declarations \
+       -Wno-attributes")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(KNOWN_WARNINGS "-Wno-error=unused-but-set-variable \
@@ -134,6 +136,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       -Wno-nullability-completeness \
       -Wno-pessimizing-move \
       -Wno-mismatched-tags \
+      -Wno-class-memaccess \
       ${KNOWN_WARNINGS}")
   # Specific definition for an issue with boost/stacktrace when building on
   # macOS. See https://github.com/boostorg/stacktrace/issues/88 and comments
@@ -142,6 +145,19 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
+
+# Keep same compile option with Velox.
+execute_process(
+  COMMAND
+    bash -c
+    "( source ${VELOX_HOME}/scripts/setup-helper-functions.sh && echo -n $(get_cxx_flags $ENV{CPU_TARGET}))"
+  OUTPUT_VARIABLE SCRIPT_CXX_FLAGS
+  RESULT_VARIABLE COMMAND_STATUS)
+if(COMMAND_STATUS EQUAL "1")
+  message(FATAL_ERROR "Unable to determine compiler flags!")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 
 #
 # Dependencies

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -22,28 +22,6 @@ include(FindPkgConfig)
 include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-attributes")
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-memaccess")
-endif()
-
-if(NOT DEFINED VELOX_HOME)
-  set(VELOX_HOME ${GLUTEN_HOME}/ep/build-velox/build/velox_ep)
-  message(STATUS "Set VELOX_HOME to ${VELOX_HOME}")
-endif()
-
-# Keep same compile option with Velox.
-execute_process(
-  COMMAND
-    bash -c
-    "( source ${VELOX_HOME}/scripts/setup-helper-functions.sh && echo -n $(get_cxx_flags $ENV{CPU_TARGET}))"
-  OUTPUT_VARIABLE SCRIPT_CXX_FLAGS
-  RESULT_VARIABLE COMMAND_STATUS)
-if(COMMAND_STATUS EQUAL "1")
-  message(FATAL_ERROR "Unable to determine compiler flags!")
-endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 message("Core module final CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 set(BOOST_MIN_VERSION "1.42.0")

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -23,12 +23,6 @@ include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 include(FindPackageHandleStandardArgs)
 
-set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-attributes")
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-memaccess")
-endif()
-
 set(SYSTEM_LIB_PATH
     "/usr/lib"
     CACHE PATH "System Lib dir")
@@ -61,18 +55,6 @@ if(NOT DEFINED VELOX_HOME)
   set(VELOX_HOME ${GLUTEN_HOME}/ep/build-velox/build/velox_ep)
   message(STATUS "Set VELOX_HOME to ${VELOX_HOME}")
 endif()
-
-# Keep same compile option with Velox.
-execute_process(
-  COMMAND
-    bash -c
-    "( source ${VELOX_HOME}/scripts/setup-helper-functions.sh && echo -n $(get_cxx_flags $ENV{CPU_TARGET}))"
-  OUTPUT_VARIABLE SCRIPT_CXX_FLAGS
-  RESULT_VARIABLE COMMAND_STATUS)
-if(COMMAND_STATUS EQUAL "1")
-  message(FATAL_ERROR "Unable to determine compiler flags!")
-endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 
 message("Velox module final CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR cleans up duplicate code in cpp/velox and cpp/core CMakeLists.txt and moves them to the top level common CMakeLists.txt


## How was this patch tested?

Local Build

