### PR TITLE
[Shims] Fix the code style issue of prepareWrite

### DIFF
--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -95,14 +95,14 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
 
     conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute, OrcFileFormat.getQuotedSchemaString(dataSchema))
 
+    // Pass compression to job conf so that the file extension can be aware of it.
     conf.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
 
     conf
       .asInstanceOf[JobConf]
       .setOutputFormat(classOf[org.apache.orc.mapred.OrcOutputFormat[OrcStruct]])
 
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-      // pass compression to job conf so that the file extension can be aware of it.
+    if (sparkSession.sparkContext.getLocalProperty("isNativeApplicable") == "true") {
       val nativeConf =
         GlutenFormatFactory(shortName()).nativeConf(options, orcOptions.compressionCodec)
 

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -82,9 +82,8 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-
-      // pass compression to job conf so that the file extension can be aware of it.
+    if (sparkSession.sparkContext.getLocalProperty("isNativeApplicable") == "true") {
+      // Pass compression to job conf so that the file extension can be aware of it.
       val conf = ContextUtil.getConfiguration(job)
       val parquetOptions = new ParquetOptions(options, sparkSession.sessionState.conf)
       conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
@@ -103,7 +102,6 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
             context: TaskAttemptContext): OutputWriter = {
           GlutenFormatFactory(shortName())
             .createOutputWriter(path, dataSchema, context, nativeConf)
-
         }
       }
     } else {

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -76,14 +76,14 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
 
     val conf = job.getConfiguration
 
+    // Pass compression to job conf so that the file extension can be aware of it.
     conf.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
 
     conf
       .asInstanceOf[JobConf]
       .setOutputFormat(classOf[org.apache.orc.mapred.OrcOutputFormat[OrcStruct]])
 
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-      // pass compression to job conf so that the file extension can be aware of it.
+    if (sparkSession.sparkContext.getLocalProperty("isNativeApplicable") == "true") {
       val nativeConf =
         GlutenFormatFactory(shortName()).nativeConf(options, orcOptions.compressionCodec)
 
@@ -93,7 +93,6 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
             val name = context.getConfiguration.get(COMPRESS.getAttribute)
             OrcUtils.extensionsForCompressionCodecNames.getOrElse(name, "")
           }
-
           compressionExtension + ".orc"
         }
 
@@ -119,7 +118,6 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
             val name = context.getConfiguration.get(COMPRESS.getAttribute)
             OrcUtils.extensionsForCompressionCodecNames.getOrElse(name, "")
           }
-
           compressionExtension + ".orc"
         }
       }

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -74,9 +74,8 @@ class ParquetFileFormat extends FileFormat with DataSourceRegister with Logging 
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
-    if ("true" == sparkSession.sparkContext.getLocalProperty("isNativeApplicable")) {
-
-      // pass compression to job conf so that the file extension can be aware of it.
+    if (sparkSession.sparkContext.getLocalProperty("isNativeApplicable") == "true") {
+      // Pass compression to job conf so that the file extension can be aware of it.
       val conf = ContextUtil.getConfiguration(job)
       val parquetOptions = new ParquetOptions(options, sparkSession.sessionState.conf)
       conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the code style issue of 'prepareWrite' in Spark 3.2 and 3.3 shims.

## How was this patch tested?

CI

