### PR TITLE
[GLUTEN-8385][VL] Support write compatible-hive bucket table for Spark3.4 and Spark3.5.

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -227,6 +227,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       format: FileFormat,
       fields: Array[StructField],
       bucketSpec: Option[BucketSpec],
+      isPartitionedTable: Boolean,
       options: Map[String, String]): ValidationResult = {
 
     def validateCompressionCodec(): Option[String] = {

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/BucketWriteUtils.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/BucketWriteUtils.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{DataFrame, GlutenQueryTest}
+import org.apache.spark.sql.catalyst.expressions.{BitwiseAnd, Expression, HiveHash, Literal, Pmod, UnsafeProjection}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SQLTestUtils
+
+import java.io.File
+
+trait BucketWriteUtils extends GlutenQueryTest with SQLTestUtils {
+
+  def tableDir(table: String): File = {
+    val identifier = spark.sessionState.sqlParser.parseTableIdentifier(table)
+    new File(spark.sessionState.catalog.defaultTablePath(identifier))
+  }
+
+  protected def testBucketing(
+      dataDir: File,
+      source: String = "parquet",
+      numBuckets: Int,
+      bucketCols: Seq[String],
+      sortCols: Seq[String] = Nil,
+      inputDF: DataFrame,
+      bucketIdExpression: (Seq[Expression], Int) => Expression,
+      getBucketIdFromFileName: String => Option[Int]): Unit = {
+    val allBucketFiles =
+      dataDir.listFiles().filterNot(f => f.getName.startsWith(".") || f.getName.startsWith("_"))
+
+    for (bucketFile <- allBucketFiles) {
+      val bucketId = getBucketIdFromFileName(bucketFile.getName).getOrElse {
+        fail(s"Unable to find the related bucket files.")
+      }
+
+      // Remove the duplicate columns in bucketCols and sortCols;
+      // Otherwise, we got analysis errors due to duplicate names
+      val selectedColumns = (bucketCols ++ sortCols).distinct
+      // We may lose the type information after write(e.g. json format doesn't keep schema
+      // information), here we get the types from the original dataframe.
+      val types = inputDF.select(selectedColumns.map(col): _*).schema.map(_.dataType)
+      val columns = selectedColumns.zip(types).map { case (colName, dt) => col(colName).cast(dt) }
+
+      // Read the bucket file into a dataframe, so that it's easier to test.
+      val readBack = spark.read
+        .format(source)
+        .load(bucketFile.getAbsolutePath)
+        .select(columns: _*)
+
+      // If we specified sort columns while writing bucket table, make sure the data in this
+      // bucket file is already sorted.
+      if (sortCols.nonEmpty) {
+        checkAnswer(readBack.sort(sortCols.map(col): _*), readBack.collect())
+      }
+
+      // Go through all rows in this bucket file, calculate bucket id according to bucket column
+      // values, and make sure it equals to the expected bucket id that inferred from file name.
+      val qe = readBack.select(bucketCols.map(col): _*).queryExecution
+      val rows = qe.toRdd.map(_.copy()).collect()
+      val getBucketId = UnsafeProjection.create(
+        bucketIdExpression(qe.analyzed.output, numBuckets) :: Nil,
+        qe.analyzed.output)
+
+      for (row <- rows) {
+        val actualBucketId = getBucketId(row).getInt(0)
+        assert(actualBucketId == bucketId)
+      }
+    }
+  }
+
+  def bucketIdExpression(expressions: Seq[Expression], numBuckets: Int): Expression =
+    Pmod(BitwiseAnd(HiveHash(expressions), Literal(Int.MaxValue)), Literal(numBuckets))
+
+  def getBucketIdFromFileName(fileName: String): Option[Int] = {
+    val hiveBucketedFileName = """^(\d+)_0_.*$""".r
+    fileName match {
+      case hiveBucketedFileName(bucketId) => Some(bucketId.toInt)
+      case _ => None
+    }
+  }
+}

--- a/docs/developers/SubstraitModifications.md
+++ b/docs/developers/SubstraitModifications.md
@@ -28,6 +28,7 @@ changed `Unbounded` in `WindowFunction` into `Unbounded_Preceding` and `Unbounde
 * Added `WriteRel` ([#3690](https://github.com/apache/incubator-gluten/pull/3690)).
 * Added `TopNRel` ([#5409](https://github.com/apache/incubator-gluten/pull/5409)).
 * Added `ref` field in window bound `Preceding` and `Following` ([#5626](https://github.com/apache/incubator-gluten/pull/5626)).
+* Added `BucketSpec` field in `WriteRel`([#8386](https://github.com/apache/incubator-gluten/pull/8386))
 
 ## Modifications to type.proto
 

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/RelBuilder.java
@@ -25,10 +25,7 @@ import org.apache.gluten.substrait.extensions.AdvancedExtensionNode;
 import org.apache.gluten.substrait.type.ColumnTypeNode;
 import org.apache.gluten.substrait.type.TypeNode;
 
-import io.substrait.proto.CrossRel;
-import io.substrait.proto.JoinRel;
-import io.substrait.proto.SetRel;
-import io.substrait.proto.SortField;
+import io.substrait.proto.*;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 
 import java.util.List;
@@ -191,10 +188,11 @@ public class RelBuilder {
       List<String> names,
       List<ColumnTypeNode> columnTypeNodes,
       AdvancedExtensionNode extensionNode,
+      WriteRel.BucketSpec bucketSpec,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
-    return new WriteRelNode(input, types, names, columnTypeNodes, extensionNode);
+    return new WriteRelNode(input, types, names, columnTypeNodes, extensionNode, bucketSpec);
   }
 
   public static RelNode makeSortRel(

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/WriteRelNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/WriteRelNode.java
@@ -21,10 +21,7 @@ import org.apache.gluten.substrait.type.ColumnTypeNode;
 import org.apache.gluten.substrait.type.TypeNode;
 import org.apache.gluten.utils.SubstraitUtil;
 
-import io.substrait.proto.NamedObjectWrite;
-import io.substrait.proto.NamedStruct;
-import io.substrait.proto.Rel;
-import io.substrait.proto.WriteRel;
+import io.substrait.proto.*;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -39,17 +36,21 @@ public class WriteRelNode implements RelNode, Serializable {
 
   private final AdvancedExtensionNode extensionNode;
 
+  private final WriteRel.BucketSpec bucketSpec;
+
   WriteRelNode(
       RelNode input,
       List<TypeNode> types,
       List<String> names,
       List<ColumnTypeNode> partitionColumnTypeNodes,
-      AdvancedExtensionNode extensionNode) {
+      AdvancedExtensionNode extensionNode,
+      WriteRel.BucketSpec bucketSpec) {
     this.input = input;
     this.types.addAll(types);
     this.names.addAll(names);
     this.columnTypeNodes.addAll(partitionColumnTypeNodes);
     this.extensionNode = extensionNode;
+    this.bucketSpec = bucketSpec;
   }
 
   @Override
@@ -66,6 +67,10 @@ public class WriteRelNode implements RelNode, Serializable {
 
     if (extensionNode != null) {
       nameObjectWriter.setAdvancedExtension(extensionNode.toProtobuf());
+    }
+
+    if (bucketSpec != null) {
+      writeBuilder.setBucketSpec(bucketSpec);
     }
 
     writeBuilder.setNamedTable(nameObjectWriter);

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -608,6 +608,9 @@ message WriteRel {
   // Output mode determines what is the output of executing this rel
   OutputMode output = 6;
 
+  // The bucket spec for the writer.
+  BucketSpec bucket_spec = 7;
+
   enum WriteOp {
     WRITE_OP_UNSPECIFIED = 0;
     // The insert of new tuples in a table
@@ -630,6 +633,13 @@ message WriteRel {
     // For scenarios in which the BEFORE image is required, the user must implement a spool (via references to
     // subplans in the body of the Rel input) and return those with anounter PlanRel.relations.
     OUTPUT_MODE_MODIFIED_TUPLES = 2;
+  }
+
+  // A container for bucketing information.
+  message BucketSpec {
+    int32 num_buckets = 1;
+    repeated string bucket_column_names = 2;
+    repeated string sort_column_names = 3;
   }
 }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -52,6 +52,7 @@ trait BackendSettingsApi {
       format: FileFormat,
       fields: Array[StructField],
       bucketSpec: Option[BucketSpec],
+      isPartitionedTable: Boolean,
       options: Map[String, String]): ValidationResult = ValidationResult.succeeded
 
   def supportNativeWrite(fields: Array[StructField]): Boolean = true


### PR DESCRIPTION

## What changes were proposed in this pull request?
This PR amins to support write compatible-hive bucket table for Spark3.4 and Spark3.5. fix https://github.com/apache/incubator-gluten/issues/8385

## How was this patch tested?
unit tests.

