### PR TITLE
[GLUTEN-8325][CH] Fix miss matched result for `$` and `.` in reg expression

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseStringFunctionsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseStringFunctionsSuite.scala
@@ -107,6 +107,23 @@ class GlutenClickhouseStringFunctionsSuite extends GlutenClickHouseWholeStageTra
     }
   }
 
+  test("GLUTEN-8325 $ missmatched") {
+    withTable("regexp_string_end") {
+      sql("create table regexp_string_end(a String) using parquet")
+      sql("""
+            |insert into regexp_string_end
+            | values ('@abc'),('@abc\n'),('@abc\nsdd')
+            |""".stripMargin)
+      val sql_s =
+        """
+          |select
+          |regexp_extract(a, '@(.*?)($)', 1), regexp_extract(a, '@(.*?)(f|$)', 1)
+          |from regexp_string_end
+          |""".stripMargin
+      runQueryAndCompare(sql_s) { _ => }
+    }
+  }
+
   test("replace") {
     val tableName = "replace_table"
     withTable(tableName) {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseStringFunctionsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseStringFunctionsSuite.scala
@@ -107,20 +107,22 @@ class GlutenClickhouseStringFunctionsSuite extends GlutenClickHouseWholeStageTra
     }
   }
 
-  test("GLUTEN-8325 $ missmatched") {
+  test("GLUTEN-8325 $. missmatched") {
     withTable("regexp_string_end") {
       sql("create table regexp_string_end(a String) using parquet")
       sql("""
             |insert into regexp_string_end
             | values ('@abc'),('@abc\n'),('@abc\nsdd')
             |""".stripMargin)
-      val sql_s =
-        """
-          |select
-          |regexp_extract(a, '@(.*?)($)', 1), regexp_extract(a, '@(.*?)(f|$)', 1)
-          |from regexp_string_end
-          |""".stripMargin
-      runQueryAndCompare(sql_s) { _ => }
+      runQueryAndCompare("""
+                           |select
+                           |regexp_extract(a, '@(.*?)($)', 1), regexp_extract(a, '@(.*?)(f|$)', 1)
+                           |from regexp_string_end""".stripMargin) { _ => }
+
+      runQueryAndCompare("""
+                           |select
+                           |regexp_extract(a, '@(.*?)($)', 1), regexp_extract(a, '@(.*)(f|$)', 1)
+                           |from regexp_string_end""".stripMargin) { _ => }
     }
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseStringFunctionsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseStringFunctionsSuite.scala
@@ -112,16 +112,21 @@ class GlutenClickhouseStringFunctionsSuite extends GlutenClickHouseWholeStageTra
       sql("create table regexp_string_end(a String) using parquet")
       sql("""
             |insert into regexp_string_end
-            | values ('@abc'),('@abc\n'),('@abc\nsdd')
+            | values ('@abc'),('@abc\n'),('@abc\nsdd'), ('sfsd\n@abc'), ('sdfsdf\n@abc\n'),
+            | ('sdfsdf\n@abc\nsdf'), ('sdfsdf@abc\nsdf\n'), ('sdfsdf@abc'), ('sdfsdf@abc\n')
             |""".stripMargin)
       runQueryAndCompare("""
                            |select
-                           |regexp_extract(a, '@(.*?)($)', 1), regexp_extract(a, '@(.*?)(f|$)', 1)
+                           |regexp_extract(a, '@(.*?)($)', 1),
+                           |regexp_extract(a, '@(.*?)(f|$)', 1),
+                           |regexp_extract(a, '^@(.*?)(f|$)', 1)
                            |from regexp_string_end""".stripMargin) { _ => }
 
       runQueryAndCompare("""
                            |select
-                           |regexp_extract(a, '@(.*?)($)', 1), regexp_extract(a, '@(.*)(f|$)', 1)
+                           |regexp_extract(a, '@(.*)($)', 1),
+                           |regexp_extract(a, '@(.*)(f|$)', 1),
+                           |regexp_extract(a, '^@(.*?)(f|$)', 1)
                            |from regexp_string_end""".stripMargin) { _ => }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #8325

align the meaning of `.` and `$` in vanila and ch

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

 unit tests


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

