### PR TITLE
[GLUTEN-8352][ICEBERG] Fix read error when partition column was drop

### DIFF
--- a/gluten-iceberg/src-iceberg/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src-iceberg/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -512,7 +512,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
       val result = resultDf.collect()
 
       assert(result.length == 1)
-      assert(result.head.getString(2) == "test_p2")
+      assert(result.head.getString(3) == "test_p2")
     }
   }
 }

--- a/gluten-iceberg/src-iceberg/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src-iceberg/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -494,7 +494,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     val testTable = "test_table_with_partition"
     withTable(testTable) {
       spark.sql(s"""
-                   |CREATE TABLE test_catalog.$testTable (id INT, data STRING, p1 STRING, p2 STRING)
+                   |CREATE TABLE $testTable (id INT, data STRING, p1 STRING, p2 STRING)
                    |USING iceberg
                    |tblproperties (
                    |  'format-version' = '1'
@@ -502,13 +502,13 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
                    |PARTITIONED BY (p1, p2);
                    |""".stripMargin)
       spark.sql(s"""
-                   |INSERT INTO test_catalog.$testTable VALUES
+                   |INSERT INTO $testTable VALUES
                    |(1, 'test_data', 'test_p1', 'test_p2');
                    |""".stripMargin)
       spark.sql(s"""
-                   |ALTER TABLE test_catalog.$testTable DROP PARTITION FIELD p2;
+                   |ALTER TABLE $testTable DROP PARTITION FIELD p2
                    |""".stripMargin)
-      val resultDf = spark.sql(s"SELECT id, data, p1, p2 FROM test_catalog.$testTable")
+      val resultDf = spark.sql(s"SELECT id, data, p1, p2 FROM $testTable")
       val result = resultDf.collect()
 
       assert(result.length == 1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the p2 partition of Iceberg  v1 table  is deleted, the column is not physically removed in the code but marked as a VoidTransform. As a result, the file path changes to xxx/p2=null/xxx. During data reading, when encountering a VoidTransform, the data should be retrieved directly from the file instead of relying on the partition value. However, in this scenario, Gluten reads the p2 values as null for all records

(Fixes: \#8352)



