### PR TITLE
[GLUTEN-8330][VL] Improve convert the viewfs path to hdfs path

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -111,23 +111,10 @@ object VeloxBackendSettings extends BackendSettingsApi {
         val resolvedPaths =
           if (GlutenConfig.getConf.enableHdfsViewfs) {
             val viewfsToHdfsCache: mutable.Map[String, String] = mutable.Map.empty
-            // Convert the viewfs path to hdfs path.
-            filteredRootPaths.map {
-              path =>
-                if (path.startsWith("viewfs")) {
-                  val pathSplit = path.split(Path.SEPARATOR)
-                  val prefixIndex = pathSplit.size - 1
-                  val pathPrefix = pathSplit.take(prefixIndex).mkString(Path.SEPARATOR)
-                  val hdfsPathPrefix = viewfsToHdfsCache.getOrElseUpdate(
-                    pathPrefix,
-                    ViewFileSystemUtils
-                      .convertViewfsToHdfs(pathPrefix, serializableHadoopConf.get.value))
-                  hdfsPathPrefix + Path.SEPARATOR +
-                    pathSplit.drop(prefixIndex).mkString(Path.SEPARATOR)
-                } else {
-                  path
-                }
-            }
+            ViewFileSystemUtils.convertViewfsToHdfs(
+              filteredRootPaths,
+              viewfsToHdfsCache,
+              serializableHadoopConf.get.value)
           } else {
             filteredRootPaths
           }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -110,10 +110,9 @@ object VeloxBackendSettings extends BackendSettingsApi {
       if (filteredRootPaths.nonEmpty) {
         val resolvedPaths =
           if (GlutenConfig.getConf.enableHdfsViewfs) {
-            val viewfsToHdfsCache: mutable.Map[String, String] = mutable.Map.empty
             ViewFileSystemUtils.convertViewfsToHdfs(
               filteredRootPaths,
-              viewfsToHdfsCache,
+              mutable.Map.empty[String, String],
               serializableHadoopConf.get.value)
           } else {
             filteredRootPaths

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -383,7 +383,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
             splitInfos.foreach {
               case splitInfo: LocalFilesNode =>
                 val newPaths = ViewFileSystemUtils.convertViewfsToHdfs(
-                  splitInfo.getPaths.asScala,
+                  splitInfo.getPaths.asScala.toSeq,
                   viewfsToHdfsCache,
                   serializableHadoopConf.value)
                 splitInfo.setPaths(newPaths.asJava)

--- a/gluten-substrait/src/main/scala/org/apache/hadoop/fs/viewfs/ViewFileSystemUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/hadoop/fs/viewfs/ViewFileSystemUtils.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.viewfs
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+object ViewFileSystemUtils {
+
+  /**
+   * Convert the viewfs path to hdfs path. Similar to ViewFileSystem.resolvePath, but does not make
+   * RPC calls.
+   */
+  def convertViewfsToHdfs(f: String, hadoopConfig: Configuration): String = {
+    val path = new Path(f)
+    FileSystem.get(path.toUri, hadoopConfig) match {
+      case vfs: ViewFileSystem =>
+        val fsStateField = vfs.getClass.getDeclaredField("fsState")
+        fsStateField.setAccessible(true)
+        val fsState = fsStateField.get(vfs).asInstanceOf[InodeTree[FileSystem]]
+        val res = fsState.resolve(f, true)
+        if (res.isInternalDir) {
+          f
+        } else {
+          Path.mergePaths(new Path(res.targetFileSystem.getUri), res.remainingPath).toString
+        }
+      case otherFileSystem =>
+        otherFileSystem.resolvePath(path).toString
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Avoid RPC calls.
2. Add a cache.

(Fixes: \#8330)

## How was this patch tested?

Manual tests, before: 225007 ms, after: 1330 ms:
```scala
import org.apache.hadoop.fs.viewfs.ViewFileSystemUtils
import org.apache.hadoop.conf.Configuration
import org.apache.hadoop.fs.{FileSystem, Path}

val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
val paths = fs.listStatus(new Path("viewfs://my-cluster/path/to/table")).take(50000).map(_.getPath.toString)

val start1 = System.currentTimeMillis
paths.map(p => FileSystem.get(new Path(p).toUri, spark.sparkContext.hadoopConfiguration).resolvePath(new Path(p)))
println(s"Convert viewfs to HDFS using resolvePath took: ${System.currentTimeMillis - start1} ms")

val start2 = System.currentTimeMillis
paths.map(p => ViewFileSystemUtils.convertViewfsToHdfs(p, spark.sparkContext.hadoopConfiguration))
println(s"Convert viewfs to HDFS using convertViewfsToHdfs took: ${System.currentTimeMillis - start2} ms")
```

Output:
```
Convert viewfs to HDFS using resolvePath took: 225007 ms
Convert viewfs to HDFS using convertViewfsToHdfs took: 1330 ms
```
