### PR TITLE
[CH] Refactor: don't `using namespace DB` in header

### DIFF
--- a/cpp-ch/local-engine/Functions/FunctionGetDateData.h
+++ b/cpp-ch/local-engine/Functions/FunctionGetDateData.h
@@ -14,19 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Common/LocalDate.h>
-#include <Common/DateLUT.h>
-#include <Common/DateLUTImpl.h>
+#pragma once
+#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnVector.h>
-#include <Columns/ColumnNullable.h>
-#include <DataTypes/DataTypeNullable.h>
 #include <Functions/FunctionFactory.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadHelpers.h>
 #include <IO/parseDateTimeBestEffort.h>
-
-using namespace DB;
+#include <Common/DateLUT.h>
+#include <Common/DateLUTImpl.h>
 
 namespace DB
 {
@@ -55,7 +52,7 @@ public:
         const auto * src_col = checkAndGetColumn<DB::ColumnString>(arg1.column.get());
         size_t size = src_col->size();
         
-        using ColVecTo = ColumnVector<T>;
+        using ColVecTo = DB::ColumnVector<T>;
         typename ColVecTo::MutablePtr result_column = ColVecTo::create(size, 0);
         typename ColVecTo::Container & result_container = result_column->getData();
         DB::ColumnUInt8::MutablePtr null_map = DB::ColumnUInt8::create(size, 0);

--- a/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.h
@@ -14,18 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
-#include <Common/NaNUtils.h>
-#include <DataTypes/IDataType.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnVector.h>
+#include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Functions/IFunction.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
-#include <Columns/ColumnsNumber.h>
-#include <Columns/ColumnVector.h>
-#include <Columns/ColumnNullable.h>
-
-using namespace DB;
+#include <Functions/IFunction.h>
+#include <Common/NaNUtils.h>
 
 namespace DB
 {
@@ -51,7 +50,7 @@ public:
     ~SparkFunctionCastFloatToInt() override = default;
     String getName() const override { return name; }
     bool useDefaultImplementationForConstants() const override { return true; }
-    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DB::DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
     DB::DataTypePtr getReturnTypeImpl(const DB::DataTypes &) const override
     {

--- a/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.h
@@ -35,10 +35,9 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-using namespace DB;
 
 template <typename From, typename To>
-Field convertNumericTypeImpl(From from)
+DB::Field convertNumericTypeImpl(From from)
 {
     To result;
     if (!accurate::convertNumeric(from, result))
@@ -47,39 +46,39 @@ Field convertNumericTypeImpl(From from)
 }
 
 template <typename To>
-Field convertNumericType(const Field & from)
+DB::Field convertNumericType(const DB::Field & from)
 {
-    if (from.getType() == Field::Types::UInt64)
+    if (from.getType() == DB::Field::Types::UInt64)
         return convertNumericTypeImpl<UInt64, To>(from.safeGet<UInt64>());
-    if (from.getType() == Field::Types::Int64)
+    if (from.getType() == DB::Field::Types::Int64)
         return convertNumericTypeImpl<Int64, To>(from.safeGet<Int64>());
-    if (from.getType() == Field::Types::UInt128)
+    if (from.getType() == DB::Field::Types::UInt128)
         return convertNumericTypeImpl<UInt128, To>(from.safeGet<UInt128>());
-    if (from.getType() == Field::Types::Int128)
+    if (from.getType() == DB::Field::Types::Int128)
         return convertNumericTypeImpl<Int128, To>(from.safeGet<Int128>());
-    if (from.getType() == Field::Types::UInt256)
+    if (from.getType() == DB::Field::Types::UInt256)
         return convertNumericTypeImpl<UInt256, To>(from.safeGet<UInt256>());
-    if (from.getType() == Field::Types::Int256)
+    if (from.getType() == DB::Field::Types::Int256)
         return convertNumericTypeImpl<Int256, To>(from.safeGet<Int256>());
 
-    throw Exception(ErrorCodes::TYPE_MISMATCH, "Type mismatch. Expected: Integer. Got: {}", from.getType());
+    throw DB::Exception(DB::ErrorCodes::TYPE_MISMATCH, "Type mismatch. Expected: Integer. Got: {}", from.getType());
 }
 
-inline UInt32 extractArgument(const ColumnWithTypeAndName & named_column)
+inline UInt32 extractArgument(const DB::ColumnWithTypeAndName & named_column)
 {
     if (!isColumnConst(*named_column.column.get()))
     {
-        throw Exception(
-            ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument, column type must be const", named_column.type->getName());
+        throw DB::Exception(
+            DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument, column type must be const", named_column.type->getName());
     }
 
-    Field from;
+    DB::Field from;
     named_column.column->get(0, from);
-    Field to = convertNumericType<UInt32>(from);
+    DB::Field to = convertNumericType<UInt32>(from);
     if (to.isNull())
     {
-        throw Exception(
-            ErrorCodes::DECIMAL_OVERFLOW, "{} convert overflow, precision/scale value must in UInt32", named_column.type->getName());
+        throw DB::Exception(
+            DB::ErrorCodes::DECIMAL_OVERFLOW, "{} convert overflow, precision/scale value must in UInt32", named_column.type->getName());
     }
     return static_cast<UInt32>(to.safeGet<UInt32>());
 }

--- a/cpp-ch/local-engine/Functions/SparkFunctionDateToUnixTimestamp.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDateToUnixTimestamp.h
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
+#include <Columns/ColumnVector.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/IDataType.h>
+#include <Functions/FunctionFactory.h>
 #include <Common/DateLUT.h>
 #include <Common/DateLUTImpl.h>
 #include <Common/LocalDateTime.h>
-#include <Columns/ColumnVector.h>
-#include <DataTypes/IDataType.h>
-#include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/DataTypesNumber.h>
-#include <Functions/FunctionFactory.h>
 
 namespace DB
 {
@@ -32,16 +32,13 @@ namespace ErrorCodes
 }
 }
 
-using namespace DB;
-
 namespace local_eingine
 {
-
-class SparkFunctionDateToUnixTimestamp : public IFunction
+class SparkFunctionDateToUnixTimestamp : public DB::IFunction
 {
 public:
     static constexpr auto name = "sparkDateToUnixTimestamp";
-    static FunctionPtr create(ContextPtr) { return std::make_shared<SparkFunctionDateToUnixTimestamp>(); }
+    static DB::FunctionPtr create(DB::ContextPtr) { return std::make_shared<SparkFunctionDateToUnixTimestamp>(); }
     SparkFunctionDateToUnixTimestamp() {}
     ~SparkFunctionDateToUnixTimestamp() override = default;
     String getName() const override { return name; }
@@ -49,17 +46,14 @@ public:
     size_t getNumberOfArguments() const override { return 0; }
     bool isVariadic() const override { return true; }
     bool useDefaultImplementationForConstants() const override { return true; }
-    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName &) const override
-    {
-        return std::make_shared<DataTypeUInt32>();
-    }
+    DB::DataTypePtr getReturnTypeImpl(const DB::ColumnsWithTypeAndName &) const override { return std::make_shared<DB::DataTypeUInt32>(); }
 
-    ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows) const override
+    DB::ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows) const override
     {
        if (arguments.size() != 1 && arguments.size() != 2)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} argument size must be 1 or 2", name);
-        
-       ColumnWithTypeAndName first_arg = arguments[0];
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} argument size must be 1 or 2", name);
+
+        DB::ColumnWithTypeAndName first_arg = arguments[0];
        if (isDate(first_arg.type))
             return executeInternal<UInt16>(first_arg.column, input_rows);
         else
@@ -67,11 +61,11 @@ public:
     }
 
     template<typename T>
-    ColumnPtr NO_SANITIZE_UNDEFINED executeInternal(const ColumnPtr & col, size_t input_rows) const
+    DB::ColumnPtr NO_SANITIZE_UNDEFINED executeInternal(const DB::ColumnPtr & col, size_t input_rows) const
     {
-        const ColumnVector<T> * col_src = checkAndGetColumn<ColumnVector<T>>(col.get());
-        MutableColumnPtr res = ColumnVector<UInt32>::create(col->size());
-        PaddedPODArray<UInt32> & data = assert_cast<ColumnVector<UInt32> *>(res.get())->getData();
+        const DB::ColumnVector<T> * col_src = checkAndGetColumn<DB::ColumnVector<T>>(col.get());
+        DB::MutableColumnPtr res = DB::ColumnVector<UInt32>::create(col->size());
+        DB::PaddedPODArray<UInt32> & data = assert_cast<DB::ColumnVector<UInt32> *>(res.get())->getData();
         if (col->size() == 0)
             return res;
         

--- a/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
@@ -14,15 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Functions/castTypeToEither.h>
-#include <Functions/FunctionHelpers.h>
-#include <Functions/FunctionFactory.h>
-#include <Functions/FunctionBinaryArithmetic.h>
+#pragma once
 #include <Columns/IColumn.h>
-#include <DataTypes/DataTypeNumberBase.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeNumberBase.h>
+#include <Functions/FunctionBinaryArithmetic.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/castTypeToEither.h>
 
-using namespace DB;
 
 namespace DB
 {
@@ -35,11 +35,10 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
 template <typename A, typename B>
 struct SparkDivideFloatingImpl
 {
-    using ResultType = typename NumberTraits::ResultOfFloatingPointDivision<A, B>::Type;
+    using ResultType = typename DB::NumberTraits::ResultOfFloatingPointDivision<A, B>::Type;
     static const constexpr bool allow_fixed_string = false;
     static const constexpr bool allow_string_integer = false;
 
@@ -54,7 +53,7 @@ struct SparkDivideFloatingImpl
     static inline llvm::Value * compile(llvm::IRBuilder<> & b, llvm::Value * left, llvm::Value * right, bool)
     {
         if (left->getType()->isIntegerTy())
-            throw Exception(DB::ErrorCodes::LOGICAL_ERROR, "SparkDivideFloatingImpl expected a floating-point type");
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "SparkDivideFloatingImpl expected a floating-point type");
         return b.CreateFDiv(left, right);
     }
 #endif
@@ -70,61 +69,70 @@ public:
     ~SparkFunctionDivide() override = default;
     String getName() const override { return name; }
     bool useDefaultImplementationForConstants() const override { return true; }
-    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DB::DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
     DB::DataTypePtr getReturnTypeImpl(const DB::DataTypes &) const override
     {
         return DB::makeNullable(std::make_shared<const DB::DataTypeFloat64>());
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    DB::ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows_count) const override
     {
         if (arguments.size() != 2)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 2", name);
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 2", name);
         if (!isNativeNumber(arguments[0].type) || !isNativeNumber(arguments[1].type))
         {
-            throw Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type must be native number", name);
+            throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type must be native number", name);
         }
-        using Types = TypeList<DataTypeFloat32, DataTypeFloat64,DataTypeUInt8, DataTypeUInt16, DataTypeUInt32,
-            DataTypeUInt64, DataTypeInt8, DataTypeInt16, DataTypeInt32, DataTypeInt64>;
+        using Types = TypeList<
+            DB::DataTypeFloat32,
+            DB::DataTypeFloat64,
+            DB::DataTypeUInt8,
+            DB::DataTypeUInt16,
+            DB::DataTypeUInt32,
+            DB::DataTypeUInt64,
+            DB::DataTypeInt8,
+            DB::DataTypeInt16,
+            DB::DataTypeInt32,
+            DB::DataTypeInt64>;
         
-        ColumnPtr result = nullptr;
+        DB::ColumnPtr result = nullptr;
         bool valid = castTypeToEither(Types{}, arguments[0].type.get(), [&](const auto & left_)
         {
             return castTypeToEither(Types{}, arguments[1].type.get(), [&](const auto & right_)
             {
                 using L = typename std::decay_t<decltype(left_)>::FieldType;
                 using R = typename std::decay_t<decltype(right_)>::FieldType;
-                using T = typename NumberTraits::ResultOfFloatingPointDivision<L, R>::Type;
-                const ColumnVector<L> * vec1 = nullptr;
-                const ColumnVector<R> * vec2 = nullptr;
-                const ColumnVector<L> * const_col_left = checkAndGetColumnConstData<ColumnVector<L>>(arguments[0].column.get());
-                const ColumnVector<R> * const_col_right = checkAndGetColumnConstData<ColumnVector<R>>(arguments[1].column.get());
+                using T = typename DB::NumberTraits::ResultOfFloatingPointDivision<L, R>::Type;
+                const DB::ColumnVector<L> * vec1 = nullptr;
+                const DB::ColumnVector<R> * vec2 = nullptr;
+                const DB::ColumnVector<L> * const_col_left = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
+                const DB::ColumnVector<R> * const_col_right = checkAndGetColumnConstData<DB::ColumnVector<R>>(arguments[1].column.get());
                 L left_const_val = 0;
                 R right_const_val = 0;
                 if (const_col_left)
                     left_const_val = const_col_left->getElement(0);
                 else
-                    vec1 = assert_cast<const ColumnVector<L> *>(arguments[0].column.get());
+                    vec1 = assert_cast<const DB::ColumnVector<L> *>(arguments[0].column.get());
                 
                 if (const_col_right)
                 {
                     right_const_val = const_col_right->getElement(0);
                     if (right_const_val == 0)
                     {
-                        auto data_col = ColumnVector<T>::create(arguments[0].column->size(), 0);
-                        auto null_map_col = ColumnVector<UInt8>::create(arguments[0].column->size(), 1);
-                        result = ColumnNullable::create(std::move(data_col), std::move(null_map_col));
+                        auto data_col = DB::ColumnVector<T>::create(arguments[0].column->size(), 0);
+                        auto null_map_col = DB::ColumnVector<UInt8>::create(arguments[0].column->size(), 1);
+                        result = DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col));
                         return true;
                     }
                 }
                 else
-                    vec2 = assert_cast<const ColumnVector<R> *>(arguments[1].column.get());
+                    vec2 = assert_cast<const DB::ColumnVector<R> *>(arguments[1].column.get());
 
-                auto vec3 = ColumnVector<T>::create(input_rows_count, 0);
-                auto null_map_col = ColumnVector<UInt8>::create(input_rows_count, 0);
-                PaddedPODArray<T> & data = vec3->getData();
-                PaddedPODArray<UInt8> & null_map = null_map_col->getData();
+                auto vec3 = DB::ColumnVector<T>::create(input_rows_count, 0);
+                auto null_map_col = DB::ColumnVector<UInt8>::create(input_rows_count, 0);
+                DB::PaddedPODArray<T> & data = vec3->getData();
+                DB::PaddedPODArray<UInt8> & null_map = null_map_col->getData();
                 for (size_t i = 0; i < input_rows_count; ++i)
                 {
                     L l = vec1 ? vec1->getElement(i) : left_const_val;
@@ -134,12 +142,12 @@ public:
                     else
                         data[i] = SparkDivideFloatingImpl<L,R>::apply(l, r);
                 }
-                result = ColumnNullable::create(std::move(vec3), std::move(null_map_col));
+                result = DB::ColumnNullable::create(std::move(vec3), std::move(null_map_col));
                 return true;
             });
         });
         if (!valid)
-            throw Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type is not valid", name);
+            throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type is not valid", name);
         return result;
     }
 };

--- a/cpp-ch/local-engine/Functions/SparkFunctionExtractYear.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionExtractYear.cpp
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Functions/FunctionGetDateData.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionGetDateData.h>
 
 using namespace DB;
 

--- a/cpp-ch/local-engine/Functions/SparkFunctionFloor.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionFloor.h
@@ -27,11 +27,8 @@
 #include <immintrin.h>
 #endif
 
