### PR TITLE
[GLUTEN-7911][CORE] Flip dependency direction for gluten-hudi

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -82,6 +82,29 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>hudi</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-hudi</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-hudi</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hudi</groupId>
+          <artifactId>hudi-spark${sparkbundle.version}-bundle_${scala.binary.version}</artifactId>
+          <version>${hudi.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/backends-velox/src-hudi/test/scala/org/apache/execution/VeloxHudiSuite.scala
+++ b/backends-velox/src-hudi/test/scala/org/apache/execution/VeloxHudiSuite.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.execution
+
+import org.apache.gluten.execution.HudiSuite
+
+class VeloxHudiSuite extends HudiSuite {}

--- a/backends-velox/src-hudi/test/scala/org/apache/execution/VeloxTPCHHudiSuite.scala
+++ b/backends-velox/src-hudi/test/scala/org/apache/execution/VeloxTPCHHudiSuite.scala
@@ -14,16 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.execution
+package org.apache.execution
 
+import org.apache.gluten.execution.VeloxTPCHSuite
 import org.apache.spark.SparkConf
 
 import java.io.File
 
 class VeloxTPCHHudiSuite extends VeloxTPCHSuite {
-
-  protected val tpchBasePath: String = new File(
-    "../backends-velox/src/test/resources").getAbsolutePath
+  protected val tpchBasePath: String =
+    getClass.getResource("/").getPath + "../../../src/test/resources"
 
   override protected val resourcePath: String =
     new File(tpchBasePath, "tpch-data-parquet").getCanonicalPath

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/spark/TreeMemoryConsumer.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/spark/TreeMemoryConsumer.java
@@ -138,7 +138,7 @@ public class TreeMemoryConsumer extends MemoryConsumer implements TreeMemoryTarg
   @Override
   public TreeMemoryTarget parent() {
     // we are root
-    throw new IllegalStateException("Unreachable code");
+    throw new IllegalStateException("Unreachable code org.apache.gluten.memory.memtarget.spark.TreeMemoryConsumer.parent");
   }
 
   @Override

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/spark/TreeMemoryConsumer.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/spark/TreeMemoryConsumer.java
@@ -138,7 +138,8 @@ public class TreeMemoryConsumer extends MemoryConsumer implements TreeMemoryTarg
   @Override
   public TreeMemoryTarget parent() {
     // we are root
-    throw new IllegalStateException("Unreachable code org.apache.gluten.memory.memtarget.spark.TreeMemoryConsumer.parent");
+    throw new IllegalStateException(
+        "Unreachable code org.apache.gluten.memory.memtarget.spark.TreeMemoryConsumer.parent");
   }
 
   @Override

--- a/gluten-core/src/main/scala/org/apache/spark/task/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/task/TaskResources.scala
@@ -298,11 +298,14 @@ class TaskResourceRegistry extends Logging {
           o1: util.Map.Entry[Int, util.LinkedHashSet[TaskResource]],
           o2: util.Map.Entry[Int, util.LinkedHashSet[TaskResource]]) => {
         val diff = o2.getKey - o1.getKey // descending by priority
-        if (diff > 0) 1
-        else if (diff < 0) -1
-        else
+        if (diff > 0) {
+          1
+        } else if (diff < 0) {
+          -1
+        } else {
           throw new IllegalStateException(
             "Unreachable code from org.apache.spark.task.TaskResourceRegistry.releaseAll")
+        }
       }
     )
     table.forEach {

--- a/gluten-core/src/main/scala/org/apache/spark/task/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/task/TaskResources.scala
@@ -300,7 +300,9 @@ class TaskResourceRegistry extends Logging {
         val diff = o2.getKey - o1.getKey // descending by priority
         if (diff > 0) 1
         else if (diff < 0) -1
-        else throw new IllegalStateException("Unreachable code")
+        else
+          throw new IllegalStateException(
+            "Unreachable code from org.apache.spark.task.TaskResourceRegistry.releaseAll")
       }
     )
     table.forEach {

--- a/gluten-hudi/pom.xml
+++ b/gluten-hudi/pom.xml
@@ -47,19 +47,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.gluten</groupId>
-      <artifactId>backends-velox</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.gluten</groupId>
-      <artifactId>backends-velox</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <type>test-jar</type>

--- a/gluten-hudi/src-hudi/test/scala/org/apache/gluten/execution/HudiSuite.scala
+++ b/gluten-hudi/src-hudi/test/scala/org/apache/gluten/execution/HudiSuite.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.execution
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 
-class VeloxHudiSuite extends WholeStageTransformerSuite {
+abstract class HudiSuite extends WholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
   override protected val resourcePath: String = "/tpch-data-parquet"

--- a/gluten-ut/common/src/test/scala/org/apache/gluten/utils/BackendTestSettings.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/gluten/utils/BackendTestSettings.scala
@@ -80,7 +80,8 @@ abstract class BackendTestSettings {
       return !isExcluded
     }
 
-    throw new IllegalStateException("Unreachable code")
+    throw new IllegalStateException(
+      "Unreachable code from org.apache.gluten.utils.BackendTestSettings.shouldRun")
   }
 
   final protected class SuiteSettings {

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -74,7 +74,8 @@ abstract class AbstractFileSourceScanExec(
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
     throw new UnsupportedOperationException(
-      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec" +
+        ".supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -73,7 +73,8 @@ abstract class AbstractFileSourceScanExec(
 
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
-    throw new UnsupportedOperationException("Unreachable code")
+    throw new UnsupportedOperationException(
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -78,7 +78,8 @@ abstract class AbstractFileSourceScanExec(
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
     throw new UnsupportedOperationException(
-      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec" +
+        ".supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -77,7 +77,8 @@ abstract class AbstractFileSourceScanExec(
 
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
-    throw new UnsupportedOperationException("Unreachable code")
+    throw new UnsupportedOperationException(
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -70,7 +70,8 @@ abstract class AbstractFileSourceScanExec(
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
     throw new UnsupportedOperationException(
-      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec" +
+        ".supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -69,7 +69,8 @@ abstract class AbstractFileSourceScanExec(
 
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
-    throw new UnsupportedOperationException("Unreachable code")
+    throw new UnsupportedOperationException(
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -70,7 +70,8 @@ abstract class AbstractFileSourceScanExec(
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
     throw new UnsupportedOperationException(
-      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec" +
+        ".supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -69,7 +69,8 @@ abstract class AbstractFileSourceScanExec(
 
   override def supportsColumnar: Boolean = {
     // The value should be defined in GlutenPlan.
-    throw new UnsupportedOperationException("Unreachable code")
+    throw new UnsupportedOperationException(
+      "Unreachable code from org.apache.spark.sql.execution.AbstractFileSourceScanExec.supportsColumnar")
   }
 
   private lazy val needsUnsafeRowConversion: Boolean = {


### PR DESCRIPTION
https://github.com/apache/incubator-gluten/issues/7911

Make Maven module backends-velox depend on gluten-hudi than the opposite, to make sure the common source code and UT code (particularly hudiSuite at the moment) to be accessible from other backend modules.

The new folder backends-velox/src-hudi is added for placing code that relate to Velox+hudi support.

TODO in subsequent PRs:

Enable Maven code linters for backends-velox/src-hudi