### PR TITLE
[GLUTEN-6920][CORE] Redesign and move trait `GlutenPlan` to `gluten-core`

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/FallbackBroadcastHashJoinRules.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/FallbackBroadcastHashJoinRules.scala
@@ -128,7 +128,7 @@ case class FallbackBroadcastHashJoinPrepQueryStage(session: SparkSession) extend
                 val exchangeTransformer = ColumnarBroadcastExchangeExec(mode, child)
                 exchangeTransformer.doValidate()
               } else {
-                isTransformable
+                isBnljTransformable
               }
             }
           }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/FallbackBroadcastHashJoinRules.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/FallbackBroadcastHashJoinRules.scala
@@ -72,13 +72,7 @@ case class FallbackBroadcastHashJoinPrepQueryStage(session: SparkSession) extend
                       bhj.left,
                       bhj.right,
                       bhj.isNullAwareAntiJoin)
-                  val isBhjTransformable = bhjTransformer.doValidate()
-                  if (isBhjTransformable.ok()) {
-                    val exchangeTransformer = ColumnarBroadcastExchangeExec(mode, child)
-                    exchangeTransformer.doValidate()
-                  } else {
-                    isBhjTransformable
-                  }
+                  bhjTransformer.doValidate()
                 }
               }
             FallbackTags.add(bhj, isTransformable)
@@ -123,13 +117,7 @@ case class FallbackBroadcastHashJoinPrepQueryStage(session: SparkSession) extend
                   bnlj.buildSide,
                   bnlj.joinType,
                   bnlj.condition)
-              val isTransformable = transformer.doValidate()
-              if (isTransformable.ok()) {
-                val exchangeTransformer = ColumnarBroadcastExchangeExec(mode, child)
-                exchangeTransformer.doValidate()
-              } else {
-                isTransformable
-              }
+              transformer.doValidate()
             }
           }
         FallbackTags.add(bnlj, isTransformable)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.execution.metrics
 
 import org.apache.gluten.execution.{ColumnarNativeIterator, GlutenClickHouseTPCDSAbstractSuite, WholeStageTransformer}
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Attribute

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.execution.metrics
 
 import org.apache.gluten.execution._
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Attribute

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.execution.tpch
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.execution._
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.utils.Arm
 
 import org.apache.spark.SparkConf

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.execution.tpch
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.clickhouse.CHConf
 import org.apache.gluten.execution._
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.DataFrame

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -19,7 +19,6 @@ package org.apache.gluten.backendsapi.velox
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.RuleApi
 import org.apache.gluten.columnarbatch.VeloxBatch
-import org.apache.gluten.datasource.ArrowConvertorRule
 import org.apache.gluten.extension._
 import org.apache.gluten.extension.columnar._
 import org.apache.gluten.extension.columnar.MiscColumnarRules.{RemoveGlutenTableCacheColumnarToRow, RemoveTopmostColumnarToRow, RewriteSubqueryBroadcast}

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -53,7 +53,6 @@ import scala.collection.mutable.ListBuffer
 case class ColumnarPartialProjectExec(original: ProjectExec, child: SparkPlan)(
     replacedAliasUdf: Seq[Alias])
   extends UnaryExecNode
