### PR TITLE
[VL] Add back RAII style Velox driver suspension into RowVectorStream

### DIFF
--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -23,6 +23,27 @@
 #include "velox/exec/Operator.h"
 #include "velox/exec/Task.h"
 
+namespace {
+class SuspendedSection {
+ public:
+  explicit SuspendedSection(facebook::velox::exec::Driver* driver) : driver_(driver) {
+    if (driver_->task()->enterSuspended(driver->state()) != facebook::velox::exec::StopReason::kNone) {
+      VELOX_FAIL("Terminate detected when entering suspended section");
+    }
+  }
+
+  virtual ~SuspendedSection() {
+    if (driver_->task()->leaveSuspended(driver_->state()) != facebook::velox::exec::StopReason::kNone) {
+      LOG(WARNING) << "Terminate detected when leaving suspended section for driver " << driver_->driverCtx()->driverId
+                   << " from task " << driver_->task()->taskId();
+    }
+  }
+
+ private:
+  facebook::velox::exec::Driver* const driver_;
+};
+} // namespace
+
 namespace gluten {
 class RowVectorStream {
  public:
@@ -47,16 +68,8 @@ class RowVectorStream {
       // As of now, non-zero running threads usually happens when:
       // 1. Task A spills task B;
       // 2. Task A trys to grow buffers created by task B, during which spill is requested on task A again.
-      // facebook::velox::exec::SuspendedSection ss(driverCtx_->driver);
-      auto driver = driverCtx_->driver;
-      if (driver->task()->enterSuspended(driver->state()) != facebook::velox::exec::StopReason::kNone) {
-        VELOX_FAIL("Terminate detected when entering suspended section");
-      }
+      SuspendedSection ss(driverCtx_->driver);
       hasNext = iterator_->hasNext();
-      if (driver->task()->leaveSuspended(driver->state()) != facebook::velox::exec::StopReason::kNone) {
-        LOG(WARNING) << "Terminate detected when leaving suspended section for driver " << driver->driverCtx()->driverId
-                     << " from task " << driver->task()->taskId();
-      }
     }
     if (!hasNext) {
       finished_ = true;
@@ -74,15 +87,8 @@ class RowVectorStream {
       // We are leaving Velox task execution and are probably entering Spark code through JNI. Suspend the current
       // driver to make the current task open to spilling.
       // facebook::velox::exec::SuspendedSection ss(driverCtx_->driver);
-      auto driver = driverCtx_->driver;
-      if (driver->task()->enterSuspended(driver->state()) != facebook::velox::exec::StopReason::kNone) {
-        VELOX_FAIL("Terminate detected when entering suspended section");
-      }
+      SuspendedSection ss(driverCtx_->driver);
       cb = iterator_->next();
-      if (driver->task()->leaveSuspended(driver->state()) != facebook::velox::exec::StopReason::kNone) {
-        LOG(WARNING) << "Terminate detected when leaving suspended section for driver " << driver->driverCtx()->driverId
-                     << " from task " << driver->task()->taskId();
-      }
     }
     const std::shared_ptr<VeloxColumnarBatch>& vb = VeloxColumnarBatch::from(pool_, cb);
     auto vp = vb->getRowVector();
@@ -129,7 +135,7 @@ class ValueStreamNode final : public facebook::velox::core::PlanNode {
   }
 
  private:
-  void addDetails(std::stringstream& stream) const override{};
+  void addDetails(std::stringstream& stream) const override {};
 
   const facebook::velox::RowTypePtr outputType_;
   std::shared_ptr<ResultIterator> iterator_;

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -134,7 +134,7 @@ class ValueStreamNode final : public facebook::velox::core::PlanNode {
   }
 
  private:
-  void addDetails(std::stringstream& stream) const override {};
+  void addDetails(std::stringstream& stream) const override{};
 
   const facebook::velox::RowTypePtr outputType_;
   std::shared_ptr<ResultIterator> iterator_;

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -86,7 +86,6 @@ class RowVectorStream {
     {
       // We are leaving Velox task execution and are probably entering Spark code through JNI. Suspend the current
       // driver to make the current task open to spilling.
-      // facebook::velox::exec::SuspendedSection ss(driverCtx_->driver);
       SuspendedSection ss(driverCtx_->driver);
       cb = iterator_->next();
     }


### PR DESCRIPTION
SuspendedSection was removed from Velox code base from commit https://github.com/facebookincubator/velox/commit/fc5aa37fe44ca5bee9c91f9bee69069f0c804b11.

The PR introduce the code back to Gluten's code base to replace the temporary manual resource suspension code to avoid UBs when exception throws from `iterator_->hasNext()` or `iterator_->next()`.