### PR TITLE
[VL] Support casting timestamp type to varchar type

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -300,7 +300,7 @@ bool SubstraitToVeloxPlanValidator::validateCast(
       LOG_VALIDATION_MSG("Invalid input type in casting: ARRAY/MAP/ROW/VARBINARY.");
       return false;
     case TypeKind::TIMESTAMP:
-      // Only support cast timestamp to date
+      // Only support casting timestamp to date or varchar.
       if (!toType->isDate() && toType->kind() != TypeKind::VARCHAR) {
         LOG_VALIDATION_MSG(
             "Casting from TIMESTAMP to " + toType->toString() + " is not supported or has incorrect result.");

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -301,7 +301,7 @@ bool SubstraitToVeloxPlanValidator::validateCast(
       return false;
     case TypeKind::TIMESTAMP:
       // Only support cast timestamp to date
-      if (!toType->isDate()) {
+      if (!toType->isDate() && toType->kind() != TypeKind::VARCHAR) {
         LOG_VALIDATION_MSG(
             "Casting from TIMESTAMP to " + toType->toString() + " is not supported or has incorrect result.");
         return false;

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -569,6 +569,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("cast string to timestamp")
     .exclude("cast from boolean")
     .exclude("data type casting")
+    .excludeGlutenTest("data type casting")
     .exclude("cast between string and interval")
     .exclude("SPARK-27671: cast from nested null type in struct")
     .exclude("Process Infinity, -Infinity, NaN in case insensitive manner")

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -71,6 +71,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-35719: cast timestamp with local time zone to timestamp without timezone")
     // User defined type.
     .exclude("SPARK-32828: cast from a derived user-defined type to a base type")
+    // Set timezone through config.
+    .exclude("data type casting")
 
   enableSuite[GlutenAnsiCastSuiteWithAnsiModeOff]
     .exclude(

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -17,9 +17,13 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, ALL_TIMEZONES, UTC, UTC_OPT}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{fromJavaTimestamp, millisToMicros, TimeZoneUTC}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
+import java.util.Calendar
 
 class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
   override def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): CastBase = {
@@ -74,5 +78,79 @@ class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
   testGluten("missing cases - date self check") {
     val d = Date.valueOf("1970-01-01")
     checkEvaluation(cast(d, DateType), d)
+  }
+
+  testGluten("data type casting") {
+    val sd = "1970-01-01"
+    val d = Date.valueOf(sd)
+    val zts = sd + " 00:00:00"
+    val sts = sd + " 00:00:02"
+    val nts = sts + ".1"
+    val ts = withDefaultTimeZone(UTC)(Timestamp.valueOf(nts))
+
+    for (tz <- ALL_TIMEZONES) {
+      withSQLConf(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz.getId
+      ) {
+        val timeZoneId = Option(tz.getId)
+        var c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 2, 8, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+        c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 10, 1, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+      }
+    }
+
+    checkEvaluation(cast("abdef", StringType), "abdef")
+    checkEvaluation(cast("12.65", DecimalType.SYSTEM_DEFAULT), Decimal(12.65))
+
+    checkEvaluation(cast(cast(sd, DateType), StringType), sd)
+    checkEvaluation(cast(cast(d, StringType), DateType), 0)
+
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC_OPT.get
+    ) {
+      checkEvaluation(cast(cast(nts, TimestampType, UTC_OPT), StringType, UTC_OPT), nts)
+      checkEvaluation(
+        cast(cast(ts, StringType, UTC_OPT), TimestampType, UTC_OPT),
+        fromJavaTimestamp(ts))
+
+      // all convert to string type to check
+      checkEvaluation(
+        cast(cast(cast(nts, TimestampType, UTC_OPT), DateType, UTC_OPT), StringType),
+        sd)
+      checkEvaluation(
+        cast(cast(cast(ts, DateType, UTC_OPT), TimestampType, UTC_OPT), StringType, UTC_OPT),
+        zts)
+    }
+
+    checkEvaluation(cast(cast("abdef", BinaryType), StringType), "abdef")
+
+    checkEvaluation(
+      cast(
+        cast(cast(cast(cast(cast("5", ByteType), ShortType), IntegerType), FloatType), DoubleType),
+        LongType),
+      5.toLong)
+
+    checkEvaluation(cast("23", DoubleType), 23d)
+    checkEvaluation(cast("23", IntegerType), 23)
+    checkEvaluation(cast("23", FloatType), 23f)
+    checkEvaluation(cast("23", DecimalType.USER_DEFAULT), Decimal(23))
+    checkEvaluation(cast("23", ByteType), 23.toByte)
+    checkEvaluation(cast("23", ShortType), 23.toShort)
+    checkEvaluation(cast(123, IntegerType), 123)
+
+    checkEvaluation(cast(Literal.create(null, IntegerType), ShortType), null)
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -588,6 +588,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("cast string to timestamp")
     .exclude("cast from boolean")
     .exclude("data type casting")
+    .excludeGlutenTest("data type casting")
     .exclude("cast between string and interval")
     .exclude("SPARK-27671: cast from nested null type in struct")
     .exclude("Process Infinity, -Infinity, NaN in case insensitive manner")

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -112,6 +112,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-35711: cast timestamp without time zone to timestamp with local time zone")
     // Timezone.
     .exclude("SPARK-35719: cast timestamp with local time zone to timestamp without timezone")
+    // Set timezone through config.
+    .exclude("data type casting")
   enableSuite[GlutenCollectionExpressionsSuite]
     // Rewrite in Gluten to replace Seq with Array
     .exclude("Shuffle")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -17,9 +17,13 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, ALL_TIMEZONES, UTC, UTC_OPT}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{fromJavaTimestamp, millisToMicros, TimeZoneUTC}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
+import java.util.Calendar
 
 class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
   override def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): CastBase = {
@@ -73,5 +77,79 @@ class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
   testGluten("missing cases - date self check") {
     val d = Date.valueOf("1970-01-01")
     checkEvaluation(cast(d, DateType), d)
+  }
+
+  testGluten("data type casting") {
+    val sd = "1970-01-01"
+    val d = Date.valueOf(sd)
+    val zts = sd + " 00:00:00"
+    val sts = sd + " 00:00:02"
+    val nts = sts + ".1"
+    val ts = withDefaultTimeZone(UTC)(Timestamp.valueOf(nts))
+
+    for (tz <- ALL_TIMEZONES) {
+      withSQLConf(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz.getId
+      ) {
+        val timeZoneId = Option(tz.getId)
+        var c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 2, 8, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+        c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 10, 1, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+      }
+    }
+
+    checkEvaluation(cast("abdef", StringType), "abdef")
+    checkEvaluation(cast("12.65", DecimalType.SYSTEM_DEFAULT), Decimal(12.65))
+
+    checkEvaluation(cast(cast(sd, DateType), StringType), sd)
+    checkEvaluation(cast(cast(d, StringType), DateType), 0)
+
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC_OPT.get
+    ) {
+      checkEvaluation(cast(cast(nts, TimestampType, UTC_OPT), StringType, UTC_OPT), nts)
+      checkEvaluation(
+        cast(cast(ts, StringType, UTC_OPT), TimestampType, UTC_OPT),
+        fromJavaTimestamp(ts))
+
+      // all convert to string type to check
+      checkEvaluation(
+        cast(cast(cast(nts, TimestampType, UTC_OPT), DateType, UTC_OPT), StringType),
+        sd)
+      checkEvaluation(
+        cast(cast(cast(ts, DateType, UTC_OPT), TimestampType, UTC_OPT), StringType, UTC_OPT),
+        zts)
+    }
+
+    checkEvaluation(cast(cast("abdef", BinaryType), StringType), "abdef")
+
+    checkEvaluation(
+      cast(
+        cast(cast(cast(cast(cast("5", ByteType), ShortType), IntegerType), FloatType), DoubleType),
+        LongType),
+      5.toLong)
+
+    checkEvaluation(cast("23", DoubleType), 23d)
+    checkEvaluation(cast("23", IntegerType), 23)
+    checkEvaluation(cast("23", FloatType), 23f)
+    checkEvaluation(cast("23", DecimalType.USER_DEFAULT), Decimal(23))
+    checkEvaluation(cast("23", ByteType), 23.toByte)
+    checkEvaluation(cast("23", ShortType), 23.toShort)
+    checkEvaluation(cast(123, IntegerType), 123)
+
+    checkEvaluation(cast(Literal.create(null, IntegerType), ShortType), null)
   }
 }

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -531,6 +531,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("cast string to timestamp")
     .exclude("cast from boolean")
     .exclude("data type casting")
+    .excludeGlutenTest("data type casting")
     .exclude("cast between string and interval")
     .exclude("SPARK-27671: cast from nested null type in struct")
     .exclude("Process Infinity, -Infinity, NaN in case insensitive manner")

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -91,6 +91,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude(
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
     )
+    // Set timezone through config.
+    .exclude("data type casting")
   enableSuite[GlutenTryCastSuite]
     .exclude(
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
@@ -101,6 +103,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
     .exclude("cast from invalid string to numeric should throw NumberFormatException")
     .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
+    // Set timezone through config.
+    .exclude("data type casting")
   enableSuite[GlutenCollectionExpressionsSuite]
     // Rewrite in Gluten to replace Seq with Array
     .exclude("Shuffle")

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -17,9 +17,13 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, ALL_TIMEZONES, UTC, UTC_OPT}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{fromJavaTimestamp, millisToMicros, TimeZoneUTC}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
+import java.util.Calendar
 
 class GlutenCastSuite extends CastSuiteBase with GlutenTestsTrait {
   override def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): Cast = {
@@ -70,6 +74,80 @@ class GlutenCastSuite extends CastSuiteBase with GlutenTestsTrait {
   testGluten("missing cases - date self check") {
     val d = Date.valueOf("1970-01-01")
     checkEvaluation(cast(d, DateType), d)
+  }
+
+  testGluten("data type casting") {
+    val sd = "1970-01-01"
+    val d = Date.valueOf(sd)
+    val zts = sd + " 00:00:00"
+    val sts = sd + " 00:00:02"
+    val nts = sts + ".1"
+    val ts = withDefaultTimeZone(UTC)(Timestamp.valueOf(nts))
+
+    for (tz <- ALL_TIMEZONES) {
+      withSQLConf(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz.getId
+      ) {
+        val timeZoneId = Option(tz.getId)
+        var c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 2, 8, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+        c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 10, 1, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+      }
+    }
+
+    checkEvaluation(cast("abdef", StringType), "abdef")
+    checkEvaluation(cast("12.65", DecimalType.SYSTEM_DEFAULT), Decimal(12.65))
+
+    checkEvaluation(cast(cast(sd, DateType), StringType), sd)
+    checkEvaluation(cast(cast(d, StringType), DateType), 0)
+
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC_OPT.get
+    ) {
+      checkEvaluation(cast(cast(nts, TimestampType, UTC_OPT), StringType, UTC_OPT), nts)
+      checkEvaluation(
+        cast(cast(ts, StringType, UTC_OPT), TimestampType, UTC_OPT),
+        fromJavaTimestamp(ts))
+
+      // all convert to string type to check
+      checkEvaluation(
+        cast(cast(cast(nts, TimestampType, UTC_OPT), DateType, UTC_OPT), StringType),
+        sd)
+      checkEvaluation(
+        cast(cast(cast(ts, DateType, UTC_OPT), TimestampType, UTC_OPT), StringType, UTC_OPT),
+        zts)
+    }
+
+    checkEvaluation(cast(cast("abdef", BinaryType), StringType), "abdef")
+
+    checkEvaluation(
+      cast(
+        cast(cast(cast(cast(cast("5", ByteType), ShortType), IntegerType), FloatType), DoubleType),
+        LongType),
+      5.toLong)
+
+    checkEvaluation(cast("23", DoubleType), 23d)
+    checkEvaluation(cast("23", IntegerType), 23)
+    checkEvaluation(cast("23", FloatType), 23f)
+    checkEvaluation(cast("23", DecimalType.USER_DEFAULT), Decimal(23))
+    checkEvaluation(cast("23", ByteType), 23.toByte)
+    checkEvaluation(cast("23", ShortType), 23.toShort)
+    checkEvaluation(cast(123, IntegerType), 123)
+
+    checkEvaluation(cast(Literal.create(null, IntegerType), ShortType), null)
   }
 
   override protected def evalMode: EvalMode.Value = EvalMode.LEGACY

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenTryCastSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenTryCastSuite.scala
@@ -17,5 +17,86 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, ALL_TIMEZONES, UTC, UTC_OPT}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{fromJavaTimestamp, millisToMicros, TimeZoneUTC}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BinaryType, ByteType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
 
-class GlutenTryCastSuite extends TryCastSuite with GlutenTestsTrait {}
+import java.sql.{Date, Timestamp}
+import java.util.Calendar
+
+class GlutenTryCastSuite extends TryCastSuite with GlutenTestsTrait {
+  testGluten("data type casting") {
+    val sd = "1970-01-01"
+    val d = Date.valueOf(sd)
+    val zts = sd + " 00:00:00"
+    val sts = sd + " 00:00:02"
+    val nts = sts + ".1"
+    val ts = withDefaultTimeZone(UTC)(Timestamp.valueOf(nts))
+
+    for (tz <- ALL_TIMEZONES) {
+      withSQLConf(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz.getId
+      ) {
+        val timeZoneId = Option(tz.getId)
+        var c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 2, 8, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+        c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 10, 1, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+      }
+    }
+
+    checkEvaluation(cast("abdef", StringType), "abdef")
+    checkEvaluation(cast("12.65", DecimalType.SYSTEM_DEFAULT), Decimal(12.65))
+
+    checkEvaluation(cast(cast(sd, DateType), StringType), sd)
+    checkEvaluation(cast(cast(d, StringType), DateType), 0)
+
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC_OPT.get
+    ) {
+      checkEvaluation(cast(cast(nts, TimestampType, UTC_OPT), StringType, UTC_OPT), nts)
+      checkEvaluation(
+        cast(cast(ts, StringType, UTC_OPT), TimestampType, UTC_OPT),
+        fromJavaTimestamp(ts))
+
+      // all convert to string type to check
+      checkEvaluation(
+        cast(cast(cast(nts, TimestampType, UTC_OPT), DateType, UTC_OPT), StringType),
+        sd)
+      checkEvaluation(
+        cast(cast(cast(ts, DateType, UTC_OPT), TimestampType, UTC_OPT), StringType, UTC_OPT),
+        zts)
+    }
+
+    checkEvaluation(cast(cast("abdef", BinaryType), StringType), "abdef")
+
+    checkEvaluation(
+      cast(
+        cast(cast(cast(cast(cast("5", ByteType), ShortType), IntegerType), FloatType), DoubleType),
+        LongType),
+      5.toLong)
+
+    checkEvaluation(cast("23", DoubleType), 23d)
+    checkEvaluation(cast("23", IntegerType), 23)
+    checkEvaluation(cast("23", FloatType), 23f)
+    checkEvaluation(cast("23", DecimalType.USER_DEFAULT), Decimal(23))
+    checkEvaluation(cast("23", ByteType), 23.toByte)
+    checkEvaluation(cast("23", ShortType), 23.toShort)
+    checkEvaluation(cast(123, IntegerType), 123)
+
+    checkEvaluation(cast(Literal.create(null, IntegerType), ShortType), null)
+  }
+}

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -531,6 +531,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("cast string to timestamp")
     .exclude("cast from boolean")
     .exclude("data type casting")
+    .excludeGlutenTest("data type casting")
     .exclude("cast between string and interval")
     .exclude("SPARK-27671: cast from nested null type in struct")
     .exclude("Process Infinity, -Infinity, NaN in case insensitive manner")

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -92,6 +92,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude(
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
     )
+    // Set timezone through config.
+    .exclude("data type casting")
   enableSuite[GlutenTryCastSuite]
     .exclude(
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
@@ -102,6 +104,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
     .exclude("cast from invalid string to numeric should throw NumberFormatException")
     .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
+    // Set timezone through config.
+    .exclude("data type casting")
   enableSuite[GlutenCollectionExpressionsSuite]
     // Rewrite in Gluten to replace Seq with Array
     .exclude("Shuffle")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -17,9 +17,13 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, ALL_TIMEZONES, UTC, UTC_OPT}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{fromJavaTimestamp, millisToMicros, TimeZoneUTC}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
+import java.util.Calendar
 
 class GlutenCastSuite extends CastSuiteBase with GlutenTestsTrait {
   override def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): Cast = {
@@ -73,6 +77,80 @@ class GlutenCastSuite extends CastSuiteBase with GlutenTestsTrait {
   testGluten("missing cases - date self check") {
     val d = Date.valueOf("1970-01-01")
     checkEvaluation(cast(d, DateType), d)
+  }
+
+  testGluten("data type casting") {
+    val sd = "1970-01-01"
+    val d = Date.valueOf(sd)
+    val zts = sd + " 00:00:00"
+    val sts = sd + " 00:00:02"
+    val nts = sts + ".1"
+    val ts = withDefaultTimeZone(UTC)(Timestamp.valueOf(nts))
+
+    for (tz <- ALL_TIMEZONES) {
+      withSQLConf(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz.getId
+      ) {
+        val timeZoneId = Option(tz.getId)
+        var c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 2, 8, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+        c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 10, 1, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+      }
+    }
+
+    checkEvaluation(cast("abdef", StringType), "abdef")
+    checkEvaluation(cast("12.65", DecimalType.SYSTEM_DEFAULT), Decimal(12.65))
+
+    checkEvaluation(cast(cast(sd, DateType), StringType), sd)
+    checkEvaluation(cast(cast(d, StringType), DateType), 0)
+
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC_OPT.get
+    ) {
+      checkEvaluation(cast(cast(nts, TimestampType, UTC_OPT), StringType, UTC_OPT), nts)
+      checkEvaluation(
+        cast(cast(ts, StringType, UTC_OPT), TimestampType, UTC_OPT),
+        fromJavaTimestamp(ts))
+
+      // all convert to string type to check
+      checkEvaluation(
+        cast(cast(cast(nts, TimestampType, UTC_OPT), DateType, UTC_OPT), StringType),
+        sd)
+      checkEvaluation(
+        cast(cast(cast(ts, DateType, UTC_OPT), TimestampType, UTC_OPT), StringType, UTC_OPT),
+        zts)
+    }
+
+    checkEvaluation(cast(cast("abdef", BinaryType), StringType), "abdef")
+
+    checkEvaluation(
+      cast(
+        cast(cast(cast(cast(cast("5", ByteType), ShortType), IntegerType), FloatType), DoubleType),
+        LongType),
+      5.toLong)
+
+    checkEvaluation(cast("23", DoubleType), 23d)
+    checkEvaluation(cast("23", IntegerType), 23)
+    checkEvaluation(cast("23", FloatType), 23f)
+    checkEvaluation(cast("23", DecimalType.USER_DEFAULT), Decimal(23))
+    checkEvaluation(cast("23", ByteType), 23.toByte)
+    checkEvaluation(cast("23", ShortType), 23.toShort)
+    checkEvaluation(cast(123, IntegerType), 123)
+
+    checkEvaluation(cast(Literal.create(null, IntegerType), ShortType), null)
   }
 
   override protected def evalMode: EvalMode.Value = EvalMode.LEGACY

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenTryCastSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenTryCastSuite.scala
@@ -17,5 +17,88 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, ALL_TIMEZONES, UTC, UTC_OPT}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{fromJavaTimestamp, millisToMicros, TimeZoneUTC}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BinaryType, ByteType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
 
-class GlutenTryCastSuite extends TryCastSuite with GlutenTestsTrait {}
+import java.sql.{Date, Timestamp}
+import java.util.Calendar
+
+class GlutenTryCastSuite extends TryCastSuite with GlutenTestsTrait {
+
+  testGluten("data type casting") {
+    val sd = "1970-01-01"
+    val d = Date.valueOf(sd)
+    val zts = sd + " 00:00:00"
+    val sts = sd + " 00:00:02"
+    val nts = sts + ".1"
+    val ts = withDefaultTimeZone(UTC)(Timestamp.valueOf(nts))
+
+    for (tz <- ALL_TIMEZONES) {
+      withSQLConf(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz.getId
+      ) {
+        val timeZoneId = Option(tz.getId)
+        var c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 2, 8, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+        c = Calendar.getInstance(TimeZoneUTC)
+        c.set(2015, 10, 1, 2, 30, 0)
+        checkEvaluation(
+          cast(
+            cast(new Timestamp(c.getTimeInMillis), StringType, timeZoneId),
+            TimestampType,
+            timeZoneId),
+          millisToMicros(c.getTimeInMillis))
+      }
+    }
+
+    checkEvaluation(cast("abdef", StringType), "abdef")
+    checkEvaluation(cast("12.65", DecimalType.SYSTEM_DEFAULT), Decimal(12.65))
+
+    checkEvaluation(cast(cast(sd, DateType), StringType), sd)
+    checkEvaluation(cast(cast(d, StringType), DateType), 0)
+
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC_OPT.get
+    ) {
+      checkEvaluation(cast(cast(nts, TimestampType, UTC_OPT), StringType, UTC_OPT), nts)
+      checkEvaluation(
+        cast(cast(ts, StringType, UTC_OPT), TimestampType, UTC_OPT),
+        fromJavaTimestamp(ts))
+
+      // all convert to string type to check
+      checkEvaluation(
+        cast(cast(cast(nts, TimestampType, UTC_OPT), DateType, UTC_OPT), StringType),
+        sd)
+      checkEvaluation(
+        cast(cast(cast(ts, DateType, UTC_OPT), TimestampType, UTC_OPT), StringType, UTC_OPT),
+        zts)
+    }
+
+    checkEvaluation(cast(cast("abdef", BinaryType), StringType), "abdef")
+
+    checkEvaluation(
+      cast(
+        cast(cast(cast(cast(cast("5", ByteType), ShortType), IntegerType), FloatType), DoubleType),
+        LongType),
+      5.toLong)
+
+    checkEvaluation(cast("23", DoubleType), 23d)
+    checkEvaluation(cast("23", IntegerType), 23)
+    checkEvaluation(cast("23", FloatType), 23f)
+    checkEvaluation(cast("23", DecimalType.USER_DEFAULT), Decimal(23))
+    checkEvaluation(cast("23", ByteType), 23.toByte)
+    checkEvaluation(cast("23", ShortType), 23.toShort)
+    checkEvaluation(cast(123, IntegerType), 123)
+
+    checkEvaluation(cast(Literal.create(null, IntegerType), ShortType), null)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

To align with Spark, we need consider session timezone in this cast operation. See https://github.com/facebookincubator/velox/pull/11958

## How was this patch tested?

Existing imported Spark tests.
