### PR TITLE
[CORE] Following #8192, amend a quick fix for build info message

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -92,6 +92,17 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     System.setProperty("gluten.version", VERSION)
 
     val glutenBuildInfo = new mutable.LinkedHashMap[String, String]()
+
+    val components = Component.sorted()
+    glutenBuildInfo.put("Components", components.map(_.buildInfo().name).mkString(","))
+    components.foreach {
+      comp =>
+        val buildInfo = comp.buildInfo()
+        glutenBuildInfo.put(s"Component ${buildInfo.name} Branch", buildInfo.branch)
+        glutenBuildInfo.put(s"Component ${buildInfo.name} Revision", buildInfo.revision)
+        glutenBuildInfo.put(s"Component ${buildInfo.name} Revision Time", buildInfo.revisionTime)
+    }
+
     glutenBuildInfo.put("Gluten Version", VERSION)
     glutenBuildInfo.put("GCC Version", GCC_VERSION)
     glutenBuildInfo.put("Java Version", JAVA_COMPILE_VERSION)
@@ -103,16 +114,6 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     glutenBuildInfo.put("Gluten Revision Time", REVISION_TIME)
     glutenBuildInfo.put("Gluten Build Time", BUILD_DATE)
     glutenBuildInfo.put("Gluten Repo URL", REPO_URL)
-
-    val components = Component.sorted()
-    glutenBuildInfo.put("Components", components.map(_.buildInfo().name).mkString(","))
-    components.foreach {
-      comp =>
-        val buildInfo = comp.buildInfo()
-        glutenBuildInfo.put(s"Component ${buildInfo.name} Branch", buildInfo.branch)
-        glutenBuildInfo.put(s"Component ${buildInfo.name} Revision", buildInfo.revision)
-        glutenBuildInfo.put(s"Component ${buildInfo.name} Revision Time", buildInfo.revisionTime)
-    }
 
     val infoMap = glutenBuildInfo.toMap
     val loggingInfo = infoMap.toSeq

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -115,8 +115,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     glutenBuildInfo.put("Gluten Build Time", BUILD_DATE)
     glutenBuildInfo.put("Gluten Repo URL", REPO_URL)
 
-    val infoMap = glutenBuildInfo.toMap
-    val loggingInfo = infoMap.toSeq
+    val loggingInfo = glutenBuildInfo
       .map { case (name, value) => s"$name: $value" }
       .mkString(
         "Gluten build info:\n==============================================================\n",
@@ -124,7 +123,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
         "\n=============================================================="
       )
     logInfo(loggingInfo)
-    val event = GlutenBuildInfoEvent(infoMap)
+    val event = GlutenBuildInfoEvent(glutenBuildInfo.toMap)
     GlutenEventUtils.post(sc, event)
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -91,7 +91,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     // export gluten version to property to spark
     System.setProperty("gluten.version", VERSION)
 
-    val glutenBuildInfo = new mutable.HashMap[String, String]()
+    val glutenBuildInfo = new mutable.LinkedHashMap[String, String]()
     glutenBuildInfo.put("Gluten Version", VERSION)
     glutenBuildInfo.put("GCC Version", GCC_VERSION)
     glutenBuildInfo.put("Java Version", JAVA_COMPILE_VERSION)

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -104,13 +104,14 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     glutenBuildInfo.put("Gluten Build Time", BUILD_DATE)
     glutenBuildInfo.put("Gluten Repo URL", REPO_URL)
 
-    Component.sorted().foreach {
+    val components = Component.sorted()
+    glutenBuildInfo.put("Components", components.map(_.buildInfo().name).mkString(","))
+    components.foreach {
       comp =>
         val buildInfo = comp.buildInfo()
-        glutenBuildInfo.put("Component", buildInfo.name)
-        glutenBuildInfo.put("Component Branch", buildInfo.branch)
-        glutenBuildInfo.put("Component Revision", buildInfo.revision)
-        glutenBuildInfo.put("Component Revision Time", buildInfo.revisionTime)
+        glutenBuildInfo.put(s"Component ${buildInfo.name} Branch", buildInfo.branch)
+        glutenBuildInfo.put(s"Component ${buildInfo.name} Revision", buildInfo.revision)
+        glutenBuildInfo.put(s"Component ${buildInfo.name} Revision Time", buildInfo.revisionTime)
     }
 
     val infoMap = glutenBuildInfo.toMap

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -117,7 +117,6 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
 
     val infoMap = glutenBuildInfo.toMap
     val loggingInfo = infoMap.toSeq
-      .sortBy(_._1)
       .map { case (name, value) => s"$name: $value" }
       .mkString(
         "Gluten build info:\n==============================================================\n",


### PR DESCRIPTION
Not all components' build information is printed. The patch fixes the issue.

Before:

```
2024-12-11T01:56:45.0402500Z Component: VeloxIceberg
2024-12-11T01:56:45.0402795Z Component Branch: N/A
2024-12-11T01:56:45.0403095Z Component Revision: N/A
2024-12-11T01:56:45.0403412Z Component Revision Time: N/A
...
```

After:
```
Components: Velox,VeloxIceberg
Component Velox Branch: HEAD
Component Velox Revision: 88964d4b480a8b5ff6bf85652b17a4b8b5fa6071
Component Velox Revision Time: 2024-11-19 08:07:56 +0800
Component VeloxIceberg Branch: N/A
Component VeloxIceberg Revision: N/A
Component VeloxIceberg Revision Time: N/A
...
```