### PR TITLE
[GLUTEN-8060][CORE] GlutenShuffleManager as a registry of shuffle managers

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/GlutenShuffleManager.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/GlutenShuffleManager.scala
@@ -1,7 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.shuffle
 
-import org.apache.spark.annotation.Experimental
 import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.annotation.Experimental
 
 /**
  * Shuffle manager that routes shuffle API calls to different shuffle managers registered by

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/GlutenShuffleManager.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/GlutenShuffleManager.scala
@@ -1,5 +1,6 @@
 package org.apache.spark.shuffle
 
+import org.apache.spark.annotation.Experimental
 import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
 
 /**
@@ -9,6 +10,7 @@ import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
  * A SPIP may cause refactoring of this class in the future:
  * https://issues.apache.org/jira/browse/SPARK-45792
  */
+@Experimental
 class GlutenShuffleManager(conf: SparkConf, isDriver: Boolean) extends ShuffleManager {
   private val routerBuilder = ShuffleManagerRegistry.get().newRouterBuilder(conf, isDriver)
 

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/GlutenShuffleManager.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/GlutenShuffleManager.scala
@@ -1,0 +1,53 @@
+package org.apache.spark.shuffle
+
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+
+/**
+ * Shuffle manager that routes shuffle API calls to different shuffle managers registered by
+ * different backends.
+ *
+ * A SPIP may cause refactoring of this class in the future:
+ * https://issues.apache.org/jira/browse/SPARK-45792
+ */
+class GlutenShuffleManager(conf: SparkConf, isDriver: Boolean) extends ShuffleManager {
+  private val routerBuilder = ShuffleManagerRegistry.get().newRouterBuilder(conf, isDriver)
+
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    routerBuilder.getOrBuild().registerShuffle(shuffleId, dependency)
+  }
+
+  override def getWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+    routerBuilder.getOrBuild().getWriter(handle, mapId, context, metrics)
+  }
+
+  override def getReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    routerBuilder
+      .getOrBuild()
+      .getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics)
+  }
+
+  override def unregisterShuffle(shuffleId: Int): Boolean = {
+    routerBuilder.getOrBuild().unregisterShuffle(shuffleId)
+  }
+
+  override def shuffleBlockResolver: ShuffleBlockResolver = {
+    routerBuilder.getOrBuild().shuffleBlockResolver
+  }
+
+  override def stop(): Unit = {
+    routerBuilder.getOrBuild().stop()
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/LookupKey.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/LookupKey.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.shuffle
 
 import org.apache.spark.ShuffleDependency

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/LookupKey.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/LookupKey.scala
@@ -1,0 +1,7 @@
+package org.apache.spark.shuffle
+
+import org.apache.spark.ShuffleDependency
+
+trait LookupKey {
+  def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean
+}

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/LookupKey.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/LookupKey.scala
@@ -2,6 +2,10 @@ package org.apache.spark.shuffle
 
 import org.apache.spark.ShuffleDependency
 
+/**
+ * Required during shuffle manager registration to determine whether the shuffle manager should be
+ * used for the particular shuffle dependency.
+ */
 trait LookupKey {
   def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean
 }

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
@@ -2,7 +2,7 @@ package org.apache.spark.shuffle
 
 import org.apache.spark.ShuffleDependency
 
-class ShuffleManagerLookup(all: Seq[(LookupKey, ShuffleManager)]) {
+private class ShuffleManagerLookup(all: Seq[(LookupKey, ShuffleManager)]) {
   private val allReversed = all.reverse
 
   def findShuffleManager[K, V, C](dependency: ShuffleDependency[K, V, C]): ShuffleManager = {

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
@@ -1,0 +1,22 @@
+package org.apache.spark.shuffle
+
+import org.apache.spark.ShuffleDependency
+
+class ShuffleManagerLookup(all: Seq[(LookupKey, ShuffleManager)]) {
+  private val allReversed = all.reverse
+
+  def findShuffleManager[K, V, C](dependency: ShuffleDependency[K, V, C]): ShuffleManager = {
+    this.synchronized {
+      // The latest shuffle manager registered will be looked up earlier.
+      allReversed.find(_._1.accepts(dependency)).map(_._2).getOrElse {
+        throw new IllegalStateException(s"No ShuffleManager found for $dependency")
+      }
+    }
+  }
+
+  def all(): Seq[ShuffleManager] = {
+    this.synchronized {
+      all.map(_._2)
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.shuffle
 
 import org.apache.spark.ShuffleDependency

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
@@ -23,7 +23,7 @@ class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
     }
   }
 
-  def newRouterBuilder(conf: SparkConf, isDriver: Boolean): RouterBuilder = this.synchronized {
+  private[shuffle] def newRouterBuilder(conf: SparkConf, isDriver: Boolean): RouterBuilder = this.synchronized {
     val out = new RouterBuilder(this, conf, isDriver)
     routerBuilders += out
     out

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
@@ -1,0 +1,58 @@
+package org.apache.spark.shuffle
+
+import org.apache.spark.SparkConf
+import org.apache.spark.util.Utils
+
+import scala.collection.mutable
+
+class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
+  import ShuffleManagerRegistry._
+  private val all: mutable.Buffer[(LookupKey, String)] = mutable.Buffer()
+  private val routerBuilders: mutable.Buffer[RouterBuilder] = mutable.Buffer()
+
+  def register(lookupKey: LookupKey, shuffleManagerClass: String): Unit = {
+    val clazz = Utils.classForName(shuffleManagerClass)
+    assert(
+      classOf[ShuffleManager].isAssignableFrom(clazz),
+      s"Shuffle manager class to register is not an implementation of Spark ShuffleManager")
+    this.synchronized {
+      all += lookupKey -> shuffleManagerClass
+      // Invalidate all shuffle managers cached in each alive router builder instances.
+      // Then, once the router builder is accessed, a new router will be forced to create.
+      routerBuilders.foreach(_.invalidateCache())
+    }
+  }
+
+  def newRouterBuilder(conf: SparkConf, isDriver: Boolean): RouterBuilder = this.synchronized {
+    val out = new RouterBuilder(this, conf, isDriver)
+    routerBuilders += out
+    out
+  }
+}
+
+object ShuffleManagerRegistry {
+  private val instance = new ShuffleManagerRegistry()
+
+  def get(): ShuffleManagerRegistry = instance
+
+  class RouterBuilder(registry: ShuffleManagerRegistry, conf: SparkConf, isDriver: Boolean) {
+    private var router: Option[ShuffleManagerRouter] = None
+
+    private[ShuffleManagerRegistry] def invalidateCache(): Unit = synchronized {
+      router = None
+    }
+
+    private[shuffle] def getOrBuild(): ShuffleManagerRouter = synchronized {
+      if (router.isEmpty) {
+        val instances = registry.all.map(key => key._1 -> instantiate(key._2, conf, isDriver))
+        router = Some(new ShuffleManagerRouter(new ShuffleManagerLookup(instances)))
+      }
+      router.get
+    }
+
+    private def instantiate(clazz: String, conf: SparkConf, isDriver: Boolean): ShuffleManager = {
+      Utils
+        .instantiateSerializerOrShuffleManager[ShuffleManager](clazz, conf, isDriver)
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.shuffle
 
 import org.apache.spark.SparkConf
@@ -18,7 +34,8 @@ class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
       "It's not allowed to register GlutenShuffleManager recursively")
     require(
       classOf[ShuffleManager].isAssignableFrom(clazz),
-      s"Shuffle manager class to register is not an implementation of Spark ShuffleManager: $shuffleManagerClass"
+      s"Shuffle manager class to register is not an implementation of Spark ShuffleManager: " +
+        s"$shuffleManagerClass"
     )
     require(
       !classDeDup.contains(shuffleManagerClass),

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
@@ -68,7 +68,7 @@ private class ShuffleManagerRouter(lookup: ShuffleManagerLookup) extends Shuffle
   }
 }
 
-object ShuffleManagerRouter {
+private object ShuffleManagerRouter {
   private class Cache {
     private val cache: java.util.Map[Int, ShuffleManager] =
       new java.util.concurrent.ConcurrentHashMap()

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+import org.apache.spark.{ShuffleDependency, TaskContext}
+import org.apache.spark.network.buffer.ManagedBuffer
+import org.apache.spark.network.shuffle.MergedBlockMeta
+import org.apache.spark.storage.{BlockId, ShuffleBlockBatchId, ShuffleBlockId, ShuffleMergedBlockId}
+
+/**
+ * The internal shuffle manager instance used by GlutenShuffleManager.
+ */
+private class ShuffleManagerRouter(lookup: ShuffleManagerLookup) extends ShuffleManager {
+  import ShuffleManagerRouter._
+  private val cache = new Cache()
+  private val resolver = new BlockResolver(cache)
+
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    val manager = lookup.findShuffleManager(dependency)
+    cache.store(shuffleId, manager).registerShuffle(shuffleId, dependency)
+  }
+
+  override def getWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+    cache.get(handle.shuffleId).getWriter(handle, mapId, context, metrics)
+  }
+
+  override def getReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    cache
+      .get(handle.shuffleId)
+      .getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics)
+  }
+
+  override def unregisterShuffle(shuffleId: Int): Boolean = {
+    cache.remove(shuffleId).unregisterShuffle(shuffleId)
+  }
+
+  override def shuffleBlockResolver: ShuffleBlockResolver = resolver
+
+  override def stop(): Unit = {
+    assert(cache.size() == 0)
+    lookup.all().reverse.foreach(_.stop())
+  }
+}
+
+object ShuffleManagerRouter {
+  private class Cache {
+    private val cache: java.util.Map[Int, ShuffleManager] =
+      new java.util.concurrent.ConcurrentHashMap()
+
+    def store(shuffleId: Int, manager: ShuffleManager): ShuffleManager = {
+      cache.compute(
+        shuffleId,
+        (id, m) => {
+          assert(m == null, s"Shuffle manager was already cached for shuffle id: $id")
+          manager
+        })
+    }
+
+    def get(shuffleId: Int): ShuffleManager = {
+      val manager = cache.get(shuffleId)
+      assert(manager != null, s"Shuffle manager not registered for shuffle id: $shuffleId")
+      manager
+    }
+
+    def remove(shuffleId: Int): ShuffleManager = {
+      val manager = cache.remove(shuffleId)
+      assert(manager != null, s"Shuffle manager not registered for shuffle id: $shuffleId")
+      manager
+    }
+
+    def size(): Int = {
+      cache.size()
+    }
+
+    def clear(): Unit = {
+      cache.clear()
+    }
+  }
+
+  private class BlockResolver(cache: Cache) extends ShuffleBlockResolver {
+    override def getBlockData(blockId: BlockId, dirs: Option[Array[String]]): ManagedBuffer = {
+      val shuffleId = blockId match {
+        case id: ShuffleBlockId =>
+          id.shuffleId
+        case batchId: ShuffleBlockBatchId =>
+          batchId.shuffleId
+        case _ =>
+          throw new IllegalArgumentException(
+            "GlutenShuffleManager: Unsupported shuffle block id: " + blockId)
+      }
+      cache.get(shuffleId).shuffleBlockResolver.getBlockData(blockId, dirs)
+    }
+
+    override def getMergedBlockData(
+        blockId: ShuffleMergedBlockId,
+        dirs: Option[Array[String]]): Seq[ManagedBuffer] = {
+      val shuffleId = blockId.shuffleId
+      cache.get(shuffleId).shuffleBlockResolver.getMergedBlockData(blockId, dirs)
+    }
+
+    override def getMergedBlockMeta(
+        blockId: ShuffleMergedBlockId,
+        dirs: Option[Array[String]]): MergedBlockMeta = {
+      val shuffleId = blockId.shuffleId
+      cache.get(shuffleId).shuffleBlockResolver.getMergedBlockMeta(blockId, dirs)
+    }
+
+    override def stop(): Unit = {
+      throw new UnsupportedOperationException(
+        s"BlockResolver ${getClass.getSimpleName} doesn't need to be explicitly stopped")
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
@@ -20,9 +20,7 @@ import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.shuffle.MergedBlockMeta
 import org.apache.spark.storage.{BlockId, ShuffleBlockBatchId, ShuffleBlockId, ShuffleMergedBlockId}
 
-/**
- * The internal shuffle manager instance used by GlutenShuffleManager.
- */
+/** The internal shuffle manager instance used by GlutenShuffleManager. */
 private class ShuffleManagerRouter(lookup: ShuffleManagerLookup) extends ShuffleManager {
   import ShuffleManagerRouter._
   private val cache = new Cache()

--- a/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import org.apache.spark.{ConstantPartitioner, ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.internal.config.SHUFFLE_MANAGER
+import org.apache.spark.rdd.EmptyRDD
+import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.sql.test.SharedSparkSession
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable
+
+class GlutenShuffleManagerSuite extends SharedSparkSession {
+  import GlutenShuffleManagerSuite._
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(SHUFFLE_MANAGER.key, classOf[GlutenShuffleManager].getName)
+  }
+
+  override protected def afterEach(): Unit = {
+    val registry = ShuffleManagerRegistry.get()
+    registry.clear()
+    counter1.clear()
+    counter2.clear()
+  }
+
+  test("register one") {
+    val registry = ShuffleManagerRegistry.get()
+
+    registry.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+      },
+      classOf[ShuffleManager1].getName)
+
+    val gm = new GlutenShuffleManager(sparkConf, true)
+    assert(counter1.count("stop") == 0)
+    gm.stop()
+    assert(counter1.count("stop") == 1)
+    gm.stop()
+    gm.stop()
+    assert(counter1.count("stop") == 3)
+  }
+
+  test("register two") {
+    val registry = ShuffleManagerRegistry.get()
+
+    registry.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+      },
+      classOf[ShuffleManager1].getName)
+    registry.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+      },
+      classOf[ShuffleManager2].getName)
+
+    val gm = new GlutenShuffleManager(sparkConf, true)
+    assert(counter1.count("registerShuffle") == 0)
+    assert(counter2.count("registerShuffle") == 0)
+    // The statement calls #registerShuffle internally.
+    new ShuffleDependency(
+      new EmptyRDD[Product2[Any, Any]](spark.sparkContext),
+      new ConstantPartitioner())
+    assert(counter1.count("registerShuffle") == 0)
+    assert(counter2.count("registerShuffle") == 1)
+
+    assert(counter1.count("stop") == 0)
+    assert(counter2.count("stop") == 0)
+    gm.stop()
+    assert(counter1.count("stop") == 1)
+    assert(counter2.count("stop") == 1)
+  }
+
+  test("register two - with empty key") {
+    val registry = ShuffleManagerRegistry.get()
+
+    registry.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+      },
+      classOf[ShuffleManager1].getName)
+    registry.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = false
+      },
+      classOf[ShuffleManager2].getName)
+
+    val gm = new GlutenShuffleManager(sparkConf, true)
+    assert(counter1.count("registerShuffle") == 0)
+    assert(counter2.count("registerShuffle") == 0)
+    // The statement calls #registerShuffle internally.
+    new ShuffleDependency(
+      new EmptyRDD[Product2[Any, Any]](spark.sparkContext),
+      new ConstantPartitioner())
+    assert(counter1.count("registerShuffle") == 1)
+    assert(counter2.count("registerShuffle") == 0)
+  }
+
+  test("register recursively") {
+    val registry = ShuffleManagerRegistry.get()
+
+    assertThrows[IllegalArgumentException](
+      registry.register(
+        new LookupKey {
+          override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+        },
+        classOf[GlutenShuffleManager].getName))
+  }
+
+  test("register duplicated") {
+    val registry = ShuffleManagerRegistry.get()
+
+    registry.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+      },
+      classOf[ShuffleManager1].getName)
+    assertThrows[IllegalArgumentException](
+      registry.register(
+        new LookupKey {
+          override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+        },
+        classOf[ShuffleManager1].getName))
+  }
+}
+
+object GlutenShuffleManagerSuite {
+  private val counter1 = new InvocationCounter
+  private val counter2 = new InvocationCounter
+
+  class ShuffleManager1(conf: SparkConf) extends ShuffleManager {
+    private val delegate = new SortShuffleManager(conf)
+    private val counter = counter1
+    override def registerShuffle[K, V, C](
+        shuffleId: Int,
+        dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+      counter.increment("registerShuffle")
+      delegate.registerShuffle(shuffleId, dependency)
+    }
+
+    override def getWriter[K, V](
+        handle: ShuffleHandle,
+        mapId: Long,
+        context: TaskContext,
+        metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+      counter.increment("getWriter")
+      delegate.getWriter(handle, mapId, context, metrics)
+    }
+
+    override def getReader[K, C](
+        handle: ShuffleHandle,
+        startMapIndex: Int,
+        endMapIndex: Int,
+        startPartition: Int,
+        endPartition: Int,
+        context: TaskContext,
+        metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+      counter.increment("getReader")
+      delegate.getReader(
+        handle,
+        startMapIndex,
+        endMapIndex,
+        startPartition,
+        endPartition,
+        context,
+        metrics)
+    }
+
+    override def unregisterShuffle(shuffleId: Int): Boolean = {
+      counter.increment("unregisterShuffle")
+      delegate.unregisterShuffle(shuffleId)
+    }
+
+    override def shuffleBlockResolver: ShuffleBlockResolver = {
+      counter.increment("shuffleBlockResolver")
+      delegate.shuffleBlockResolver
+    }
+
+    override def stop(): Unit = {
+      counter.increment("stop")
+      delegate.stop()
+    }
+  }
+
+  class ShuffleManager2(conf: SparkConf, isDriver: Boolean) extends ShuffleManager {
+    private val delegate = new SortShuffleManager(conf)
+    private val counter = counter2
+    override def registerShuffle[K, V, C](
+        shuffleId: Int,
+        dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+      counter.increment("registerShuffle")
+      delegate.registerShuffle(shuffleId, dependency)
+    }
+
+    override def getWriter[K, V](
+        handle: ShuffleHandle,
+        mapId: Long,
+        context: TaskContext,
+        metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+      counter.increment("getWriter")
+      delegate.getWriter(handle, mapId, context, metrics)
+    }
+
+    override def getReader[K, C](
+        handle: ShuffleHandle,
+        startMapIndex: Int,
+        endMapIndex: Int,
+        startPartition: Int,
+        endPartition: Int,
+        context: TaskContext,
+        metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+      counter.increment("getReader")
+      delegate.getReader(
+        handle,
+        startMapIndex,
+        endMapIndex,
+        startPartition,
+        endPartition,
+        context,
+        metrics)
+    }
+
+    override def unregisterShuffle(shuffleId: Int): Boolean = {
+      counter.increment("unregisterShuffle")
+      delegate.unregisterShuffle(shuffleId)
+    }
+
+    override def shuffleBlockResolver: ShuffleBlockResolver = {
+      counter.increment("shuffleBlockResolver")
+      delegate.shuffleBlockResolver
+    }
+
+    override def stop(): Unit = {
+      counter.increment("stop")
+      delegate.stop()
+    }
+  }
+
+  private class InvocationCounter {
+    private val counter: mutable.Map[String, AtomicInteger] = mutable.Map()
+
+    def increment(name: String): Unit = synchronized {
+      counter.getOrElseUpdate(name, new AtomicInteger()).incrementAndGet()
+    }
+
+    def count(name: String): Int = {
+      counter.getOrElse(name, new AtomicInteger()).get()
+    }
+
+    def clear(): Unit = {
+      counter.clear()
+    }
+  }
+}

