### PR TITLE
[VL] Fix timezone for Parquet timestamp write 

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetWriterInjects.scala
@@ -39,6 +39,11 @@ class VeloxParquetWriterInjects extends VeloxFormatWriterInjects {
       GlutenConfig.PARQUET_BLOCK_ROWS,
       GlutenConfig.get.columnarParquetWriteBlockRows.toString)
     sparkOptions.put(GlutenConfig.PARQUET_BLOCK_ROWS, blockRows)
+    sparkOptions.put(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key,
+      options.getOrElse(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key,
+        SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString))
     options
       .get(GlutenConfig.PARQUET_GZIP_WINDOW_SIZE)
       .foreach(sparkOptions.put(GlutenConfig.PARQUET_GZIP_WINDOW_SIZE, _))

--- a/cpp/velox/operators/writer/VeloxParquetDataSource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDataSource.cc
@@ -97,6 +97,7 @@ void VeloxParquetDataSource::init(const std::unordered_map<std::string, std::str
     return std::make_unique<velox::parquet::LambdaFlushPolicy>(
         maxRowGroupRows_, maxRowGroupBytes_, [&]() { return false; });
   };
+  writeOption.parquetWriteTimestampTimeZone = getConfigValue(sparkConfs, kSessionTimezone, std::nullopt);
   auto schema = gluten::fromArrowSchema(schema_);
 
   parquetWriter_ = std::make_unique<velox::parquet::Writer>(std::move(sink_), writeOption, pool_, asRowType(schema));

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2025_02_11
+VELOX_BRANCH=2025_02_11_fix
 VELOX_HOME=""
 
 OS=`uname -s`


### PR DESCRIPTION
## What changes were proposed in this pull request?

Passes timestamp timezone to writeOption.

## How was this patch tested?

UT verified.

