### PR TITLE
[MINOR] [VL] Enhance the gluten timer to support seconds, milliseconds, and microseconds

### DIFF
--- a/cpp/core/shuffle/Payload.cc
+++ b/cpp/core/shuffle/Payload.cc
@@ -300,7 +300,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>> BlockPayload::deseria
     uint32_t& numRows,
     int64_t& deserializeTime,
     int64_t& decompressTime) {
-  Timer timer;
+  auto timer = std::make_unique<ScopedTimer>(&deserializeTime);
   static const std::vector<std::shared_ptr<arrow::Buffer>> kEmptyBuffers{};
   ARROW_ASSIGN_OR_RAISE(auto type, readType(inputStream));
   if (type == 0) {
@@ -310,7 +310,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>> BlockPayload::deseria
   RETURN_NOT_OK(inputStream->Read(sizeof(uint32_t), &numRows));
   uint32_t numBuffers;
   RETURN_NOT_OK(inputStream->Read(sizeof(uint32_t), &numBuffers));
-  deserializeTime += timer.realTimeUsed();
+  timer.reset();
 
   bool isCompressionEnabled = type == Type::kCompressed;
   std::vector<std::shared_ptr<arrow::Buffer>> buffers;

--- a/cpp/core/shuffle/Payload.cc
+++ b/cpp/core/shuffle/Payload.cc
@@ -300,7 +300,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>> BlockPayload::deseria
     uint32_t& numRows,
     int64_t& deserializeTime,
     int64_t& decompressTime) {
-  auto timer = std::make_unique<ScopedTimer>(&deserializeTime);
+  Timer timer;
   static const std::vector<std::shared_ptr<arrow::Buffer>> kEmptyBuffers{};
   ARROW_ASSIGN_OR_RAISE(auto type, readType(inputStream));
   if (type == 0) {
@@ -310,7 +310,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>> BlockPayload::deseria
   RETURN_NOT_OK(inputStream->Read(sizeof(uint32_t), &numRows));
   uint32_t numBuffers;
   RETURN_NOT_OK(inputStream->Read(sizeof(uint32_t), &numBuffers));
-  timer.reset();
+  deserializeTime += timer.realTimeUsed();
 
   bool isCompressionEnabled = type == Type::kCompressed;
   std::vector<std::shared_ptr<arrow::Buffer>> buffers;

--- a/cpp/core/utils/Timer.h
+++ b/cpp/core/utils/Timer.h
@@ -62,13 +62,13 @@ class Timer {
 };
 
 template <typename T = std::chrono::nanoseconds>
-class ScopedTimer {
+class ScopedTimerImpl {
  public:
-  explicit ScopedTimer(int64_t* toAdd) : toAdd_(toAdd) {
+  explicit ScopedTimerImpl(int64_t* toAdd) : toAdd_(toAdd) {
     startInternal();
   }
 
-  ~ScopedTimer() {
+  ~ScopedTimerImpl() {
     stopInternal();
   }
 
@@ -93,8 +93,9 @@ class ScopedTimer {
   }
 };
 
-using ScopedSecondsTimer = ScopedTimer<std::chrono::seconds>;
-using ScopedMillisecondsTimer = ScopedTimer<std::chrono::milliseconds>;
-using ScopedMicrosecondsTimer = ScopedTimer<std::chrono::microseconds>;
+using ScopedTimer = ScopedTimerImpl<std::chrono::nanoseconds>;
+using ScopedSecondsTimer = ScopedTimerImpl<std::chrono::seconds>;
+using ScopedMillisecondsTimer = ScopedTimerImpl<std::chrono::milliseconds>;
+using ScopedMicrosecondsTimer = ScopedTimerImpl<std::chrono::microseconds>;
 
 } // namespace gluten

--- a/cpp/core/utils/Timer.h
+++ b/cpp/core/utils/Timer.h
@@ -19,11 +19,11 @@
 
 #include <chrono>
 
-using TimePoint = std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>;
-
 namespace gluten {
+template <typename T = std::chrono::nanoseconds>
 class Timer {
  public:
+  using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
   explicit Timer() = default;
 
   void start() {
@@ -36,8 +36,7 @@ class Timer {
       return;
     }
     running_ = false;
-    realTimeUsed_ +=
-        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - startTime_).count();
+    realTimeUsed_ += std::chrono::duration_cast<T>(std::chrono::steady_clock::now() - startTime_).count();
   }
 
   void reset() {
@@ -62,6 +61,7 @@ class Timer {
   int64_t realTimeUsed_ = 0;
 };
 
+template <typename T = std::chrono::nanoseconds>
 class ScopedTimer {
  public:
   explicit ScopedTimer(int64_t* toAdd) : toAdd_(toAdd) {
@@ -79,7 +79,7 @@ class ScopedTimer {
   }
 
  private:
-  Timer timer_{};
+  Timer<T> timer_{};
   int64_t* toAdd_;
 
   void stopInternal() {
@@ -92,4 +92,9 @@ class ScopedTimer {
     timer_.start();
   }
 };
+
+using ScopedSecondsTimer = ScopedTimer<std::chrono::seconds>;
+using ScopedMillisecondsTimer = ScopedTimer<std::chrono::milliseconds>;
+using ScopedMicrosecondsTimer = ScopedTimer<std::chrono::microseconds>;
+
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sometimes we need a timer in seconds, e.g., for measuring file write time. Enhance the gluten timer to support seconds, milliseconds, microseconds and nanoseconds.

## How was this patch tested?
Exist CI.