--- a/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.spark.{ConstantPartitioner, ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.{Partitioner, ShuffleDependency, SparkConf, TaskContext}
 import org.apache.spark.internal.config.SHUFFLE_MANAGER
 import org.apache.spark.rdd.EmptyRDD
 import org.apache.spark.shuffle.sort.SortShuffleManager
@@ -76,9 +76,7 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 0)
     // The statement calls #registerShuffle internally.
-    new ShuffleDependency(
-      new EmptyRDD[Product2[Any, Any]](spark.sparkContext),
-      new ConstantPartitioner())
+    new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 1)
 
@@ -107,9 +105,7 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 0)
     // The statement calls #registerShuffle internally.
-    new ShuffleDependency(
-      new EmptyRDD[Product2[Any, Any]](spark.sparkContext),
-      new ConstantPartitioner())
+    new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
     assert(counter1.count("registerShuffle") == 1)
     assert(counter2.count("registerShuffle") == 0)
   }
@@ -268,5 +264,10 @@ object GlutenShuffleManagerSuite {
     def clear(): Unit = {
       counter.clear()
     }
+  }
+
+  private object DummyPartitioner extends Partitioner {
+    override def numPartitions: Int = 0
+    override def getPartition(key: Any): Int = 0
   }
 }

--- a/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
@@ -49,7 +49,7 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
       },
       classOf[ShuffleManager1].getName)
 
