### PR TITLE
[CORE] Minor: OverTarget is required only with sufficient memory and doesn't spill due to zero used bytes post-borrow

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ReservationListeners.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ReservationListeners.java
@@ -54,15 +54,7 @@ public final class ReservationListeners {
         MemoryTargets.newConsumer(
             tmm,
             consumer.name() + ".OverAcquire",
-            new Spiller() {
-              @Override
-              public long spill(MemoryTarget self, Phase phase, long size) {
-                if (!Spillers.PHASE_SET_ALL.contains(phase)) {
-                  return 0L;
-                }
-                return self.repay(size);
-              }
-            },
+            Spillers.NOOP,
             Collections.emptyMap());
     final MemoryTarget target =
         MemoryTargets.throwOnOom(

--- a/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ReservationListeners.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ReservationListeners.java
@@ -52,10 +52,7 @@ public final class ReservationListeners {
             tmm, name, Spillers.withMinSpillSize(spiller, reservationBlockSize), mutableStats);
     final MemoryTarget overConsumer =
         MemoryTargets.newConsumer(
-            tmm,
-            consumer.name() + ".OverAcquire",
-            Spillers.NOOP,
-            Collections.emptyMap());
+            tmm, consumer.name() + ".OverAcquire", Spillers.NOOP, Collections.emptyMap());
     final MemoryTarget target =
         MemoryTargets.throwOnOom(
             MemoryTargets.overAcquire(

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/OverAcquire.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/OverAcquire.java
@@ -57,13 +57,15 @@ public class OverAcquire implements MemoryTarget {
     }
     Preconditions.checkState(overTarget.usedBytes() == 0);
     long granted = target.borrow(size);
-    long majorSize = target.usedBytes();
-    long overSize = (long) (ratio * majorSize);
-    long overAcquired = overTarget.borrow(overSize);
-    Preconditions.checkState(overAcquired == overTarget.usedBytes());
-    long releasedOverSize = overTarget.repay(overAcquired);
-    Preconditions.checkState(releasedOverSize == overAcquired);
-    Preconditions.checkState(overTarget.usedBytes() == 0);
+    if (granted >= size) {
+      long majorSize = target.usedBytes();
+      long overSize = (long) (ratio * majorSize);
+      long overAcquired = overTarget.borrow(overSize);
+      Preconditions.checkState(overAcquired == overTarget.usedBytes());
+      long releasedOverSize = overTarget.repay(overAcquired);
+      Preconditions.checkState(releasedOverSize == overAcquired);
+      Preconditions.checkState(overTarget.usedBytes() == 0);
+    }
     return granted;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Two minor updates:
1. Require overTarget only when sufficient target memory is granted.
2. overTarget doesn't need to really spill because overTarget.usedBytes() is always 0 after OverAcquire.borrow().

## How was this patch tested?
Exist CI.