### PR TITLE
[GLUTEN-7028][CH][Part-12] Add Local SortExec for Partition Write in one pipeline mode

### DIFF
--- a/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
+++ b/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/FileDeltaColumnarWrite.scala
@@ -137,7 +137,8 @@ case class FileDeltaColumnarWrite(
       // stats.map(row => x.apply(row).getString(0)).foreach(println)
       // process stats
       val commitInfo = DeltaFileCommitInfo(committer)
-      val basicNativeStat = NativeBasicWriteTaskStatsTracker(description, basicWriteJobStatsTracker)
+      val basicNativeStat =
+        NativeBasicWriteTaskStatsTracker(description.path, basicWriteJobStatsTracker)
       val basicNativeStats = Seq(commitInfo, basicNativeStat)
       NativeStatCompute(stats)(basicNativeStats, nativeDeltaStats)
 

--- a/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/datasources/DeltaV1Writes.scala
+++ b/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/execution/datasources/DeltaV1Writes.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources
+import org.apache.gluten.backendsapi.BackendsApiManager
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.execution.{QueryExecution, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.V1WritesUtils.isOrderingMatched
+
+case class DeltaV1Writes(
+    spark: SparkSession,
+    query: SparkPlan,
+    fileFormat: FileFormat,
+    partitionColumns: Seq[Attribute],
+    bucketSpec: Option[BucketSpec],
+    options: Map[String, String],
+    staticPartitions: TablePartitionSpec = Map.empty) {
+
+  require(fileFormat != null, "FileFormat is required to write files.")
+  require(BackendsApiManager.getSettings.enableNativeWriteFiles())
+
+  private lazy val requiredOrdering: Seq[SortOrder] =
+    V1WritesUtils.getSortOrder(
+      query.output,
+      partitionColumns,
+      bucketSpec,
+      options,
+      staticPartitions.size)
+
+  lazy val sortPlan: SparkPlan = {
+    val outputOrdering = query.outputOrdering
+    val orderingMatched = isOrderingMatched(requiredOrdering.map(_.child), outputOrdering)
+    if (orderingMatched) {
+      query
+    } else {
+      SortExec(requiredOrdering, global = false, query)
+    }
+  }
+
+  lazy val writePlan: SparkPlan =
+    WriteFilesExec(
+      sortPlan,
+      fileFormat = fileFormat,
+      partitionColumns = partitionColumns,
+      bucketSpec = bucketSpec,
+      options = options,
+      staticPartitions = staticPartitions)
+
+  lazy val executedPlan: SparkPlan =
+    CallTransformer(spark, writePlan).executedPlan
+}
+
+case class CallTransformer(spark: SparkSession, physicalPlan: SparkPlan)
+  extends QueryExecution(spark, LocalRelation()) {
+  override lazy val sparkPlan: SparkPlan = physicalPlan
+}

--- a/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/sql/execution/datasources/DeltaV1WritesSuite.scala
+++ b/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/sql/execution/datasources/DeltaV1WritesSuite.scala
@@ -18,10 +18,9 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.execution.{GlutenClickHouseWholeStageTransformerSuite, GlutenPlan, SortExecTransformer}
-
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.execution.{SortExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
 
 class DeltaV1WritesSuite extends GlutenClickHouseWholeStageTransformerSuite {
 

--- a/backends-clickhouse/src/main/resources/org/apache/spark/sql/execution/datasources/v1/write_optimization.proto
+++ b/backends-clickhouse/src/main/resources/org/apache/spark/sql/execution/datasources/v1/write_optimization.proto
@@ -12,6 +12,9 @@ message Write {
   message Common {
     string format = 1;
     string job_task_attempt_id = 2; // currently used in mergetree format
+
+    // Describes the partition index in the WriteRel.table_schema.
+    repeated int32 partition_col_index = 3;
   }
   message ParquetWrite{}
   message OrcWrite{}

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -93,7 +93,6 @@ object CHRuleApi {
 
     // Legacy: Post-transform rules.
     injector.injectPostTransform(_ => PruneNestedColumnsInHiveTableScan)
-    injector.injectPostTransform(_ => RemoveNativeWriteFilesSortAndProject())
     injector.injectPostTransform(c => intercept(RewriteTransformer.apply(c.session)))
     injector.injectPostTransform(_ => PushDownFilterToScan)
     injector.injectPostTransform(_ => PushDownInputFileExpression.PostOffload)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.backendsapi.clickhouse
 
 import org.apache.gluten.backendsapi.TransformerApi
-import org.apache.gluten.execution.CHHashAggregateExecTransformer
+import org.apache.gluten.execution.{CHHashAggregateExecTransformer, WriteFilesExecTransformer}
 import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.substrait.expression.{BooleanLiteralNode, ExpressionBuilder, ExpressionNode}
 import org.apache.gluten.utils.{CHInputPartitionsUtil, ExpressionDocUtil}
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.catalog.ClickHouseTableV2
 import org.apache.spark.sql.delta.files.TahoeFileIndex
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
-import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v1.Write
@@ -243,10 +243,8 @@ class CHTransformerApi extends TransformerApi with Logging {
     GlutenDriverEndpoint.invalidateResourceRelation(executionId)
   }
 
-  override def genWriteParameters(
-      fileFormat: FileFormat,
-      writeOptions: Map[String, String]): Any = {
-    val fileFormatStr = fileFormat match {
+  override def genWriteParameters(writeExec: WriteFilesExecTransformer): Any = {
+    val fileFormatStr = writeExec.fileFormat match {
       case register: DataSourceRegister =>
         register.shortName
       case _ => "UnknownFileFormat"
@@ -257,10 +255,10 @@ class CHTransformerApi extends TransformerApi with Logging {
         Write.Common
           .newBuilder()
           .setFormat(fileFormatStr)
-          .setJobTaskAttemptId("") // we can get job and task id at the driver side
+          .setJobTaskAttemptId("") // we cannot get job and task id at the driver side
           .build())
 
-    fileFormat match {
+    writeExec.fileFormat match {
       case d: MergeTreeFileFormat =>
         write.setMergetree(MergeTreeFileFormat.createWrite(d.metadata))
       case _: ParquetFileFormat =>

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeConfig.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeConfig.scala
@@ -22,6 +22,7 @@ object RuntimeConfig {
   import CHConf._
   import SQLConf._
 
+  /** Clickhouse Configuration */
   val PATH =
     buildConf(runtimeConfig("path"))
       .doc(
@@ -37,9 +38,25 @@ object RuntimeConfig {
       .createWithDefault("/tmp/libch")
   // scalastyle:on line.size.limit
 
+  // scalastyle:off line.size.limit
+  val LOGGER_LEVEL =
+    buildConf(runtimeConfig("logger.level"))
+      .doc(
+        "https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#logger")
+      .stringConf
+      .createWithDefault("warning")
+  // scalastyle:on line.size.limit
+
+  /** Gluten Configuration */
   val USE_CURRENT_DIRECTORY_AS_TMP =
     buildConf(runtimeConfig("use_current_directory_as_tmp"))
       .doc("Use the current directory as the temporary directory.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DUMP_PIPELINE =
+    buildConf(runtimeConfig("dump_pipeline"))
+      .doc("Dump pipeline to file after execution")
       .booleanConf
       .createWithDefault(false)
 }

--- a/backends-clickhouse/src/test/delta-32/org/apache/spark/sql/execution/datasources/DeltaV1WritesSuite.scala
+++ b/backends-clickhouse/src/test/delta-32/org/apache/spark/sql/execution/datasources/DeltaV1WritesSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.gluten.GlutenConfig
+import org.apache.gluten.execution.{GlutenClickHouseWholeStageTransformerSuite, GlutenPlan, SortExecTransformer}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+
+class DeltaV1WritesSuite extends GlutenClickHouseWholeStageTransformerSuite {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    (0 to 20)
+      .map(i => (i, i % 5, (i % 10).toString))
+      .toDF("i", "j", "k")
+      .write
+      .saveAsTable("t0")
+  }
+
+  override def afterAll(): Unit = {
+    sql("drop table if exists t0")
+    super.afterAll()
+  }
+
+  val format = new ParquetFileFormat
+  def getSort(child: SparkPlan): Option[SortExecTransformer] = {
+    child.collectFirst { case w: SortExecTransformer => w }
+  }
+  test("don't add sort when the required ordering is empty") {
+    val df = sql("select * from t0")
+    val plan = df.queryExecution.sparkPlan
+    val writes = DeltaV1Writes(spark, plan, format, Nil, None, Map.empty)
+    assert(writes.sortPlan === plan)
+    assert(writes.writePlan != null)
+    assert(writes.executedPlan.isInstanceOf[GlutenPlan])
+    val writeFilesOpt = V1WritesUtils.getWriteFilesOpt(writes.executedPlan)
+    assert(writeFilesOpt.isDefined)
+    val sortExec = getSort(writes.executedPlan)
+    assert(sortExec.isEmpty)
+  }
+
+  test("don't add sort when the required ordering is already satisfied") {
+    val df = sql("select * from t0")
+    def check(plan: SparkPlan): Unit = {
+      val partitionColumns = plan.output.find(_.name == "k").toSeq
+      val writes = DeltaV1Writes(spark, plan, format, partitionColumns, None, Map.empty)
+      assert(writes.sortPlan === plan)
+      assert(writes.writePlan != null)
+      assert(writes.executedPlan.isInstanceOf[GlutenPlan])
+      val writeFilesOpt = V1WritesUtils.getWriteFilesOpt(writes.executedPlan)
+      assert(writeFilesOpt.isDefined)
+      val sortExec = getSort(writes.executedPlan)
+      assert(sortExec.isDefined)
+    }
+    check(df.orderBy("k").queryExecution.sparkPlan)
+    check(df.orderBy("k", "j").queryExecution.sparkPlan)
+  }
+
+  test("add sort when the required ordering is not satisfied") {
+    val df = sql("select * from t0")
+    def check(plan: SparkPlan): Unit = {
+      val partitionColumns = plan.output.find(_.name == "k").toSeq
+      val writes = DeltaV1Writes(spark, plan, format, partitionColumns, None, Map.empty)
+      val sort = writes.sortPlan.asInstanceOf[SortExec]
+      assert(sort.child === plan)
+      assert(writes.writePlan != null)
+      assert(writes.executedPlan.isInstanceOf[GlutenPlan])
+      val writeFilesOpt = V1WritesUtils.getWriteFilesOpt(writes.executedPlan)
+      assert(writeFilesOpt.isDefined)
+      val sortExec = getSort(writes.executedPlan)
+      assert(sortExec.isDefined, s"writes.executedPlan: ${writes.executedPlan}")
+    }
+    check(df.queryExecution.sparkPlan)
+    check(df.orderBy("j", "k").queryExecution.sparkPlan)
+  }
+
+}

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
@@ -1025,6 +1025,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
     }
   }
 
+  // FIXME: optimize
   testSparkVersionLE33("test parquet optimize with the path based table") {
     val dataPath = s"$basePath/lineitem_delta_parquet_optimize_path_based"
     clearDataPath(dataPath)

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
@@ -27,7 +27,7 @@ import org.apache.gluten.vectorized.PlanEvaluatorJniWrapper
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.types._
 import org.apache.spark.task.TaskResources
@@ -96,16 +96,14 @@ class VeloxTransformerApi extends TransformerApi with Logging {
 
   override def packPBMessage(message: Message): Any = Any.pack(message, "")
 
-  override def genWriteParameters(
-      fileFormat: FileFormat,
-      writeOptions: Map[String, String]): Any = {
-    val fileFormatStr = fileFormat match {
+  override def genWriteParameters(write: WriteFilesExecTransformer): Any = {
+    val fileFormatStr = write.fileFormat match {
       case register: DataSourceRegister =>
         register.shortName
       case _ => "UnknownFileFormat"
     }
     val compressionCodec =
-      WriteFilesExecTransformer.getCompressionCodec(writeOptions).capitalize
+      WriteFilesExecTransformer.getCompressionCodec(write.caseInsensitiveOptions).capitalize
     val writeParametersStr = new StringBuffer("WriteParameters:")
     writeParametersStr.append("is").append(compressionCodec).append("=1")
     writeParametersStr.append(";format=").append(fileFormatStr).append("\n")

--- a/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.cpp
@@ -21,9 +21,8 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <Interpreters/Context.h>
 #include <Parser/TypeParser.h>
-#include <Processors/Transforms/ApplySquashingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
-#include <Processors/Transforms/PlanSquashingTransform.h>
+#include <Processors/Transforms/MaterializingTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/SparkMergeTreeMeta.h>
 #include <Storages/MergeTree/SparkMergeTreeSink.h>
@@ -103,7 +102,7 @@ void adjust_output(const DB::QueryPipelineBuilderPtr & builder, const DB::Block 
     {
         throw DB::Exception(
             DB::ErrorCodes::LOGICAL_ERROR,
-            "Missmatch result columns size, input size is {}, but output size is {}",
+            "Mismatch result columns size, input size is {}, but output size is {}",
             input.columns(),
             output.columns());
     }
@@ -164,12 +163,6 @@ void addMergeTreeSinkTransform(
         : std::make_shared<SparkMergeTreePartitionedFileSink>(header, partition_by, merge_tree_table, write_settings, context, stats);
 
     chain.addSource(sink);
-    const DB::Settings & settings = context->getSettingsRef();
-    chain.addSource(std::make_shared<ApplySquashingTransform>(
-        header, settings[Setting::min_insert_block_size_rows], settings[Setting::min_insert_block_size_bytes]));
-    chain.addSource(std::make_shared<PlanSquashingTransform>(
-        header, settings[Setting::min_insert_block_size_rows], settings[Setting::min_insert_block_size_bytes]));
-
     builder->addChain(std::move(chain));
 }
 
@@ -212,6 +205,7 @@ void addNormalFileWriterSinkTransform(
 namespace local_engine
 {
 
+
 IMPLEMENT_GLUTEN_SETTINGS(GlutenWriteSettings, WRITE_RELATED_SETTINGS)
 
 void addSinkTransform(const DB::ContextPtr & context, const substrait::WriteRel & write_rel, const DB::QueryPipelineBuilderPtr & builder)
@@ -224,12 +218,18 @@ void addSinkTransform(const DB::ContextPtr & context, const substrait::WriteRel 
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Failed to unpack write optimization with local_engine::Write.");
     assert(write.has_common());
     const substrait::NamedStruct & table_schema = write_rel.table_schema();
-    auto output = TypeParser::buildBlockFromNamedStruct(table_schema);
-    adjust_output(builder, output);
-    const auto partitionCols = collect_partition_cols(output, table_schema);
+    auto partition_indexes = write.common().partition_col_index();
     if (write.has_mergetree())
     {
-        local_engine::MergeTreeTable merge_tree_table(write, table_schema);
+        MergeTreeTable merge_tree_table(write, table_schema);
+        auto output = TypeParser::buildBlockFromNamedStruct(table_schema, merge_tree_table.low_card_key);
+        adjust_output(builder, output);
+
+        builder->addSimpleTransform(
+            [&](const Block & in_header) -> ProcessorPtr { return std::make_shared<MaterializingTransform>(in_header, false); });
+
+        const auto partition_by = collect_partition_cols(output, table_schema, partition_indexes);
+
         GlutenWriteSettings write_settings = GlutenWriteSettings::get(context);
         if (write_settings.task_write_tmp_dir.empty())
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "MergeTree Write Pipeline need inject relative path.");
@@ -237,23 +237,35 @@ void addSinkTransform(const DB::ContextPtr & context, const substrait::WriteRel 
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Non empty relative path for MergeTree table in pipeline mode.");
 
         merge_tree_table.relative_path = write_settings.task_write_tmp_dir;
-        addMergeTreeSinkTransform(context, builder, merge_tree_table, output, partitionCols);
+        addMergeTreeSinkTransform(context, builder, merge_tree_table, output, partition_by);
     }
     else
-        addNormalFileWriterSinkTransform(context, builder, write.common().format(), output, partitionCols);
+    {
+        auto output = TypeParser::buildBlockFromNamedStruct(table_schema);
+        adjust_output(builder, output);
+        const auto partition_by = collect_partition_cols(output, table_schema, partition_indexes);
+        addNormalFileWriterSinkTransform(context, builder, write.common().format(), output, partition_by);
+    }
 }
-
-DB::Names collect_partition_cols(const DB::Block & header, const substrait::NamedStruct & struct_)
+DB::Names collect_partition_cols(const DB::Block & header, const substrait::NamedStruct & struct_, const PartitionIndexes & partition_by)
 {
-    DB::Names result;
+    if (partition_by.empty())
+    {
+        assert(std::ranges::all_of(
+            struct_.column_types(), [](const int32_t type) { return type != ::substrait::NamedStruct::PARTITION_COL; }));
+        return {};
+    }
     assert(struct_.column_types_size() == header.columns());
     assert(struct_.column_types_size() == struct_.struct_().types_size());
 
-    auto name_iter = header.begin();
-    auto type_iter = struct_.column_types().begin();
-    for (; name_iter != header.end(); ++name_iter, ++type_iter)
-        if (*type_iter == ::substrait::NamedStruct::PARTITION_COL)
-            result.push_back(name_iter->name);
+    DB::Names result;
+    result.reserve(partition_by.size());
+    for (auto idx : partition_by)
+    {
+        assert(idx >= 0 && idx < header.columns());
+        assert(struct_.column_types(idx) == ::substrait::NamedStruct::PARTITION_COL);
+        result.emplace_back(header.getByPosition(idx).name);
+    }
     return result;
 }
 

--- a/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.h
@@ -21,6 +21,7 @@
 #include <Core/Block.h>
 #include <Core/Names.h>
 #include <Interpreters/Context_fwd.h>
+#include <google/protobuf/repeated_field.h>
 #include <Common/GlutenSettings.h>
 
 namespace substrait
@@ -38,9 +39,11 @@ using QueryPipelineBuilderPtr = std::unique_ptr<QueryPipelineBuilder>;
 namespace local_engine
 {
 
+using PartitionIndexes = google::protobuf::RepeatedField<::int32_t>;
+
 void addSinkTransform(const DB::ContextPtr & context, const substrait::WriteRel & write_rel, const DB::QueryPipelineBuilderPtr & builder);
 
-DB::Names collect_partition_cols(const DB::Block & header, const substrait::NamedStruct & struct_);
+DB::Names collect_partition_cols(const DB::Block & header, const substrait::NamedStruct & struct_, const PartitionIndexes & partition_by);
 
 #define WRITE_RELATED_SETTINGS(M, ALIAS) \
     M(String, task_write_tmp_dir, , "The temporary directory for writing data") \

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
@@ -227,8 +227,17 @@ public:
         const DB::ContextMutablePtr & context,
         const SinkStatsOption & stats = {});
 
-    explicit SparkMergeTreeSink(const SinkHelperPtr & sink_helper_, const ContextPtr & context_, const SinkStatsOption & stats)
-        : SinkToStorage(sink_helper_->metadata_snapshot->getSampleBlock()), context(context_), sink_helper(sink_helper_), stats_(stats)
+    explicit SparkMergeTreeSink(
+        const SinkHelperPtr & sink_helper_,
+        const ContextPtr & context_,
+        const SinkStatsOption & stats,
+        size_t min_block_size_rows,
+        size_t min_block_size_bytes)
+        : SinkToStorage(sink_helper_->metadata_snapshot->getSampleBlock())
+        , context(context_)
+        , sink_helper(sink_helper_)
+        , stats_(stats)
+        , squashing(sink_helper_->metadata_snapshot->getSampleBlock(), min_block_size_rows, min_block_size_bytes)
     {
     }
     ~SparkMergeTreeSink() override = default;
@@ -241,9 +250,13 @@ public:
     const SinkHelper & sinkHelper() const { return *sink_helper; }
 
 private:
+    void write(const Chunk & chunk);
+
     ContextPtr context;
     SinkHelperPtr sink_helper;
     std::optional<std::shared_ptr<MergeTreeStats>> stats_;
+    Squashing squashing;
+    Chunk squashed_chunk;
     int part_num = 1;
 };
 

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriter.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeWriter.cpp
@@ -18,8 +18,6 @@
 
 #include <Core/Settings.h>
 #include <Interpreters/ActionsDAG.h>
-#include <Processors/Transforms/ApplySquashingTransform.h>
-#include <Processors/Transforms/PlanSquashingTransform.h>
 #include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
 #include <Storages/MergeTree/MetaDataHelper.h>
 #include <Storages/MergeTree/SparkMergeTreeSink.h>
@@ -28,11 +26,6 @@
 #include <Poco/StringTokenizer.h>
 #include <Common/JNIUtils.h>
 
-namespace DB::Setting
-{
-extern const SettingsUInt64 min_insert_block_size_rows;
-extern const SettingsUInt64 min_insert_block_size_bytes;
-}
 using namespace DB;
 namespace
 {
@@ -125,12 +118,6 @@ std::unique_ptr<SparkMergeTreeWriter> SparkMergeTreeWriter::create(
     //
     // auto stats = std::make_shared<MergeTreeStats>(header, sink_helper);
     // chain.addSink(stats);
-    //
-    chain.addSource(std::make_shared<ApplySquashingTransform>(
-        header, settings[Setting::min_insert_block_size_rows], settings[Setting::min_insert_block_size_bytes]));
-    chain.addSource(std::make_shared<PlanSquashingTransform>(
-        header, settings[Setting::min_insert_block_size_rows], settings[Setting::min_insert_block_size_bytes]));
-
     return std::make_unique<SparkMergeTreeWriter>(header, sink_helper, QueryPipeline{std::move(chain)}, spark_job_id);
 }
 

--- a/cpp-ch/local-engine/tests/gtest_write_pipeline.cpp
+++ b/cpp-ch/local-engine/tests/gtest_write_pipeline.cpp
@@ -146,7 +146,7 @@ TEST(WritePipeline, SubstraitFileSink)
     DB::Names expected{"s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment111"};
     EXPECT_EQ(expected, names);
 
-    auto partitionCols = collect_partition_cols(block, table_schema);
+    auto partitionCols = collect_partition_cols(block, table_schema, {});
     DB::Names expected_partition_cols;
     EXPECT_EQ(expected_partition_cols, partitionCols);
 
@@ -164,7 +164,7 @@ TEST(WritePipeline, SubstraitFileSink)
 
 INCBIN(native_write_one_partition, SOURCE_DIR "/utils/extern-local-engine/tests/json/native_write_one_partition.json");
 
-TEST(WritePipeline, SubstraitPartitionedFileSink)
+/*TEST(WritePipeline, SubstraitPartitionedFileSink)
 {
     const auto context = DB::Context::createCopy(QueryContext::globalContext());
     GlutenWriteSettings settings{
@@ -193,7 +193,7 @@ TEST(WritePipeline, SubstraitPartitionedFileSink)
     DB::Names expected{"s_suppkey", "s_name", "s_address", "s_phone", "s_acctbal", "s_comment", "s_nationkey"};
     EXPECT_EQ(expected, names);
 
-    auto partitionCols = local_engine::collect_partition_cols(block, table_schema);
+    auto partitionCols = local_engine::collect_partition_cols(block, table_schema, {});
     DB::Names expected_partition_cols{"s_nationkey"};
     EXPECT_EQ(expected_partition_cols, partitionCols);
 
@@ -201,12 +201,12 @@ TEST(WritePipeline, SubstraitPartitionedFileSink)
     const Block & x = *local_executor->nextColumnar();
     debug::headBlock(x, 25);
     EXPECT_EQ(25, x.rows());
-}
+}*/
 
 TEST(WritePipeline, ComputePartitionedExpression)
 {
     const auto context = DB::Context::createCopy(QueryContext::globalContext());
-    
+
     Block sample_block{{STRING(), "name"}, {UINT(), "s_nationkey"}};
     auto partition_by = SubstraitPartitionedFileSink::make_partition_expression({"s_nationkey", "name"}, sample_block);
     // auto partition_by = printColumn("s_nationkey");

--- a/cpp-ch/local-engine/tests/json/mergetree/4_one_pipeline.json
+++ b/cpp-ch/local-engine/tests/json/mergetree/4_one_pipeline.json
@@ -9,13 +9,18 @@
                 "optimization": {
                   "@type": "type.googleapis.com/local_engine.Write",
                   "common": {
-                    "format": "mergetree"
+                    "format": "mergetree",
+                    "partitionColIndex": [
+                      10,
+                      8
+                    ]
                   },
                   "mergetree": {
                     "database": "default",
-                    "table": "lineitem_mergetree_insertoverwrite2",
-                    "snapshotId": "1731309448915_0",
-                    "orderByKey": "tuple()",
+                    "table": "lineitem_mergetree_partition",
+                    "snapshotId": "1734145864855_0",
+                    "orderByKey": "l_orderkey",
+                    "primaryKey": "l_orderkey",
                     "storagePolicy": "default"
                   }
                 },
@@ -221,7 +226,7 @@
                 "NORMAL_COL",
                 "NORMAL_COL",
                 "NORMAL_COL",
-                "NORMAL_COL",
+                "PARTITION_COL",
                 "NORMAL_COL",
                 "PARTITION_COL",
                 "NORMAL_COL",
@@ -232,138 +237,171 @@
               ]
             },
             "input": {
-              "read": {
+              "sort": {
                 "common": {
                   "direct": {}
                 },
-                "baseSchema": {
-                  "names": [
-                    "l_orderkey",
-                    "l_partkey",
-                    "l_suppkey",
-                    "l_linenumber",
-                    "l_quantity",
-                    "l_extendedprice",
-                    "l_discount",
-                    "l_tax",
-                    "l_returnflag",
-                    "l_linestatus",
-                    "l_shipdate",
-                    "l_commitdate",
-                    "l_receiptdate",
-                    "l_shipinstruct",
-                    "l_shipmode",
-                    "l_comment"
-                  ],
-                  "struct": {
-                    "types": [
-                      {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
+                "input": {
+                  "read": {
+                    "common": {
+                      "direct": {}
+                    },
+                    "baseSchema": {
+                      "names": [
+                        "l_orderkey",
+                        "l_partkey",
+                        "l_suppkey",
+                        "l_linenumber",
+                        "l_quantity",
+                        "l_extendedprice",
+                        "l_discount",
+                        "l_tax",
+                        "l_returnflag",
+                        "l_linestatus",
+                        "l_shipdate",
+                        "l_commitdate",
+                        "l_receiptdate",
+                        "l_shipinstruct",
+                        "l_shipmode",
+                        "l_comment"
+                      ],
+                      "struct": {
+                        "types": [
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "fp64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "date": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "date": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "date": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          {
+                            "string": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        ]
                       },
-                      {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "fp64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "fp64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "fp64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "fp64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "string": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "string": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "date": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "date": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "date": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "string": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "string": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      },
-                      {
-                        "string": {
-                          "nullability": "NULLABILITY_NULLABLE"
+                      "columnTypes": [
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL",
+                        "NORMAL_COL"
+                      ]
+                    },
+                    "advancedExtension": {
+                      "optimization": {
+                        "@type": "type.googleapis.com/google.protobuf.StringValue",
+                        "value": "isMergeTree=0\n"
+                      }
+                    }
+                  }
+                },
+                "sorts": [
+                  {
+                    "expr": {
+                      "selection": {
+                        "directReference": {
+                          "structField": {
+                            "field": 10
+                          }
                         }
                       }
-                    ]
+                    },
+                    "direction": "SORT_DIRECTION_ASC_NULLS_FIRST"
                   },
-                  "columnTypes": [
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL",
-                    "NORMAL_COL"
-                  ]
-                },
-                "advancedExtension": {
-                  "optimization": {
-                    "@type": "type.googleapis.com/google.protobuf.StringValue",
-                    "value": "isMergeTree=0\n"
+                  {
+                    "expr": {
+                      "selection": {
+                        "directReference": {
+                          "structField": {
+                            "field": 8
+                          }
+                        }
+                      }
+                    },
+                    "direction": "SORT_DIRECTION_ASC_NULLS_FIRST"
                   }
-                }
+                ]
               }
             }
           }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/TransformerApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/TransformerApi.scala
@@ -16,12 +16,13 @@
  */
 package org.apache.gluten.backendsapi
 
+import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.substrait.expression.ExpressionNode
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.types.{DataType, DecimalType, StructType}
 import org.apache.spark.util.collection.BitSet
 
@@ -75,7 +76,7 @@ trait TransformerApi {
   /** This method is only used for CH backend tests */
   def invalidateSQLExecutionResource(executionId: String): Unit = {}
 
-  def genWriteParameters(fileFormat: FileFormat, writeOptions: Map[String, String]): Any
+  def genWriteParameters(write: WriteFilesExecTransformer): Any
 
   /** use Hadoop Path class to encode the file path */
   def encodeFilePathIfNeed(filePath: String): String = filePath

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WriteFilesExecTransformer.scala
@@ -67,7 +67,7 @@ case class WriteFilesExecTransformer(
 
   override def output: Seq[Attribute] = Seq.empty
 
-  private val caseInsensitiveOptions = CaseInsensitiveMap(options)
+  val caseInsensitiveOptions: CaseInsensitiveMap[String] = CaseInsensitiveMap(options)
 
   def getRelNode(
       context: SubstraitContext,
@@ -99,8 +99,7 @@ case class WriteFilesExecTransformer(
       ConverterUtils.collectAttributeNames(inputAttributes.toSeq)
     val extensionNode = if (!validation) {
       ExtensionBuilder.makeAdvancedExtension(
-        BackendsApiManager.getTransformerApiInstance
-          .genWriteParameters(fileFormat, caseInsensitiveOptions),
+        BackendsApiManager.getTransformerApiInstance.genWriteParameters(this),
         SubstraitUtil.createEnhancement(originalInputAttributes)
       )
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since Clickhouse backend doesn't add local sort by itself,  this is differnet with velox backend. This PR and Local `SortExec`  based on `SparkPlan` instead of  `LogicalPlan` for **Delta Write** and remove `RemoveNativeWriteFilesSortAndProject` for datasource v1 write.

1. I  also fix an issue caused by `WriteRel` doesn't including partition column order issue by adding such information in [write_optimization.proto](https://github.com/apache/incubator-gluten/pull/8237/files#diff-c4d35f61ef1f60be2b950d7960c3f0fd1211366efc670f831d7ebd8bfed99538)
2. Since we already sort blocks, hence we can remove`ApplySquashingTransform` and `PlanSquashingTransform` from pipeline and adding `Squashing`  in `SparkMergeTreeSink`.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

