### PR TITLE
[MISC] Velox maintainers as triage member

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,9 @@ github:
     - spark-sql
     - vectorization
     - velox
+  collaborators:
+    - majetideepak
+    - pedroerp
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION


## What changes were proposed in this pull request?

This patch adds Velox maintainer Deepak and Pedro as triage member, so they could help to manage the issues related with Velox easier.


## How was this patch tested?

no tests required