-    val gm = new GlutenShuffleManager(sparkConf, true)
+    val gm = spark.sparkContext.env.shuffleManager
     assert(counter1.count("stop") == 0)
     gm.stop()
     assert(counter1.count("stop") == 1)
@@ -72,11 +72,13 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
       },
       classOf[ShuffleManager2].getName)
 
-    val gm = new GlutenShuffleManager(sparkConf, true)
+    val gm = spark.sparkContext.env.shuffleManager
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 0)
     // The statement calls #registerShuffle internally.
-    new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    val dep =
+      new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    gm.unregisterShuffle(dep.shuffleId)
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 1)
 
@@ -96,11 +98,12 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
       },
       classOf[ShuffleManager1].getName)
 
-    val gm = new GlutenShuffleManager(sparkConf, true)
+    val gm = spark.sparkContext.env.shuffleManager
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 0)
-    // The statement calls #registerShuffle internally.
-    new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    val dep1 =
+      new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    gm.unregisterShuffle(dep1.shuffleId)
     assert(counter1.count("registerShuffle") == 1)
     assert(counter2.count("registerShuffle") == 0)
 
@@ -111,7 +114,9 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
       classOf[ShuffleManager2].getName)
 
     // The statement calls #registerShuffle internally.
-    new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    val dep2 =
+      new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    gm.unregisterShuffle(dep2.shuffleId)
     assert(counter1.count("registerShuffle") == 1)
     assert(counter2.count("registerShuffle") == 1)
 
