### PR TITLE
[VL] RAS: A benchmark suite for performance of query optimization

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
@@ -18,7 +18,6 @@ package org.apache.gluten.extension.columnar.enumerated.planner
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.extension.columnar.enumerated.EnumeratedTransform
-import org.apache.gluten.extension.columnar.enumerated.planner.GlutenOptimization
 import org.apache.gluten.extension.columnar.enumerated.planner.cost.{LegacyCoster, LongCostModel}
 import org.apache.gluten.extension.columnar.enumerated.planner.property.Conv
 import org.apache.gluten.extension.columnar.transition.ConventionReq

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.planner
+package org.apache.gluten.extension.columnar.enumerated.planner
 
 import org.apache.gluten.GlutenConfig
 import org.apache.gluten.extension.columnar.enumerated.EnumeratedTransform

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -129,7 +129,7 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val benchmark = new Benchmark(
       this.getClass.getCanonicalName,
-      rounds * allQueryIds.size,
+      allQueryIds.size,
       output = output,
       warmupTime = 15.seconds,
       minTime = 60.seconds)

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -133,7 +133,7 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
       output = output,
       warmupTime = 15.seconds,
       minTime = 60.seconds)
-    benchmark.addTimerCase("RAS") {
+    benchmark.addTimerCase("RAS Planner") {
       timer =>
         val spark = createRasSession()
         createTpchTables(spark)
@@ -145,7 +145,7 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
         }
         timer.stopTiming()
     }
-    benchmark.addTimerCase("Legacy") {
+    benchmark.addTimerCase("Legacy Planner") {
       timer =>
         val spark = createLegacySession()
         createTpchTables(spark)

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -141,7 +141,9 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
         allQueryIds.foreach {
           id =>
             val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+            // scalastyle:off println
             println("[RAS] Optimized query plan: " + p.toString())
+            // scalastyle:on println
         }
         timer.stopTiming()
     }
@@ -153,7 +155,9 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
         allQueryIds.foreach {
           id =>
             val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+            // scalastyle:off println
             println("[Legacy] Optimized query plan: " + p.toString())
+            // scalastyle:on println
         }
         timer.stopTiming()
     }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql.execution.benchmark
 
 import org.apache.gluten.GlutenConfig

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -31,8 +31,8 @@ import scala.concurrent.duration.DurationInt
 import scala.io.Source
 
 /**
- * The benchmark measures on RAS query optimization performance only. Query performance is not
- * considered.
+ * The benchmark measures on RAS query optimization performance only. Performance of query execution
+ * is not considered.
  */
 object VeloxRasBenchmark extends SqlBasedBenchmark {
   private val tpchQueries: String =

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -133,18 +133,6 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
       output = output,
       warmupTime = 15.seconds,
       minTime = 60.seconds)
