### PR TITLE
[GLUTEN-8128][VL] Retry borrowing when granted size is less than requested in multi-slot and shared mode

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargetVisitor.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargetVisitor.java
@@ -35,4 +35,6 @@ public interface MemoryTargetVisitor<T> {
   T visit(NoopMemoryTarget noopMemoryTarget);
 
   T visit(DynamicOffHeapSizingMemoryTarget dynamicOffHeapSizingMemoryTarget);
+
+  T visit(RetryOnOomMemoryTarget retryOnOomMemoryTarget);
 }

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/RetryOnOomMemoryTarget.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/RetryOnOomMemoryTarget.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.memory.memtarget;
 
 import org.apache.gluten.memory.MemoryUsageStatsBuilder;
+import org.apache.gluten.proto.MemoryUsageStats;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,5 +98,9 @@ public class RetryOnOomMemoryTarget implements TreeMemoryTarget {
   @Override
   public Spiller getNodeSpiller() {
     return target.getNodeSpiller();
+  }
+
+  public TreeMemoryTarget target() {
+    return target;
   }
 }

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/RetryOnOomMemoryTarget.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/RetryOnOomMemoryTarget.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.memory.memtarget;
+
+import org.apache.gluten.memory.MemoryUsageStatsBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class RetryOnOomMemoryTarget implements TreeMemoryTarget {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RetryOnOomMemoryTarget.class);
+  private final TreeMemoryTarget target;
+
+  RetryOnOomMemoryTarget(TreeMemoryTarget target) {
+    this.target = target;
+  }
+
+  @Override
+  public long borrow(long size) {
+    long granted = target.borrow(size);
+    if (granted < size) {
+
+      LOGGER.info(
+          "Exceed Spark perTaskLimit with maxTaskSizeDynamic when "
+              + "require:{} got:{}, try spill all.",
+          size,
+          granted);
+      final long spilled = TreeMemoryTargets.spillTree(target, Long.MAX_VALUE);
+      final long remaining = size - granted;
+      if (spilled >= remaining) {
+        granted += target.borrow(remaining);
+      }
+    }
+    return granted;
+  }
+
+  @Override
+  public long repay(long size) {
+    return target.repay(size);
+  }
+
+  @Override
+  public long usedBytes() {
+    return target.usedBytes();
+  }
+
+  @Override
+  public <T> T accept(MemoryTargetVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+
+  @Override
+  public String name() {
+    return target.name();
+  }
+
+  @Override
+  public MemoryUsageStats stats() {
+    return target.stats();
+  }
+
+  @Override
+  public TreeMemoryTarget newChild(
+      String name,
+      long capacity,
+      Spiller spiller,
+      Map<String, MemoryUsageStatsBuilder> virtualChildren) {
+    return target.newChild(name, capacity, spiller, virtualChildren);
+  }
+
+  @Override
+  public Map<String, TreeMemoryTarget> children() {
+    return target.children();
+  }
+
+  @Override
+  public TreeMemoryTarget parent() {
+    return target.parent();
+  }
+
+  @Override
+  public Spiller getNodeSpiller() {
+    return target.getNodeSpiller();
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
@@ -131,6 +131,10 @@ object SparkMemoryUtil {
           dynamicOffHeapSizingMemoryTarget: DynamicOffHeapSizingMemoryTarget): String = {
         dynamicOffHeapSizingMemoryTarget.delegated().accept(this)
       }
+
+      override def visit(retryOnOomMemoryTarget: RetryOnOomMemoryTarget): String = {
+        retryOnOomMemoryTarget.target().accept(this)
+      }
     })
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Retry memory borrow when granted less than requested size in multi-slot and Gluten shared mode. If ThrowOnOomMemoryTarget cannot acquire memory, spill more memory and then retry.

(Fixes: \#8128)

If the case in issue #8128 occurs, the first borrow(sizeA) will spill sizeA memory. After spill, if curMemory is greater than the maxPerTaskSize, we'll get 0 returned. So we retry spill(long.max), then re-borrow.
- Add argument `isDynamicCapacity` when construct `TreeMemoryTargets#Node`, which means multi-task-slot and shared mode.

## How was this patch tested?
Test with my production ETL.