### PR TITLE
[GLUTEN-8202][ICEBERG] Fix get iceberg index error

### DIFF
--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -152,9 +152,13 @@ object GlutenIcebergSourceUtil {
     val spec = task.spec()
     val partition = task.partition()
     if (spec.isPartitioned) {
-      val partitionFields =
-        spec.partitionType().fields().asScala.filter(f => readPartitionFields.contains(f.name()))
-      partitionFields.zipWithIndex.foreach {
+      val partitionFields = spec
+        .partitionType()
+        .fields()
+        .asScala
+        .zipWithIndex
+        .filter(f => readPartitionFields.contains(f._1.name()))
+      partitionFields.foreach {
         case (field, index) =>
           val partitionValue = partition.get(index, field.`type`().typeId().javaClass())
           val partitionType = field.`type`()


### PR DESCRIPTION
## What changes were proposed in this pull request?
When parsing Iceberg partition column fields, you should build the index first and then apply the filter. Otherwise, the field cannot correspond correctly when retrieving data using `partition.get`
for error

```
Error operating EXECUTE_STATEMENT: Wrong class, expected java.lang.Integer, but was java.lang.String, for object: xxx
java.lang.IllegalArgumentException: Wrong class, expected java.lang.Integer, but was java.lang.String, for object: xxxx
	at org.apache.iceberg.PartitionData.get(PartitionData.java:119)
	at org.apache.iceberg.spark.source.GlutenIcebergSourceUtil$.$anonfun$getPartitionColumns$3(GlutenIcebergSourceUtil.scala:180)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
```
[fix-8202](https://github.com/apache/incubator-gluten/issues/8202)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