-using namespace DB;
-
 namespace local_engine
 {
-
 template <typename T>
 requires std::is_floating_point_v<T>
 static void checkAndSetNullable(T & t, UInt8 & null_flag)
@@ -129,25 +126,25 @@ DECLARE_AVX2_SPECIFIC_CODE(
 
 )
 
-template <typename T, ScaleMode scale_mode>
+template <typename T, DB::ScaleMode scale_mode>
 requires std::is_floating_point_v<T>
 struct SparkFloatFloorImpl
 {
 private:
-    static_assert(!is_decimal<T>);
+    static_assert(!DB::is_decimal<T>);
     template <
-        Vectorize vectorize =
+        DB::Vectorize vectorize =
 #ifdef __SSE4_1__
-            Vectorize::Yes
+            DB::Vectorize::Yes
 #else
-            Vectorize::No
+            DB::Vectorize::No
 #endif
         >
-    using Op = FloatRoundingComputation<T, RoundingMode::Floor, scale_mode, vectorize>;
+    using Op = DB::FloatRoundingComputation<T, DB::RoundingMode::Floor, scale_mode, vectorize>;
     using Data = std::array<T, Op<>::data_count>;
 
 public:
-    static void apply(const PaddedPODArray<T> & in, size_t scale, PaddedPODArray<T> & out, PaddedPODArray<UInt8> & null_map)
+    static void apply(const DB::PaddedPODArray<T> & in, size_t scale, DB::PaddedPODArray<T> & out, DB::PaddedPODArray<UInt8> & null_map)
     {
         auto mm_scale = Op<>::prepare(scale);
         const size_t data_count = std::tuple_size<Data>();
@@ -173,7 +170,7 @@ public:
         }
 
 #if USE_MULTITARGET_CODE
-        if (isArchSupported(TargetArch::AVX2))
+        if (isArchSupported(DB::TargetArch::AVX2))
         {
             if constexpr (std::is_same_v<T, Float32>)
             {
@@ -194,21 +191,21 @@ public:
 
 class SparkFunctionFloor : public DB::FunctionFloor
 {
-    static Scale getScaleArg(const ColumnsWithTypeAndName & arguments)
+    static DB::Scale getScaleArg(const DB::ColumnsWithTypeAndName & arguments)
     {
         if (arguments.size() == 2)
         {
-            const IColumn & scale_column = *arguments[1].column;
+            const DB::IColumn & scale_column = *arguments[1].column;
             if (!isColumnConst(scale_column))
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Scale argument for rounding functions must be constant");
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_COLUMN, "Scale argument for rounding functions must be constant");
 
-            Field scale_field = assert_cast<const ColumnConst &>(scale_column).getField();
-            if (scale_field.getType() != Field::Types::UInt64 && scale_field.getType() != Field::Types::Int64)
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Scale argument for rounding functions must have integer type");
+            DB::Field scale_field = assert_cast<const DB::ColumnConst &>(scale_column).getField();
+            if (scale_field.getType() != DB::Field::Types::UInt64 && scale_field.getType() != DB::Field::Types::Int64)
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_COLUMN, "Scale argument for rounding functions must have integer type");
 
             Int64 scale64 = scale_field.safeGet<Int64>();
-            if (scale64 > std::numeric_limits<Scale>::max() || scale64 < std::numeric_limits<Scale>::min())
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Scale argument for rounding function is too large");
+            if (scale64 > std::numeric_limits<DB::Scale>::max() || scale64 < std::numeric_limits<DB::Scale>::min())
+                throw DB::Exception(DB::ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Scale argument for rounding function is too large");
 
             return scale64;
         }
@@ -222,9 +219,9 @@ public:
     ~SparkFunctionFloor() override = default;
     String getName() const override { return name; }
 
-    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
+    DB::ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
 
-    DB::DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    DB::DataTypePtr getReturnTypeImpl(const DB::ColumnsWithTypeAndName & arguments) const override
     {
         auto result_type = DB::FunctionFloor::getReturnTypeImpl(arguments);
         return makeNullable(result_type);
@@ -233,13 +230,13 @@ public:
     DB::ColumnPtr
     executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows) const override
     {
-        const ColumnWithTypeAndName & first_arg = arguments[0];
-        Scale scale_arg = getScaleArg(arguments);
+        const DB::ColumnWithTypeAndName & first_arg = arguments[0];
+        DB::Scale scale_arg = getScaleArg(arguments);
         switch (first_arg.type->getTypeId())
         {
-            case TypeIndex::Float32:
+            case DB::TypeIndex::Float32:
                 return executeInternal<Float32>(first_arg.column, scale_arg);
-            case TypeIndex::Float64:
+            case DB::TypeIndex::Float64:
                 return executeInternal<Float64>(first_arg.column, scale_arg);
             default:
                 DB::ColumnPtr res = DB::FunctionFloor::executeImpl(arguments, result_type, input_rows);
@@ -249,29 +246,29 @@ public:
     }
 
     template <typename T>
-    static ColumnPtr executeInternal(const ColumnPtr & col_arg, const Scale & scale_arg)
+    static DB::ColumnPtr executeInternal(const DB::ColumnPtr & col_arg, const DB::Scale & scale_arg)
     {
-        const auto * col = checkAndGetColumn<ColumnVector<T>>(col_arg.get());
-        auto col_res = ColumnVector<T>::create(col->size());
-        MutableColumnPtr null_map_col = DB::ColumnUInt8::create(col->size(), 0);
-        PaddedPODArray<T> & vec_res = col_res->getData();
-        PaddedPODArray<UInt8> & null_map_data = assert_cast<ColumnVector<UInt8> *>(null_map_col.get())->getData();
+        const auto * col = checkAndGetColumn<DB::ColumnVector<T>>(col_arg.get());
+        auto col_res = DB::ColumnVector<T>::create(col->size());
+        DB::MutableColumnPtr null_map_col = DB::ColumnUInt8::create(col->size(), 0);
+        DB::PaddedPODArray<T> & vec_res = col_res->getData();
+        DB::PaddedPODArray<UInt8> & null_map_data = assert_cast<DB::ColumnVector<UInt8> *>(null_map_col.get())->getData();
         if (!vec_res.empty())
         {
             if (scale_arg == 0)
             {
                 size_t scale = 1;
-                SparkFloatFloorImpl<T, ScaleMode::Zero>::apply(col->getData(), scale, vec_res, null_map_data);
+                SparkFloatFloorImpl<T, DB::ScaleMode::Zero>::apply(col->getData(), scale, vec_res, null_map_data);
             }
             else if (scale_arg > 0)
             {
                 size_t scale = intExp10(scale_arg);
-                SparkFloatFloorImpl<T, ScaleMode::Positive>::apply(col->getData(), scale, vec_res, null_map_data);
+                SparkFloatFloorImpl<T, DB::ScaleMode::Positive>::apply(col->getData(), scale, vec_res, null_map_data);
             }
             else
             {
                 size_t scale = intExp10(-scale_arg);
-                SparkFloatFloorImpl<T, ScaleMode::Negative>::apply(col->getData(), scale, vec_res, null_map_data);
+                SparkFloatFloorImpl<T, DB::ScaleMode::Negative>::apply(col->getData(), scale, vec_res, null_map_data);
             }
         }
         return DB::ColumnNullable::create(std::move(col_res), std::move(null_map_col));

--- a/cpp-ch/local-engine/Functions/SparkFunctionRoundHalfUp.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionRoundHalfUp.cpp
@@ -14,22 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "Functions/SparkFunctionRoundHalfUp.h"
+#include "SparkFunctionRoundHalfUp.h"
 #include <Functions/FunctionFactory.h>
-
 
 namespace local_engine
 {
 REGISTER_FUNCTION(RoundSpark)
 {
     factory.registerFunction<FunctionRoundHalfUp>(
-        FunctionDocumentation{
+        DB::FunctionDocumentation{
             .description=R"(
 Similar to function round,except that in case when given number has equal distance to surrounding numbers, the function rounds away from zero(towards +inf/-inf).
         )",
             .examples{{"roundHalfUp", "SELECT roundHalfUp(3.165,2)", "3.17"}},
             .categories{"Rounding"}
-        }, FunctionFactory::Case::Insensitive);
+        },
+        DB::FunctionFactory::Case::Insensitive);
 
 }
 }

--- a/cpp-ch/local-engine/Functions/SparkFunctionRoundHalfUp.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionRoundHalfUp.h
@@ -25,9 +25,8 @@ extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 
 namespace local_engine
 {
-using namespace DB;
 
-template <typename T, Vectorize vectorize>
+template <typename T, DB::Vectorize vectorize>
 class BaseFloatRoundingHalfUpComputation;
 
 #ifdef __SSE4_1__
@@ -35,7 +34,7 @@ class BaseFloatRoundingHalfUpComputation;
 /// vectorized implementation for x86
 
 template <>
-class BaseFloatRoundingHalfUpComputation<Float32, Vectorize::Yes>
+class BaseFloatRoundingHalfUpComputation<Float32, DB::Vectorize::Yes>
 {
 public:
     using ScalarType = Float32;
@@ -47,7 +46,7 @@ public:
     static void store(ScalarType * out, VectorType val) { _mm_storeu_ps(out, val); }
     static VectorType multiply(VectorType val, VectorType scale) { return _mm_mul_ps(val, scale); }
     static VectorType divide(VectorType val, VectorType scale) { return _mm_div_ps(val, scale); }
-    template <RoundingMode mode>
+    template <DB::RoundingMode mode>
     static VectorType apply(VectorType val)
     {
         ScalarType tempFloatsIn[data_count];
@@ -63,7 +62,7 @@ public:
 };
 
 template <>
-class BaseFloatRoundingHalfUpComputation<Float64, Vectorize::Yes>
+class BaseFloatRoundingHalfUpComputation<Float64, DB::Vectorize::Yes>
 {
 public:
     using ScalarType = Float64;
@@ -75,7 +74,7 @@ public:
     static void store(ScalarType * out, VectorType val) { _mm_storeu_pd(out, val); }
     static VectorType multiply(VectorType val, VectorType scale) { return _mm_mul_pd(val, scale); }
     static VectorType divide(VectorType val, VectorType scale) { return _mm_div_pd(val, scale); }
-    template <RoundingMode mode>
+    template <DB::RoundingMode mode>
     static VectorType apply(VectorType val)
     {
         ScalarType tempFloatsIn[data_count];
@@ -96,7 +95,7 @@ public:
 /// Sequential implementation for ARM. Also used for scalar arguments
 
 template <typename T>
-class BaseFloatRoundingHalfUpComputation<T, Vectorize::No>
+class BaseFloatRoundingHalfUpComputation<T, DB::Vectorize::No>
 {
 public:
     using ScalarType = T;
@@ -108,7 +107,7 @@ public:
     static VectorType store(ScalarType * out, ScalarType val) { return *out = val;}
     static VectorType multiply(VectorType val, VectorType scale) { return val * scale; }
     static VectorType divide(VectorType val, VectorType scale) { return val / scale; }
-    template <RoundingMode mode>
+    template <DB::RoundingMode mode>
     static VectorType apply(VectorType val)
     {
         if constexpr (std::is_same_v<ScalarType, Float32>)
@@ -128,7 +127,7 @@ public:
 };
 
 template <>
-class BaseFloatRoundingHalfUpComputation<BFloat16, Vectorize::No>
+class BaseFloatRoundingHalfUpComputation<BFloat16, DB::Vectorize::No>
 {
 public:
     using ScalarType = BFloat16;
@@ -140,7 +139,7 @@ public:
     static VectorType store(ScalarType * out, ScalarType val) { return *out = val;}
     static VectorType multiply(VectorType val, VectorType scale) { return val * scale; }
     static VectorType divide(VectorType val, VectorType scale) { return val / scale; }
-    template <RoundingMode mode>
+    template <DB::RoundingMode mode>
     static VectorType apply(VectorType val)
     {
         return BFloat16(std::roundf(static_cast<Float32>(val)));
@@ -155,7 +154,7 @@ public:
 
 /** Implementation of low-level round-off functions for floating-point values.
   */
-template <typename T, RoundingMode rounding_mode, ScaleMode scale_mode, Vectorize vectorize>
+template <typename T, DB::RoundingMode rounding_mode, DB::ScaleMode scale_mode, DB::Vectorize vectorize>
 class FloatRoundingHalfUpComputation : public BaseFloatRoundingHalfUpComputation<T, vectorize>
 {
     using Base = BaseFloatRoundingHalfUpComputation<T, vectorize>;
@@ -165,16 +164,16 @@ public:
     {
         auto val = Base::load(in);
 
-        if (scale_mode == ScaleMode::Positive)
+        if (scale_mode == DB::ScaleMode::Positive)
             val = Base::multiply(val, scale);
-        else if (scale_mode == ScaleMode::Negative)
+        else if (scale_mode == DB::ScaleMode::Negative)
             val = Base::divide(val, scale);
 
         val = Base::template apply<rounding_mode>(val);
 
-        if (scale_mode == ScaleMode::Positive)
+        if (scale_mode == DB::ScaleMode::Positive)
             val = Base::divide(val, scale);
-        else if (scale_mode == ScaleMode::Negative)
+        else if (scale_mode == DB::ScaleMode::Negative)
             val = Base::multiply(val, scale);
 
         Base::store(out, val);
@@ -184,22 +183,22 @@ public:
 
 /** Implementing high-level rounding functions.
   */
-template <typename T, RoundingMode rounding_mode, ScaleMode scale_mode>
+template <typename T, DB::RoundingMode rounding_mode, DB::ScaleMode scale_mode>
 struct FloatRoundingHalfUpImpl
 {
 private:
-    static_assert(!is_decimal<T>);
+    static_assert(!DB::is_decimal<T>);
 
-    template <Vectorize vectorize =
+    template <DB::Vectorize vectorize =
 #ifdef __SSE4_1__
-    std::is_same_v<T, BFloat16> ? Vectorize::No : Vectorize::Yes
+    std::is_same_v<T, BFloat16> ? DB::Vectorize::No : DB::Vectorize::Yes
 #else
-    Vectorize::No
+    DB::Vectorize::No
 #endif
     >
     using Op = FloatRoundingHalfUpComputation<T, rounding_mode, scale_mode, vectorize>;
     using Data = std::array<T, Op<>::data_count>;
-    using ColumnType = ColumnVector<T>;
+    using ColumnType = DB::ColumnVector<T>;
     using Container = typename ColumnType::Container;
 
 public:
@@ -239,21 +238,21 @@ public:
 
 /** Select the appropriate processing algorithm depending on the scale.
   */
-template <typename T, RoundingMode rounding_mode, TieBreakingMode tie_breaking_mode>
+template <typename T, DB::RoundingMode rounding_mode, DB::TieBreakingMode tie_breaking_mode>
 struct DispatcherRoundingHalfUp
 {
-    template <ScaleMode scale_mode>
+    template <DB::ScaleMode scale_mode>
     using FunctionRoundingImpl = std::conditional_t<
         std::is_floating_point_v<T> || std::is_same_v<T, BFloat16>,
         FloatRoundingHalfUpImpl<T, rounding_mode, scale_mode>,
-        IntegerRoundingImpl<T, rounding_mode, scale_mode, tie_breaking_mode>>;
+        DB::IntegerRoundingImpl<T, rounding_mode, scale_mode, tie_breaking_mode>>;
 
-    static ColumnPtr apply(const IColumn * col_general, Scale scale_arg)
+    static DB::ColumnPtr apply(const DB::IColumn * col_general, DB::Scale scale_arg)
     {
-        const auto * const col = checkAndGetColumn<ColumnVector<T>>(col_general);
-        auto col_res = ColumnVector<T>::create();
+        const auto * const col = checkAndGetColumn<DB::ColumnVector<T>>(col_general);
+        auto col_res = DB::ColumnVector<T>::create();
 
-        typename ColumnVector<T>::Container & vec_res = col_res->getData();
+        typename DB::ColumnVector<T>::Container & vec_res = col_res->getData();
         vec_res.resize_exact(col->getData().size());
 
         if (!vec_res.empty())
@@ -261,17 +260,17 @@ struct DispatcherRoundingHalfUp
             if (scale_arg == 0)
             {
                 size_t scale = 1;
-                FunctionRoundingImpl<ScaleMode::Zero>::apply(col->getData(), scale, vec_res);
+                FunctionRoundingImpl<DB::ScaleMode::Zero>::apply(col->getData(), scale, vec_res);
             }
             else if (scale_arg > 0)
             {
                 size_t scale = intExp10(scale_arg);
-                FunctionRoundingImpl<ScaleMode::Positive>::apply(col->getData(), scale, vec_res);
+                FunctionRoundingImpl<DB::ScaleMode::Positive>::apply(col->getData(), scale, vec_res);
             }
             else
             {
                 size_t scale = intExp10(-scale_arg);
-                FunctionRoundingImpl<ScaleMode::Negative>::apply(col->getData(), scale, vec_res);
+                FunctionRoundingImpl<DB::ScaleMode::Negative>::apply(col->getData(), scale, vec_res);
             }
         }
 
@@ -279,20 +278,20 @@ struct DispatcherRoundingHalfUp
     }
 };
 
-template <is_decimal T, RoundingMode rounding_mode, TieBreakingMode tie_breaking_mode>
+template <DB::is_decimal T, DB::RoundingMode rounding_mode, DB::TieBreakingMode tie_breaking_mode>
 struct DispatcherRoundingHalfUp<T, rounding_mode, tie_breaking_mode>
 {
 public:
-    static ColumnPtr apply(const IColumn * col_general, Scale scale_arg)
+    static DB::ColumnPtr apply(const DB::IColumn * col_general, DB::Scale scale_arg)
     {
-        const auto * const col = checkAndGetColumn<ColumnDecimal<T>>(col_general);
-        const typename ColumnDecimal<T>::Container & vec_src = col->getData();
+        const auto * const col = checkAndGetColumn<DB::ColumnDecimal<T>>(col_general);
+        const typename DB::ColumnDecimal<T>::Container & vec_src = col->getData();
 
-        auto col_res = ColumnDecimal<T>::create(vec_src.size(), col->getScale());
+        auto col_res = DB::ColumnDecimal<T>::create(vec_src.size(), col->getScale());
         auto & vec_res = col_res->getData();
 
         if (!vec_res.empty())
-            DecimalRoundingImpl<T, rounding_mode, tie_breaking_mode>::apply(col->getData(), col->getScale(), vec_res, scale_arg);
+            DB::DecimalRoundingImpl<T, rounding_mode, tie_breaking_mode>::apply(col->getData(), col->getScale(), vec_res, scale_arg);
 
         return col_res;
     }
@@ -301,52 +300,52 @@ public:
 /** A template for functions that round the value of an input parameter of type
   * (U)Int8/16/32/64, Float32/64 or Decimal32/64/128, and accept an additional optional parameter (default is 0).
   */
-template <typename Name, RoundingMode rounding_mode, TieBreakingMode tie_breaking_mode>
-class FunctionRoundingHalfUp : public IFunction
+template <typename Name, DB::RoundingMode rounding_mode, DB::TieBreakingMode tie_breaking_mode>
+class FunctionRoundingHalfUp : public DB::IFunction
 {
 public:
     static constexpr auto name = "roundHalfUp";
-    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionRoundingHalfUp>(); }
+    static DB::FunctionPtr create(DB::ContextPtr) { return std::make_shared<FunctionRoundingHalfUp>(); }
 
     String getName() const override { return name; }
 
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
-    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DB::DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
     /// Get result types by argument types. If the function does not apply to these arguments, throw an exception.
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    DB::DataTypePtr getReturnTypeImpl(const DB::DataTypes & arguments) const override
     {
         if ((arguments.empty()) || (arguments.size() > 2))
-            throw Exception(
-                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+            throw DB::Exception(
+                DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
                 "Number of arguments for function {} doesn't match: passed {}, should be 1 or 2.",
                 getName(),
                 arguments.size());
 
         for (const auto & type : arguments)
             if (!isNumber(type))
-                throw Exception(
-                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {}", arguments[0]->getName(), getName());
+                throw DB::Exception(
+                    DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {}", arguments[0]->getName(), getName());
 
         return arguments[0];
     }
 
-    static Scale getScaleArg(const ColumnsWithTypeAndName & arguments)
+    static DB::Scale getScaleArg(const DB::ColumnsWithTypeAndName & arguments)
     {
         if (arguments.size() == 2)
         {
-            const IColumn & scale_column = *arguments[1].column;
+            const DB::IColumn & scale_column = *arguments[1].column;
             if (!isColumnConst(scale_column))
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Scale argument for rounding functions must be constant");
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_COLUMN, "DB::Scale argument for rounding functions must be constant");
 
-            Field scale_field = assert_cast<const ColumnConst &>(scale_column).getField();
-            if (scale_field.getType() != Field::Types::UInt64 && scale_field.getType() != Field::Types::Int64)
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Scale argument for rounding functions must have integer type");
+            DB::Field scale_field = assert_cast<const DB::ColumnConst &>(scale_column).getField();
+            if (scale_field.getType() != DB::Field::Types::UInt64 && scale_field.getType() != DB::Field::Types::Int64)
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_COLUMN, "DB::Scale argument for rounding functions must have integer type");
 
             Int64 scale64 = scale_field.safeGet<Int64>();
-            if (scale64 > std::numeric_limits<Scale>::max() || scale64 < std::numeric_limits<Scale>::min())
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Scale argument for rounding function is too large");
+            if (scale64 > std::numeric_limits<DB::Scale>::max() || scale64 < std::numeric_limits<DB::Scale>::min())
+                throw DB::Exception(DB::ErrorCodes::ARGUMENT_OUT_OF_BOUND, "DB::Scale argument for rounding function is too large");
 
             return scale64;
         }
@@ -354,20 +353,20 @@ public:
     }
 
     bool useDefaultImplementationForConstants() const override { return true; }
-    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
+    DB::ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
+    DB::ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr &, size_t /*input_rows_count*/) const override
     {
-        const ColumnWithTypeAndName & column = arguments[0];
-        Scale scale_arg = getScaleArg(arguments);
+        const DB::ColumnWithTypeAndName & column = arguments[0];
+        DB::Scale scale_arg = getScaleArg(arguments);
 
-        ColumnPtr res;
+        DB::ColumnPtr res;
         auto call = [&](const auto & types) -> bool
         {
             using Types = std::decay_t<decltype(types)>;
             using DataType = typename Types::LeftType;
 
-            if constexpr (IsDataTypeNumber<DataType> || IsDataTypeDecimal<DataType>)
+            if constexpr (DB::IsDataTypeNumber<DataType> || DB::IsDataTypeDecimal<DataType>)
             {
                 using FieldType = typename DataType::FieldType;
                 res = DispatcherRoundingHalfUp<FieldType, rounding_mode, tie_breaking_mode>::apply(column.column.get(), scale_arg);
@@ -377,14 +376,14 @@ public:
         };
 
         if (!callOnIndexAndDataType<void>(column.type->getTypeId(), call))
-            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of argument of function {}", column.name, getName());
+            throw DB::Exception(DB::ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of argument of function {}", column.name, getName());
 
         return res;
     }
 
     bool hasInformationAboutMonotonicity() const override { return true; }
 
-    Monotonicity getMonotonicityForRange(const IDataType &, const Field &, const Field &) const override
+    Monotonicity getMonotonicityForRange(const DB::IDataType &, const DB::Field &, const DB::Field &) const override
     {
         return {.is_monotonic = true, .is_always_monotonic = true};
     }
@@ -396,6 +395,6 @@ struct NameRoundHalfUp
     static constexpr auto name = "roundHalfUp";
 };
 
-using FunctionRoundHalfUp = FunctionRoundingHalfUp<NameRoundHalfUp, RoundingMode::Round, TieBreakingMode::Auto>;
+using FunctionRoundHalfUp = FunctionRoundingHalfUp<NameRoundHalfUp, DB::RoundingMode::Round, DB::TieBreakingMode::Auto>;
 
 }

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Functions/FunctionGetDateData.h>
 #include <DataTypes/DataTypeDate32.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Functions/FunctionGetDateData.h>
 
 namespace local_engine
 {

--- a/cpp-ch/local-engine/Join/BroadCastJoinBuilder.cpp
+++ b/cpp-ch/local-engine/Join/BroadCastJoinBuilder.cpp
@@ -42,6 +42,7 @@ namespace local_engine
 {
 namespace BroadCastJoinBuilder
 {
+using namespace DB;
 static jclass Java_CHBroadcastBuildSideCache = nullptr;
 static jmethodID Java_get = nullptr;
 jlong callJavaGet(const std::string & id)

--- a/cpp-ch/local-engine/Parser/AggregateFunctionParser.cpp
+++ b/cpp-ch/local-engine/Parser/AggregateFunctionParser.cpp
@@ -18,6 +18,7 @@
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionHelpers.h>
 #include <Parser/ExpressionParser.h>
 #include <Parser/RelParsers/RelParser.h>
@@ -37,6 +38,7 @@ extern const int UNKNOWN_FUNCTION;
 
 namespace local_engine
 {
+using namespace DB;
 AggregateFunctionParser::AggregateFunctionParser(ParserContextPtr parser_context_) : parser_context(parser_context_)
 {
     expression_parser = std::make_unique<ExpressionParser>(parser_context);

--- a/cpp-ch/local-engine/Parser/AggregateFunctionParser.h
+++ b/cpp-ch/local-engine/Parser/AggregateFunctionParser.h
@@ -22,12 +22,9 @@
 #include <Parser/ParserContext.h>
 #include <Parser/SerializedPlanParser.h>
 #include <base/types.h>
-#include <boost/noncopyable.hpp>
 #include <substrait/algebra.pb.h>
 #include <Poco/Logger.h>
 #include <Common/IFactoryWithAliases.h>
-#include <Common/logger_useful.h>
-#include "ParserContext.h"
 
 namespace local_engine
 {
@@ -142,7 +139,7 @@ protected:
 
     const DB::ActionsDAG::Node * parseExpression(DB::ActionsDAG & actions_dag, const substrait::Expression & rel) const;
 
-    std::pair<DataTypePtr, Field> parseLiteral(const substrait::Expression_Literal & literal) const;
+    std::pair<DB::DataTypePtr, DB::Field> parseLiteral(const substrait::Expression_Literal & literal) const;
 
     const DB::ActionsDAG::Node * convertNanToNullIfNeed(
         const CommonFunctionInfo & func_info, const DB::ActionsDAG::Node * func_node, DB::ActionsDAG & actions_dag) const;

--- a/cpp-ch/local-engine/Parser/ExpressionParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpressionParser.cpp
@@ -51,6 +51,7 @@ extern const int BAD_ARGUMENTS;
 
 namespace local_engine
 {
+using namespace DB;
 std::pair<DB::DataTypePtr, DB::Field> LiteralParser::parse(const substrait::Expression_Literal & literal)
 {
     DB::DataTypePtr type;

--- a/cpp-ch/local-engine/Parser/FunctionExecutor.h
+++ b/cpp-ch/local-engine/Parser/FunctionExecutor.h
@@ -20,9 +20,9 @@
 #include <DataTypes/IDataType.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
-#include <Parser/SerializedPlanParser.h>
-#include <Parser/ParserContext.h>
 #include <Parser/ExpressionParser.h>
+#include <Parser/ParserContext.h>
+#include <Parser/SerializedPlanParser.h>
 #include <base/types.h>
 #include <substrait/algebra.pb.h>
 #include <substrait/extensions/extensions.pb.h>
@@ -59,7 +59,7 @@ public:
 
     bool executeAndCompare(const std::vector<TestCase> & cases);
 
-    Block getHeader() const;
+    DB::Block getHeader() const;
 
     String getResultName() const;
 
@@ -81,7 +81,7 @@ private:
     substrait::Expression expression;
     DB::Block header;
     String result_name;
-    std::unique_ptr<ExpressionActions> expression_actions;
+    std::unique_ptr<DB::ExpressionActions> expression_actions;
 
     Poco::Logger * log;
 };

--- a/cpp-ch/local-engine/Parser/FunctionParser.h
+++ b/cpp-ch/local-engine/Parser/FunctionParser.h
@@ -20,11 +20,10 @@
 #include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/ActionsDAG.h>
+#include <Parser/ExpressionParser.h>
 #include <Parser/ParserContext.h>
 #include <Parser/SerializedPlanParser.h>
-#include <Parser/ExpressionParser.h>
 #include <base/types.h>
-#include <boost/noncopyable.hpp>
 #include <substrait/algebra.pb.h>
 #include <Common/IFactoryWithAliases.h>
 
@@ -85,12 +84,12 @@ protected:
         const String & result_name,
         const DB::ActionsDAG::NodeRawConstPtrs & args) const;
 
-    const ActionsDAG::Node * parseFunctionWithDAG(
+    const DB::ActionsDAG::Node * parseFunctionWithDAG(
         const substrait::Expression & rel, std::string & result_name, DB::ActionsDAG & actions_dag, bool keep_result = false) const;
 
     const DB::ActionsDAG::Node * parseExpression(DB::ActionsDAG & actions_dag, const substrait::Expression & rel) const;
 
-    std::pair<DataTypePtr, Field> parseLiteral(const substrait::Expression_Literal & literal) const;
+    std::pair<DB::DataTypePtr, DB::Field> parseLiteral(const substrait::Expression_Literal & literal) const;
 
     ParserContextPtr parser_context;
     std::unique_ptr<ExpressionParser> expression_parser;

--- a/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.cpp
@@ -53,7 +53,7 @@ extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 namespace local_engine
 {
-
+using namespace DB;
 AggregateRelParser::AggregateRelParser(ParserContextPtr parser_context_) : RelParser(parser_context_)
 {
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.h
@@ -37,9 +37,9 @@ private:
     {
         const substrait::AggregateRel::Measure * measure = nullptr;
         String measure_column_name;
-        Strings arg_column_names;
+        DB::Strings arg_column_names;
         DB::DataTypes arg_column_types;
-        Array params;
+        DB::Array params;
         String signature_function_name;
         String function_name;
         // If no combinator be applied on it, same as function_name
@@ -60,7 +60,7 @@ private:
     DB::QueryPlanPtr plan = nullptr;
     const substrait::AggregateRel * aggregate_rel = nullptr;
     std::vector<AggregateInfo> aggregates;
-    Names grouping_keys;
+    DB::Names grouping_keys;
 
     void setup(DB::QueryPlanPtr query_plan, const substrait::Rel & rel);
     void addPreProjection();
@@ -69,6 +69,6 @@ private:
     void addAggregatingStep();
     void addPostProjection();
 
-    void buildAggregateDescriptions(AggregateDescriptions & descriptions);
+    void buildAggregateDescriptions(DB::AggregateDescriptions & descriptions);
 };
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/CrossRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/CrossRelParser.cpp
@@ -51,10 +51,10 @@ extern const int BAD_ARGUMENTS;
 }
 }
 
-using namespace DB;
-
 namespace local_engine
 {
+using namespace DB;
+
 std::shared_ptr<DB::TableJoin> createCrossTableJoin(substrait::CrossRel_JoinType join_type)
 {
     auto global_context = QueryContext::globalContext();

--- a/cpp-ch/local-engine/Parser/RelParsers/CrossRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/CrossRelParser.h
@@ -48,13 +48,13 @@ public:
     std::vector<DB::QueryPlanPtr> extraPlans() override { return std::move(extra_plan_holder); }
 
 private:
-    ContextPtr context;
-    std::vector<QueryPlanPtr> extra_plan_holder;
+    DB::ContextPtr context;
+    std::vector<DB::QueryPlanPtr> extra_plan_holder;
 
 
     DB::QueryPlanPtr parseJoin(const substrait::CrossRel & join, DB::QueryPlanPtr left, DB::QueryPlanPtr right);
     void renamePlanColumns(DB::QueryPlan & left, DB::QueryPlan & right, const StorageJoinFromReadBuffer & storage_join);
-    void addConvertStep(TableJoin & table_join, DB::QueryPlan & left, DB::QueryPlan & right);
+    void addConvertStep(DB::TableJoin & table_join, DB::QueryPlan & left, DB::QueryPlan & right);
     void addPostFilter(DB::QueryPlan & query_plan, const substrait::CrossRel & join);
     bool applyJoinFilter(
         DB::TableJoin & table_join,

--- a/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
@@ -20,9 +20,10 @@
 #include <unordered_set>
 #include <utility>
 #include <Columns/IColumn.h>
-#include <Core/ColumnsWithTypeAndName.h>
 #include <Core/Settings.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
 #include <DataTypes/Serializations/ISerialization.h>
 #include <IO/WriteBufferFromString.h>
@@ -35,18 +36,13 @@
 #include <Parser/AdvancedParametersParseUtil.h>
 #include <Parser/RelParsers/SortParsingUtils.h>
 #include <Parser/RelParsers/SortRelParser.h>
-#include <Processors/IProcessor.h>
-#include <Processors/Port.h>
-#include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
-#include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/WindowStep.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-#include <QueryPipeline/QueryPlanResourceHolder.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/wrappers.pb.h>
 #include <Common/AggregateUtil.h>
@@ -72,6 +68,7 @@ extern const SettingsMaxThreads max_threads;
 
 namespace local_engine
 {
+using namespace DB;
 GroupLimitRelParser::GroupLimitRelParser(ParserContextPtr parser_context_) : RelParser(parser_context_)
 {
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/JoinRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/JoinRelParser.cpp
@@ -19,8 +19,6 @@
 #include <Core/Block.h>
 #include <Core/Settings.h>
 #include <Functions/FunctionFactory.h>
-#include <IO/ReadBufferFromString.h>
-#include <IO/ReadHelpers.h>
 #include <Interpreters/CollectJoinOnKeysVisitor.h>
 #include <Interpreters/FullSortingMergeJoin.h>
 #include <Interpreters/GraceHashJoin.h>

--- a/cpp-ch/local-engine/Parser/RelParsers/JoinRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/JoinRelParser.h
@@ -50,15 +50,15 @@ public:
     std::vector<DB::QueryPlanPtr> extraPlans() override { return std::move(extra_plan_holder); }
 
 private:
-    ContextPtr context;
-    std::vector<QueryPlanPtr> extra_plan_holder;
+    DB::ContextPtr context;
+    std::vector<DB::QueryPlanPtr> extra_plan_holder;
 
 
     DB::QueryPlanPtr parseJoin(const substrait::JoinRel & join, DB::QueryPlanPtr left, DB::QueryPlanPtr right);
     void renamePlanColumns(DB::QueryPlan & left, DB::QueryPlan & right, const StorageJoinFromReadBuffer & storage_join);
-    void addConvertStep(TableJoin & table_join, DB::QueryPlan & left, DB::QueryPlan & right);
+    void addConvertStep(DB::TableJoin & table_join, DB::QueryPlan & left, DB::QueryPlan & right);
     void collectJoinKeys(
-        TableJoin & table_join, const substrait::JoinRel & join_rel, const DB::Block & left_header, const DB::Block & right_header);
+        DB::TableJoin & table_join, const substrait::JoinRel & join_rel, const DB::Block & left_header, const DB::Block & right_header);
 
     bool applyJoinFilter(
         DB::TableJoin & table_join,

--- a/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.cpp
@@ -165,7 +165,7 @@ DB::QueryPlanPtr MergeTreeRelParser::parseReadRel(
     return query_plan;
 }
 
-PrewhereInfoPtr MergeTreeRelParser::parsePreWhereInfo(const substrait::Expression & rel, Block & input)
+PrewhereInfoPtr MergeTreeRelParser::parsePreWhereInfo(const substrait::Expression & rel, const Block & input)
 {
     std::string filter_name;
     auto prewhere_info = std::make_shared<PrewhereInfo>();
@@ -179,7 +179,7 @@ PrewhereInfoPtr MergeTreeRelParser::parsePreWhereInfo(const substrait::Expressio
     return prewhere_info;
 }
 
-DB::ActionsDAG MergeTreeRelParser::optimizePrewhereAction(const substrait::Expression & rel, std::string & filter_name, Block & block)
+DB::ActionsDAG MergeTreeRelParser::optimizePrewhereAction(const substrait::Expression & rel, std::string & filter_name, const Block & block)
 {
     Conditions res;
     std::set<Int64> pk_positions;
@@ -244,7 +244,7 @@ void MergeTreeRelParser::parseToAction(ActionsDAG & filter_action, const substra
 }
 
 void MergeTreeRelParser::analyzeExpressions(
-    Conditions & res, const substrait::Expression & rel, std::set<Int64> & pk_positions, Block & block)
+    Conditions & res, const substrait::Expression & rel, std::set<Int64> & pk_positions, const Block & block)
 {
     if (rel.has_scalar_function() && getCHFunctionName(rel.scalar_function()) == "and")
     {
@@ -282,7 +282,7 @@ UInt64 MergeTreeRelParser::getColumnsSize(const NameSet & columns)
     return size;
 }
 
-void MergeTreeRelParser::collectColumns(const substrait::Expression & rel, NameSet & columns, Block & block)
+void MergeTreeRelParser::collectColumns(const substrait::Expression & rel, NameSet & columns, const Block & block)
 {
     switch (rel.rex_type_case())
     {

--- a/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.h
@@ -32,12 +32,11 @@ extern const int LOGICAL_ERROR;
 
 namespace local_engine
 {
-using namespace DB;
 
 class MergeTreeRelParser : public RelParser
 {
 public:
-    explicit MergeTreeRelParser(ParserContextPtr parser_context_, const ContextPtr & context_)
+    explicit MergeTreeRelParser(ParserContextPtr parser_context_, const DB::ContextPtr & context_)
         : RelParser(parser_context_), context(context_)
     {
     }
@@ -46,7 +45,7 @@ public:
 
     DB::QueryPlanPtr parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_) override
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call parse(), call parseReadRel instead.");
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call parse(), call parseReadRel instead.");
     }
 
     DB::QueryPlanPtr parseReadRel(
@@ -54,7 +53,7 @@ public:
 
     std::optional<const substrait::Rel *> getSingleInput(const substrait::Rel &) override
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call getSingleInput().");
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call getSingleInput().");
     }
 
     String filterRangesOnDriver(const substrait::ReadRel & read_rel);
@@ -65,7 +64,7 @@ public:
 
         const substrait::Expression node;
         size_t columns_size = 0;
-        NameSet table_columns;
+        DB::NameSet table_columns;
         Int64 min_position_in_primary_key = std::numeric_limits<Int64>::max() - 1;
 
         auto tuple() const { return std::make_tuple(-min_position_in_primary_key, columns_size, table_columns.size()); }
@@ -75,20 +74,20 @@ public:
     using Conditions = std::list<Condition>;
 
     // visable for test
-    void analyzeExpressions(Conditions & res, const substrait::Expression & rel, std::set<Int64> & pk_positions, Block & block);
+    void analyzeExpressions(Conditions & res, const substrait::Expression & rel, std::set<Int64> & pk_positions, const DB::Block & block);
 
 public:
     std::unordered_map<std::string, UInt64> column_sizes;
 
 private:
-    void parseToAction(ActionsDAG & filter_action, const substrait::Expression & rel, std::string & filter_name);
-    DB::PrewhereInfoPtr parsePreWhereInfo(const substrait::Expression & rel, Block & input);
-    ActionsDAG optimizePrewhereAction(const substrait::Expression & rel, std::string & filter_name, Block & block);
+    void parseToAction(DB::ActionsDAG & filter_action, const substrait::Expression & rel, std::string & filter_name);
+    DB::PrewhereInfoPtr parsePreWhereInfo(const substrait::Expression & rel, const DB::Block & input);
+    DB::ActionsDAG optimizePrewhereAction(const substrait::Expression & rel, std::string & filter_name, const DB::Block & block);
     String getCHFunctionName(const substrait::Expression_ScalarFunction & substrait_func) const;
-    static void collectColumns(const substrait::Expression & rel, NameSet & columns, Block & block);
-    UInt64 getColumnsSize(const NameSet & columns);
+    static void collectColumns(const substrait::Expression & rel, DB::NameSet & columns, const DB::Block & block);
+    UInt64 getColumnsSize(const DB::NameSet & columns);
 
-    ContextPtr context;
+    DB::ContextPtr context;
 };
 
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.h
@@ -18,9 +18,9 @@
 
 #include <memory>
 #include <optional>
-#include <substrait/algebra.pb.h>
-
 #include <Parser/RelParsers/RelParser.h>
+#include <Storages/SelectQueryInfo.h>
+#include <substrait/algebra.pb.h>
 
 namespace DB
 {
@@ -82,7 +82,7 @@ public:
 
 private:
     void parseToAction(ActionsDAG & filter_action, const substrait::Expression & rel, std::string & filter_name);
-    PrewhereInfoPtr parsePreWhereInfo(const substrait::Expression & rel, Block & input);
+    DB::PrewhereInfoPtr parsePreWhereInfo(const substrait::Expression & rel, Block & input);
     ActionsDAG optimizePrewhereAction(const substrait::Expression & rel, std::string & filter_name, Block & block);
     String getCHFunctionName(const substrait::Expression_ScalarFunction & substrait_func) const;
     static void collectColumns(const substrait::Expression & rel, NameSet & columns, Block & block);

--- a/cpp-ch/local-engine/Parser/RelParsers/ProjectRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/ProjectRelParser.h
@@ -40,7 +40,7 @@ private:
 
     bool isReplicateRows(substrait::GenerateRel rel);
 
-    DB::QueryPlanPtr parseReplicateRows(QueryPlanPtr query_plan, substrait::GenerateRel generate_rel);
+    DB::QueryPlanPtr parseReplicateRows(DB::QueryPlanPtr query_plan, substrait::GenerateRel generate_rel);
 
     std::optional<const substrait::Rel *> getSingleInput(const substrait::Rel & rel) override
     {

--- a/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.cpp
@@ -45,6 +45,7 @@ extern const int LOGICAL_ERROR;
 }
 namespace local_engine
 {
+using namespace DB;
 DB::QueryPlanPtr ReadRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> &)
 {
     if (query_plan)

--- a/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.h
@@ -54,6 +54,6 @@ private:
     bool is_input_iter_materialize;
     String split_info;
     DB::QueryPlanStepPtr parseReadRelWithJavaIter(const substrait::ReadRel & rel);
-    QueryPlanStepPtr parseReadRelWithLocalFile(const substrait::ReadRel & rel);
+    DB::QueryPlanStepPtr parseReadRelWithLocalFile(const substrait::ReadRel & rel);
 };
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/RelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/RelParser.cpp
@@ -39,6 +39,8 @@ extern const int LOGICAL_ERROR;
 
 namespace local_engine
 {
+using namespace DB;
+
 RelParser::RelParser(ParserContextPtr parser_context_) : parser_context(parser_context_)
 {
     expression_parser = std::make_unique<ExpressionParser>(parser_context);

--- a/cpp-ch/local-engine/Parser/RelParsers/RelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/RelParser.h
@@ -27,7 +27,6 @@
 #include <Parser/SerializedPlanParser.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <base/types.h>
-#include <substrait/extensions/extensions.pb.h>
 #include <substrait/plan.pb.h>
 
 namespace local_engine
@@ -47,16 +46,16 @@ public:
     parse(std::vector<DB::QueryPlanPtr> & input_plans_, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_);
     virtual std::vector<const substrait::Rel *> getInputs(const substrait::Rel & rel);
     virtual std::optional<const substrait::Rel *> getSingleInput(const substrait::Rel & rel) = 0;
-    const std::vector<IQueryPlanStep *> & getSteps() const { return steps; }
+    const std::vector<DB::IQueryPlanStep *> & getSteps() const { return steps; }
 
-    static AggregateFunctionPtr getAggregateFunction(
+    static DB::AggregateFunctionPtr getAggregateFunction(
         const String & name, DB::DataTypes arg_types, DB::AggregateFunctionProperties & properties, const DB::Array & parameters = {});
 
     virtual std::vector<DB::QueryPlanPtr> extraPlans() { return {}; }
 
 protected:
     // inline SerializedPlanParser * getPlanParser() const { return plan_parser; }
-    inline ContextPtr getContext() const { return parser_context->queryContext(); }
+    inline DB::ContextPtr getContext() const { return parser_context->queryContext(); }
 
     String getUniqueName(const std::string & name) const;
 
@@ -64,18 +63,18 @@ protected:
     // Get coresponding function name in ClickHouse.
     std::optional<String> parseFunctionName(const substrait::Expression_ScalarFunction & function) const;
 
-    const DB::ActionsDAG::Node * parseArgument(ActionsDAG & action_dag, const substrait::Expression & rel) const;
+    const DB::ActionsDAG::Node * parseArgument(DB::ActionsDAG & action_dag, const substrait::Expression & rel) const;
 
-    const DB::ActionsDAG::Node * parseExpression(ActionsDAG & action_dag, const substrait::Expression & rel) const;
+    const DB::ActionsDAG::Node * parseExpression(DB::ActionsDAG & action_dag, const substrait::Expression & rel) const;
 
     DB::ActionsDAG expressionsToActionsDAG(const std::vector<substrait::Expression> & expressions, const DB::Block & header) const;
 
-    std::pair<DataTypePtr, Field> parseLiteral(const substrait::Expression_Literal & literal) const;
+    std::pair<DB::DataTypePtr, DB::Field> parseLiteral(const substrait::Expression_Literal & literal) const;
     // collect all steps for metrics
-    std::vector<IQueryPlanStep *> steps;
+    std::vector<DB::IQueryPlanStep *> steps;
 
-    const ActionsDAG::Node *
-    buildFunctionNode(ActionsDAG & action_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args) const;
+    const DB::ActionsDAG::Node *
+    buildFunctionNode(DB::ActionsDAG & action_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args) const;
 
     ParserContextPtr parser_context;
     std::unique_ptr<ExpressionParser> expression_parser;

--- a/cpp-ch/local-engine/Parser/RelParsers/SortRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/SortRelParser.cpp
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 #include "SortRelParser.h"
-
-#include <Parser/RelParsers/SortParsingUtils.h>
 #include <Parser/RelParsers/RelParser.h>
+#include <Parser/RelParsers/SortParsingUtils.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Common/GlutenConfig.h>
 #include <Common/QueryContext.h>
@@ -33,6 +32,7 @@ extern const int LOGICAL_ERROR;
 
 namespace local_engine
 {
+using namespace DB;
 SortRelParser::SortRelParser(ParserContextPtr parser_context_) : RelParser(parser_context_)
 {
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/WindowRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/WindowRelParser.cpp
@@ -29,8 +29,8 @@
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/WindowDescription.h>
-#include <Parser/RelParsers/SortParsingUtils.h>
 #include <Parser/RelParsers/RelParser.h>
+#include <Parser/RelParsers/SortParsingUtils.h>
 #include <Parser/RelParsers/SortRelParser.h>
 #include <Parser/TypeParser.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
@@ -51,6 +51,7 @@ extern const int BAD_ARGUMENTS;
 }
 namespace local_engine
 {
+using namespace DB;
 WindowRelParser::WindowRelParser(ParserContextPtr parser_context_) : RelParser(parser_context_)
 {
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/WindowRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/WindowRelParser.h
@@ -42,7 +42,7 @@ private:
     {
         const substrait::WindowRel::Measure * measure = nullptr;
         String result_column_name;
-        Strings arg_column_names;
+        DB::Strings arg_column_names;
         DB::DataTypes arg_column_types;
         DB::Array params;
         String signature_function_name;
@@ -64,7 +64,7 @@ private:
     std::vector<WindowInfo> win_infos;
 
     /// There will be window descrptions generated for different window frame type;
-    std::unordered_map<DB::String, WindowDescription> parseWindowDescriptions();
+    std::unordered_map<String, DB::WindowDescription> parseWindowDescriptions();
 
     // Build a window description in CH with respect to a window function, since the same
     // function may have different window frame in CH and spark.
@@ -76,7 +76,7 @@ private:
         const substrait::Expression::WindowFunction::Bound & bound,
         bool is_begin_or_end,
         DB::WindowFrame::BoundaryType & bound_type,
-        Field & offset,
+        DB::Field & offset,
         bool & preceding);
     DB::WindowFunctionDescription parseWindowFunctionDescription(
         const String & ch_function_name,

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -27,11 +27,9 @@
 #include <Core/NamesAndTypes.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
-#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
-#include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/QueryPriorities.h>

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -19,13 +19,12 @@
 #include <Core/Block.h>
 #include <Core/SortDescription.h>
 #include <DataTypes/DataTypeFactory.h>
-#include <DataTypes/Serializations/ISerialization.h>
+#include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Aggregator.h>
 #include <Parser/CHColumnToSparkRow.h>
 #include <Parser/RelMetric.h>
 #include <Processors/QueryPlan/ISourceStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
-#include <Storages/MergeTree/SparkStorageMergeTree.h>
 #include <Storages/SourceFromJavaIter.h>
 #include <base/types.h>
 #include <substrait/plan.pb.h>
@@ -33,7 +32,7 @@
 namespace local_engine
 {
 
-std::string join(const ActionsDAG::NodeRawConstPtrs & v, char c);
+std::string join(const DB::ActionsDAG::NodeRawConstPtrs & v, char c);
 
 class SerializedPlanParser;
 class LocalExecutor;
@@ -98,8 +97,8 @@ public:
     int nextSplitInfoIndex()
     {
         if (split_info_index >= split_infos.size())
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
+            throw DB::Exception(
+                DB::ErrorCodes::LOGICAL_ERROR,
                 "split info index out of range, split_info_index: {}, split_infos.size(): {}",
                 split_info_index,
                 split_infos.size());
@@ -114,7 +113,7 @@ public:
 
     RelMetricPtr getMetric() { return metrics.empty() ? nullptr : metrics.at(0); }
 
-    std::vector<QueryPlanPtr> extra_plan_holder;
+    std::vector<DB::QueryPlanPtr> extra_plan_holder;
 
 private:
     DB::QueryPlanPtr parseOp(const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack);
@@ -124,7 +123,7 @@ private:
     std::vector<std::string> split_infos;
     int split_info_index = 0;
     std::vector<bool> materialize_inputs;
-    ContextPtr context;
+    DB::ContextPtr context;
     std::shared_ptr<const ParserContext> parser_context;
     std::vector<RelMetricPtr> metrics;
 };

--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -19,7 +19,6 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnVector.h>
-#include <Core/ColumnsWithTypeAndName.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeMap.h>

--- a/cpp-ch/local-engine/Parser/TypeParser.cpp
+++ b/cpp-ch/local-engine/Parser/TypeParser.cpp
@@ -22,6 +22,7 @@
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeFixedString.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -50,6 +51,7 @@ extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 
 namespace local_engine
 {
+using namespace DB;
 std::unordered_map<String, String> TypeParser::type_names_mapping
     = {{"BooleanType", "UInt8"},
        {"ByteType", "Int8"},

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/ApproxPercentileParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/ApproxPercentileParser.cpp
@@ -19,7 +19,7 @@
 
 namespace local_engine
 {
-
+using namespace DB;
 /*
 spark: approx_percentile(col, percentage [, accuracy])
 1. When percentage is an array literal, spark returns an array of percentiles, corresponding to CH: quantilesGK(accuracy, percentage[0], ...)(col)

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/BloomFilterAggParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/BloomFilterAggParser.cpp
@@ -19,7 +19,6 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Parser/AggregateFunctionParser.h>
 #include <Parser/aggregate_function_parser/BloomFilterAggParser.h>
-#include <Poco/StringTokenizer.h>
 #include "substrait/algebra.pb.h"
 
 namespace DB
@@ -33,6 +32,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
+using namespace DB;
 // This is copied from Spark, org.apache.spark.util.sketch.BloomFilter#optimalNumOfHashFunctions,
 // which in return learned from https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions.
 Int64 optimalNumOfHashFunctions(Int64 n, Int64 m)

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 #include "CollectListParser.h"
-#include <DataTypes/DataTypeNullable.h>
-#include <Interpreters/ActionsDAG.h>
 
 namespace local_engine
 {

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.h
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.h
@@ -61,7 +61,7 @@ public:
             auto nested_type = typeid_cast<const DB::DataTypeNullable *>(func_node->result_type.get())->getNestedType();
             DB::Field empty_field = nested_type->getDefault();
             const auto * default_value_node = &actions_dag.addColumn(
-                ColumnWithTypeAndName(nested_type->createColumnConst(1, empty_field), nested_type, getUniqueName("[]")));
+                DB::ColumnWithTypeAndName(nested_type->createColumnConst(1, empty_field), nested_type, getUniqueName("[]")));
             args.push_back(default_value_node);
             const auto * if_null_node = toFunctionNode(actions_dag, "ifNull", func_node->result_name, args);
             actions_dag.addOrReplaceInOutputs(*if_null_node);

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/LeadLagParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/LeadLagParser.cpp
@@ -23,6 +23,7 @@
 
 namespace local_engine
 {
+using namespace DB;
 DB::ActionsDAG::NodeRawConstPtrs
 LeadParser::parseFunctionArguments(const CommonFunctionInfo & func_info, DB::ActionsDAG & actions_dag) const
 {

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/NtileParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/NtileParser.cpp
@@ -21,6 +21,7 @@
 
 namespace local_engine
 {
+using namespace DB;
 DB::ActionsDAG::NodeRawConstPtrs
 NtileParser::parseFunctionArguments(const CommonFunctionInfo & func_info, DB::ActionsDAG & actions_dag) const
 {

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/PercentileParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/PercentileParser.cpp
@@ -19,7 +19,7 @@
 
 namespace local_engine
 {
-
+using namespace DB;
 /*
 spark: percentile(col, percentage, [, frequency])
 1. When percentage is an array literal, spark returns an array of percentiles, corresponding to CH: quantilesExact(percentage[0], ...)(col)

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/PercentileParserBase.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/PercentileParserBase.cpp
@@ -17,13 +17,13 @@
 
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Parser/AggregateFunctionParser.h>
 #include <Parser/aggregate_function_parser/PercentileParserBase.h>
-#include <Common/CHUtil.h>
-
 #include <substrait/algebra.pb.h>
+#include <Common/CHUtil.h>
 
 namespace DB
 {
@@ -36,7 +36,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 void PercentileParserBase::assertArgumentsSize(substrait::AggregationPhase phase, size_t size, size_t expect) const
 {
     if (size != expect)

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/PercentileParserBase.h
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/PercentileParserBase.h
@@ -46,7 +46,7 @@ protected:
 
     /// Get argument indexes in first stage substrait function which should be treated as parameters in CH aggregate function.
     /// Note: the indexes are 0-based, and we must guarantee the order of returned parameters matches the order of parameters in CH aggregate function
-    virtual ColumnNumbers getArgumentsThatAreParameters() const = 0;
+    virtual DB::ColumnNumbers getArgumentsThatAreParameters() const = 0;
 
     virtual DB::Array getDefaultFunctionParametersImpl() const = 0;
 

--- a/cpp-ch/local-engine/Parser/example_udf/myMd5.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/myMd5.cpp
@@ -27,7 +27,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserMyMd5 : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_add.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_add.cpp
@@ -16,6 +16,7 @@
  */
 #include <iostream>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionExecutor.h>
 #include <Parser/FunctionParser.h>
 #include <gtest/gtest.h>

--- a/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_md5.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/tests/gtest_my_md5.cpp
@@ -16,6 +16,7 @@
  */
 #include <iostream>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <Parser/FunctionExecutor.h>
 #include <Parser/FunctionParser.h>
 #include <gtest/gtest.h>

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arithmetic.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arithmetic.cpp
@@ -31,7 +31,7 @@ extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 
 namespace local_engine
 {
-
+using namespace DB;
 class DecimalType
 {
     static constexpr Int32 spark_max_precision = 38;

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayContains.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayContains.cpp
@@ -17,6 +17,7 @@
 #include <Core/Field.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionHelpers.h>
 #include <Parser/FunctionParser.h>
 
@@ -31,7 +32,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserArrayContains : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayDistinct.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayDistinct.cpp
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
-#include <DataTypes/IDataType.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
@@ -30,7 +27,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserArrayDistinct : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayExcept.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayExcept.cpp
@@ -31,6 +31,7 @@ extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
 
 namespace local_engine
 {
+using namespace DB;
 class FunctionParserArrayExcept : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayHighOrderFunctions.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayHighOrderFunctions.cpp
@@ -35,6 +35,8 @@ namespace DB::ErrorCodes
 
 namespace local_engine
 {
+using namespace DB;
+
 class FunctionParserArrayFilter : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayIntersect.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayIntersect.cpp
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
-#include <DataTypes/IDataType.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
@@ -30,6 +27,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
+using namespace DB;
 
 class FunctionParserArrayIntersect : public FunctionParser
 {

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayMaxAndMin.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayMaxAndMin.cpp
@@ -16,13 +16,12 @@
  */
 #include <Core/Field.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/IDataType.h>
 #include <Parser/FunctionParser.h>
 
-
 namespace DB
 {
-
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
@@ -31,7 +30,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class BaseFunctionParserArrayMaxAndMin : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayPosition.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayPosition.cpp
@@ -30,7 +30,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserArrayPosition : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayRemove.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayRemove.cpp
@@ -30,6 +30,7 @@ extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
 
 namespace local_engine
 {
+using namespace DB;
 class FunctionParserArrayRemove : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayRepeat.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayRepeat.cpp
@@ -32,6 +32,7 @@ extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
 
 namespace local_engine
 {
+using namespace DB;
 class FunctionParserArrayRepeat : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayUnion.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayUnion.cpp
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
-#include <DataTypes/IDataType.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
@@ -30,7 +27,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserArrayUnion : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/bitLength.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/bitLength.cpp
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
 #include <Parser/FunctionParser.h>
 
@@ -39,23 +40,23 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         // parse bit_length(a) as octet_length(a) * 8
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * arg = parsed_args[0];
         const auto * new_arg = arg;
         if (isInt(DB::removeNullable(arg->result_type)))
         {
-            const auto * string_type_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "Nullable(String)");
+            const auto * string_type_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "Nullable(String)");
             new_arg = toFunctionNode(actions_dag, "CAST", {arg, string_type_node});
         }
 
         const auto * octet_length_node = toFunctionNode(actions_dag, "octet_length", {new_arg});
-        const auto * const_eight_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 8);
+        const auto * const_eight_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 8);
         const auto * result_node = toFunctionNode(actions_dag, "multiply", {octet_length_node, const_eight_node});
 
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/checkOverflow.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/checkOverflow.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 #include <Common/Exception.h>
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/chr.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/chr.cpp
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <DataTypes/IDataType.h>
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
@@ -38,23 +38,23 @@ public:
     static constexpr auto name = "chr";
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires two or three arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires two or three arguments", getName());
 
         /*
             parse chr(number) as if(number < 0, '', convertCharset(char(0, number), 'unicode', 'utf-8'))
         */
         const auto & num_arg = parsed_args[0];
-        const auto * const_zero_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 0);
-        const auto * const_empty_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "");
-        const auto * const_four_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 4);
-        const auto * const_unicode_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "unicode");
-        const auto * const_utf8_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "utf-8");
+        const auto * const_zero_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 0);
+        const auto * const_empty_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "");
+        const auto * const_four_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 4);
+        const auto * const_unicode_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "unicode");
+        const auto * const_utf8_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "utf-8");
 
         const auto * less_node = toFunctionNode(actions_dag, "less", {num_arg, const_zero_node});
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/concat.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/concat.cpp
@@ -32,7 +32,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserConcat : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/concatWs.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/concatWs.cpp
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/IDataType.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
@@ -44,9 +44,9 @@ public:
     String getName() const override { return name; }
     String getCHFunctionName(const substrait::Expression_ScalarFunction &) const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /*
             parse concat_ws(sep, s1, s2, arr1, arr2, ...)) as
@@ -54,10 +54,10 @@ public:
         */
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.empty())
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires at least one argument", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires at least one argument", getName());
 
         const auto * first_arg = parsed_args[0];
-        ActionsDAG::NodeRawConstPtrs new_args;
+        DB::ActionsDAG::NodeRawConstPtrs new_args;
         new_args.reserve(parsed_args.size() - 1);
 
         for (size_t i = 1; i < parsed_args.size(); ++i)
@@ -74,12 +74,12 @@ public:
                 new_args.push_back(array_not_null_node);
             }
             else
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {} requires string or array of string arguments", getName());
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Function {} requires string or array of string arguments", getName());
         }
 
         if (new_args.empty())
         {
-            const auto * null_const_node = addColumnToActionsDAG(actions_dag, makeNullable(std::make_shared<DataTypeString>()), Field());
+            const auto * null_const_node = addColumnToActionsDAG(actions_dag, makeNullable(std::make_shared<DB::DataTypeString>()), DB::Field());
             const auto * array_node = toFunctionNode(actions_dag, "array", {null_const_node});
             new_args.push_back(array_node);
         }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/cot.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/cot.cpp
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -39,18 +39,18 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /// parse cot(x) as 1 / tan(x)
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * x = parsed_args[0];
         const auto * tan_node = toFunctionNode(actions_dag, "tan", {x});
-        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeFloat64>(), 1.0);
+        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeFloat64>(), 1.0);
         const auto * result_node = toFunctionNode(actions_dag, "divide", {one_const_node, tan_node});
 
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);;

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/csc.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/csc.cpp
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -39,18 +39,18 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /// parse csc(x) as 1 / sin(x)
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * x = parsed_args[0];
         const auto * sin_node = toFunctionNode(actions_dag, "sin", {x});
-        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeFloat64>(), 1.0);
+        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeFloat64>(), 1.0);
         const auto * result_node = toFunctionNode(actions_dag, "divide", {one_const_node, sin_node});
 
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);;

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/decode.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/decode.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
+#include <DataTypes/DataTypeString.h>
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -40,18 +40,18 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /// Parse decode(bin, charset) as convertCharset(bin, charset, 'UTF-8')
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         const auto * bin_arg = parsed_args[0];
         const auto * from_charset_arg = parsed_args[1];
-        const auto * to_charset_arg = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "UTF-8");
+        const auto * to_charset_arg = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "UTF-8");
         const auto * result_node = toFunctionNode(actions_dag, "convertCharset", {bin_arg, from_charset_arg, to_charset_arg});
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/elementAt.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/elementAt.cpp
@@ -17,6 +17,8 @@
 
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
 #include <Functions/FunctionHelpers.h>
 #include <Parser/FunctionParser.h>
@@ -41,7 +43,7 @@ public:
     static constexpr auto name = "element_at";
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /*
             parse element_at(arr, idx) as
@@ -54,17 +56,17 @@ public:
         */
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         auto arg_type = removeNullable(parsed_args[0]->result_type);
         if (isMap(arg_type))
         {
             const auto * map_arg = parsed_args[0];
-            const DataTypeMap * map_type = checkAndGetDataType<DataTypeMap>(removeNullable(map_arg->result_type).get());
+            const DB::DataTypeMap * map_type = checkAndGetDataType<DB::DataTypeMap>(removeNullable(map_arg->result_type).get());
             if (isNothing(map_type->getKeyType()))
             {
-                const DataTypePtr value_type = map_type->getValueType();
-                const auto * null_const_node = addColumnToActionsDAG(actions_dag, makeNullable(value_type), Field{});
+                const DB::DataTypePtr value_type = map_type->getValueType();
+                const auto * null_const_node = addColumnToActionsDAG(actions_dag, makeNullable(value_type), DB::Field{});
                 return null_const_node;
             }
             const auto * key_arg = parsed_args[1];
@@ -76,10 +78,10 @@ public:
             const auto * arr_arg = parsed_args[0];
             const auto * idx_arg = parsed_args[1];
 
-            const auto * zero_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 0);
+            const auto * zero_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 0);
             const auto * equal_zero_node = toFunctionNode(actions_dag, "equals", {idx_arg, zero_node});
             const auto * throw_message
-                = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "SQL array indices start at 1");
+                = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "SQL array indices start at 1");
             /// throwIf(idx == 0, 'SQL array indices start at 1')
             const auto * throw_if_node = toFunctionNode(actions_dag, "throwIf", {equal_zero_node, throw_message});
 
@@ -88,7 +90,7 @@ public:
             const auto * if_node = toFunctionNode(actions_dag, "if", {throw_if_node, array_element_node, array_element_node});
             return convertNodeTypeIfNeeded(substrait_func, if_node, actions_dag);
         }
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "First argument of function {} must be an array or a map", getName());
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "First argument of function {} must be an array or a map", getName());
     }
 };
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/empty2null.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/empty2null.cpp
@@ -16,6 +16,7 @@
  */
 #include <Core/Field.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/IDataType.h>
 #include <Parser/FunctionParser.h>
 
@@ -40,15 +41,15 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Function {} requires exactly one arguments", getName());
         if (parsed_args.at(0)->result_type->getName() != "Nullable(String)")
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {}'s argument has to be Nullable(String)", getName());
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Function {}'s argument has to be Nullable(String)", getName());
 
-        const auto * null_node = addColumnToActionsDAG(actions_dag, makeNullableSafe(std::make_shared<DataTypeString>()), Field());
+        const auto * null_node = addColumnToActionsDAG(actions_dag, makeNullableSafe(std::make_shared<DB::DataTypeString>()), DB::Field());
 
         auto cond = toFunctionNode(actions_dag, "empty", {parsed_args.at(0)});
         auto * if_function = toFunctionNode(actions_dag, "if", {cond, null_node, parsed_args.at(0)});

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/encode.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/encode.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
+#include <DataTypes/DataTypeString.h>
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -40,17 +40,17 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /// Parse encode(str, charset) as convertCharset(str, 'UTF-8', charset)
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         const auto * str_arg = parsed_args[0];
-        const auto * from_charset_arg = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "UTF-8");
+        const auto * from_charset_arg = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "UTF-8");
         const auto * to_charset_arg = parsed_args[1];
         const auto * result_node = toFunctionNode(actions_dag, "convertCharset", {str_arg, from_charset_arg, to_charset_arg});
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/equalNullSafe.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/equalNullSafe.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -40,7 +40,7 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /// Parse equal_null_safe(left, right) as:
         /// if (isNull(left) && isNull(right))
@@ -51,7 +51,7 @@ public:
         ///     return equals(left, right)
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         const auto * left_arg = parsed_args[0];
         const auto * right_arg = parsed_args[1];
@@ -61,7 +61,7 @@ public:
         const auto * is_either_null_node = toFunctionNode(actions_dag, "or", {is_left_null_node, is_right_null_node});
         const auto * equals_node = toFunctionNode(actions_dag, "equals", {left_arg, right_arg});
 
-        auto result_type = std::make_shared<DataTypeUInt8>();
+        auto result_type = std::make_shared<DB::DataTypeUInt8>();
         const auto * true_node = addColumnToActionsDAG(actions_dag, result_type, 1);
         const auto * false_node = addColumnToActionsDAG(actions_dag, result_type, 0);
         const auto * result_node

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/expm1.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/expm1.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 
 namespace DB
@@ -37,18 +38,18 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /// parse expm1(x) as exp(x) - 1
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * x_node = parsed_args[0];
         const auto * exp_node = toFunctionNode(actions_dag, "exp", {x_node});
-        const auto * one_const_node = addColumnToActionsDAG(actions_dag,  std::make_shared<DataTypeFloat64>(), 1.0);
+        const auto * one_const_node = addColumnToActionsDAG(actions_dag,  std::make_shared<DB::DataTypeFloat64>(), 1.0);
         const auto * result_node = toFunctionNode(actions_dag, "minus", {exp_node, one_const_node});
 
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/extract.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/extract.cpp
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeNumberBase.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 #include <Common/Exception.h>
-#include <DataTypes/DataTypeNumberBase.h>
-#include <DataTypes/DataTypeNullable.h>
 
 namespace DB::ErrorCodes
 {
@@ -41,7 +42,7 @@ public:
         if (args.size() != 2)
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Spark function extract requires two args, function:{}", func.ShortDebugString());
         const auto & extract_field = args.at(0);
-        String ch_function_name = "";
+        String ch_function_name;
         if (extract_field.value().has_literal())
         {
             const auto & field_value = extract_field.value().literal().string();

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/fromJson.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/fromJson.cpp
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypeString.h>
 #include <Parser/FunctionParser.h>
 #include <Parser/TypeParser.h>
-#include <Common/Exception.h>
-#include <DataTypes/DataTypeString.h>
 
 namespace local_engine
 {
@@ -40,11 +39,10 @@ public:
         auto ch_function_name = getCHFunctionName(substrait_func);
         parsed_args.emplace_back(parseExpression(actions_dag, substrait_func.arguments()[0].value()));
         auto data_type = TypeParser::parseType(substrait_func.output_type());
-        parsed_args.emplace_back(addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), data_type->getName()));
+        parsed_args.emplace_back(addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), data_type->getName()));
         const auto * func_node = toFunctionNode(actions_dag, ch_function_name, parsed_args);
         return convertNodeTypeIfNeeded(substrait_func, func_node, actions_dag);
     }
 };
 static FunctionParserRegister<SparkFunctionFromJsonParser> register_from_json;
 }
-

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/getArrayItem.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/getArrayItem.cpp
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <DataTypes/IDataType.h>
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionHelpers.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
@@ -42,7 +41,7 @@ public:
     static constexpr auto name = "get_array_item";
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /**
             parse get_array_item(arr, idx) as
@@ -53,22 +52,22 @@ public:
         */
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         const auto * arr_arg = parsed_args[0];
         const auto * idx_arg = parsed_args[1];
-        const DataTypeArray * arr_type = checkAndGetDataType<DataTypeArray>(removeNullable(arr_arg->result_type).get());
+        const DB::DataTypeArray * arr_type = checkAndGetDataType<DB::DataTypeArray>(removeNullable(arr_arg->result_type).get());
         if (!arr_type)
-            throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "First argument of function {} must be an array", getName());
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "First argument of function {} must be an array", getName());
 
         /// arrayElementOrNull(arrary, idx)
         const auto * array_element_node = toFunctionNode(actions_dag, "arrayElementOrNull", {arr_arg, idx_arg});
 
         /// idx <= 0
-        const auto * zero_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 0);
+        const auto * zero_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 0);
         const auto * idx_le_zero_node = toFunctionNode(actions_dag, "lessOrEquals", {idx_arg, zero_node});
 
-        const auto * null_node = addColumnToActionsDAG(actions_dag, makeNullable(arr_type->getNestedType()), Field{});
+        const auto * null_node = addColumnToActionsDAG(actions_dag, makeNullable(arr_type->getNestedType()), DB::Field{});
         const auto * if_node = toFunctionNode(actions_dag, "if", {idx_le_zero_node, null_node, array_element_node});
         return convertNodeTypeIfNeeded(substrait_func, if_node, actions_dag);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/isNaN.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/isNaN.cpp
@@ -16,10 +16,9 @@
  */
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeNumberBase.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 #include <Parser/TypeParser.h>
-
-#include <Common/Exception.h>
 
 namespace local_engine
 {
@@ -52,7 +51,7 @@ public:
         else
             arg_node = parseExpression(actions_dag, args[0].value());
 
-        DB::ActionsDAG::NodeRawConstPtrs ifnull_args = {arg_node, addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 0)};
+        DB::ActionsDAG::NodeRawConstPtrs ifnull_args = {arg_node, addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 0)};
         parsed_args.emplace_back(toFunctionNode(actions_dag, "IfNull", ifnull_args));
 
         const auto * func_node = toFunctionNode(actions_dag, ch_function_name, parsed_args);

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/lambdaFunction.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/lambdaFunction.cpp
@@ -78,7 +78,7 @@ public:
         DB::NamesAndTypesList parent_header;
         for (const auto * output_node : actions_dag.getOutputs())
             parent_header.emplace_back(output_node->result_name, output_node->result_type);
-        ActionsDAG lambda_actions_dag{parent_header};
+        DB::ActionsDAG lambda_actions_dag{parent_header};
 
         /// The first argument is the lambda function body, followings are the lambda arguments which is
         /// needed by the lambda function body.
@@ -90,7 +90,7 @@ public:
         const auto & substrait_lambda_body = substrait_func.arguments()[0].value();
         const auto * lambda_body_node = parseExpression(lambda_actions_dag, substrait_lambda_body);
         lambda_actions_dag.getOutputs().push_back(lambda_body_node);
-        lambda_actions_dag.removeUnusedActions(Names(1, lambda_body_node->result_name));
+        lambda_actions_dag.removeUnusedActions(DB::Names(1, lambda_body_node->result_name));
 
         DB::Names captured_column_names;
         DB::Names required_column_names = lambda_actions_dag.getRequiredColumnsNames();

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/ln.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/ln.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include <Parser/scalar_function_parser/logarithm.h>
-#include <Parser/ExpressionParser.h>
 
 namespace local_engine
 {
@@ -30,7 +29,7 @@ public:
 
     String getName() const override { return name; }
     String getCHFunctionName() const override { return name; }
-    const DB::ActionsDAG::Node * getParameterLowerBound(ActionsDAG & actions_dag, const DataTypePtr & data_type) const override
+    const DB::ActionsDAG::Node * getParameterLowerBound(DB::ActionsDAG & actions_dag, const DB::DataTypePtr & data_type) const override
     {
         return addColumnToActionsDAG(actions_dag, data_type, 0.0);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/locate.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/locate.cpp
@@ -32,7 +32,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 class FunctionParserLocate : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/log.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/log.cpp
@@ -17,9 +17,10 @@
 
 #include <Core/Field.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Parser/ExpressionParser.h>
 #include <Parser/FunctionParser.h>
 #include <Common/CHUtil.h>
-#include <Parser/ExpressionParser.h>
 
 namespace DB
 {
@@ -33,6 +34,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
+using namespace DB;
 class FunctionParserLog : public FunctionParser
 {
 public:

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/log10.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/log10.cpp
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Parser/scalar_function_parser/logarithm.h>
 #include <Parser/ExpressionParser.h>
+#include <Parser/scalar_function_parser/logarithm.h>
 
 namespace local_engine
 {
@@ -30,7 +30,7 @@ public:
 
     String getName() const override { return name; }
     String getCHFunctionName() const override { return name; }
-    const DB::ActionsDAG::Node * getParameterLowerBound(ActionsDAG & actions_dag, const DataTypePtr & data_type) const override
+    const DB::ActionsDAG::Node * getParameterLowerBound(DB::ActionsDAG & actions_dag, const DB::DataTypePtr & data_type) const override
     {
         return addColumnToActionsDAG(actions_dag, data_type, 0.0);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/log1p.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/log1p.cpp
@@ -29,7 +29,7 @@ public:
 
     String getName() const override { return name; }
     String getCHFunctionName() const override { return name; }
-    const DB::ActionsDAG::Node * getParameterLowerBound(ActionsDAG & actions_dag, const DataTypePtr & data_type) const override
+    const DB::ActionsDAG::Node * getParameterLowerBound(DB::ActionsDAG & actions_dag, const DB::DataTypePtr & data_type) const override
     {
         return addColumnToActionsDAG(actions_dag, data_type, -1.0);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/log2.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/log2.cpp
@@ -29,7 +29,7 @@ public:
 
     String getName() const override { return name; }
     String getCHFunctionName() const override { return name; }
-    const DB::ActionsDAG::Node * getParameterLowerBound(ActionsDAG & actions_dag, const DataTypePtr & data_type) const override
+    const DB::ActionsDAG::Node * getParameterLowerBound(DB::ActionsDAG & actions_dag, const DB::DataTypePtr & data_type) const override
     {
         return addColumnToActionsDAG(actions_dag, data_type, 0.0);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/makeDecimal.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/makeDecimal.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 #include <Common/Exception.h>
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/mapHighOrderFunctions.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/mapHighOrderFunctions.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeFunction.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <Functions/FunctionHelpers.h>
 #include <Parser/FunctionParser.h>
 #include <Parser/TypeParser.h>
 #include <Parser/scalar_function_parser/lambdaFunction.h>
@@ -25,8 +25,6 @@
 #include <Common/CHUtil.h>
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
-#include <DataTypes/DataTypeMap.h>
-#include <Functions/FunctionHelpers.h>
 
 namespace DB::ErrorCodes
 {
@@ -64,9 +62,9 @@ public:
         const auto * map_node = parsed_args[0];
         const auto * func_node = parsed_args[1];
         const auto & map_type = map_node->result_type;
-        auto array_type = checkAndGetDataType<DataTypeMap>(removeNullable(map_type).get())->getNestedType();
+        auto array_type = checkAndGetDataType<DB::DataTypeMap>(removeNullable(map_type).get())->getNestedType();
         if (map_type->isNullable())
-            array_type = std::make_shared<DataTypeNullable>(array_type);
+            array_type = std::make_shared<DB::DataTypeNullable>(array_type);
         const auto * array_node = ActionsDAGUtil::convertNodeTypeIfNeeded(actions_dag, map_node, array_type);
         const auto * transformed_node = toFunctionNode(actions_dag, "arrayMap", {func_node, array_node});
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/md5.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/md5.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -40,12 +39,12 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /// Parse md5(str) as lower(hex(md5(str)))
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * str_arg = parsed_args[0];
         const auto * md5_node = toFunctionNode(actions_dag, "MD5", {str_arg});

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/nanvl.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/nanvl.cpp
@@ -19,7 +19,6 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <Parser/FunctionParser.h>
 
-
 namespace DB
 {
 
@@ -42,9 +41,9 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /*
             parse nanvl(e1, e2) as
@@ -57,7 +56,7 @@ public:
         */
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires at least two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires at least two arguments", getName());
 
         const auto * e1 = parsed_args[0];
         const auto * e2 = parsed_args[1];
@@ -67,7 +66,7 @@ public:
         const auto * e1_is_null_node = toFunctionNode(actions_dag, "isNull", {e1});
         const auto * e1_is_nan_node = toFunctionNode(actions_dag, "isNaN", {e1});
 
-        const auto * null_const_node = addColumnToActionsDAG(actions_dag, makeNullable(result_type), Field());
+        const auto * null_const_node = addColumnToActionsDAG(actions_dag, makeNullable(result_type), DB::Field());
         const auto * result_node = toFunctionNode(actions_dag, "multiIf", {
             e1_is_null_node,
             null_const_node,

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/octetLength.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/octetLength.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/IDataType.h>
 #include <Parser/FunctionParser.h>
 
@@ -39,17 +40,17 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * arg = parsed_args[0];
         const auto * new_arg = arg;
         if (isInt(DB::removeNullable(arg->result_type)))
         {
-            const auto * string_type_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "Nullable(String)");
+            const auto * string_type_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "Nullable(String)");
             new_arg = toFunctionNode(actions_dag, "CAST", {arg, string_type_node});
         }
         const auto * octet_length_node = toFunctionNode(actions_dag, "octet_length", {new_arg});

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/parseUrl.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/parseUrl.cpp
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 #include "parseUrl.h"
-#include <iterator>
-#include <Common/Exception.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/IDataType.h>
-#include <unordered_map>
+#include <Common/Exception.h>
 
 namespace DB
 {
@@ -121,7 +120,7 @@ const DB::ActionsDAG::Node * ParseURLParser::convertNodeTypeIfNeeded(
     // Empty string is converted to NULL.
     auto str_type = std::make_shared<DB::DataTypeString>();
     const auto * empty_str_node
-        = &actions_dag.addColumn(ColumnWithTypeAndName(str_type->createColumnConst(1, DB::Field("")), str_type, getUniqueName("")));
+        = &actions_dag.addColumn(DB::ColumnWithTypeAndName(str_type->createColumnConst(1, DB::Field("")), str_type, getUniqueName("")));
     return toFunctionNode(actions_dag, "nullIf", {func_node, empty_str_node});
 }
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/regexp_extract.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/regexp_extract.cpp
@@ -17,6 +17,8 @@
 
 #include <stack>
 
+#include <DataTypes/DataTypeString.h>
+#include <IO/ReadBufferFromString.h>
 #include <Parser/FunctionParser.h>
 
 namespace DB

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/repeat.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/repeat.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <DataTypes/DataTypeNullable.h>
 #include <Parser/FunctionParser.h>
 #include <Parser/TypeParser.h>
 #include <Common/BlockTypeUtils.h>
@@ -42,7 +41,7 @@ public:
         parsed_args.emplace_back(parseExpression(actions_dag, args[0].value()));
         const auto * repeat_times_node = parseExpression(actions_dag, args[1].value());
         const auto cast_or_default_args
-            = {repeat_times_node, expression_parser->addConstColumn(actions_dag, std::make_shared<DataTypeString>(), "UInt32")};
+            = {repeat_times_node, expression_parser->addConstColumn(actions_dag, std::make_shared<DB::DataTypeString>(), "UInt32")};
         parsed_args.emplace_back(
             toFunctionNode(actions_dag, "accurateCastOrDefault", repeat_times_node->result_name, cast_or_default_args));
         const auto * func_node = toFunctionNode(actions_dag, ch_function_name, parsed_args);

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/reverse.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/reverse.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include <Parser/FunctionParser.h>
-#include <Common/Exception.h>
 
 namespace DB
 {

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/sec.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/sec.cpp
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -39,18 +39,18 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /// parse sec(x) as 1 / cos(x)
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * x = parsed_args[0];
         const auto * cos_node = toFunctionNode(actions_dag, "cos", {x});
-        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeFloat64>(), 1.0);
+        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeFloat64>(), 1.0);
         const auto * result_node = toFunctionNode(actions_dag, "divide", {one_const_node, cos_node});
 
         return convertNodeTypeIfNeeded(substrait_func, result_node, actions_dag);;

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/sequence.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/sequence.cpp
@@ -16,8 +16,8 @@
  */
 #include <Core/Field.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
-
 
 namespace DB
 {
@@ -40,9 +40,9 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /**
             parse sequence(start, end, step) as
@@ -63,16 +63,16 @@ public:
 
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() < 2 || parsed_args.size() > 3)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires two or three arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires two or three arguments", getName());
 
         const auto * start_arg = parsed_args[0];
         const auto * end_arg = parsed_args[1];
         const auto * step_arg = parsed_args.size() == 3 ? parsed_args[2] : nullptr;
 
-        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 1);
+        const auto * one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 1);
         if (!step_arg)
         {
-            const auto * minus_one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), -1);
+            const auto * minus_one_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), -1);
             /// start <= end
             const auto * start_le_end_node = toFunctionNode(actions_dag, "lessOrEquals", {start_arg, end_arg});
             /// if(start <= end, 1, -1)
@@ -85,7 +85,7 @@ public:
 
         const auto * end_minus_start_node = toFunctionNode(actions_dag, "minus", {end_arg, start_arg});
         const auto * modulo_step_node = toFunctionNode(actions_dag, "modulo", {end_minus_start_node, step_arg});
-        const auto * zero_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 0);
+        const auto * zero_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 0);
         /// (end - start) % step = 0
         const auto * modulo_step_eq_zero_node = toFunctionNode(actions_dag, "equals", {modulo_step_node, zero_const_node});
 
@@ -103,7 +103,7 @@ public:
         /// range(assumeNotNull(start), assumeNotNull(end), assumeNotNull(step))
         const auto * range_2_node = toFunctionNode(actions_dag, "range", {start_not_null_node, end_not_null_node, tricky_step_node});
 
-        DataTypePtr result_type = makeNullable(range_1_node->result_type);
+        DB::DataTypePtr result_type = makeNullable(range_1_node->result_type);
         const auto * null_const_node = addColumnToActionsDAG(actions_dag, result_type, {});
         const auto * or_condition_node = toFunctionNode(actions_dag, "or", {start_is_null_node, end_is_null_node, step_is_null_node});
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/sha1.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/sha1.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Parser/FunctionParser.h>
-#include <DataTypes/IDataType.h>
 
 namespace DB
 {
@@ -40,12 +39,12 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /// Parse sha1(str) as lower(hex(sha1(str)))
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * str_arg = parsed_args[0];
         const auto * md5_node = toFunctionNode(actions_dag, "SHA1", {str_arg});

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/sha2.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/sha2.cpp
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-#include <Parser/FunctionParser.h>
 #include <DataTypes/IDataType.h>
-
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
@@ -41,7 +40,7 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /// Parse sha2(str, 0) or sha2(str, 0) as lower(hex(SHA256(str)))
         /// Parse sha2(str, 224) as lower(hex(SHA224(str)))
@@ -49,12 +48,12 @@ public:
         /// Parse sha2(str, 512) as lower(hex(SHA512(str)))
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         const auto * str_arg = parsed_args[0];
         const auto * bit_length_arg = parsed_args[1];
-        if (bit_length_arg->type != ActionsDAG::ActionType::COLUMN || !isColumnConst(*bit_length_arg->column))
-            throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Second argument of function {} must be a constant integer", getName());
+        if (bit_length_arg->type != DB::ActionsDAG::ActionType::COLUMN || !isColumnConst(*bit_length_arg->column))
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Second argument of function {} must be a constant integer", getName());
 
         Int32 bit_length = bit_length_arg->column->getInt(0);
         String ch_func_name;
@@ -74,7 +73,7 @@ public:
                 ch_func_name = "SHA512";
                 break;
             default:
-                throw Exception(
+                throw DB::Exception(
                     DB::ErrorCodes::BAD_ARGUMENTS, "Second argument of function {} must be one of 0, 224, 256, 384 or 512", getName());
         }
 

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/slice.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/slice.cpp
@@ -41,9 +41,9 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         /**
             parse slice(arr, start, length) as
@@ -63,7 +63,7 @@ public:
 
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 3)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {} requires exactly three arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Function {} requires exactly three arguments", getName());
 
         const auto * arr_arg = parsed_args[0];
         const auto * start_arg = parsed_args[1];
@@ -73,7 +73,7 @@ public:
         auto is_start_nullable = start_arg->result_type->isNullable();
         auto is_length_nullable = length_arg->result_type->isNullable();
 
-        const auto * zero_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeInt32>(), 0);
+        const auto * zero_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeInt32>(), 0);
         const auto * start_if_node = makeStartIfNode(actions_dag, start_arg, zero_const_node);
         const auto * length_if_node = makeLengthIfNode(actions_dag, length_arg, zero_const_node);
 
@@ -86,11 +86,11 @@ public:
         // There is at least one nullable argument, should return nullable result
         const auto * arr_not_null_node = is_arr_nullable ? toFunctionNode(actions_dag, "assumeNotNull", {arr_arg}) : arr_arg;
         const auto * slice_node = toFunctionNode(actions_dag, "arraySlice", {arr_not_null_node, start_if_node, length_if_node});
-        DataTypePtr wrap_arr_nullable_type = wrapNullableType(true, slice_node->result_type);
+        DB::DataTypePtr wrap_arr_nullable_type = wrapNullableType(true, slice_node->result_type);
 
         const auto * wrap_slice_node = ActionsDAGUtil::convertNodeType(
             actions_dag, slice_node, wrap_arr_nullable_type, slice_node->result_name);
-        const auto * null_const_node = addColumnToActionsDAG(actions_dag, wrap_arr_nullable_type, Field{});
+        const auto * null_const_node = addColumnToActionsDAG(actions_dag, wrap_arr_nullable_type, DB::Field{});
 
         const auto * arr_is_null_node = toFunctionNode(actions_dag, "isNull", {arr_arg});
         const auto * start_is_null_node = toFunctionNode(actions_dag, "isNull", {start_arg});
@@ -103,25 +103,25 @@ public:
 
 private:
     // if (start=0) then throwIf(start=0) else start
-    const ActionsDAG::Node * makeStartIfNode(
-        ActionsDAG & actions_dag,
-        const ActionsDAG::Node * start_arg,
-        const ActionsDAG::Node * zero_const_node) const
+    const DB::ActionsDAG::Node * makeStartIfNode(
+        DB::ActionsDAG & actions_dag,
+        const DB::ActionsDAG::Node * start_arg,
+        const DB::ActionsDAG::Node * zero_const_node) const
     {
         const auto * start_equal_zero_node = toFunctionNode(actions_dag, "equals", {start_arg, zero_const_node});
-        const auto * start_msg_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "Unexpected value for start");
+        const auto * start_msg_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "Unexpected value for start");
         const auto * start_throw_if_node = toFunctionNode(actions_dag, "throwIf", {start_equal_zero_node, start_msg_const_node});
         return toFunctionNode(actions_dag, "if", {start_equal_zero_node, start_throw_if_node, start_arg});
     }
 
      // if (length<0) then throwIf(length<0) else length
-    const ActionsDAG::Node * makeLengthIfNode(
-        ActionsDAG & actions_dag,
-        const ActionsDAG::Node * length_arg,
-        const ActionsDAG::Node * zero_const_node) const
+    const DB::ActionsDAG::Node * makeLengthIfNode(
+        DB::ActionsDAG & actions_dag,
+        const DB::ActionsDAG::Node * length_arg,
+        const DB::ActionsDAG::Node * zero_const_node) const
     {
         const auto * length_less_zero_node = toFunctionNode(actions_dag, "less", {length_arg, zero_const_node});
-        const auto * length_msg_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), "Unexpected value for length");
+        const auto * length_msg_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeString>(), "Unexpected value for length");
         const auto * length_throw_if_node = toFunctionNode(actions_dag, "throwIf", {length_less_zero_node, length_msg_const_node});
         return toFunctionNode(actions_dag, "if", {length_less_zero_node, length_throw_if_node, length_arg});
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/sortArray.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/sortArray.cpp
@@ -14,10 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
-#include <DataTypes/IDataType.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
@@ -41,13 +39,13 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
-        ActionsDAG & actions_dag) const override
+        DB::ActionsDAG & actions_dag) const override
     {
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 2)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
 
         const auto * array_arg = parsed_args[0];
         const auto * order_arg = parsed_args[1];

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/space.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/space.cpp
@@ -18,8 +18,6 @@
 #include <Parser/FunctionParser.h>
 #include <Parser/TypeParser.h>
 
-#include <Common/Exception.h>
-
 namespace local_engine
 {
 class SparkFunctionSpaceParser : public FunctionParser

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/split.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/split.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include <Parser/FunctionParser.h>
-#include <Common/Exception.h>
 
 namespace local_engine
 {

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/substring.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/substring.cpp
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <DataTypes/IDataType.h>
-#include <Parser/FunctionParser.h>
-
 #include <Core/Field.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Parser/FunctionParser.h>
 
 namespace DB
 {
@@ -38,13 +37,13 @@ public:
     static constexpr auto name = "substring";
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(
+    const DB::ActionsDAG::Node * parse(
     const substrait::Expression_ScalarFunction & substrait_func,
-    ActionsDAG & actions_dag) const override
+    DB::ActionsDAG & actions_dag) const override
     {
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 3)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires two or three arguments", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires two or three arguments", getName());
 
         /*
             parse substring(str, index, length) as

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/timestampSeconds.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/timestampSeconds.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 
 namespace DB
@@ -40,15 +40,15 @@ public:
 
     String getName() const override { return name; }
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /// Parse timestamp_seconds(expr) as toDateTime64(expr, 6)
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
         if (parsed_args.size() != 1)
-            throw Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one argument", getName());
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one argument", getName());
 
         const auto * arg = parsed_args[0];
-        const auto * precision_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeUInt8>(), 6);
+        const auto * precision_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeUInt8>(), 6);
         const auto * to_datetime64_node = toFunctionNode(actions_dag, "toDateTime64", {arg, precision_node});
         return convertNodeTypeIfNeeded(substrait_func, to_datetime64_node, actions_dag);
     }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/trimFunctions.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/trimFunctions.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include <Parser/FunctionParser.h>
-#include <Common/Exception.h>
 
 namespace local_engine
 {

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/tupleElement.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/tupleElement.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <DataTypes/DataTypesNumber.h>
 #include <Parser/FunctionParser.h>
 #include <Parser/TypeParser.h>
 #include <Common/Exception.h>
@@ -46,7 +47,7 @@ namespace local_engine
             if (!DB::WhichDataType(data_type).isInt32()) \
                 throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "{}'s second argument must be i32", #substrait_name); \
             Int32 field_index = static_cast<Int32>(field.safeGet<Int32>() + 1); \
-            const auto * index_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeUInt32>(), field_index); \
+            const auto * index_node = addColumnToActionsDAG(actions_dag, std::make_shared<DB::DataTypeUInt32>(), field_index); \
             parsed_args.emplace_back(index_node); \
             const auto * func_node = toFunctionNode(actions_dag, ch_function_name, parsed_args); \
             return convertNodeTypeIfNeeded(substrait_func, func_node, actions_dag); \
@@ -57,4 +58,3 @@ namespace local_engine
 REGISTER_TUPLE_ELEMENT_PARSER(GetStructField, get_struct_field, sparkTupleElement);
 REGISTER_TUPLE_ELEMENT_PARSER(GetArrayStructFields, get_array_struct_fields, sparkTupleElement);
 }
-

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/utcTimestampTransform.h
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/utcTimestampTransform.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeString.h>
 #include <Parser/FunctionParser.h>
 #include <Common/CHUtil.h>
 
@@ -41,7 +41,7 @@ public:
     explicit FunctionParserUtcTimestampTransform(ParserContextPtr parser_context_) : FunctionParser(parser_context_) { }
     ~FunctionParserUtcTimestampTransform() override = default;
 
-    const ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, ActionsDAG & actions_dag) const override
+    const DB::ActionsDAG::Node * parse(const substrait::Expression_ScalarFunction & substrait_func, DB::ActionsDAG & actions_dag) const override
     {
         /// Convert timezone value to clickhouse backend supported, i.e. GMT+8 -> Etc/GMT-8, +08:00 -> Etc/GMT-8
         if (substrait_func.arguments_size() != 2)

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
@@ -43,6 +43,7 @@ extern const int LOGICAL_ERROR;
 }
 namespace local_engine
 {
+using namespace DB;
 PartitionInfo PartitionInfo::fromSelector(DB::IColumn::Selector selector, size_t partition_num, bool use_external_sort_shuffle)
 {
     if (use_external_sort_shuffle)

--- a/cpp-ch/local-engine/Storages/Cache/CacheManager.cpp
+++ b/cpp-ch/local-engine/Storages/Cache/CacheManager.cpp
@@ -54,7 +54,7 @@ extern const Metric LocalThreadScheduled;
 
 namespace local_engine
 {
-
+using namespace DB;
 jclass CacheManager::cache_result_class = nullptr;
 jmethodID CacheManager::cache_result_constructor = nullptr;
 

--- a/cpp-ch/local-engine/Storages/MergeTree/MergeSparkMergeTreeTask.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/MergeSparkMergeTreeTask.h
@@ -21,26 +21,22 @@
 #include <Storages/MergeTree/MergeMutateSelectedEntry.h>
 #include <Storages/MergeTree/MergeTask.h>
 
-using namespace DB;
-
-
 namespace local_engine
 {
 class SparkStorageMergeTree;
 
-
-class MergeSparkMergeTreeTask : public IExecutableTask
+class MergeSparkMergeTreeTask : public DB::IExecutableTask
 {
 public:
     MergeSparkMergeTreeTask(
         SparkStorageMergeTree & storage_,
-        StorageMetadataPtr metadata_snapshot_,
+        DB::StorageMetadataPtr metadata_snapshot_,
         bool deduplicate_,
-        Names deduplicate_by_columns_,
+        DB::Names deduplicate_by_columns_,
         bool cleanup_,
-        MergeMutateSelectedEntryPtr merge_mutate_entry_,
-        TableLockHolder table_lock_holder_,
-        IExecutableTask::TaskResultCallback & task_result_callback_)
+        DB::MergeMutateSelectedEntryPtr merge_mutate_entry_,
+        DB::TableLockHolder table_lock_holder_,
+        DB::IExecutableTask::TaskResultCallback & task_result_callback_)
         : storage(storage_)
         , metadata_snapshot(std::move(metadata_snapshot_))
         , deduplicate(deduplicate_)
@@ -56,11 +52,11 @@ public:
 
     bool executeStep() override;
     void onCompleted() override;
-    StorageID getStorageID() const override;
+    DB::StorageID getStorageID() const override;
     Priority getPriority() const override { return priority; }
     String getQueryId() const override { return getStorageID().getShortName() + "::" + merge_mutate_entry->future_part->name; }
 
-    void setCurrentTransaction(MergeTreeTransactionHolder && txn_holder_, MergeTreeTransactionPtr && txn_)
+    void setCurrentTransaction(DB::MergeTreeTransactionHolder && txn_holder_, DB::MergeTreeTransactionPtr && txn_)
     {
         txn_holder = std::move(txn_holder_);
         txn = std::move(txn_);
@@ -84,33 +80,33 @@ private:
 
     SparkStorageMergeTree & storage;
 
-    StorageMetadataPtr metadata_snapshot;
+    DB::StorageMetadataPtr metadata_snapshot;
     bool deduplicate;
-    Names deduplicate_by_columns;
+    DB::Names deduplicate_by_columns;
     bool cleanup;
-    MergeMutateSelectedEntryPtr merge_mutate_entry{nullptr};
-    TableLockHolder table_lock_holder;
-    FutureMergedMutatedPartPtr future_part{nullptr};
-    MergeTreeData::MutableDataPartPtr new_part;
+    DB::MergeMutateSelectedEntryPtr merge_mutate_entry{nullptr};
+    DB::TableLockHolder table_lock_holder;
+    DB::FutureMergedMutatedPartPtr future_part{nullptr};
+    DB::MergeTreeData::MutableDataPartPtr new_part;
     std::unique_ptr<Stopwatch> stopwatch_ptr{nullptr};
-    using MergeListEntryPtr = std::unique_ptr<MergeListEntry>;
+    using MergeListEntryPtr = std::unique_ptr<DB::MergeListEntry>;
     MergeListEntryPtr merge_list_entry;
 
     Priority priority;
 
-    std::function<void(const ExecutionStatus &)> write_part_log;
+    std::function<void(const DB::ExecutionStatus &)> write_part_log;
     std::function<void()> transfer_profile_counters_to_initial_query;
-    IExecutableTask::TaskResultCallback task_result_callback;
-    MergeTaskPtr merge_task{nullptr};
+    DB::IExecutableTask::TaskResultCallback task_result_callback;
+    DB::MergeTaskPtr merge_task{nullptr};
 
-    MergeTreeTransactionHolder txn_holder;
-    MergeTreeTransactionPtr txn;
+    DB::MergeTreeTransactionHolder txn_holder;
+    DB::MergeTreeTransactionPtr txn;
 
     ProfileEvents::Counters profile_counters;
 
-    ContextMutablePtr task_context;
+    DB::ContextMutablePtr task_context;
 
-    ContextMutablePtr createTaskContext() const;
+    DB::ContextMutablePtr createTaskContext() const;
 };
 
 

--- a/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/MetaDataHelper.h
@@ -26,12 +26,12 @@ namespace local_engine
 
 bool isMergeTreePartMetaDataFile(const String & file_name);
 
-void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const Context & context);
+void restoreMetaData(const SparkStorageMergeTreePtr & storage, const MergeTreeTableInstance & mergeTreeTable, const DB::Context & context);
 
 void saveFileStatus(
-    const DB::MergeTreeData & storage, const DB::ContextPtr & context, const String & part_name, IDataPartStorage & data_part_storage);
+    const DB::MergeTreeData & storage, const DB::ContextPtr & context, const String & part_name, DB::IDataPartStorage & data_part_storage);
 
-MergeTreeDataPartPtr mergeParts(
+DB::MergeTreeDataPartPtr mergeParts(
     std::vector<DB::DataPartPtr> selected_parts,
     const String & new_part_uuid,
     SparkStorageMergeTree & storage,

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeMeta.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeMeta.h
@@ -33,7 +33,6 @@ namespace local_engine
 class Write;
 class SparkStorageMergeTree;
 using SparkStorageMergeTreePtr = std::shared_ptr<SparkStorageMergeTree>;
-using namespace DB;
 
 struct MergeTreePart
 {
@@ -66,16 +65,16 @@ struct MergeTreeTable
 
     bool sameTable(const MergeTreeTable & other) const;
 
-    SparkStorageMergeTreePtr getStorage(ContextMutablePtr context) const;
+    SparkStorageMergeTreePtr getStorage(DB::ContextMutablePtr context) const;
 
     /// Create random table name and table path and use default storage policy.
     /// In insert case, mergetree data can be uploaded after merges in default storage(Local Disk).
-    SparkStorageMergeTreePtr copyToDefaultPolicyStorage(const ContextMutablePtr & context) const;
+    SparkStorageMergeTreePtr copyToDefaultPolicyStorage(const DB::ContextMutablePtr & context) const;
 
     /// Use same table path and data path as the original table.
-    SparkStorageMergeTreePtr copyToVirtualStorage(const ContextMutablePtr & context) const;
+    SparkStorageMergeTreePtr copyToVirtualStorage(const DB::ContextMutablePtr & context) const;
 
-    std::shared_ptr<DB::StorageInMemoryMetadata> buildMetaData(const DB::Block & header, const ContextPtr & context) const;
+    std::shared_ptr<DB::StorageInMemoryMetadata> buildMetaData(const DB::Block & header, const DB::ContextPtr & context) const;
 
     MergeTreeTable() = default;
     MergeTreeTable(const local_engine::Write & write, const substrait::NamedStruct & table_schema);
@@ -85,14 +84,14 @@ struct MergeTreeTableInstance : MergeTreeTable
 {
     std::vector<MergeTreePart> parts;
     std::unordered_set<std::string> getPartNames() const;
-    RangesInDataParts extractRange(DataPartsVector parts_vector) const;
+    DB::RangesInDataParts extractRange(DB::DataPartsVector parts_vector) const;
 
-    SparkStorageMergeTreePtr restoreStorage(const ContextMutablePtr & context) const;
+    SparkStorageMergeTreePtr restoreStorage(const DB::ContextMutablePtr & context) const;
 
     explicit MergeTreeTableInstance(const google::protobuf::Any & any);
     explicit MergeTreeTableInstance(const substrait::ReadRel::ExtensionTable & extension_table);
     explicit MergeTreeTableInstance(const std::string & info);
 };
 
-std::unique_ptr<SelectQueryInfo> buildQueryInfo(NamesAndTypesList & names_and_types_list);
+std::unique_ptr<DB::SelectQueryInfo> buildQueryInfo(DB::NamesAndTypesList & names_and_types_list);
 }

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.cpp
@@ -38,7 +38,7 @@ extern const SettingsUInt64 min_insert_block_size_bytes;
 }
 namespace local_engine
 {
-
+using namespace DB;
 void SparkMergeTreeSink::write(const Chunk & chunk)
 {
     CurrentThread::flushUntrackedMemory();

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkMergeTreeSink.h
@@ -114,14 +114,14 @@ protected:
     void doMergePartsAsync(const std::vector<PartWithStats> & merge_parts_with_stats);
     void finalizeMerge();
     virtual void cleanup() { }
-    virtual void commit(const ReadSettings & read_settings, const WriteSettings & write_settings) { }
+    virtual void commit(const DB::ReadSettings & read_settings, const DB::WriteSettings & write_settings) { }
     void saveMetadata(const DB::ContextPtr & context);
     SparkWriteStorageMergeTree & dataRef() const { return assert_cast<SparkWriteStorageMergeTree &>(*data); }
 
 public:
     const std::deque<PartWithStats> & unsafeGet() const { return new_parts.unsafeGet(); }
     void
-    writeTempPart(DB::BlockWithPartition & block_with_partition, PartWithStats part_with_stats, const ContextPtr & context, int part_num);
+    writeTempPart(DB::BlockWithPartition & block_with_partition, PartWithStats part_with_stats, const DB::ContextPtr & context, int part_num);
     void checkAndMerge(bool force = false);
     void finish(const DB::ContextPtr & context);
 
@@ -147,7 +147,7 @@ class CopyToRemoteSinkHelper : public SinkHelper
     SparkStorageMergeTreePtr dest;
 
 protected:
-    void commit(const ReadSettings & read_settings, const WriteSettings & write_settings) override;
+    void commit(const DB::ReadSettings & read_settings, const DB::WriteSettings & write_settings) override;
     SparkStorageMergeTree & dest_storage() override { return *dest; }
     const SparkStorageMergeTreePtr & temp_storage() const { return data; }
 
@@ -256,7 +256,7 @@ class SparkMergeTreeSink : public DB::SinkToStorage
 public:
     using SinkStatsOption = std::optional<std::shared_ptr<MergeTreeStats>>;
     using DeltaStatsOption = std::optional<DeltaStats>;
-    static SinkToStoragePtr create(
+    static DB::SinkToStoragePtr create(
         const MergeTreeTable & merge_tree_table,
         const SparkMergeTreeWriteSettings & write_settings_,
         const DB::ContextMutablePtr & context,
@@ -265,7 +265,7 @@ public:
 
     explicit SparkMergeTreeSink(
         const SinkHelperPtr & sink_helper_,
-        const ContextPtr & context_,
+        const DB::ContextPtr & context_,
         const DeltaStatsOption & delta_stats,
         const SinkStatsOption & stats,
         size_t min_block_size_rows,
@@ -281,20 +281,20 @@ public:
     ~SparkMergeTreeSink() override = default;
 
     String getName() const override { return "SparkMergeTreeSink"; }
-    void consume(Chunk & chunk) override;
+    void consume(DB::Chunk & chunk) override;
     void onStart() override;
     void onFinish() override;
 
     const SinkHelper & sinkHelper() const { return *sink_helper; }
 
 private:
-    void write(const Chunk & chunk);
+    void write(const DB::Chunk & chunk);
 
-    ContextPtr context;
+    DB::ContextPtr context;
     SinkHelperPtr sink_helper;
     std::optional<std::shared_ptr<MergeTreeStats>> stats_;
-    Squashing squashing;
-    Chunk squashed_chunk;
+    DB::Squashing squashing;
+    DB::Chunk squashed_chunk;
     DeltaStatsOption empty_delta_stats_;
     int part_num = 1;
 };
@@ -317,7 +317,7 @@ public:
     {
     }
 
-    SinkPtr createSinkForPartition(const String & partition_id) override
+    DB::SinkPtr createSinkForPartition(const String & partition_id) override
     {
         SparkMergeTreeWriteSettings write_settings{write_settings_};
 

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkStorageMergeTree.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkStorageMergeTree.cpp
@@ -50,7 +50,7 @@ extern const int NO_SUCH_DATA_PART;
 
 namespace local_engine
 {
-
+using namespace DB;
 void SparkStorageMergeTree::analysisPartsByRanges(DB::ReadFromMergeTree & source, const DB::RangesInDataParts & ranges_in_data_parts)
 {
     ReadFromMergeTree::AnalysisResult result;

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkStorageMergeTree.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkStorageMergeTree.h
@@ -34,19 +34,19 @@ struct SparkMergeTreeWritePartitionSettings;
 class SparkMergeTreeDataWriter
 {
 public:
-    explicit SparkMergeTreeDataWriter(MergeTreeData & data_) : data(data_), log(getLogger(data.getLogName() + " (Writer)")) { }
-    MergeTreeDataWriter::TemporaryPart writeTempPart(
+    explicit SparkMergeTreeDataWriter(DB::MergeTreeData & data_) : data(data_), log(getLogger(data.getLogName() + " (Writer)")) { }
+    DB::MergeTreeDataWriter::TemporaryPart writeTempPart(
         DB::BlockWithPartition & block_with_partition,
         const DB::StorageMetadataPtr & metadata_snapshot,
-        const ContextPtr & context,
+        const DB::ContextPtr & context,
         const std::string & part_dir) const;
 
 private:
-    MergeTreeData & data;
+    DB::MergeTreeData & data;
     LoggerPtr log;
 };
 
-class SparkStorageMergeTree : public MergeTreeData
+class SparkStorageMergeTree : public DB::MergeTreeData
 {
     friend class MergeSparkMergeTreeTask;
 
@@ -54,39 +54,39 @@ class SparkStorageMergeTree : public MergeTreeData
     {
         SparkMutationsSnapshot() = default;
 
-        MutationCommands getAlterMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const override { return {}; }
+        DB::MutationCommands getAlterMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const override { return {}; }
         std::shared_ptr<MergeTreeData::IMutationsSnapshot> cloneEmpty() const override
         {
             return std::make_shared<SparkMutationsSnapshot>();
         }
 
-        NameSet getAllUpdatedColumns() const override { return {}; }
+        DB::NameSet getAllUpdatedColumns() const override { return {}; }
     };
 
 public:
     static void wrapRangesInDataParts(DB::ReadFromMergeTree & source, const DB::RangesInDataParts & ranges);
     static void analysisPartsByRanges(DB::ReadFromMergeTree & source, const DB::RangesInDataParts & ranges_in_data_parts);
     std::string getName() const override;
-    std::vector<MergeTreeMutationStatus> getMutationsStatus() const override;
-    bool scheduleDataProcessingJob(BackgroundJobsAssignee & executor) override;
-    std::map<std::string, MutationCommands> getUnfinishedMutationCommands() const override;
-    std::vector<MergeTreeDataPartPtr> loadDataPartsWithNames(const std::unordered_set<std::string> & parts);
+    std::vector<DB::MergeTreeMutationStatus> getMutationsStatus() const override;
+    bool scheduleDataProcessingJob(DB::BackgroundJobsAssignee & executor) override;
+    std::map<std::string, DB::MutationCommands> getUnfinishedMutationCommands() const override;
+    std::vector<DB::MergeTreeDataPartPtr> loadDataPartsWithNames(const std::unordered_set<std::string> & parts);
     void removePartFromMemory(const MergeTreeData::DataPart & part_to_detach);
     void prefetchPartDataFile(const std::unordered_set<std::string> & parts) const;
 
-    MergeTreeDataSelectExecutor reader;
-    MergeTreeDataMergerMutator merger_mutator;
+    DB::MergeTreeDataSelectExecutor reader;
+    DB::MergeTreeDataMergerMutator merger_mutator;
 
 protected:
     SparkStorageMergeTree(
-        const StorageID & table_id_,
+        const DB::StorageID & table_id_,
         const String & relative_data_path_,
-        const StorageInMemoryMetadata & metadata,
+        const DB::StorageInMemoryMetadata & metadata,
         bool attach,
-        const ContextMutablePtr & context_,
+        const DB::ContextMutablePtr & context_,
         const String & date_column_name,
         const MergingParams & merging_params_,
-        std::unique_ptr<MergeTreeSettings> settings_,
+        std::unique_ptr<DB::MergeTreeSettings> settings_,
         bool has_force_restore_data_flag = false);
 
 private:
@@ -96,18 +96,18 @@ private:
     void prefetchPartFiles(const std::unordered_set<std::string> & parts, String file_name) const;
     void prefetchMetaDataFile(const std::unordered_set<std::string> & parts) const;
     void startBackgroundMovesIfNeeded() override;
-    std::unique_ptr<MergeTreeSettings> getDefaultSettings() const override;
+    std::unique_ptr<DB::MergeTreeSettings> getDefaultSettings() const override;
     LoadPartResult loadDataPart(
-        const MergeTreePartInfo & part_info, const String & part_name, const DiskPtr & part_disk_ptr, MergeTreeDataPartState to_state);
+        const DB::MergeTreePartInfo & part_info, const String & part_name, const DB::DiskPtr & part_disk_ptr, DB::MergeTreeDataPartState to_state);
 
 protected:
     void dropPartNoWaitNoThrow(const String & part_name) override;
-    void dropPart(const String & part_name, bool detach, ContextPtr context) override;
-    void dropPartition(const ASTPtr & partition, bool detach, ContextPtr context) override;
-    PartitionCommandsResultInfo
-    attachPartition(const ASTPtr & partition, const StorageMetadataPtr & metadata_snapshot, bool part, ContextPtr context) override;
-    void replacePartitionFrom(const StoragePtr & source_table, const ASTPtr & partition, bool replace, ContextPtr context) override;
-    void movePartitionToTable(const StoragePtr & dest_table, const ASTPtr & partition, ContextPtr context) override;
+    void dropPart(const String & part_name, bool detach, DB::ContextPtr context) override;
+    void dropPartition(const DB::ASTPtr & partition, bool detach, DB::ContextPtr context) override;
+    DB::PartitionCommandsResultInfo
+    attachPartition(const DB::ASTPtr & partition, const DB::StorageMetadataPtr & metadata_snapshot, bool part, DB::ContextPtr context) override;
+    void replacePartitionFrom(const DB::StoragePtr & source_table, const DB::ASTPtr & partition, bool replace, DB::ContextPtr context) override;
+    void movePartitionToTable(const DB::StoragePtr & dest_table, const DB::ASTPtr & partition, DB::ContextPtr context) override;
     bool partIsAssignedToBackgroundOperation(const DataPartPtr & part) const override;
     void attachRestoredParts(MutableDataPartsVector && /*parts*/) override { throw std::runtime_error("not implement"); }
 
@@ -120,13 +120,13 @@ public:
 
 class SparkWriteStorageMergeTree final : public SparkStorageMergeTree
 {
-    static std::unique_ptr<MergeTreeSettings>
-    buildMergeTreeSettings(const ContextMutablePtr & context, const MergeTreeTableSettings & config);
+    static std::unique_ptr<DB::MergeTreeSettings>
+    buildMergeTreeSettings(const DB::ContextMutablePtr & context, const MergeTreeTableSettings & config);
 
 public:
-    SparkWriteStorageMergeTree(const MergeTreeTable & table_, const StorageInMemoryMetadata & metadata, const ContextMutablePtr & context_)
+    SparkWriteStorageMergeTree(const MergeTreeTable & table_, const DB::StorageInMemoryMetadata & metadata, const DB::ContextMutablePtr & context_)
         : SparkStorageMergeTree(
-              StorageID(table_.database, table_.table),
+              DB::StorageID(table_.database, table_.table),
               table_.relative_path,
               metadata,
               false,
@@ -140,8 +140,8 @@ public:
     {
     }
 
-    SinkToStoragePtr
-    write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr context, bool async_insert) override;
+    DB::SinkToStoragePtr
+    write(const DB::ASTPtr & query, const DB::StorageMetadataPtr & /*metadata_snapshot*/, DB::ContextPtr context, bool async_insert) override;
 
     SparkMergeTreeDataWriter & getWriter() { return writer; }
 

--- a/cpp-ch/local-engine/Storages/MergeTree/SparkStorageMergeTree.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/SparkStorageMergeTree.h
@@ -30,7 +30,6 @@
 namespace local_engine
 {
 struct SparkMergeTreeWritePartitionSettings;
-using namespace DB;
 
 class SparkMergeTreeDataWriter
 {

--- a/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.cpp
+++ b/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.cpp
@@ -22,7 +22,7 @@
 
 namespace local_engine
 {
-
+using namespace DB;
 String StorageMergeTreeFactory::getTableName(const StorageID & id, const String & snapshot_id)
 {
     auto table_name = id.database_name + "." + id.table_name;

--- a/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.h
+++ b/cpp-ch/local-engine/Storages/MergeTree/StorageMergeTreeFactory.h
@@ -29,13 +29,13 @@ using SparkStorageMergeTreePtr = std::shared_ptr<SparkStorageMergeTree>;
 class DataPartStorageHolder
 {
 public:
-    DataPartStorageHolder(const DataPartPtr& data_part, const SparkStorageMergeTreePtr& storage)
+    DataPartStorageHolder(const DB::DataPartPtr& data_part, const SparkStorageMergeTreePtr& storage)
         : storage_(storage),
           data_part_(data_part)
     {
     }
 
-    [[nodiscard]] DataPartPtr dataPart() const
+    [[nodiscard]] DB::DataPartPtr dataPart() const
     {
         return data_part_;
     }
@@ -52,7 +52,7 @@ public:
 
 private:
     SparkStorageMergeTreePtr storage_;
-    DataPartPtr data_part_;
+    DB::DataPartPtr data_part_;
 };
 
 using DataPartStorageHolderPtr = std::shared_ptr<DataPartStorageHolder>;
@@ -63,11 +63,11 @@ class StorageMergeTreeFactory
 {
 public:
     static StorageMergeTreeFactory & instance();
-    static void freeStorage(const StorageID & id, const String & snapshot_id = "");
+    static void freeStorage(const DB::StorageID & id, const String & snapshot_id = "");
     static SparkStorageMergeTreePtr
-    getStorage(const StorageID& id, const String & snapshot_id, MergeTreeTable merge_tree_table,
+    getStorage(const DB::StorageID& id, const String & snapshot_id, MergeTreeTable merge_tree_table,
         const std::function<SparkStorageMergeTreePtr()> & creator);
-    static DataPartsVector getDataPartsByNames(const StorageID & id, const String & snapshot_id, std::unordered_set<String> part_name);
+    static DB::DataPartsVector getDataPartsByNames(const DB::StorageID & id, const String & snapshot_id, std::unordered_set<String> part_name);
     static void init_cache_map()
     {
         auto config = MergeTreeConfig::loadFromContext(QueryContext::globalContext());
@@ -96,7 +96,7 @@ public:
         if (datapart_map) datapart_map->clear();
     }
 
-    static String getTableName(const StorageID & id, const String & snapshot_id);
+    static String getTableName(const DB::StorageID & id, const String & snapshot_id);
 
 private:
     static std::unique_ptr<storage_map_cache> storage_map;

--- a/cpp-ch/local-engine/Storages/Parquet/ParquetConverter.h
+++ b/cpp-ch/local-engine/Storages/Parquet/ParquetConverter.h
@@ -248,7 +248,6 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
 {
     std::shared_ptr<BaseConverter> result;
 
-    using namespace DB;
     switch (DType::type_num)
     {
         case parquet::Type::BOOLEAN:
@@ -256,25 +255,25 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
         case parquet::Type::INT32:
             switch (c->getDataType())
             {
-                case TypeIndex::Int8:
+                case DB::TypeIndex::Int8:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterInt32_8>>(ConverterInt32_8(c));
                     break;
-                case TypeIndex::Int16:
+                case DB::TypeIndex::Int16:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterInt32_16>>(ConverterInt32_16(c));
                     break;
-                case TypeIndex::Int32:
+                case DB::TypeIndex::Int32:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterInt32>>(ConverterInt32(c));
                     break;
-                case TypeIndex::UInt8:
+                case DB::TypeIndex::UInt8:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterInt32_u8>>(ConverterInt32_u8(c));
                     break;
-                case TypeIndex::UInt16:
+                case DB::TypeIndex::UInt16:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterInt32_u16>>(ConverterInt32_u16(c));
                     break;
-                case TypeIndex::UInt32:
+                case DB::TypeIndex::UInt32:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterInt32_u>>(ConverterInt32_u(c));
                     break;
-                case TypeIndex::Decimal32:
+                case DB::TypeIndex::Decimal32:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int32Type, ConverterDecimal32>>(ConverterDecimal32(c));
                 default:
                     break;
@@ -282,13 +281,13 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
         case parquet::Type::INT64:
             switch (c->getDataType())
             {
-                case TypeIndex::Int64:
+                case DB::TypeIndex::Int64:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int64Type, ConverterInt64>>(ConverterInt64(c));
                     break;
-                case TypeIndex::UInt64:
+                case DB::TypeIndex::UInt64:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int64Type, ConverterInt64_u>>(ConverterInt64_u(c));
                     break;
-                case TypeIndex::Decimal64:
+                case DB::TypeIndex::Decimal64:
                     result = std::make_shared<ParquetConverterImpl<parquet::Int64Type, ConverterDecimal64>>(ConverterDecimal64(c));
                 default:
                     break;
@@ -299,7 +298,7 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
         case parquet::Type::FLOAT:
             switch (c->getDataType())
             {
-                case TypeIndex::Float32:
+                case DB::TypeIndex::Float32:
                     result = std::make_shared<ParquetConverterImpl<parquet::FloatType, ConverterFloat>>(ConverterFloat(c));
                     break;
                 default:
@@ -309,7 +308,7 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
         case parquet::Type::DOUBLE:
             switch (c->getDataType())
             {
-                case TypeIndex::Float64:
+                case DB::TypeIndex::Float64:
                     result = std::make_shared<ParquetConverterImpl<parquet::DoubleType, ConverterDouble>>(ConverterDouble(c));
                     break;
                 default:
@@ -319,7 +318,7 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
         case parquet::Type::BYTE_ARRAY:
             switch (c->getDataType())
             {
-                case TypeIndex::String:
+                case DB::TypeIndex::String:
                     result = std::make_shared<ParquetConverterImpl<parquet::ByteArrayType, ConverterString>>(ConverterString(c));
                     break;
                 default:
@@ -329,13 +328,13 @@ std::shared_ptr<ParquetConverter<DType>> ParquetConverter<DType>::Make(const DB:
         case parquet::Type::FIXED_LEN_BYTE_ARRAY:
             switch (c->getDataType())
             {
-                case TypeIndex::Decimal128:
+                case DB::TypeIndex::Decimal128:
                     result = std::make_shared<ParquetConverterImpl<parquet::FLBAType, Decimal128ToFLB>>(Decimal128ToFLB(c, desc));
                     break;
-                case TypeIndex::Decimal64:
+                case DB::TypeIndex::Decimal64:
                     result = std::make_shared<ParquetConverterImpl<parquet::FLBAType, Decimal64ToFLB>>(Decimal64ToFLB(c, desc));
                     break;
-                case TypeIndex::Decimal32:
+                case DB::TypeIndex::Decimal32:
                     result = std::make_shared<ParquetConverterImpl<parquet::FLBAType, Decimal32ToFLB>>(Decimal32ToFLB(c, desc));
                     break;
                 default:

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelBoolReader.cpp
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelBoolReader.cpp
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "ExcelBoolReader.h"
 #include <Columns/ColumnsNumber.h>
 #include <IO/PeekableReadBuffer.h>
 #include <IO/ReadHelpers.h>
-
-#include "ExcelBoolReader.h"
 
 namespace DB
 {

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelBoolReader.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelBoolReader.h
@@ -18,15 +18,13 @@
 
 #include <Columns/IColumn.h>
 #include <Formats/FormatSettings.h>
-#include <IO/ReadBuffer.h>
 
-
+namespace DB
+{
+class ReadBuffer;
+}
 namespace local_engine
 {
-using namespace DB;
-
-
-
-void deserializeExcelBoolTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings);
+void deserializeExcelBoolTextCSV(DB::IColumn & column, DB::ReadBuffer & istr, const DB::FormatSettings & settings);
 
 }

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalReader.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalReader.h
@@ -16,6 +16,9 @@
  */
 #pragma once
 
+#include "Common/assert_cast.h"
+
+
 #include <Columns/ColumnDecimal.h>
 #include <IO/ReadHelpers.h>
 #include <IO/readDecimalText.h>
@@ -30,10 +33,9 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-using namespace DB;
 
 template <typename T>
-bool readExcelCSVDecimalText(ReadBuffer & buf, T & x, uint32_t precision, uint32_t & scale, const FormatSettings & format_settings)
+bool readExcelCSVDecimalText(DB::ReadBuffer & buf, T & x, uint32_t precision, uint32_t & scale, const DB::FormatSettings & format_settings)
 {
     char maybe_quote = *buf.position();
     bool has_quote = false;
@@ -64,15 +66,16 @@ bool readExcelCSVDecimalText(ReadBuffer & buf, T & x, uint32_t precision, uint32
 }
 
 template <typename T>
-void deserializeExcelDecimalText(IColumn & column, ReadBuffer & istr, UInt32 precision, UInt32 scale, const FormatSettings & formatSettings)
+void deserializeExcelDecimalText(
+    DB::IColumn & column, DB::ReadBuffer & istr, UInt32 precision, UInt32 scale, const DB::FormatSettings & formatSettings)
 {
     if (istr.eof())
-        throwReadAfterEOF();
+        DB::throwReadAfterEOF();
 
     T x;
     UInt32 unread_scale = scale;
     bool result = readExcelCSVDecimalText(istr, x, precision, unread_scale, formatSettings);
-    if (result && !common::mulOverflow(x.value, DecimalUtils::scaleMultiplier<T>(unread_scale), x.value))
-        assert_cast<ColumnDecimal<T> &>(column).getData().push_back(x);
+    if (result && !common::mulOverflow(x.value, DB::DecimalUtils::scaleMultiplier<T>(unread_scale), x.value))
+        assert_cast<DB::ColumnDecimal<T> &>(column).getData().push_back(x);
 }
 }

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalSerialization.cpp
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalSerialization.cpp
@@ -17,8 +17,8 @@
 #include "ExcelDecimalSerialization.h"
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/Serializations/SerializationString.h>
-#include "ExcelDecimalReader.h"
-#include "ExcelStringReader.h"
+#include <Storages/Serializations/ExcelDecimalReader.h>
+#include <Storages/Serializations/ExcelStringReader.h>
 
 namespace DB
 {
@@ -31,7 +31,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 template <is_decimal T>
 void ExcelDecimalSerialization<T>::deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & formatSettings) const
 {

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalSerialization.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalSerialization.h
@@ -16,79 +16,77 @@
  */
 #pragma once
 
-#include <DataTypes/Serializations/SerializationDate32.h>
 #include <DataTypes/Serializations/SerializationNumber.h>
 #include <Common/DateLUTImpl.h>
 
 namespace local_engine
 {
-using namespace DB;
 
-template <is_decimal T>
+template <DB::is_decimal T>
 class ExcelDecimalSerialization final : public DB::ISerialization
 {
 public:
-    explicit ExcelDecimalSerialization(const SerializationPtr & nested_, UInt32 precision_, UInt32 scale_)
+    explicit ExcelDecimalSerialization(const DB::SerializationPtr & nested_, UInt32 precision_, UInt32 scale_)
         : nested_ptr(nested_), precision(precision_), scale(scale_){}
 
-    void serializeBinary(const Field &, WriteBuffer &, const FormatSettings &) const override
+    void serializeBinary(const DB::Field &, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeBinary(Field &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeBinary(DB::Field &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeBinary(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeBinary(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeBinary(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeBinary(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeText(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeText(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeWholeText(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeWholeText(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextEscaped(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextEscaped(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextEscaped(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeTextEscaped(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextQuoted(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextQuoted(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextQuoted(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeTextQuoted(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextJSON(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextJSON(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextJSON(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeTextJSON(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextCSV(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextCSV(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
 
-    void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings &) const override;
+    void deserializeTextCSV(DB::IColumn & column, DB::ReadBuffer & istr, const DB::FormatSettings &) const override;
 
 
 private:
-    SerializationPtr nested_ptr;
+    DB::SerializationPtr nested_ptr;
     const UInt32 precision;
     const UInt32 scale;
 };

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelSerialization.cpp
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelSerialization.cpp
@@ -23,9 +23,9 @@
 #include <DataTypes/Serializations/SerializationDecimal.h>
 #include <DataTypes/Serializations/SerializationNumber.h>
 #include <DataTypes/Serializations/SerializationString.h>
-#include "ExcelBoolReader.h"
-#include "ExcelReadHelpers.h"
-#include "ExcelStringReader.h"
+#include <Storages/Serializations/ExcelBoolReader.h>
+#include <Storages/Serializations/ExcelReadHelpers.h>
+#include <Storages/Serializations/ExcelStringReader.h>
 
 namespace DB
 {
@@ -37,7 +37,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 void ExcelSerialization::deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
 {
     if (typeid_cast<const DB::SerializationDate32 *>(nested_ptr.get()))

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelSerialization.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelSerialization.h
@@ -31,85 +31,83 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-using namespace DB;
-
 
 class ExcelSerialization final : public DB::ISerialization
 {
 public:
-    explicit ExcelSerialization(const SerializationPtr & nested_, String escape_) : nested_ptr(nested_), escape(escape_){}
+    explicit ExcelSerialization(const DB::SerializationPtr & nested_, String escape_) : nested_ptr(nested_), escape(escape_){}
 
-    void serializeBinary(const Field &, WriteBuffer &, const FormatSettings &) const override
+    void serializeBinary(const DB::Field &, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeBinary(Field &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeBinary(DB::Field &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeBinary(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeBinary(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeBinary(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeBinary(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeText(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeText(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeWholeText(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeWholeText(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextEscaped(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextEscaped(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextEscaped(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeTextEscaped(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextQuoted(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextQuoted(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextQuoted(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeTextQuoted(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextJSON(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextJSON(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextJSON(IColumn &, ReadBuffer &, const FormatSettings &) const override
+    void deserializeTextJSON(DB::IColumn &, DB::ReadBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void serializeTextCSV(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
+    void serializeTextCSV(const DB::IColumn &, size_t, DB::WriteBuffer &, const DB::FormatSettings &) const override
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
     }
-    void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
+    void deserializeTextCSV(DB::IColumn & column, DB::ReadBuffer & istr, const DB::FormatSettings & settings) const override;
 
 private:
-    void deserializeDate32TextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const;
+    void deserializeDate32TextCSV(DB::IColumn & column, DB::ReadBuffer & istr, const DB::FormatSettings & settings) const;
 
     template <typename T>
     requires is_arithmetic_v<T>
-    void deserializeNumberTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings &) const;
+    void deserializeNumberTextCSV(DB::IColumn & column, DB::ReadBuffer & istr, const DB::FormatSettings &) const;
 
     template <typename T>
     void deserializeDatetimeTextCSV(
-        IColumn & column,
-        ReadBuffer & istr,
-        const FormatSettings & settings,
+        DB::IColumn & column,
+        DB::ReadBuffer & istr,
+        const DB::FormatSettings & settings,
         const DateLUTImpl & time_zone,
         const DateLUTImpl & utc_time_zone) const;
 
 private:
-    SerializationPtr nested_ptr;
+    DB::SerializationPtr nested_ptr;
     String escape;
 };
 }

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelStringReader.cpp
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelStringReader.cpp
@@ -14,16 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "ExcelStringReader.h"
+
 #include <bit>
 #include <IO/Operators.h>
 #include <IO/PeekableReadBuffer.h>
-#include <base/hex.h>
 #include <Common/PODArray.h>
-#include <Common/StringUtils.h>
-#include <Common/memcpySmall.h>
-
-#include "ExcelStringReader.h"
-
 
 #ifdef __SSE2__
 #    include <emmintrin.h>

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelStringReader.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelStringReader.h
@@ -15,25 +15,19 @@
  * limitations under the License.
  */
 #pragma once
-
-
 #include <Columns/ColumnString.h>
 #include <Columns/IColumn.h>
 #include <Formats/FormatSettings.h>
-#include <IO/ReadBuffer.h>
-
 
 namespace local_engine
 {
-using namespace DB;
-
 
 template <typename Reader>
-static inline void excelRead(IColumn & column, Reader && reader)
+static inline void excelRead(DB::IColumn & column, Reader && reader)
 {
-    ColumnString & column_string = assert_cast<ColumnString &>(column);
-    ColumnString::Chars & data = column_string.getChars();
-    ColumnString::Offsets & offsets = column_string.getOffsets();
+    auto & column_string = assert_cast<DB::ColumnString &>(column);
+    DB::ColumnString::Chars & data = column_string.getChars();
+    DB::ColumnString::Offsets & offsets = column_string.getOffsets();
     size_t old_chars_size = data.size();
     size_t old_offsets_size = offsets.size();
     try
@@ -51,12 +45,13 @@ static inline void excelRead(IColumn & column, Reader && reader)
 }
 
 template <typename Vector, bool include_quotes = false>
-void readExcelCSVQuoteString(Vector & s, ReadBuffer & buf, const char delimiter, const String & escape_value, const char & quote);
+void readExcelCSVQuoteString(Vector & s, DB::ReadBuffer & buf, const char delimiter, const String & escape_value, const char & quote);
 template <typename Vector>
-void readExcelCSVStringInto(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings, const String & escape_value);
+void readExcelCSVStringInto(Vector & s, DB::ReadBuffer & buf, const DB::FormatSettings::CSV & settings, const String & escape_value);
 
 
-void deserializeExcelStringTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings, const String & escape_value);
+void deserializeExcelStringTextCSV(
+    DB::IColumn & column, DB::ReadBuffer & istr, const DB::FormatSettings & settings, const String & escape_value);
 
 
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.cpp
@@ -43,7 +43,7 @@ namespace ErrorCodes
 
 namespace local_engine
 {
-
+using namespace DB;
 void skipErrorChars(DB::ReadBuffer & buf, bool has_quote, char quote, String & escape, const DB::FormatSettings & settings)
 {
     if (has_quote)

--- a/cpp-ch/local-engine/tests/gtest_ch_storages.cpp
+++ b/cpp-ch/local-engine/tests/gtest_ch_storages.cpp
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 #include <Functions/FunctionFactory.h>
-#include <Parser/RelParsers/MergeTreeRelParser.h>
 #include <Parser/ParserContext.h>
+#include <Parser/RelParsers/MergeTreeRelParser.h>
 #include <Processors/Executors/PipelineExecutor.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/SparkMergeTreeMeta.h>
 #include <Storages/SubstraitSource/SubstraitFileSource.h>

--- a/cpp-ch/local-engine/tests/gtest_local_engine.cpp
+++ b/cpp-ch/local-engine/tests/gtest_local_engine.cpp
@@ -35,12 +35,12 @@
 #include <Common/GlutenConfig.h>
 
 using namespace local_engine;
-using namespace dbms;
+using namespace DB;
 
 TEST(TESTUtil, TestByteToLong)
 {
     Int64 expected = 0xf085460ccf7f0000l;
-    char * arr = new char[8];
+    char arr[8];
     arr[0] = -16;
     arr[1] = -123;
     arr[2] = 70;


### PR DESCRIPTION
## What changes were proposed in this pull request?

By exlcuding `Storages/MergeTree/SparkStorageMergeTree.h` from **cpp-ch/local-engine/Parser/SerializedPlanParser.h** for reduceing unnecessry dependency,  I found many compiler erros since `SparkStorageMergeTree.h` contains `using namespace DB` in `namespace local_engine`.

> [!NOTE]
> In some [guidelines](https://github.com/kmhofmann/cpp-coding-guidelines/blob/master/guidelines/namespaces.md):
> 5. Never ever use a using namespace statement at global or namespace scope in a header file.
> This is strongly discouraged, since it would pollute the global or respective namespace for every file that includes said header file.

So, I remove `using namespace DB` from headers

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

