### PR TITLE
[CH] Hotfix to #8212

### DIFF
--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -286,6 +286,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("groupBy.as")
   enableSuite[GlutenDateFunctionsSuite]
     .exclude("function to_date")
+    .excludeGlutenTest("function to_date")
     .exclude("unix_timestamp")
     .exclude("to_unix_timestamp")
     .exclude("to_timestamp")


### PR DESCRIPTION
## What changes were proposed in this pull request?

#8212 introduced `testGluten("function to_date") ` which is failed in spark32, let's ignore it

```
[2024-12-17T09:40:35.895Z] - Gluten - function to_date *** FAILED ***
[2024-12-17T09:40:35.895Z]   org.apache.spark.sql.catalyst.analysis.UnresolvedException: Invalid call to dataType on unresolved object
[2024-12-17T09:40:35.895Z]   at org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute.dataType(unresolved.scala:160)
[2024-12-17T09:40:35.895Z]   at org.apache.gluten.extension.RewriteToDateExpresstionRule.rewriteParseToDate(RewriteToDateExpresstionRule.scala:98)
[2024-12-17T09:40:35.895Z]   at org.apache.gluten.extension.RewriteToDateExpresstionRule.visitExpression(RewriteToDateExpresstionRule.scala:66)
[2024-12-17T09:40:35.895Z]   at org.apache.gluten.extension.RewriteToDateExpresstionRule.$anonfun$visitPlan$1(RewriteToDateExpresstionRule.scala:56)
[2024-12-17T09:40:35.895Z]   at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
[2024-12-17T09:40:35.895Z]   at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
[2024-12-17T09:40:35.895Z]   at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
[2024-12-17T09:40:35.895Z]   at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
[2024-12-17T09:40:35.895Z]   at scala.collection.TraversableLike.map(TraversableLike.scala:286)
[2024-12-17T09:40:35.895Z]   at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
```
## How was this patch tested?

Existed UTs
