### PR TITLE
[GLUTEN-8268][CORE] Remove preconditions in OverAcquire.repay

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/OverAcquire.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/OverAcquire.java
@@ -74,7 +74,6 @@ public class OverAcquire implements MemoryTarget {
     if (size == 0) {
       return 0;
     }
-    Preconditions.checkState(overTarget.usedBytes() == 0);
     return target.repay(size);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After https://github.com/apache/incubator-gluten/pull/8132, overTarget.borrow(overSize) may trigger a retrying spill. If so, it calls OverAcquire.repay() during the spill procedure, which checks Preconditions.checkState(overTarget.usedBytes() == 0);. However, currently, 0 < overTarget.usedBytes() < overSize. We can remove this precondition in repay(), and only keep the precondition in borrow().

(Fixes: \#8268)

## How was this patch tested?

integration tests

