### PR TITLE
[GLUTEN-8060][CORE][VL] Various of fixes for the experimental `GlutenShuffleManager`

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -456,7 +456,11 @@ object VeloxBackendSettings extends BackendSettingsApi {
   }
 
   override def supportColumnarShuffleExec(): Boolean = {
-    GlutenConfig.getConf.enableColumnarShuffle
+    val conf = GlutenConfig.getConf
+    conf.enableColumnarShuffle && (conf.isUseGlutenShuffleManager
+      || conf.isUseColumnarShuffleManager
+      || conf.isUseCelebornShuffleManager
+      || conf.isUseUniffleShuffleManager)
   }
 
   override def enableJoinKeysRewrite(): Boolean = false

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -456,9 +456,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
   }
 
   override def supportColumnarShuffleExec(): Boolean = {
-    GlutenConfig.getConf.enableColumnarShuffle && (GlutenConfig.getConf.isUseColumnarShuffleManager
-      || GlutenConfig.getConf.isUseCelebornShuffleManager
-      || GlutenConfig.getConf.isUseUniffleShuffleManager)
+    GlutenConfig.getConf.enableColumnarShuffle
   }
 
   override def enableJoinKeysRewrite(): Boolean = false

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -130,8 +130,8 @@ class VeloxListenerApi extends ListenerApi with Logging {
     ArrowJavaBatch.ensureRegistered()
     ArrowNativeBatch.ensureRegistered()
 
-    // Register shuffle so can be considered when `org.apache.spark.shuffle.GlutenShuffleManager`
-    // is set as Spark shuffle manager.
+    // Register columnar shuffle so can be considered when
+    // `org.apache.spark.shuffle.GlutenShuffleManager` is set as Spark shuffle manager.
     ShuffleManagerRegistry
       .get()
       .register(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -137,7 +137,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
       .register(
         new LookupKey {
           override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = {
-            dependency.isInstanceOf[ColumnarShuffleDependency[_, _, _]]
+            dependency.getClass == classOf[ColumnarShuffleDependency[_, _, _]]
           }
         },
         classOf[ColumnarShuffleManager].getName

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -295,6 +295,17 @@ class VeloxTPCHV1Suite extends VeloxTPCHSuite {
   }
 }
 
+class VeloxTPCHV1GlutenShuffleManagerSuite extends VeloxTPCHSuite {
+  override def subType(): String = "v1-gluten-shuffle-manager"
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.sql.sources.useV1SourceList", "parquet")
+      .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.GlutenShuffleManager")
+  }
+}
+
 class VeloxTPCHV1BhjSuite extends VeloxTPCHSuite {
   override def subType(): String = "v1-bhj"
 

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerLookup.scala
@@ -19,12 +19,10 @@ package org.apache.spark.shuffle
 import org.apache.spark.ShuffleDependency
 
 private class ShuffleManagerLookup(all: Seq[(LookupKey, ShuffleManager)]) {
-  private val allReversed = all.reverse
-
   def findShuffleManager[K, V, C](dependency: ShuffleDependency[K, V, C]): ShuffleManager = {
     this.synchronized {
       // The latest shuffle manager registered will be looked up earlier.
-      allReversed.find(_._1.accepts(dependency)).map(_._2).getOrElse {
+      all.find(_._1.accepts(dependency)).map(_._2).getOrElse {
         throw new IllegalStateException(s"No ShuffleManager found for $dependency")
       }
     }

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
@@ -16,17 +16,20 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.spark.SparkConf
+import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.{ShuffleDependency, SparkConf}
 import org.apache.spark.util.{SparkTestUtil, Utils}
 
 import scala.collection.mutable
 
 class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
   import ShuffleManagerRegistry._
-  private val all: mutable.Buffer[(LookupKey, String)] = mutable.Buffer()
+  private val all: mutable.ListBuffer[(LookupKey, String)] = mutable.ListBuffer()
   private val routerBuilders: mutable.Buffer[RouterBuilder] = mutable.Buffer()
   private val classDeDup: mutable.Set[String] = mutable.Set()
 
+  // The shuffle manager class registered through this API later
+  // will take higher precedence during lookup.
   def register(lookupKey: LookupKey, shuffleManagerClass: String): Unit = {
     val clazz = Utils.classForName(shuffleManagerClass)
     require(
@@ -42,7 +45,7 @@ class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
       s"Shuffle manager class already registered: $shuffleManagerClass")
     this.synchronized {
       classDeDup += shuffleManagerClass
-      all += lookupKey -> shuffleManagerClass
+      (lookupKey -> shuffleManagerClass) +=: all
       // Invalidate all shuffle managers cached in each alive router builder instances.
       // Then, once the router builder is accessed, a new router will be forced to create.
       routerBuilders.foreach(_.invalidateCache())
@@ -68,7 +71,13 @@ class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
 }
 
 object ShuffleManagerRegistry {
-  private val instance = new ShuffleManagerRegistry()
+  private val instance = {
+    val r = new ShuffleManagerRegistry()
+    r.register(new LookupKey {
+      override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
+    }, classOf[SortShuffleManager].getName)
+    r
+  }
 
   def get(): ShuffleManagerRegistry = instance
 

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRegistry.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.{ShuffleDependency, SparkConf}
+import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.util.{SparkTestUtil, Utils}
 
 import scala.collection.mutable
@@ -73,9 +73,14 @@ class ShuffleManagerRegistry private[ShuffleManagerRegistry] {
 object ShuffleManagerRegistry {
   private val instance = {
     val r = new ShuffleManagerRegistry()
-    r.register(new LookupKey {
-      override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = true
-    }, classOf[SortShuffleManager].getName)
+    r.register(
+      new LookupKey {
+        override def accepts[K, V, C](dependency: ShuffleDependency[K, V, C]): Boolean = {
+          dependency.getClass == classOf[ShuffleDependency[_, _, _]]
+        }
+      },
+      classOf[SortShuffleManager].getName
+    )
     r
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
@@ -83,7 +83,7 @@ private class ShuffleManagerRouter(lookup: ShuffleManagerLookup)
             s"GlutenShuffleManager")
     }
     val shuffleId = baseShuffleHandle.shuffleId
-    if (!cache.has(shuffleId)) {
+    if (cache.has(shuffleId)) {
       return
     }
     val dependency = baseShuffleHandle.dependency

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/ShuffleManagerRouter.scala
@@ -69,7 +69,7 @@ private class ShuffleManagerRouter(lookup: ShuffleManagerLookup)
         s"Shuffle router cache is not empty when being stopped. This might be because the " +
           s"shuffle is not unregistered.")
     }
-    lookup.all().reverse.foreach(_.stop())
+    lookup.all().foreach(_.stop())
   }
 }
 

--- a/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/shuffle/GlutenShuffleManagerSuite.scala
@@ -33,6 +33,11 @@ class GlutenShuffleManagerSuite extends SharedSparkSession {
       .set(SHUFFLE_MANAGER.key, classOf[GlutenShuffleManager].getName)
   }
 
+  override protected def beforeEach(): Unit = {
+    val registry = ShuffleManagerRegistry.get()
+    registry.clear()
+  }
+
   override protected def afterEach(): Unit = {
     val registry = ShuffleManagerRegistry.get()
     registry.clear()

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -129,18 +129,25 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def scanFileSchemeValidationEnabled: Boolean =
     conf.getConf(VELOX_SCAN_FILE_SCHEME_VALIDATION_ENABLED)
 
-  // whether to use ColumnarShuffleManager
+  // Whether to use GlutenShuffleManager (experimental).
+  def isUseGlutenShuffleManager: Boolean =
+    conf
+      .getConfString("spark.shuffle.manager", "sort")
+      .equals("org.apache.spark.shuffle.sort.GlutenShuffleManager")
+
+  // Whether to use ColumnarShuffleManager
   def isUseColumnarShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")
       .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")
 
-  // whether to use CelebornShuffleManager
+  // Whether to use CelebornShuffleManager
   def isUseCelebornShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")
       .contains("celeborn")
 
+  // Whether to use UniffleShuffleManager
   def isUseUniffleShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenConfig.scala
@@ -135,19 +135,19 @@ class GlutenConfig(conf: SQLConf) extends Logging {
       .getConfString("spark.shuffle.manager", "sort")
       .equals("org.apache.spark.shuffle.sort.GlutenShuffleManager")
 
-  // Whether to use ColumnarShuffleManager
+  // Whether to use ColumnarShuffleManager.
   def isUseColumnarShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")
       .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")
 
-  // Whether to use CelebornShuffleManager
+  // Whether to use CelebornShuffleManager.
   def isUseCelebornShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")
       .contains("celeborn")
 
-  // Whether to use UniffleShuffleManager
+  // Whether to use UniffleShuffleManager.
   def isUseUniffleShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")


### PR DESCRIPTION
Note: `GlutenShuffleManager` is still experimental. The change shouldn't impact production behavior.

1. Register `SortShuffleManager` through  `GlutenShuffleManager` by default
2. (Velox backend) Register `ColumnarShuffleManager` through  `GlutenShuffleManager` by default
3. Make `GlutenShuffleManager` work correctly in cluster mode
4. Add some simple test code

This will remove some blockers against the mixed backend work.