### PR TITLE
[GLUTEN-7631][VL] Fall back lead/lag if input is foldable

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -400,7 +400,9 @@ object VeloxBackendSettings extends BackendSettingsApi {
           }
           windowExpression.windowFunction match {
             case _: RowNumber | _: Rank | _: CumeDist | _: DenseRank | _: PercentRank |
-                _: NthValue | _: NTile | _: Lag | _: Lead =>
+                _: NthValue | _: NTile =>
+            case l: Lag if !l.input.foldable =>
+            case l: Lead if !l.input.foldable =>
             case aggrExpr: AggregateExpression
                 if !aggrExpr.aggregateFunction.isInstanceOf[ApproximatePercentile]
                   && !aggrExpr.aggregateFunction.isInstanceOf[Percentile] =>

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -318,9 +318,6 @@ class VeloxTestSettings extends BackendTestSettings {
   // spill not supported yet.
   enableSuite[GlutenSQLWindowFunctionSuite]
     .exclude("test with low buffer spill threshold")
-    // https://github.com/apache/incubator-gluten/issues/7631
-    .exclude(
-      "SPARK-16633: lead/lag should return the default value if the offset row does not exist")
   enableSuite[GlutenSortSuite]
     // Sort spill is not supported.
     .exclude("sorting does not crash for large inputs")

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -886,9 +886,6 @@ class VeloxTestSettings extends BackendTestSettings {
   // spill not supported yet.
   enableSuite[GlutenSQLWindowFunctionSuite]
     .exclude("test with low buffer spill threshold")
-    // https://github.com/apache/incubator-gluten/issues/7631
-    .exclude(
-      "SPARK-16633: lead/lag should return the default value if the offset row does not exist")
   enableSuite[GlutenTakeOrderedAndProjectSuite]
   enableSuite[GlutenSessionExtensionSuite]
   enableSuite[TestFileSourceScanExecTransformer]

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -886,9 +886,6 @@ class VeloxTestSettings extends BackendTestSettings {
   // spill not supported yet.enableSuite[GlutenSQLWindowFunctionSuite]
   enableSuite[GlutenSQLWindowFunctionSuite]
     .exclude("test with low buffer spill threshold")
-    // https://github.com/apache/incubator-gluten/issues/7631
-    .exclude(
-      "SPARK-16633: lead/lag should return the default value if the offset row does not exist")
   enableSuite[GlutenTakeOrderedAndProjectSuite]
   enableSuite[GlutenSessionExtensionSuite]
   enableSuite[TestFileSourceScanExecTransformer]

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -900,9 +900,6 @@ class VeloxTestSettings extends BackendTestSettings {
   // spill not supported yet.
   enableSuite[GlutenSQLWindowFunctionSuite]
     .exclude("test with low buffer spill threshold")
-    // https://github.com/apache/incubator-gluten/issues/7631
-    .exclude(
-      "SPARK-16633: lead/lag should return the default value if the offset row does not exist")
   enableSuite[GlutenTakeOrderedAndProjectSuite]
   enableSuite[GlutenSessionExtensionSuite]
   enableSuite[TestFileSourceScanExecTransformer]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox does not support lead/lag when its input is foldable.

(Fixes: \#7631)

## How was this patch tested?

UT

