### PR TITLE
[CORE] Query planner: Simplify validator `FallbackByNativeValidation` 

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.backendsapi.clickhouse
 
 import org.apache.gluten.GlutenBuildInfo._
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backend.Component.BuildInfo
+import org.apache.gluten.component.Component.BuildInfo
 import org.apache.gluten.backendsapi._
 import org.apache.gluten.columnarbatch.CHBatch
 import org.apache.gluten.execution.WriteFilesExecTransformer

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -18,9 +18,9 @@ package org.apache.gluten.backendsapi.clickhouse
 
 import org.apache.gluten.GlutenBuildInfo._
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.component.Component.BuildInfo
 import org.apache.gluten.backendsapi._
 import org.apache.gluten.columnarbatch.CHBatch
+import org.apache.gluten.component.Component.BuildInfo
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.ValidationResult

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -82,6 +82,7 @@ object CHRuleApi {
     injector.injectPreTransform(_ => WriteFilesWithBucketValue)
 
     // Legacy: The legacy transform rule.
+    val offloads = Seq(OffloadOthers(), OffloadExchange(), OffloadJoin())
     val validatorBuilder: GlutenConfig => Validator = conf =>
       Validator
         .builder()
@@ -91,11 +92,10 @@ object CHRuleApi {
         .fallbackByBackendSettings()
         .fallbackByUserOptions()
         .fallbackByTestInjects()
-        .fallbackByNativeValidation()
+        .fallbackByNativeValidation(offloads)
         .build()
     val rewrites =
       Seq(RewriteIn, RewriteMultiChildrenCount, RewriteJoin, PullOutPreProject, PullOutPostProject)
-    val offloads = Seq(OffloadOthers(), OffloadExchange(), OffloadJoin())
     injector.injectTransform(
       c => intercept(HeuristicTransform.Single(validatorBuilder(c.glutenConf), rewrites, offloads)))
 

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -666,6 +666,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
     CHColumnarWriteFilesExec(
       child,
       noop,
+      child,
       fileFormat,
       partitionColumns,
       bucketSpec,

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -656,7 +656,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
   }
 
   override def createColumnarWriteFilesExec(
-      child: SparkPlan,
+      child: WriteFilesExecTransformer,
       noop: SparkPlan,
       fileFormat: FileFormat,
       partitionColumns: Seq[Attribute],

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.execution
 
+import org.apache.gluten.execution.WriteFilesExecTransformer
+import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.memory.CHThreadGroup
 
 import org.apache.spark.{Partition, SparkException, TaskContext, TaskOutputFileAlreadyExistException}
@@ -149,12 +151,17 @@ class CHColumnarWriteFilesRDD(
 case class CHColumnarWriteFilesExec(
     override val left: SparkPlan,
     override val right: SparkPlan,
+    t: WriteFilesExecTransformer,
     fileFormat: FileFormat,
     partitionColumns: Seq[Attribute],
     bucketSpec: Option[BucketSpec],
     options: Map[String, String],
     staticPartitions: TablePartitionSpec
 ) extends ColumnarWriteFilesExec(left, right) {
+
+  override protected def doValidateInternal(): ValidationResult = {
+    t.doValidateInternal()
+  }
 
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan,

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
@@ -166,7 +166,7 @@ case class CHColumnarWriteFilesExec(
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan,
       newRight: SparkPlan): SparkPlan =
-    copy(newLeft, newRight, fileFormat, partitionColumns, bucketSpec, options, staticPartitions)
+    copy(newLeft, newRight, t, fileFormat, partitionColumns, bucketSpec, options, staticPartitions)
 
   override def doExecuteWrite(writeFilesSpec: WriteFilesSpec): RDD[WriterCommitMessage] = {
     assert(child.supportsColumnar)

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -18,9 +18,9 @@ package org.apache.gluten.backendsapi.velox
 
 import org.apache.gluten.GlutenBuildInfo._
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.component.Component.BuildInfo
 import org.apache.gluten.backendsapi._
 import org.apache.gluten.columnarbatch.VeloxBatch
+import org.apache.gluten.component.Component.BuildInfo
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.backendsapi.velox
 
 import org.apache.gluten.GlutenBuildInfo._
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backend.Component.BuildInfo
+import org.apache.gluten.component.Component.BuildInfo
 import org.apache.gluten.backendsapi._
 import org.apache.gluten.columnarbatch.VeloxBatch
 import org.apache.gluten.exception.GlutenNotSupportException

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -74,6 +74,7 @@ object VeloxRuleApi {
     injector.injectPreTransform(c => ArrowScanReplaceRule.apply(c.session))
 
     // Legacy: The legacy transform rule.
+    val offloads = Seq(OffloadOthers(), OffloadExchange(), OffloadJoin())
     val validatorBuilder: GlutenConfig => Validator = conf =>
       Validator
         .builder()
@@ -83,11 +84,10 @@ object VeloxRuleApi {
         .fallbackByBackendSettings()
         .fallbackByUserOptions()
         .fallbackByTestInjects()
-        .fallbackByNativeValidation()
+        .fallbackByNativeValidation(offloads)
         .build()
     val rewrites =
       Seq(RewriteIn, RewriteMultiChildrenCount, RewriteJoin, PullOutPreProject, PullOutPostProject)
-    val offloads = Seq(OffloadOthers(), OffloadExchange(), OffloadJoin())
     injector.injectTransform(
       c => HeuristicTransform.Single(validatorBuilder(c.glutenConf), rewrites, offloads))
 

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -560,7 +560,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     ShuffleUtil.genColumnarShuffleWriter(parameters)
   }
   override def createColumnarWriteFilesExec(
-      child: SparkPlan,
+      child: WriteFilesExecTransformer,
       noop: SparkPlan,
       fileFormat: FileFormat,
       partitionColumns: Seq[Attribute],
@@ -570,6 +570,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     VeloxColumnarWriteFilesExec(
       child,
       noop,
+      child,
       fileFormat,
       partitionColumns,
       bucketSpec,

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -18,7 +18,7 @@ package org.apache.gluten
 
 import org.apache.gluten.GlutenBuildInfo._
 import org.apache.gluten.GlutenConfig._
-import org.apache.gluten.backend.Component
+import org.apache.gluten.component.Component
 import org.apache.gluten.events.GlutenBuildInfoEvent
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.GlutenSessionExtensions

--- a/gluten-core/src/main/scala/org/apache/gluten/backend/Backend.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/backend/Backend.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten.backend
 
+import org.apache.gluten.component.Component
+
 trait Backend extends Component {
 
   /**

--- a/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.backend
+package org.apache.gluten.component
 
 import org.apache.gluten.extension.columnar.transition.ConventionFunc
 import org.apache.gluten.extension.injector.Injector
@@ -100,7 +100,7 @@ object Component {
     graph.sorted()
   }
 
-  private[backend] def sortedUnsafe(): Seq[Component] = {
+  private[component] def sortedUnsafe(): Seq[Component] = {
     graph.sorted()
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten
 
+import org.apache.gluten.backend.Backend
+
 import org.apache.spark.internal.Logging
 
 import java.util.ServiceLoader
@@ -23,10 +25,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
 
-package object backend extends Logging {
-  private[backend] val allComponentsLoaded: AtomicBoolean = new AtomicBoolean(false)
+package object component extends Logging {
+  private val allComponentsLoaded: AtomicBoolean = new AtomicBoolean(false)
 
-  private[backend] def ensureAllComponentsRegistered(): Unit = {
+  private[component] def ensureAllComponentsRegistered(): Unit = {
     if (!allComponentsLoaded.compareAndSet(false, true)) {
       return
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenSessionExtensions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenSessionExtensions.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.extension
 
 import org.apache.gluten.GlutenConfig
-import org.apache.gluten.backend.Component
+import org.apache.gluten.component.Component
 import org.apache.gluten.extension.injector.Injector
 
 import org.apache.spark.internal.Logging

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/EnumeratedTransform.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.enumerated
 
-import org.apache.gluten.backend.Component
+import org.apache.gluten.component.Component
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
 import org.apache.gluten.extension.columnar.enumerated.planner.GlutenOptimization

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.extension.columnar.enumerated.planner.plan
 
 import org.apache.gluten.execution.GlutenPlan
-import org.apache.gluten.extension.columnar.enumerated.planner.metadata.GlutenMetadata
+import org.apache.gluten.extension.columnar.enumerated.planner.metadata.{GlutenMetadata, LogicalLink}
 import org.apache.gluten.extension.columnar.enumerated.planner.property.{Conv, ConvDef}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 import org.apache.gluten.ras.{Metadata, PlanModel}
@@ -27,6 +27,7 @@ import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{ColumnarToRowExec, LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExecBase
 import org.apache.spark.task.{SparkTaskUtil, TaskResources}
@@ -75,6 +76,16 @@ object GlutenPlanModel {
     final override val supportsRowBased: Boolean = {
       rowType() != Convention.RowType.None
     }
+
+    override def logicalLink: Option[LogicalPlan] = {
+      if (metadata.logicalLink() eq LogicalLink.notFound) {
+        return None
+      }
+      Some(metadata.logicalLink().plan)
+    }
+
+    override def setLogicalLink(logicalPlan: LogicalPlan): Unit =
+      throw new UnsupportedOperationException()
   }
 
   private object PlanModelImpl extends PlanModel[SparkPlan] {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicTransform.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicTransform.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.heuristic
 
-import org.apache.gluten.backend.Component
+import org.apache.gluten.component.Component
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
 import org.apache.gluten.extension.columnar.offload.OffloadSingleNode

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/LegacyOffload.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/LegacyOffload.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 
 class LegacyOffload(rules: Seq[OffloadSingleNode]) extends Rule[SparkPlan] with LogLevelUtil {
-
   def apply(plan: SparkPlan): SparkPlan = {
     val out =
       rules.foldLeft(plan)((p, rule) => p.transformUp { case p => rule.offload(p) })

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionFunc.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionFunc.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.extension.columnar.transition
 
-import org.apache.gluten.backend.Component
+import org.apache.gluten.component.Component
 import org.apache.gluten.extension.columnar.transition.ConventionReq.KnownChildConvention
 import org.apache.gluten.sql.shims.SparkShimLoader
 

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.backend
+package org.apache.gluten.component
 
+import org.apache.gluten.backend.Backend
 import org.apache.gluten.extension.injector.Injector
-
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.component
 
 import org.apache.gluten.backend.Backend
 import org.apache.gluten.extension.injector.Injector
+
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendsApiManager.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendsApiManager.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.backendsapi
 
-import org.apache.gluten.backend.Component
+import org.apache.gluten.component.Component
 
 object BackendsApiManager {
   private lazy val backend: SubstraitBackend = initializeInternal()

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -365,7 +365,7 @@ trait SparkPlanExecApi {
 
   /** Create ColumnarWriteFilesExec */
   def createColumnarWriteFilesExec(
-      child: SparkPlan,
+      child: WriteFilesExecTransformer,
       noop: SparkPlan,
       fileFormat: FileFormat,
       partitionColumns: Seq[Attribute],

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -198,7 +198,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
     val transformStageId: Int
 ) extends WholeStageTransformerGenerateTreeStringShim
   with UnaryTransformSupport {
-  assert(child.isInstanceOf[TransformSupport])
 
   def stageId: Int = transformStageId
 
@@ -353,6 +352,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
   }
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    assert(child.isInstanceOf[TransformSupport])
     val pipelineTime: SQLMetric = longMetric("pipelineTime")
     // We should do transform first to make sure all subqueries are materialized
     val wsCtx = GlutenTimeMetric.withMillisTime {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.GlutenConfig
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.extension.ValidationResult
-import org.apache.gluten.extension.columnar.enumerated.planner.plan.GlutenPlanModel.GroupLeafExec
 import org.apache.gluten.metrics.MetricsUpdater
 import org.apache.gluten.substrait.`type`.ColumnTypeNode
 import org.apache.gluten.substrait.SubstraitContext
@@ -33,13 +32,12 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, MapType}
-import org.apache.spark.sql.types.MetadataBuilder
+import org.apache.spark.sql.types.{ArrayType, MapType, MetadataBuilder}
 
 import io.substrait.proto.NamedStruct
 import org.apache.parquet.hadoop.ParquetOutputFormat
@@ -139,23 +137,11 @@ case class WriteFilesExecTransformer(
       }
     }
 
-    lazy val hasConstantComplexType = child match {
-      case t: ProjectExecTransformer =>
-        t.projectList.exists(isConstantComplexType)
-      case p: ProjectExec =>
-        p.projectList.exists(isConstantComplexType)
-      case g: GroupLeafExec => // support the ras
-        g.metadata
-          .logicalLink()
-          .plan
-          .collectFirst {
-            case p: Project if p.projectList.exists(isConstantComplexType) => true
-          }
-          .isDefined
-      case _ => false
-    }
-    // TODO: currently the velox don't support parquet write with complex data type
-    //  with constant.
+    def hasConstantComplexType = child.logicalLink.collectFirst {
+      case p: Project if p.projectList.exists(isConstantComplexType) => true
+    }.isDefined
+
+    // TODO: Currently Velox doesn't support Parquet write of constant with complex data type.
     if (fileFormat.isInstanceOf[ParquetFileFormat] && hasConstantComplexType) {
       return ValidationResult.failed(
         "Unsupported native parquet write: " +

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
@@ -127,7 +127,7 @@ case class WriteFilesExecTransformer(
     child.output.map(attr => WriteFilesExecTransformer.removeMetadata(attr, metadataExclusionList))
   }
 
-  override protected def doValidateInternal(): ValidationResult = {
+  override def doValidateInternal(): ValidationResult = {
     val finalChildOutput = getFinalChildOutput
 
     def isConstantComplexType(e: Expression): Boolean = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.{SortExec, SparkPlan}
  * This rule is similar with `EnsureRequirements` but only handle local `SortExec`.
  *
  * The reason is that, during transform SparkPlan to GlutenPlan, some operators do not need local
- * sort any more, e.g., convert SortAggregate to HashAggregateTransformer, and we remove local sort
+ * sort anymore, e.g., convert SortAggregate to HashAggregateTransformer, and we remove local sort
  * eagerly. However, it may break the other operator's requirements, e.g., A SortMergeJoin on top of
  * SortAggregate with the same key. So, this rule adds local sort back if necessary.
  */

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -312,7 +312,10 @@ object OffloadOthers {
           val child = plan.child
           // For ArrowEvalPythonExec, CH supports it through EvalPythonExecTransformer while
           // Velox backend uses ColumnarArrowEvalPythonExec.
-          if (!BackendsApiManager.getSettings.supportColumnarArrowUdf()) {
+          if (
+            !BackendsApiManager.getSettings.supportColumnarArrowUdf() ||
+            !GlutenConfig.getConf.enableColumnarArrowUDF
+          ) {
             EvalPythonExecTransformer(plan.udfs, plan.resultAttrs, child)
           } else {
             BackendsApiManager.getSparkPlanExecApiInstance.createColumnarArrowEvalPythonExec(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -39,8 +39,6 @@ import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
-import scala.collection.Seq
-
 object Validators {
   implicit class ValidatorBuilderImplicits(builder: Validator.Builder) {
     private val conf = GlutenConfig.getConf

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -266,7 +266,12 @@ object Validators {
     }
 
     private def applyOnSingleNode[T](plan: SparkPlan)(body: SparkPlan => T): T = {
-      val newChildren = plan.children.map(child => FakeLeaf(originalChild = child))
+      val newChildren = plan.children.map(
+        child => {
+          val fl = FakeLeaf(originalChild = child)
+          child.logicalLink.foreach(link => fl.setLogicalLink(link))
+          fl
+        })
       val newPlan = plan.withNewChildren(newChildren)
       val applied = body(newPlan)
       applied

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -231,7 +231,7 @@ object Validators {
     import FallbackByNativeValidation._
     private val offloadAttempt: LegacyOffload = LegacyOffload(offloadRules)
     override def validate(plan: SparkPlan): Validator.OutCome = {
-      applyAsSingleNode(plan) {
+      applyOnSingleNode(plan) {
         node =>
           val offloadedNode = offloadAttempt.apply(node)
           val outcomes = offloadedNode.collect {
@@ -265,7 +265,7 @@ object Validators {
       override def outputPartitioning: Partitioning = originalChild.outputPartitioning
     }
 
-    private def applyAsSingleNode[T](plan: SparkPlan)(body: SparkPlan => T): T = {
+    private def applyOnSingleNode[T](plan: SparkPlan)(body: SparkPlan => T): T = {
       val newChildren = plan.children.map(child => FakeLeaf(originalChild = child))
       val newPlan = plan.withNewChildren(newChildren)
       val applied = body(newPlan)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -250,6 +250,7 @@ object Validators {
   }
 
   private object FallbackByNativeValidation {
+
     /**
      * A fake leaf node that hides a subtree from the parent node to make sure the native validation
      * only called on the interested plan nodes.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -259,8 +259,7 @@ object Validators {
       override protected def doExecute(): RDD[InternalRow] =
         throw new UnsupportedOperationException()
       override def output: Seq[Attribute] = originalChild.output
-      override def supportsRowBased: Boolean = throw new UnsupportedOperationException()
-      override def supportsColumnar: Boolean = throw new UnsupportedOperationException()
+      override def supportsColumnar: Boolean = originalChild.supportsColumnar
     }
 
     private def applyAsSingleNode[T](plan: SparkPlan)(body: SparkPlan => T): T = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -21,10 +21,10 @@ import org.apache.gluten.backendsapi.{BackendsApiManager, BackendSettingsApi}
 import org.apache.gluten.execution._
 import org.apache.gluten.expression.ExpressionUtils
 import org.apache.gluten.extension.columnar.FallbackTags
-import org.apache.gluten.extension.columnar.offload.OffloadJoin
+import org.apache.gluten.extension.columnar.heuristic.LegacyOffload
+import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.sql.shims.SparkShimLoader
 
-import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
@@ -32,8 +32,7 @@ import org.apache.spark.sql.execution.datasources.WriteFilesExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.execution.python.{ArrowEvalPythonExec, BatchEvalPythonExec}
-import org.apache.spark.sql.execution.window.{WindowExec, WindowGroupLimitExecShim}
+import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 object Validators {
@@ -93,8 +92,8 @@ object Validators {
      * Attempts to offload the input query plan node and check native validation result. Fails when
      * native validation failed.
      */
-    def fallbackByNativeValidation(): Validator.Builder = {
-      builder.add(new FallbackByNativeValidation)
+    def fallbackByNativeValidation(rules: Seq[OffloadSingleNode]): Validator.Builder = {
+      builder.add(new FallbackByNativeValidation(rules))
     }
   }
 
@@ -222,182 +221,18 @@ object Validators {
     }
   }
 
-  private class FallbackByNativeValidation extends Validator with Logging {
-    override def validate(plan: SparkPlan): Validator.OutCome = plan match {
-      case plan: BatchScanExec =>
-        val transformer = ScanTransformerFactory.createBatchScanTransformer(plan)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: FileSourceScanExec =>
-        val transformer = ScanTransformerFactory.createFileSourceScanTransformer(plan)
-        transformer.doValidate().toValidatorOutcome()
-      case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
-        HiveTableScanExecTransformer(plan).doValidate().toValidatorOutcome()
-      case plan: ProjectExec =>
-        val transformer = ProjectExecTransformer(plan.projectList, plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: FilterExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance
-          .genFilterExecTransformer(plan.condition, plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: HashAggregateExec =>
-        val transformer = HashAggregateExecBaseTransformer.from(plan)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: SortAggregateExec =>
-        val transformer = HashAggregateExecBaseTransformer.from(plan)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: ObjectHashAggregateExec =>
-        val transformer = HashAggregateExecBaseTransformer.from(plan)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: UnionExec =>
-        val transformer = ColumnarUnionExec(plan.children)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: ExpandExec =>
-        val transformer = ExpandExecTransformer(plan.projections, plan.output, plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: WriteFilesExec =>
-        val transformer = WriteFilesExecTransformer(
-          plan.child,
-          plan.fileFormat,
-          plan.partitionColumns,
-          plan.bucketSpec,
-          plan.options,
-          plan.staticPartitions)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: SortExec =>
-        val transformer =
-          SortExecTransformer(plan.sortOrder, plan.global, plan.child, plan.testSpillFrequency)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: ShuffleExchangeExec =>
-        val transformer = ColumnarShuffleExchangeExec(plan, plan.child, plan.child.output)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: ShuffledHashJoinExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance
-          .genShuffledHashJoinExecTransformer(
-            plan.leftKeys,
-            plan.rightKeys,
-            plan.joinType,
-            OffloadJoin.getShjBuildSide(plan),
-            plan.condition,
-            plan.left,
-            plan.right,
-            plan.isSkewJoin)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: BroadcastExchangeExec =>
-        val transformer = ColumnarBroadcastExchangeExec(plan.mode, plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case bhj: BroadcastHashJoinExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance
-          .genBroadcastHashJoinExecTransformer(
-            bhj.leftKeys,
-            bhj.rightKeys,
-            bhj.joinType,
-            bhj.buildSide,
-            bhj.condition,
-            bhj.left,
-            bhj.right,
-            isNullAwareAntiJoin = bhj.isNullAwareAntiJoin)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: SortMergeJoinExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance
-          .genSortMergeJoinExecTransformer(
-            plan.leftKeys,
-            plan.rightKeys,
-            plan.joinType,
-            plan.condition,
-            plan.left,
-            plan.right,
-            plan.isSkewJoin)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: CartesianProductExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance
-          .genCartesianProductExecTransformer(plan.left, plan.right, plan.condition)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: BroadcastNestedLoopJoinExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance
-          .genBroadcastNestedLoopJoinExecTransformer(
-            plan.left,
-            plan.right,
-            plan.buildSide,
-            plan.joinType,
-            plan.condition)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: WindowExec =>
-        val transformer = WindowExecTransformer(
-          plan.windowExpression,
-          plan.partitionSpec,
-          plan.orderSpec,
-          plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case plan if SparkShimLoader.getSparkShims.isWindowGroupLimitExec(plan) =>
-        val windowGroupLimitPlan = SparkShimLoader.getSparkShims
-          .getWindowGroupLimitExecShim(plan)
-          .asInstanceOf[WindowGroupLimitExecShim]
-        val transformer = WindowGroupLimitExecTransformer(
-          windowGroupLimitPlan.partitionSpec,
-          windowGroupLimitPlan.orderSpec,
-          windowGroupLimitPlan.rankLikeFunction,
-          windowGroupLimitPlan.limit,
-          windowGroupLimitPlan.mode,
-          windowGroupLimitPlan.child
-        )
-        transformer.doValidate().toValidatorOutcome()
-      case plan: CoalesceExec =>
-        ColumnarCoalesceExec(plan.numPartitions, plan.child)
-          .doValidate()
-          .toValidatorOutcome()
-      case plan: GlobalLimitExec =>
-        val (limit, offset) =
-          SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)
-        val transformer = LimitExecTransformer(plan.child, offset, limit)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: LocalLimitExec =>
-        val transformer = LimitExecTransformer(plan.child, 0L, plan.limit)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: GenerateExec =>
-        val transformer = BackendsApiManager.getSparkPlanExecApiInstance.genGenerateTransformer(
-          plan.generator,
-          plan.requiredChildOutput,
-          plan.outer,
-          plan.generatorOutput,
-          plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: BatchEvalPythonExec =>
-        val transformer = EvalPythonExecTransformer(plan.udfs, plan.resultAttrs, plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: ArrowEvalPythonExec =>
-        // When backend doesn't support ColumnarArrow or colunmnar arrow configuration not
-        // enabled, we will try offloading through EvalPythonExecTransformer
-        if (
-          !BackendsApiManager.getSettings.supportColumnarArrowUdf() ||
-          !GlutenConfig.getConf.enableColumnarArrowUDF
-        ) {
-          // Both CH and Velox will try using backend's built-in functions for calculate
-          val transformer = EvalPythonExecTransformer(plan.udfs, plan.resultAttrs, plan.child)
-          transformer.doValidate().toValidatorOutcome()
-        }
-        pass()
-      case plan: TakeOrderedAndProjectExec =>
-        val (limit, offset) =
-          SparkShimLoader.getSparkShims.getLimitAndOffsetFromTopK(plan)
-        val transformer = TakeOrderedAndProjectExecTransformer(
-          limit,
-          plan.sortOrder,
-          plan.projectList,
-          plan.child,
-          offset)
-        transformer.doValidate().toValidatorOutcome()
-      case plan: SampleExec =>
-        val transformer =
-          BackendsApiManager.getSparkPlanExecApiInstance.genSampleExecTransformer(
-            plan.lowerBound,
-            plan.upperBound,
-            plan.withReplacement,
-            plan.seed,
-            plan.child)
-        transformer.doValidate().toValidatorOutcome()
-      case _ =>
-        // Currently we assume a plan to be offload-able by default.
-        pass()
+  private class FallbackByNativeValidation(offloadRules: Seq[OffloadSingleNode])
+    extends Validator
+    with Logging {
+    private val offloadAttempt: LegacyOffload = LegacyOffload(offloadRules)
+    override def validate(plan: SparkPlan): Validator.OutCome = {
+      offloadAttempt.apply(plan) match {
+        case v: ValidatablePlan =>
+          v.doValidate().toValidatorOutcome()
+        case _ =>
+          // Currently we assume a plan to be offload-able by default.
+          pass()
+      }
     }
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -250,7 +250,6 @@ object Validators {
   }
 
   private object FallbackByNativeValidation {
-
     /**
      * A fake leaf node that hides a subtree from the parent node to make sure the native validation
      * only called on the interested plan nodes.

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.execution.{ValidatablePlan, WriteFilesExecTransformer}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 import org.apache.gluten.extension.columnar.transition.Convention.RowType
 import org.apache.gluten.sql.shims.SparkShimLoader
@@ -43,7 +43,7 @@ abstract class ColumnarWriteFilesExec protected (
     override val left: SparkPlan,
     override val right: SparkPlan)
   extends BinaryExecNode
-  with GlutenPlan
+  with ValidatablePlan
   with ColumnarWriteFilesExec.ExecuteWriteCompatible {
 
   val child: SparkPlan = left
@@ -118,7 +118,7 @@ abstract class ColumnarWriteFilesExec protected (
 object ColumnarWriteFilesExec {
 
   def apply(
-      child: SparkPlan,
+      child: WriteFilesExecTransformer,
       fileFormat: FileFormat,
       partitionColumns: Seq[Attribute],
       bucketSpec: Option[BucketSpec],


### PR DESCRIPTION
It's to remove all code in `FallbackByNativeValidation` instead reuse the code from offload rules for native validation. 

Also, amend a minor package name refactor following https://github.com/apache/incubator-gluten/pull/8143.

Test:
All existing UTs.