### PR TITLE
[VL] Fix crash when there are unreleased memory pools during termintating a Velox task

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -336,8 +336,8 @@ bool VeloxMemoryManager::tryDestructSafe() {
   // Velox memory manager considered safe to destruct when no alive pools.
   if (veloxMemoryManager_) {
     if (veloxMemoryManager_->numPools() > 3) {
-      LOG(WARNING) << "Failed to destruct VeloxMemoryManager because there are " << veloxMemoryManager_->numPools()
-                   << " outstanding memory pools.";
+      VLOG(2) << "Attempt to destruct VeloxMemoryManager failed because there are " << veloxMemoryManager_->numPools()
+              << " outstanding memory pools.";
       return false;
     }
     if (veloxMemoryManager_->numPools() == 3) {

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -336,7 +336,8 @@ bool VeloxMemoryManager::tryDestructSafe() {
   // Velox memory manager considered safe to destruct when no alive pools.
   if (veloxMemoryManager_) {
     if (veloxMemoryManager_->numPools() > 3) {
-      GLUTEN_CHECK(false, "Unreachable code");
+      LOG(WARNING) << "Failed to destruct VeloxMemoryManager because there are " << veloxMemoryManager_->numPools()
+                   << " outstanding memory pools.";
       return false;
     }
     if (veloxMemoryManager_->numPools() == 3) {


### PR DESCRIPTION
A quick fix for a crash issue introduced by https://github.com/apache/incubator-gluten/pull/8223.

Error:
```
terminate called after throwing an instance of 'gluten::GlutenException'
  what():  Unreachable code
```