-  with GlutenPlan
   with ValidatablePlan {
 
   private val projectAttributes: ListBuffer[Attribute] = ListBuffer()

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -43,7 +43,6 @@ import org.apache.arrow.memory.ArrowBuf
 import scala.collection.mutable.ListBuffer
 
 case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBase(child = child) {
-
   override def doExecuteColumnarInternal(): RDD[ColumnarBatch] = {
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxResizeBatchesExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxResizeBatchesExec.scala
@@ -16,7 +16,8 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.utils.VeloxBatchResizer
 
@@ -52,6 +53,10 @@ case class VeloxResizeBatchesExec(
     "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"),
     "selfTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to append / split batches")
   )
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
 

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/ArrowConvertorRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/ArrowConvertorRule.scala
@@ -20,20 +20,22 @@ import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.datasource.ArrowCSVFileFormat
 import org.apache.gluten.datasource.v2.ArrowCSVTable
 import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.PermissiveMode
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVTable
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkArrowUtil
 
 import java.nio.charset.StandardCharsets
+
 import scala.collection.convert.ImplicitConversions.`map AsScala`
 
 @Experimental

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/ArrowConvertorRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/ArrowConvertorRule.scala
@@ -14,27 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.datasource
+package org.apache.gluten.extension
 
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.datasource.ArrowCSVFileFormat
 import org.apache.gluten.datasource.v2.ArrowCSVTable
 import org.apache.gluten.sql.shims.SparkShimLoader
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.PermissiveMode
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVTable
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkArrowUtil
 
 import java.nio.charset.StandardCharsets
-
 import scala.collection.convert.ImplicitConversions.`map AsScala`
 
 @Experimental

--- a/backends-velox/src/main/scala/org/apache/spark/api/python/ColumnarArrowEvalPythonExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/api/python/ColumnarArrowEvalPythonExec.scala
@@ -19,9 +19,9 @@ package org.apache.spark.api.python
 import org.apache.gluten.columnarbatch.ArrowBatches.ArrowJavaBatch
 import org.apache.gluten.columnarbatch.ColumnarBatches
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
-import org.apache.gluten.extension.columnar.transition.ConventionReq.KnownChildrenConventions
+import org.apache.gluten.extension.columnar.transition.ConventionReq.KnownChildConvention
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.utils.PullOutProjectHelper
@@ -213,11 +213,13 @@ case class ColumnarArrowEvalPythonExec(
     evalType: Int)
   extends EvalPythonExec
   with GlutenPlan
-  with KnownChildrenConventions {
+  with KnownChildConvention {
 
   override def batchType(): Convention.BatchType = ArrowJavaBatch
 
-  override def requiredChildrenConventions(): Seq[ConventionReq] = List(
+  override def rowType0(): Convention.RowType = Convention.RowType.None
+
+  override def requiredChildConvention(): Seq[ConventionReq] = List(
     ConventionReq.of(ConventionReq.RowType.Any, ConventionReq.BatchType.Is(ArrowJavaBatch)))
 
   override lazy val metrics = Map(

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/BaseArrowScanExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/BaseArrowScanExec.scala
@@ -17,11 +17,13 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.columnarbatch.ArrowBatches
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.transition.Convention
 
 trait BaseArrowScanExec extends GlutenPlan {
   final override def batchType(): Convention.BatchType = {
     ArrowBatches.ArrowJavaBatch
   }
+
+  final override def rowType0(): Convention.RowType = Convention.RowType.None
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.extension.GlutenPlan
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.{ColumnarBroadcastExchangeExec, ColumnarShuffleExchangeExec, SparkPlan}

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarToColumnarExec.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarToColumnarExec.scala
@@ -30,9 +30,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 abstract class ColumnarToColumnarExec(from: Convention.BatchType, to: Convention.BatchType)
   extends ColumnarToColumnarTransition
-  with Convention.KnownBatchType
-  with Convention.KnownRowTypeForSpark33AndLater
-  with ConventionReq.KnownChildConvention {
+  with GlutenPlan {
 
   def child: SparkPlan
   protected def mapIterator(in: Iterator[ColumnarBatch]): Iterator[ColumnarBatch]
@@ -46,15 +44,7 @@ abstract class ColumnarToColumnarExec(from: Convention.BatchType, to: Convention
       "selfTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to convert batches")
     )
 
-  final override val supportsColumnar: Boolean = {
-    batchType() != Convention.BatchType.None
-  }
-
   override def batchType(): Convention.BatchType = to
-
-  final override val supportsRowBased: Boolean = {
-    rowType() != Convention.RowType.None
-  }
 
   override def rowType0(): Convention.RowType = {
     Convention.RowType.None

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarToColumnarExec.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/ColumnarToColumnarExec.scala
@@ -32,7 +32,7 @@ abstract class ColumnarToColumnarExec(from: Convention.BatchType, to: Convention
   extends ColumnarToColumnarTransition
   with Convention.KnownBatchType
   with Convention.KnownRowTypeForSpark33AndLater
-  with ConventionReq.KnownChildrenConventions {
+  with ConventionReq.KnownChildConvention {
 
   def child: SparkPlan
   protected def mapIterator(in: Iterator[ColumnarBatch]): Iterator[ColumnarBatch]
@@ -60,7 +60,7 @@ abstract class ColumnarToColumnarExec(from: Convention.BatchType, to: Convention
     Convention.RowType.None
   }
 
-  override def requiredChildrenConventions(): Seq[ConventionReq] = List(
+  override def requiredChildConvention(): Seq[ConventionReq] = List(
     ConventionReq.of(ConventionReq.RowType.Any, ConventionReq.BatchType.Is(from)))
 
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenPlan.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 
 import org.apache.spark.sql.execution.SparkPlan
@@ -24,6 +25,7 @@ trait GlutenPlan
   extends SparkPlan
   with Convention.KnownBatchType
   with Convention.KnownRowTypeForSpark33AndLater
+  with GlutenPlan.SupportsRowBasedCompatible
   with ConventionReq.KnownChildConvention {
 
   final override val supportsColumnar: Boolean = {
@@ -45,5 +47,14 @@ trait GlutenPlan
       _ => {
         childReq
       })
+  }
+}
+
+object GlutenPlan {
+  // To be compatible with Spark (version < 3.3)
+  trait SupportsRowBasedCompatible {
+    def supportsRowBased(): Boolean = {
+      throw new GlutenException("Illegal state: The method is not expected to be called")
+    }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenPlan.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
+
+import org.apache.spark.sql.execution.SparkPlan
+
+trait GlutenPlan
+  extends SparkPlan
+  with Convention.KnownBatchType
+  with Convention.KnownRowTypeForSpark33AndLater
+  with ConventionReq.KnownChildConvention {
+
+  final override val supportsColumnar: Boolean = {
+    batchType() != Convention.BatchType.None
+  }
+
+  override def batchType(): Convention.BatchType
+
+  final override val supportsRowBased: Boolean = {
+    rowType() != Convention.RowType.None
+  }
+
+  override def rowType0(): Convention.RowType
+
+  override def requiredChildConvention(): Seq[ConventionReq] = {
+    // In the normal case, children's convention should follow parent node's convention.
+    val childReq = Convention.of(rowType(), batchType()).asReq()
+    Seq.tabulate(children.size)(
+      _ => {
+        childReq
+      })
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.enumerated.planner.plan
 
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.enumerated.planner.metadata.GlutenMetadata
 import org.apache.gluten.extension.columnar.enumerated.planner.property.{Conv, ConvDef}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
@@ -37,13 +38,15 @@ object GlutenPlanModel {
     PlanModelImpl
   }
 
+  // TODO: Make this inherit from GlutenPlan.
   case class GroupLeafExec(
       groupId: Int,
       metadata: GlutenMetadata,
       constraintSet: PropertySet[SparkPlan])
     extends LeafExecNode
     with Convention.KnownBatchType
-    with Convention.KnownRowTypeForSpark33AndLater {
+    with Convention.KnownRowTypeForSpark33AndLater
+    with GlutenPlan.SupportsRowBasedCompatible {
     private val req: Conv.Req = constraintSet.get(ConvDef).asInstanceOf[Conv.Req]
 
     override protected def doExecute(): RDD[InternalRow] = throw new IllegalStateException()

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/property/Conv.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/property/Conv.scala
@@ -92,7 +92,7 @@ object ConvDef extends PropertyDef[SparkPlan, Conv] {
   override def getChildrenConstraints(
       constraint: Property[SparkPlan],
       plan: SparkPlan): Seq[Conv] = {
-    val out = List.tabulate(plan.children.size)(_ => Conv.req(ConventionReq.get(plan)))
+    val out = ConventionReq.get(plan).map(Conv.req)
     out
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -55,6 +55,19 @@ object Convention {
       }
       Convention.of(rowType(), batchType())
     }
+
+    def asReq(): ConventionReq = {
+      val rowTypeReq = conv.rowType match {
+        case Convention.RowType.None => ConventionReq.RowType.Any
+        case r => ConventionReq.RowType.Is(r)
+      }
+
+      val batchTypeReq = conv.batchType match {
+        case Convention.BatchType.None => ConventionReq.BatchType.Any
+        case b => ConventionReq.BatchType.Is(b)
+      }
+      ConventionReq.of(rowTypeReq, batchTypeReq)
+    }
   }
 
   private case class Impl(override val rowType: RowType, override val batchType: BatchType)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.extension.columnar.transition
 
-import org.apache.gluten.exception.GlutenException
-
 import org.apache.spark.sql.execution.{ColumnarToRowExec, RowToColumnarExec, SparkPlan}
 import org.apache.spark.util.SparkVersionUtil
 
@@ -155,17 +153,8 @@ object Convention {
     def batchType(): BatchType
   }
 
-  sealed trait KnownRowType extends KnownRowType.SupportsRowBasedCompatible {
+  sealed trait KnownRowType {
     def rowType(): RowType
-  }
-
-  object KnownRowType {
-    // To be compatible with Spark (version < 3.3)
-    sealed trait SupportsRowBasedCompatible {
-      def supportsRowBased(): Boolean = {
-        throw new GlutenException("Illegal state: The method is not expected to be called")
-      }
-    }
   }
 
   trait KnownRowTypeForSpark33AndLater extends KnownRowType {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionReq.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionReq.scala
@@ -55,12 +55,12 @@ object ConventionReq {
   val row: ConventionReq = ofRow(RowType.Is(Convention.RowType.VanillaRow))
   val vanillaBatch: ConventionReq = ofBatch(BatchType.Is(Convention.BatchType.VanillaBatch))
 
-  def get(plan: SparkPlan): ConventionReq = ConventionFunc.create().conventionReqOf(plan)
+  def get(plan: SparkPlan): Seq[ConventionReq] = ConventionFunc.create().conventionReqOf(plan)
   def of(rowType: RowType, batchType: BatchType): ConventionReq = Impl(rowType, batchType)
   def ofRow(rowType: RowType): ConventionReq = Impl(rowType, BatchType.Any)
   def ofBatch(batchType: BatchType): ConventionReq = Impl(RowType.Any, batchType)
 
-  trait KnownChildrenConventions {
-    def requiredChildrenConventions(): Seq[ConventionReq]
+  trait KnownChildConvention {
+    def requiredChildConvention(): Seq[ConventionReq]
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
@@ -42,13 +42,13 @@ case class InsertTransitions(convReq: ConventionReq) extends Rule[SparkPlan] {
     if (node.children.isEmpty) {
       return node
     }
-    val convReq = convFunc.conventionReqOf(node)
-    val newChildren = node.children.map {
-      child =>
+    val convReqs = convFunc.conventionReqOf(node)
+    val newChildren = node.children.zip(convReqs).map {
+      case (child, convReq) =>
         val from = convFunc.conventionOf(child)
         if (from.isNone) {
           // For example, a union op with row child and columnar child at the same time,
-          // The plan is actually not executable and we cannot tell about its convention.
+          // The plan is actually not executable, and we cannot tell about its convention.
           child
         } else {
           val transition =

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -19,7 +19,8 @@ package org.apache.gluten.execution
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter, ExpressionTransformer}
-import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
+import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.MetricsUpdater
 import org.apache.gluten.substrait.`type`.TypeBuilder
 import org.apache.gluten.substrait.SubstraitContext
@@ -267,6 +268,10 @@ case class ColumnarUnionExec(children: Seq[SparkPlan]) extends GlutenPlan {
       w.setOutputSchemaForPlan(output)
     case _ =>
   }
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override def output: Seq[Attribute] = {
     children.map(_.output).transpose.map {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -262,7 +262,7 @@ abstract class ProjectExecTransformerBase(val list: Seq[NamedExpression], val in
 }
 
 // An alternatives for UnionExec.
-case class ColumnarUnionExec(children: Seq[SparkPlan]) extends GlutenPlan {
+case class ColumnarUnionExec(children: Seq[SparkPlan]) extends ValidatablePlan {
   children.foreach {
     case w: WholeStageTransformer =>
       w.setOutputSchemaForPlan(output)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/CartesianProductExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/CartesianProductExecTransformer.scala
@@ -18,7 +18,8 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.expression.ExpressionConverter
-import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
+import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.MetricsUpdater
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.rel.RelBuilder
@@ -45,6 +46,8 @@ import java.io.{IOException, ObjectOutputStream}
  */
 case class ColumnarCartesianProductBridge(child: SparkPlan) extends UnaryExecNode with GlutenPlan {
   override def output: Seq[Attribute] = child.output
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+  override def rowType0(): Convention.RowType = Convention.RowType.None
   override protected def doExecute(): RDD[InternalRow] =
     throw new UnsupportedOperationException()
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child.executeColumnar()

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
@@ -16,7 +16,8 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.extension.columnar.transition.Convention
 
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
@@ -35,6 +36,10 @@ case class ColumnarCoalesceExec(numPartitions: Int, child: SparkPlan)
   override def outputPartitioning: Partitioning = {
     if (numPartitions == 1) SinglePartition else UnknownPartitioning(numPartitions)
   }
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override protected def doExecute(): RDD[InternalRow] = {
     throw new UnsupportedOperationException()

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarCoalesceExec.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class ColumnarCoalesceExec(numPartitions: Int, child: SparkPlan)
   extends UnaryExecNode
-  with GlutenPlan {
+  with ValidatablePlan {
 
   override def output: Seq[Attribute] = child.output
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarToRowExecBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarToRowExecBase.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 
 abstract class ColumnarToRowExecBase(child: SparkPlan)
   extends ColumnarToRowTransition
-  with GlutenPlan
   with KnownChildConvention
   with ValidatablePlan {
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarToRowExecBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarToRowExecBase.scala
@@ -17,9 +17,8 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
-import org.apache.gluten.extension.columnar.transition.ConventionReq.KnownChildrenConventions
+import org.apache.gluten.extension.columnar.transition.ConventionReq.KnownChildConvention
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
@@ -31,7 +30,8 @@ import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 abstract class ColumnarToRowExecBase(child: SparkPlan)
   extends ColumnarToRowTransition
   with GlutenPlan
-  with KnownChildrenConventions {
+  with KnownChildConvention
+  with ValidatablePlan {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
@@ -58,7 +58,7 @@ abstract class ColumnarToRowExecBase(child: SparkPlan)
     doExecuteInternal()
   }
 
-  override def requiredChildrenConventions(): Seq[ConventionReq] = {
+  override def requiredChildConvention(): Seq[ConventionReq] = {
     List(
       ConventionReq.ofBatch(
         ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarToRowExecBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarToRowExecBase.scala
@@ -46,6 +46,12 @@ abstract class ColumnarToRowExecBase(child: SparkPlan)
 
   override def rowType0(): Convention.RowType = Convention.RowType.VanillaRow
 
+  override def requiredChildConvention(): Seq[ConventionReq] = {
+    List(
+      ConventionReq.ofBatch(
+        ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))
+  }
+
   override def doExecuteBroadcast[T](): Broadcast[T] = {
     // Require for explicit implementation, otherwise throw error.
     super.doExecuteBroadcast[T]()
@@ -55,11 +61,5 @@ abstract class ColumnarToRowExecBase(child: SparkPlan)
 
   override def doExecute(): RDD[InternalRow] = {
     doExecuteInternal()
-  }
-
-  override def requiredChildConvention(): Seq[ConventionReq] = {
-    List(
-      ConventionReq.ofBatch(
-        ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/RowToColumnarExecBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/RowToColumnarExecBase.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.columnar.transition.Convention
+import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 
 import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
@@ -48,6 +48,10 @@ abstract class RowToColumnarExecBase(child: SparkPlan)
   override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
 
   override def rowType0(): Convention.RowType = Convention.RowType.None
+
+  override def requiredChildConvention(): Seq[ConventionReq] = {
+    Seq(ConventionReq.row)
+  }
 
   final override def doExecute(): RDD[InternalRow] = {
     child.execute()

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/RowToColumnarExecBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/RowToColumnarExecBase.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.extension.columnar.transition.Convention
 
 import org.apache.spark.broadcast
@@ -45,6 +44,8 @@ abstract class RowToColumnarExecBase(child: SparkPlan)
   final override def outputPartitioning: Partitioning = child.outputPartitioning
 
   final override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
 
   override def rowType0(): Convention.RowType = Convention.RowType.None
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -41,7 +41,6 @@ case class TakeOrderedAndProjectExecTransformer(
     child: SparkPlan,
     offset: Int = 0)
   extends UnaryExecNode
-  with GlutenPlan
   with ValidatablePlan {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -17,7 +17,8 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
+import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.columnar.transition.Convention
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -40,9 +41,12 @@ case class TakeOrderedAndProjectExecTransformer(
     child: SparkPlan,
     offset: Int = 0)
   extends UnaryExecNode
-  with GlutenPlan {
+  with GlutenPlan
+  with ValidatablePlan {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override def output: Seq[Attribute] = {
     projectList.map(_.toAttribute)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -57,7 +57,7 @@ case class TransformContext(outputAttributes: Seq[Attribute], root: RelNode)
 case class WholeStageTransformContext(root: PlanNode, substraitContext: SubstraitContext = null)
 
 /**
- * Base interface indicating the Gluten query plan is open to validation calls.
+ * Base interface for a Gluten query plan that is also open to validation calls.
  *
  * Since https://github.com/apache/incubator-gluten/pull/2185.
  */

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -57,11 +57,11 @@ case class TransformContext(outputAttributes: Seq[Attribute], root: RelNode)
 case class WholeStageTransformContext(root: PlanNode, substraitContext: SubstraitContext = null)
 
 /**
- * Base interface indicating the query plan is open to validation calls.
+ * Base interface indicating the Gluten query plan is open to validation calls.
  *
  * Since https://github.com/apache/incubator-gluten/pull/2185.
  */
-trait ValidatablePlan extends SparkPlan with LogLevelUtil {
+trait ValidatablePlan extends GlutenPlan with LogLevelUtil {
   protected def glutenConf: GlutenConfig = GlutenConfig.getConf
 
   protected lazy val enableNativeValidation = glutenConf.enableNativeValidation
@@ -116,7 +116,7 @@ trait ValidatablePlan extends SparkPlan with LogLevelUtil {
 }
 
 /** Base interface for a query plan that can be interpreted to Substrait representation. */
-trait TransformSupport extends GlutenPlan with ValidatablePlan {
+trait TransformSupport extends ValidatablePlan {
   override def batchType(): Convention.BatchType = {
     BackendsApiManager.getSettings.primaryBatchType
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/GlutenPlan.scala
@@ -16,25 +16,12 @@
  */
 package org.apache.gluten.extension
 
-import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.exception.GlutenNotSupportException
-import org.apache.gluten.expression.TransformerState
 import org.apache.gluten.extension.columnar.FallbackTag
 import org.apache.gluten.extension.columnar.FallbackTag.{Appendable, Converter}
 import org.apache.gluten.extension.columnar.FallbackTags.add
-import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.extension.columnar.validator.Validator
-import org.apache.gluten.logging.LogLevelUtil
-import org.apache.gluten.substrait.SubstraitContext
-import org.apache.gluten.substrait.plan.PlanBuilder
-import org.apache.gluten.substrait.rel.RelNode
-import org.apache.gluten.test.TestStats
 
 import org.apache.spark.sql.catalyst.trees.TreeNode
-import org.apache.spark.sql.execution.SparkPlan
-
-import com.google.common.collect.Lists
 
 sealed trait ValidationResult {
   def ok(): Boolean
@@ -77,91 +64,6 @@ object ValidationResult {
         return Validator.Passed
       }
       Validator.Failed(result.reason())
-    }
-  }
-}
-
-/** Every Gluten Operator should extend this trait. */
-trait GlutenPlan
-  extends SparkPlan
-  with Convention.KnownBatchType
-  with Convention.KnownRowTypeForSpark33AndLater
-  with LogLevelUtil {
-  protected lazy val enableNativeValidation = glutenConf.enableNativeValidation
-
-  protected def glutenConf: GlutenConfig = GlutenConfig.getConf
-
-  /**
-   * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
-   */
-  final def doValidate(): ValidationResult = {
-    val schemaValidationResult = BackendsApiManager.getValidatorApiInstance
-      .doSchemaValidate(schema)
-      .map {
-        reason =>
-          ValidationResult.failed(s"Found schema check failure for $schema, due to: $reason")
-      }
-      .getOrElse(ValidationResult.succeeded)
-    if (!schemaValidationResult.ok()) {
-      TestStats.addFallBackClassName(this.getClass.toString)
-      return schemaValidationResult
-    }
-    try {
-      TransformerState.enterValidation
-      val res = doValidateInternal()
-      if (!res.ok()) {
-        TestStats.addFallBackClassName(this.getClass.toString)
-      }
-      res
-    } catch {
-      case e @ (_: GlutenNotSupportException | _: UnsupportedOperationException) =>
-        if (!e.isInstanceOf[GlutenNotSupportException]) {
-          logDebug(s"Just a warning. This exception perhaps needs to be fixed.", e)
-        }
-        // FIXME: Use a validation-specific method to catch validation failures
-        TestStats.addFallBackClassName(this.getClass.toString)
-        logValidationMessage(
-          s"Validation failed with exception for plan: $nodeName, due to: ${e.getMessage}",
-          e)
-        ValidationResult.failed(e.getMessage)
-    } finally {
-      TransformerState.finishValidation
-    }
-  }
-
-  final override val supportsColumnar: Boolean = {
-    batchType() != Convention.BatchType.None
-  }
-
-  override def batchType(): Convention.BatchType = {
-    BackendsApiManager.getSettings.primaryBatchType
-  }
-
-  final override val supportsRowBased: Boolean = {
-    rowType() != Convention.RowType.None
-  }
-
-  override def rowType0(): Convention.RowType = {
-    Convention.RowType.None
-  }
-
-  protected def doValidateInternal(): ValidationResult = ValidationResult.succeeded
-
-  protected def doNativeValidation(context: SubstraitContext, node: RelNode): ValidationResult = {
-    if (node != null && glutenConf.enableNativeValidation) {
-      val planNode = PlanBuilder.makePlan(context, Lists.newArrayList(node))
-      BackendsApiManager.getValidatorApiInstance
-        .doNativeValidateWithFailureReason(planNode)
-    } else {
-      ValidationResult.succeeded
-    }
-  }
-
-  private def logValidationMessage(msg: => String, e: Throwable): Unit = {
-    if (glutenConf.printStackOnValidationFailure) {
-      logOnLevel(glutenConf.validationLogLevel, msg, e)
-    } else {
-      logOnLevel(glutenConf.validationLogLevel, msg)
     }
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.enumerated
 
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.{GlutenPlan, ValidatablePlan}
 import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.extension.columnar.rewrite.RewriteSingleNode
 import org.apache.gluten.extension.columnar.validator.Validator
@@ -119,7 +119,9 @@ object RasOffload {
             validator.validate(from) match {
               case Validator.Passed =>
                 val offloadedPlan = base.offload(from)
-                val offloadedNodes = offloadedPlan.collect[GlutenPlan] { case t: GlutenPlan => t }
+                val offloadedNodes = offloadedPlan.collect[ValidatablePlan] {
+                  case t: ValidatablePlan => t
+                }
                 val outComes = offloadedNodes.map(_.doValidate()).filter(!_.ok())
                 if (outComes.nonEmpty) {
                   // 5. If native validation fails on at least one of the offloaded nodes, return

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RemoveSort.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RemoveSort.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.enumerated
 
-import org.apache.gluten.execution.{HashAggregateExecBaseTransformer, ShuffledHashJoinExecTransformerBase, SortExecTransformer}
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.{GlutenPlan, HashAggregateExecBaseTransformer, ShuffledHashJoinExecTransformerBase, SortExecTransformer}
 import org.apache.gluten.ras.path.Pattern._
 import org.apache.gluten.ras.path.Pattern.Matchers._
 import org.apache.gluten.ras.rule.{RasRule, Shape}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/heuristic/ExpandFallbackPolicy.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/heuristic/ExpandFallbackPolicy.scala
@@ -17,12 +17,11 @@
 package org.apache.gluten.extension.columnar.heuristic
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.{FallbackTag, FallbackTags}
 import org.apache.gluten.extension.columnar.FallbackTags.add
 import org.apache.gluten.extension.columnar.transition.{BackendTransitions, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
-
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.execution._
@@ -30,6 +29,7 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStag
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.exchange.Exchange
+
 
 
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution._
-import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.logging.LogLevelUtil
 import org.apache.gluten.sql.shims.SparkShimLoader
@@ -330,8 +329,7 @@ object OffloadOthers {
             child)
         case p if !p.isInstanceOf[GlutenPlan] =>
           logDebug(s"Transformation for ${p.getClass} is currently not supported.")
-          val children = plan.children
-          p.withNewChildren(children)
+          p
         case other => other
       }
     }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -268,7 +268,8 @@ object Validators {
         val transformer = HashAggregateExecBaseTransformer.from(plan)
         transformer.doValidate().toValidatorOutcome()
       case plan: UnionExec =>
-        pass()
+        val transformer = ColumnarUnionExec(plan.children)
+        transformer.doValidate().toValidatorOutcome()
       case plan: ExpandExec =>
         val transformer = ExpandExecTransformer(plan.projections, plan.output, plan.child)
         transformer.doValidate().toValidatorOutcome()
@@ -301,7 +302,8 @@ object Validators {
             plan.isSkewJoin)
         transformer.doValidate().toValidatorOutcome()
       case plan: BroadcastExchangeExec =>
-        pass()
+        val transformer = ColumnarBroadcastExchangeExec(plan.mode, plan.child)
+        transformer.doValidate().toValidatorOutcome()
       case bhj: BroadcastHashJoinExec =>
         val transformer = BackendsApiManager.getSparkPlanExecApiInstance
           .genBroadcastHashJoinExecTransformer(
@@ -359,7 +361,9 @@ object Validators {
         )
         transformer.doValidate().toValidatorOutcome()
       case plan: CoalesceExec =>
-        pass()
+        ColumnarCoalesceExec(plan.numPartitions, plan.child)
+          .doValidate()
+          .toValidatorOutcome()
       case plan: GlobalLimitExec =>
         val (limit, offset) =
           SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.extension.columnar.validator
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.{BackendsApiManager, BackendSettingsApi}
 import org.apache.gluten.exception.GlutenNotSupportException
-import org.apache.gluten.execution.{BasicScanExecTransformer, ColumnarCoalesceExec, ColumnarUnionExec, ExpandExecTransformer, HashAggregateExecBaseTransformer, LimitExecTransformer, ProjectExecTransformer, ScanTransformerFactory, SortExecTransformer, TakeOrderedAndProjectExecTransformer, WindowExecTransformer, WindowGroupLimitExecTransformer, WriteFilesExecTransformer}
+import org.apache.gluten.execution._
 import org.apache.gluten.expression.ExpressionUtils
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.extension.columnar.offload.OffloadJoin
@@ -268,8 +268,7 @@ object Validators {
         val transformer = HashAggregateExecBaseTransformer.from(plan)
         transformer.doValidate().toValidatorOutcome()
       case plan: UnionExec =>
-        val transformer = ColumnarUnionExec(plan.children)
-        transformer.doValidate().toValidatorOutcome()
+        pass()
       case plan: ExpandExec =>
         val transformer = ExpandExecTransformer(plan.projections, plan.output, plan.child)
         transformer.doValidate().toValidatorOutcome()
@@ -302,8 +301,7 @@ object Validators {
             plan.isSkewJoin)
         transformer.doValidate().toValidatorOutcome()
       case plan: BroadcastExchangeExec =>
-        val transformer = ColumnarBroadcastExchangeExec(plan.mode, plan.child)
-        transformer.doValidate().toValidatorOutcome()
+        pass()
       case bhj: BroadcastHashJoinExec =>
         val transformer = BackendsApiManager.getSparkPlanExecApiInstance
           .genBroadcastHashJoinExecTransformer(
@@ -361,9 +359,7 @@ object Validators {
         )
         transformer.doValidate().toValidatorOutcome()
       case plan: CoalesceExec =>
-        ColumnarCoalesceExec(plan.numPartitions, plan.child)
-          .doValidate()
-          .toValidatorOutcome()
+        pass()
       case plan: GlobalLimitExec =>
         val (limit, offset) =
           SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.execution.{GlutenPlan, ValidatablePlan}
 import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.sql.shims.SparkShimLoader
@@ -42,7 +42,7 @@ import scala.util.control.NonFatal
 
 case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
   extends BroadcastExchangeLike
-  with GlutenPlan {
+  with ValidatablePlan {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] =

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.sql.shims.SparkShimLoader
 
@@ -124,6 +125,10 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
   override def output: Seq[Attribute] = child.output
 
   override def outputPartitioning: Partitioning = BroadcastPartitioning(mode)
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override def doCanonicalize(): SparkPlan = {
     val canonicalized =

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.execution.{GlutenPlan, ValidatablePlan}
+import org.apache.gluten.execution.ValidatablePlan
 import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.sql.shims.SparkShimLoader

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.execution._
-import org.apache.gluten.extension.columnar.transition.Convention
+import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 import org.apache.gluten.metrics.MetricsUpdater
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.rel.RelBuilder
@@ -173,14 +173,22 @@ case class ColumnarCollapseTransformStages(
   }
 }
 
+// TODO: Make this inherit from GlutenPlan.
 case class ColumnarInputAdapter(child: SparkPlan)
   extends InputAdapterGenerateTreeStringShim
   with Convention.KnownBatchType
-  with Convention.KnownRowTypeForSpark33AndLater {
+  with Convention.KnownRowTypeForSpark33AndLater
+  with GlutenPlan.SupportsRowBasedCompatible
+  with ConventionReq.KnownChildConvention {
   override def output: Seq[Attribute] = child.output
+  final override val supportsColumnar: Boolean = true
+  final override val supportsRowBased: Boolean = false
   override def rowType0(): Convention.RowType = Convention.RowType.None
   override def batchType(): Convention.BatchType =
     BackendsApiManager.getSettings.primaryBatchType
+  override def requiredChildConvention(): Seq[ConventionReq] = Seq(
+    ConventionReq.ofBatch(
+      ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child.executeColumnar()
   override def outputPartitioning: Partitioning = child.outputPartitioning

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -175,7 +175,8 @@ case class ColumnarCollapseTransformStages(
 
 case class ColumnarInputAdapter(child: SparkPlan)
   extends InputAdapterGenerateTreeStringShim
-  with GlutenPlan {
+  with Convention.KnownBatchType
+  with Convention.KnownRowTypeForSpark33AndLater {
   override def output: Seq[Attribute] = child.output
   override def rowType0(): Convention.RowType = Convention.RowType.None
   override def batchType(): Convention.BatchType =

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -175,9 +175,9 @@ case class ColumnarCollapseTransformStages(
 
 case class ColumnarInputAdapter(child: SparkPlan)
   extends InputAdapterGenerateTreeStringShim
-  with Convention.KnownBatchType {
+  with GlutenPlan {
   override def output: Seq[Attribute] = child.output
-  override val supportsColumnar: Boolean = true
+  override def rowType0(): Convention.RowType = Convention.RowType.None
   override def batchType(): Convention.BatchType =
     BackendsApiManager.getSettings.primaryBatchType
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.execution.{GlutenPlan, ValidatablePlan}
+import org.apache.gluten.execution.ValidatablePlan
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.sql.shims.SparkShimLoader

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -18,7 +18,9 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.{GlutenPlan, ValidationResult}
+import org.apache.gluten.execution.{GlutenPlan, ValidatablePlan}
+import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark._
@@ -45,7 +47,8 @@ case class ColumnarShuffleExchangeExec(
     projectOutputAttributes: Seq[Attribute],
     advisoryPartitionSize: Option[Long] = None)
   extends ShuffleExchangeLike
-  with GlutenPlan {
+  with GlutenPlan
+  with ValidatablePlan {
   private[sql] lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
 
@@ -147,6 +150,10 @@ case class ColumnarShuffleExchangeExec(
     }
     super.stringArgs ++ Iterator(s"[shuffle_writer_type=$shuffleWriterType]")
   }
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override def doExecute(): RDD[InternalRow] = {
     throw new UnsupportedOperationException()

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -47,7 +47,6 @@ case class ColumnarShuffleExchangeExec(
     projectOutputAttributes: Seq[Attribute],
     advisoryPartitionSize: Option[Long] = None)
   extends ShuffleExchangeLike
-  with GlutenPlan
   with ValidatablePlan {
   private[sql] lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarSubqueryBroadcastExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarSubqueryBroadcastExec.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.GlutenTimeMetric
 
 import org.apache.spark.rdd.RDD
@@ -106,6 +107,10 @@ case class ColumnarSubqueryBroadcastExec(
   override protected def doPrepare(): Unit = {
     relationFuture
   }
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+
+  override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override protected def doExecute(): RDD[InternalRow] = {
     throw new UnsupportedOperationException(

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 import org.apache.gluten.extension.columnar.transition.Convention.RowType
-import org.apache.gluten.extension.columnar.transition.ConventionReq
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.TaskContext
@@ -44,14 +44,13 @@ abstract class ColumnarWriteFilesExec protected (
     override val right: SparkPlan)
   extends BinaryExecNode
   with GlutenPlan
-  with ConventionReq.KnownChildrenConventions
   with ColumnarWriteFilesExec.ExecuteWriteCompatible {
 
   val child: SparkPlan = left
 
   override lazy val references: AttributeSet = AttributeSet.empty
 
-  override def requiredChildrenConventions(): Seq[ConventionReq] = {
+  override def requiredChildConvention(): Seq[ConventionReq] = {
     List(
       ConventionReq.ofBatch(
         ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))
@@ -67,6 +66,7 @@ abstract class ColumnarWriteFilesExec protected (
    *
    * Since https://github.com/apache/incubator-gluten/pull/6745.
    */
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
   override def rowType0(): RowType = {
     RowType.VanillaRow
   }

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
@@ -51,9 +51,12 @@ abstract class ColumnarWriteFilesExec protected (
   override lazy val references: AttributeSet = AttributeSet.empty
 
   override def requiredChildConvention(): Seq[ConventionReq] = {
-    List(
-      ConventionReq.ofBatch(
-        ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))
+    val req = ConventionReq.ofBatch(
+      ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType))
+    Seq.tabulate(2)(
+      _ => {
+        req
+      })
   }
 
   /**

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.gluten.execution.WholeStageTransformer
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.{GlutenPlan, WholeStageTransformer}
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PlanUtil

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.events.GlutenPlanFallbackEvent
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.logging.LogLevelUtil
 

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -16,16 +16,14 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.gluten.execution.WholeStageTransformer
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.{GlutenPlan, WholeStageTransformer}
 import org.apache.gluten.utils.PlanUtil
-
 import org.apache.spark.sql.{AnalysisException, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.execution.ColumnarWriteFilesExec.NoopLeaf
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, QueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, AdaptiveSparkPlanExec, QueryStageExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenWriterColumnarRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenWriterColumnarRules.scala
@@ -17,9 +17,8 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.execution.ColumnarToRowExecBase
+import org.apache.gluten.execution.{ColumnarToRowExecBase, GlutenPlan}
 import org.apache.gluten.execution.datasource.GlutenFormatFactory
-import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.extension.columnar.transition.{Convention, Transitions}
 
 import org.apache.spark.rdd.RDD
@@ -60,6 +59,8 @@ case class FakeRowAdaptor(child: SparkPlan)
   }
 
   override def output: Seq[Attribute] = child.output
+
+  override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
 
   override def rowType0(): Convention.RowType = Convention.RowType.VanillaRow
 

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
@@ -17,8 +17,7 @@
 package org.apache.gluten.extension.columnar.transition
 
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.execution.ColumnarToColumnarExec
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.{ColumnarToColumnarExec, GlutenPlan}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -117,6 +116,7 @@ object TransitionSuite extends TransitionSuiteBase {
     extends RowToColumnarTransition
     with GlutenPlan {
     override def batchType(): Convention.BatchType = toBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
       copy(child = newChild)
     override protected def doExecute(): RDD[InternalRow] =

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuiteBase.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuiteBase.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.transition
 
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -27,6 +27,7 @@ trait TransitionSuiteBase {
   case class BatchLeaf(override val batchType: Convention.BatchType)
     extends LeafExecNode
     with GlutenPlan {
+    override def rowType0(): Convention.RowType = Convention.RowType.None
 
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
 
@@ -36,6 +37,7 @@ trait TransitionSuiteBase {
   case class BatchUnary(override val batchType: Convention.BatchType, override val child: SparkPlan)
     extends UnaryExecNode
     with GlutenPlan {
+    override def rowType0(): Convention.RowType = Convention.RowType.None
 
     override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
       copy(child = newChild)
@@ -51,6 +53,7 @@ trait TransitionSuiteBase {
       override val right: SparkPlan)
     extends BinaryExecNode
     with GlutenPlan {
+    override def rowType0(): Convention.RowType = Convention.RowType.None
 
     override protected def withNewChildrenInternal(
         newLeft: SparkPlan,

--- a/gluten-substrait/src/test/scala/org/apache/gluten/test/FallbackUtil.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/test/FallbackUtil.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.test
 
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution._

--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
@@ -21,8 +21,8 @@ package org.apache.spark.sql
  *   1. We need to modify the way org.apache.spark.sql.CHQueryTest#compare compares double
  */
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.execution.TransformSupport
-import org.apache.gluten.extension.GlutenPlan
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.SPARK_VERSION_SHORT

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.execution.BasicScanExecTransformer
-import org.apache.gluten.extension.{GlutenPlan, GlutenSessionExtensions}
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.execution.{BasicScanExecTransformer, GlutenPlan}
+import org.apache.gluten.extension.GlutenSessionExtensions
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
 import org.apache.gluten.extension.columnar.MiscColumnarRules.RemoveTopmostColumnarToRow
 import org.apache.gluten.extension.columnar.RemoveFallbackTagRule
 import org.apache.gluten.extension.columnar.heuristic.{ExpandFallbackPolicy, HeuristicApplier}
-import org.apache.gluten.extension.columnar.transition.InsertBackendTransitions
+import org.apache.gluten.extension.columnar.transition.{Convention, InsertBackendTransitions}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{GlutenSQLTestsTrait, SparkSession}
@@ -200,6 +201,8 @@ private object FallbackStrategiesSuite {
 
 // For replacing LeafOp.
   case class LeafOpTransformer() extends LeafExecNode with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = Seq.empty
   }
@@ -208,6 +211,8 @@ private object FallbackStrategiesSuite {
   case class UnaryOp1Transformer(override val child: SparkPlan)
     extends UnaryExecNode
     with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = child.output
     override protected def withNewChildInternal(newChild: SparkPlan): UnaryOp1Transformer =

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.statistics
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.utils.{BackendTestUtils, SystemParameters}
 
 import org.apache.spark.sql.{GlutenTestConstants, QueryTest, SparkSession}

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.execution.BasicScanExecTransformer
-import org.apache.gluten.extension.{GlutenPlan, GlutenSessionExtensions}
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.execution.{BasicScanExecTransformer, GlutenPlan}
+import org.apache.gluten.extension.GlutenSessionExtensions
 import org.apache.gluten.extension.columnar.{FallbackTags, RemoveFallbackTagRule}
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
 import org.apache.gluten.extension.columnar.MiscColumnarRules.RemoveTopmostColumnarToRow
 import org.apache.gluten.extension.columnar.heuristic.{ExpandFallbackPolicy, HeuristicApplier}
-import org.apache.gluten.extension.columnar.transition.InsertBackendTransitions
+import org.apache.gluten.extension.columnar.transition.{Convention, InsertBackendTransitions}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{GlutenSQLTestsTrait, SparkSession}
@@ -229,6 +230,8 @@ private object FallbackStrategiesSuite {
 
   // For replacing LeafOp.
   case class LeafOpTransformer() extends LeafExecNode with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = Seq.empty
   }
@@ -237,6 +240,8 @@ private object FallbackStrategiesSuite {
   case class UnaryOp1Transformer(override val child: SparkPlan)
     extends UnaryExecNode
     with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = child.output
     override protected def withNewChildInternal(newChild: SparkPlan): UnaryOp1Transformer =

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.statistics
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.utils.{BackendTestUtils, SystemParameters}
 
 import org.apache.spark.sql.{GlutenTestConstants, QueryTest, SparkSession}

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.execution.BasicScanExecTransformer
-import org.apache.gluten.extension.{GlutenPlan, GlutenSessionExtensions}
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.execution.{BasicScanExecTransformer, GlutenPlan}
+import org.apache.gluten.extension.GlutenSessionExtensions
 import org.apache.gluten.extension.columnar.{FallbackTags, RemoveFallbackTagRule}
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
 import org.apache.gluten.extension.columnar.MiscColumnarRules.RemoveTopmostColumnarToRow
 import org.apache.gluten.extension.columnar.heuristic.{ExpandFallbackPolicy, HeuristicApplier}
-import org.apache.gluten.extension.columnar.transition.InsertBackendTransitions
+import org.apache.gluten.extension.columnar.transition.{Convention, InsertBackendTransitions}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{GlutenSQLTestsTrait, SparkSession}
@@ -229,6 +230,8 @@ private object FallbackStrategiesSuite {
 
   // For replacing LeafOp.
   case class LeafOpTransformer() extends LeafExecNode with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = Seq.empty
   }
@@ -237,6 +240,8 @@ private object FallbackStrategiesSuite {
   case class UnaryOp1Transformer(override val child: SparkPlan)
     extends UnaryExecNode
     with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = child.output
     override protected def withNewChildInternal(newChild: SparkPlan): UnaryOp1Transformer =

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.sources
 
 import org.apache.gluten.execution.{ProjectExecTransformer, SortExecTransformer}
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.OutputMetrics

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.statistics
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.utils.{BackendTestUtils, SystemParameters}
 
 import org.apache.spark.sql.{GlutenTestConstants, QueryTest, SparkSession}

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.execution.BasicScanExecTransformer
-import org.apache.gluten.extension.{GlutenPlan, GlutenSessionExtensions}
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.execution.{BasicScanExecTransformer, GlutenPlan}
+import org.apache.gluten.extension.GlutenSessionExtensions
 import org.apache.gluten.extension.columnar.{FallbackTags, RemoveFallbackTagRule}
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
 import org.apache.gluten.extension.columnar.MiscColumnarRules.RemoveTopmostColumnarToRow
 import org.apache.gluten.extension.columnar.heuristic.{ExpandFallbackPolicy, HeuristicApplier}
-import org.apache.gluten.extension.columnar.transition.InsertBackendTransitions
+import org.apache.gluten.extension.columnar.transition.{Convention, InsertBackendTransitions}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{GlutenSQLTestsTrait, SparkSession}
@@ -230,6 +231,8 @@ private object FallbackStrategiesSuite {
 
 // For replacing LeafOp.
   case class LeafOpTransformer() extends LeafExecNode with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = Seq.empty
   }
@@ -238,6 +241,8 @@ private object FallbackStrategiesSuite {
   case class UnaryOp1Transformer(override val child: SparkPlan)
     extends UnaryExecNode
     with GlutenPlan {
+    override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
+    override def rowType0(): Convention.RowType = Convention.RowType.None
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = child.output
     override protected def withNewChildInternal(newChild: SparkPlan): UnaryOp1Transformer =

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.sources
 
 import org.apache.gluten.GlutenColumnarWriteTestSupport
 import org.apache.gluten.execution.SortExecTransformer
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.OutputMetrics

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -17,8 +17,8 @@
 package org.apache.spark.sql.sources
 
 import org.apache.gluten.GlutenColumnarWriteTestSupport
-import org.apache.gluten.execution.SortExecTransformer
 import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.execution.SortExecTransformer
 
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.OutputMetrics

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/statistics/SparkFunctionStatistics.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.statistics
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.utils.{BackendTestUtils, SystemParameters}
 
 import org.apache.spark.sql.{GlutenTestConstants, QueryTest, SparkSession}

--- a/gluten-ut/test/src/test/scala/org/apache/spark/sql/GlutenExpressionDataTypesValidation.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/spark/sql/GlutenExpressionDataTypesValidation.scala
@@ -17,8 +17,7 @@
 package org.apache.spark.sql
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.execution.{ProjectExecTransformer, WholeStageTransformerSuite}
-import org.apache.gluten.extension.GlutenPlan
+import org.apache.gluten.execution.{ProjectExecTransformer, TransformSupport, WholeStageTransformerSuite}
 import org.apache.gluten.utils.{BackendTestUtils, SystemParameters}
 
 import org.apache.spark.SparkConf
@@ -100,7 +99,8 @@ class GlutenExpressionDataTypesValidation extends WholeStageTransformerSuite {
       case _ => throw new UnsupportedOperationException("Not supported type: " + t)
     }
   }
-  def generateGlutenProjectPlan(expr: Expression): GlutenPlan = {
+
+  def generateGlutenProjectPlan(expr: Expression): TransformSupport = {
     val namedExpr = Seq(Alias(expr, "r")())
     ProjectExecTransformer(namedExpr, DummyPlan())
   }


### PR DESCRIPTION
Part of #6920

This work factors out `GlutenPlan` to separate the APIs to 2 places:

1. For APIs related to native validation, e.g., `doValidate`, move to new API `ValidatablePlan` and `TransformSupport`
2. Other convention-related APIs, move to gluten-core, and still be in `GlutenPlan`

After the change, `GlutenPlan` will become a thin and base interface for query plans of all Gluten backends. APIs in `GlutenPlan` will be used by query planner to decide whether pre-transition or post-transition is needed for this plan node. Backends could still define their own validation logic if needed, by extending the trait by themselves.

`GlutenPlan` will hide `supportsColumnar` and `supportsRowBased` (for Spark version > 3.2) up and expose Gluten APIs `rowType` and `batchType` to sub-classes instead. The latter two are more flexible since Gluten's query planner could distinguish between different batch types and add essential transitions among them and vanilla rows.