-    benchmark.addTimerCase("Legacy") {
-      timer =>
-        val spark = createLegacySession()
-        createTpchTables(spark)
-        timer.startTiming()
-        allQueryIds.foreach {
-          id =>
-            val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
-            println("[Legacy] Optimized query plan: " + p.toString())
-        }
-        timer.stopTiming()
-    }
     benchmark.addTimerCase("RAS") {
       timer =>
         val spark = createRasSession()
@@ -154,6 +142,18 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
           id =>
             val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
             println("[RAS] Optimized query plan: " + p.toString())
+        }
+        timer.stopTiming()
+    }
+    benchmark.addTimerCase("Legacy") {
+      timer =>
+        val spark = createLegacySession()
+        createTpchTables(spark)
+        timer.startTiming()
+        allQueryIds.foreach {
+          id =>
+            val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+            println("[Legacy] Optimized query plan: " + p.toString())
         }
         timer.stopTiming()
     }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -127,7 +127,6 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
   )
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val rounds = 5
     val benchmark = new Benchmark(
       this.getClass.getCanonicalName,
       rounds * allQueryIds.size,
@@ -139,13 +138,10 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
         val spark = createLegacySession()
         createTpchTables(spark)
         timer.startTiming()
-        (0 until rounds).foreach {
-          _ =>
-            allQueryIds.foreach {
-              id =>
-                val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
-                println("[Legacy] Optimized query plan: " + p.toString())
-            }
+        allQueryIds.foreach {
+          id =>
+            val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+            println("[Legacy] Optimized query plan: " + p.toString())
         }
         timer.stopTiming()
     }
@@ -154,13 +150,10 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
         val spark = createRasSession()
         createTpchTables(spark)
         timer.startTiming()
-        (0 until rounds).foreach {
-          _ =>
-            allQueryIds.foreach {
-              id =>
-                val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
-                println("[RAS] Optimized query plan: " + p.toString())
-            }
+        allQueryIds.foreach {
+          id =>
+            val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+            println("[RAS] Optimized query plan: " + p.toString())
         }
         timer.stopTiming()
     }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.gluten.GlutenConfig
+import org.apache.gluten.execution.Table
+import org.apache.gluten.utils.Arm
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+
+import java.io.File
+
+import scala.io.Source
+
+/**
+ * The benchmark measures on RAS query optimization performance only. Query performance is not
+ * considered.
+ */
+object VeloxRasBenchmark extends SqlBasedBenchmark {
+  private val tpchQueries: String =
+    getClass
+      .getResource("/")
+      .getPath + "../../../../tools/gluten-it/common/src/main/resources/tpch-queries"
+  private val dataDirPath: String =
+    getClass
+      .getResource("/tpch-data-parquet")
+      .getFile
+
+  private val tpchTables: Seq[Table] = Seq(
+    Table("part", partitionColumns = "p_brand" :: Nil),
+    Table("supplier", partitionColumns = Nil),
+    Table("partsupp", partitionColumns = Nil),
+    Table("customer", partitionColumns = "c_mktsegment" :: Nil),
+    Table("orders", partitionColumns = "o_orderdate" :: Nil),
+    Table("lineitem", partitionColumns = "l_shipdate" :: Nil),
+    Table("nation", partitionColumns = Nil),
+    Table("region", partitionColumns = Nil)
+  )
+
+  private def sessionBuilder() = {
+    SparkSession
+      .builder()
+      .master("local[1]")
+      .appName(this.getClass.getCanonicalName)
+      .config(SQLConf.SHUFFLE_PARTITIONS.key, 1)
+      .config(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, 1)
+      .config("spark.plugins", "org.apache.gluten.GlutenPlugin")
+      .config("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .config("spark.ui.enabled", "false")
+      .config("spark.gluten.ui.enabled", "false")
+      .config("spark.memory.offHeap.enabled", "true")
+      .config("spark.memory.offHeap.size", "2g")
+      .config("spark.sql.adaptive.enabled", "false")
+  }
+
+  private def createLegacySession(): SparkSession = {
+    SparkSession.cleanupAnyExistingSession()
+    sessionBuilder()
+      .config(GlutenConfig.RAS_ENABLED.key, false)
+      .getOrCreate()
+  }
+
+  private def createRasSession(): SparkSession = {
+    SparkSession.cleanupAnyExistingSession()
+    sessionBuilder()
+      .config(GlutenConfig.RAS_ENABLED.key, true)
+      .getOrCreate()
+  }
+
+  private def createTpchTables(spark: SparkSession): Unit = {
+    tpchTables
+      .map(_.name)
+      .map {
+        table =>
+          val tablePath = new File(dataDirPath, table).getAbsolutePath
+          val tableDF = spark.read.format("parquet").load(tablePath)
+          tableDF.createOrReplaceTempView(table)
+          (table, tableDF)
+      }
+      .toMap
+  }
+
+  private def tpchSQL(queryId: String): String =
+    Arm.withResource(Source.fromFile(new File(s"$tpchQueries/$queryId.sql"), "UTF-8"))(_.mkString)
+
+  private val allQueryIds: Seq[String] = Seq(
+    "q1",
+    "q2",
+    "q3",
+    "q4",
+    "q5",
+    "q6",
+    "q7",
+    "q8",
+    "q9",
+    "q10",
+    "q11",
+    "q12",
+    "q13",
+    "q14",
+    "q15",
+    "q16",
+    "q17",
+    "q18",
+    "q19",
+    "q20",
+    "q21",
+    "q22"
+  )
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val rounds = 5
+    val benchmark = new Benchmark(this.getClass.getCanonicalName, rounds, output = output)
+    benchmark.addTimerCase("Legacy") {
+      timer =>
+        val spark = createLegacySession()
+        createTpchTables(spark)
+        timer.startTiming()
+        (0 until rounds).foreach {
+          _ =>
+            allQueryIds.foreach {
+              id =>
+                val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+                println("[Legacy] Optimized query plan: " + p.toString())
+            }
+        }
+        timer.stopTiming()
+    }
+    benchmark.addTimerCase("RAS") {
+      timer =>
+        val spark = createRasSession()
+        createTpchTables(spark)
+        timer.startTiming()
+        (0 until rounds).foreach {
+          _ =>
+            allQueryIds.foreach {
+              id =>
+                val p = spark.sql(tpchSQL(id)).queryExecution.executedPlan
+                println("[RAS] Optimized query plan: " + p.toString())
+            }
+        }
+        timer.stopTiming()
+    }
+    benchmark.run()
+  }
+}

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 
 import java.io.File
 
+import scala.concurrent.duration.DurationInt
 import scala.io.Source
 
 /**
@@ -127,7 +128,12 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val rounds = 5
-    val benchmark = new Benchmark(this.getClass.getCanonicalName, rounds, output = output)
+    val benchmark = new Benchmark(
+      this.getClass.getCanonicalName,
+      rounds * allQueryIds.size,
+      output = output,
+      warmupTime = 15.seconds,
+      minTime = 60.seconds)
     benchmark.addTimerCase("Legacy") {
       timer =>
         val spark = createLegacySession()


### PR DESCRIPTION
As title. Add `VeloxRasBenchmark` to measure on performance of query optimization with RAS planner.

The benchmark is based on TPC-H data and queires.

Current benchmark output:

```
OpenJDK 64-Bit Server VM 1.8.0_382-b05 on Linux 5.4.0-200-generic
Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
org.apache.spark.sql.execution.benchmark.VeloxRasBenchmark$:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------
RAS Planner                                                           3765           4484         546          0.0   171143418.3       1.0X
Legacy Planner                                                        5383           5889         440          0.0   244701076.3       0.7X
```

With some minor cleanups.