@@ -136,11 +141,13 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
       },
       classOf[ShuffleManager2].getName)
 
-    val gm = new GlutenShuffleManager(sparkConf, true)
+    val gm = spark.sparkContext.env.shuffleManager
     assert(counter1.count("registerShuffle") == 0)
     assert(counter2.count("registerShuffle") == 0)
     // The statement calls #registerShuffle internally.
-    new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    val dep =
+      new ShuffleDependency(new EmptyRDD[Product2[Any, Any]](spark.sparkContext), DummyPartitioner)
+    gm.unregisterShuffle(dep.shuffleId)
     assert(counter1.count("registerShuffle") == 1)
     assert(counter2.count("registerShuffle") == 0)
   }


### PR DESCRIPTION
#8060

Prepare `GlutenShuffleManager` as the new shuffle manager implementation of Gluten.

The shuffle manager is simply a router for all shuffle managers registered through API `ShuffleManagerRegistry.get().register`.

About backward compatibility:

1. Use of `ColumnarShuffleManager` / `CelebornShuffleManager` / `UniffleShuffleManager` will be deprecated in future (perhaps, in next few of PRs). Then once Spark configuration like `spark.shuffle.manager=....ColumnarShuffleManager` is specified explicitly, Gluten could still run but raise a warning indicating that the option is deprecated.
2. Instead, use of `GlutenShuffleManager` will be recommended. `GlutenShuffleManager` will maintain a mechanism (either automatically or by configuration) to route shuffle manager calls to the underlying registered shuffle managers. Hence, it will become recommended to use `spark.shuffle.manager=....GlutenShuffleManager` instead, no matter RSS is required or not.

This PR is only an API preparation with essential UTs. No existing production code is affected.