### PR TITLE
[VL] Allow shared dependencies for lib GCS

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -119,10 +119,7 @@ macro(find_awssdk)
 endmacro()
 
 macro(find_gcssdk)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   find_package(google_cloud_cpp_storage CONFIG 2.22.0 REQUIRED)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
 endmacro()
 
 macro(find_azure)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr simply removes the setting for CMAKE_FIND_LIBRARY_SUFFIXES before finding lib GCS.

