### PR TITLE
[GLUTEN-8061][VL] Fall back nth_value if input is foldable

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -399,8 +399,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
             case _ =>
           }
           windowExpression.windowFunction match {
-            case _: RowNumber | _: Rank | _: CumeDist | _: DenseRank | _: PercentRank |
-                _: NthValue | _: NTile =>
+            case _: RowNumber | _: Rank | _: CumeDist | _: DenseRank | _: PercentRank | _: NTile =>
+            case nv: NthValue if !nv.input.foldable =>
             case l: Lag if !l.input.foldable =>
             case l: Lead if !l.input.foldable =>
             case aggrExpr: AggregateExpression

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -512,6 +512,13 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
             checkGlutenOperatorMatch[WindowExecTransformer]
           }
         }
+
+        // Foldable input of nth_value is not supported.
+        runQueryAndCompare(
+          "select l_suppkey, l_orderkey, nth_value(1, 2) over" +
+            " (partition by l_suppkey order by l_orderkey) from lineitem ") {
+          checkSparkOperatorMatch[WindowExec]
+        }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox does not support nth_value when its input is foldable.

Although vanilla Spark supports foldable input of nth_value, there is almost no usage scenario in this case, and the values ​​obtained are all null, so simply fall back for it.

(Fixes: \#8061)

## How was this patch tested?

UT

