### PR TITLE
[CH] [MINOR] Configure Log4j2 to print logs of `org.apache.iceberg` for tracing `ClickHouseIcebergSuite` aborted issues

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHBroadcastBuildSideCache.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHBroadcastBuildSideCache.scala
@@ -38,9 +38,6 @@ case class BroadcastHashTable(pointer: Long, relation: ClickHouseBuildSideRelati
  */
 object CHBroadcastBuildSideCache extends Logging with RemovalListener[String, BroadcastHashTable] {
 
-  private def threadLog(msg: => String): Unit =
-    logDebug(s"Thread: ${Thread.currentThread().getId} -- $msg")
-
   private lazy val expiredTime = SparkEnv.get.conf.getLong(
     CHBackendSettings.GLUTEN_CLICKHOUSE_BROADCAST_CACHE_EXPIRED_TIME,
     CHBackendSettings.GLUTEN_CLICKHOUSE_BROADCAST_CACHE_EXPIRED_TIME_DEFAULT
@@ -66,7 +63,7 @@ object CHBroadcastBuildSideCache extends Logging with RemovalListener[String, Br
             broadcast.value
               .asInstanceOf[ClickHouseBuildSideRelation]
               .buildHashTable(broadCastContext)
-          threadLog(s"create bhj $broadcast_id = 0x${pointer.toHexString}")
+          logDebug(s"Create bhj $broadcast_id = 0x${pointer.toHexString}")
           BroadcastHashTable(pointer, relation)
         }
       )
@@ -89,7 +86,7 @@ object CHBroadcastBuildSideCache extends Logging with RemovalListener[String, Br
   def cleanAll(): Unit = buildSideRelationCache.invalidateAll()
 
   override def onRemoval(key: String, value: BroadcastHashTable, cause: RemovalCause): Unit = {
-    threadLog(s"remove bhj $key = 0x${value.pointer.toHexString}")
+    logDebug(s"Remove bhj $key = 0x${value.pointer.toHexString}")
     if (value.relation != null) {
       value.relation.reset()
     }

--- a/backends-clickhouse/src/test/resources/log4j2.properties
+++ b/backends-clickhouse/src/test/resources/log4j2.properties
@@ -24,7 +24,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n%ex
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%tid][%t] %p %c: %m%n%ex
 appender.console.filter.threshold.type = ThresholdFilter
 appender.console.filter.threshold.level = debug
 
@@ -66,3 +66,8 @@ logger.parquet1.level = error
 
 logger.parquet2.name = parquet.CorruptStatistics
 logger.parquet2.level = error
+
+# Iceberg related logging for debugging
+logger.Iceberg.name=org.apache.iceberg
+logger.Iceberg.additivity=true
+logger.Iceberg.level=debug


### PR DESCRIPTION
## What changes were proposed in this pull request?

Configure Log4j2 to print logs of `org.apache.iceberg` for tracing `ClickHouseIcebergSuite` aborted issues. I also remove threadLog in `CHBroadcastBuildSideCache`, since **Log4j2** supports printing thread name and id.

## How was this patch tested?

Current UTs

