### PR TITLE
[VL] Support loading dependency libs for Oracle linux

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoader.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoader.scala
@@ -90,9 +90,15 @@ object SharedLibraryLoader {
       new SharedLibraryLoaderUbuntu2204
     } else if (systemName.contains("CentOS") && systemVersion.startsWith("9")) {
       new SharedLibraryLoaderCentos9
-    } else if (systemName.contains("CentOS") && systemVersion.startsWith("8")) {
+    } else if (
+      (systemName.contains("CentOS") || systemName.contains("Oracle"))
+      && systemVersion.startsWith("8")
+    ) {
       new SharedLibraryLoaderCentos8
-    } else if (systemName.contains("CentOS") && systemVersion.startsWith("7")) {
+    } else if (
+      (systemName.contains("CentOS") || systemName.contains("Oracle"))
+      && systemVersion.startsWith("7")
+    ) {
       new SharedLibraryLoaderCentos7
     } else if (systemName.contains("Alibaba Cloud Linux") && systemVersion.startsWith("3")) {
       new SharedLibraryLoaderCentos8
@@ -119,7 +125,7 @@ object SharedLibraryLoader {
     } else {
       throw new GlutenException(
         s"Found unsupported OS($systemName, $systemVersion)! Currently, Gluten's Velox backend" +
-          " only supports Ubuntu 20.04/22.04, CentOS 7/8, " +
+          " only supports Ubuntu 20.04/22.04, CentOS 7/8, Oracle 7/8" +
           "Alibaba Cloud Linux 2/3 & Anolis 7/8, tencentos 2.4/3.2, RedHat 7/8, " +
           "Debian 11/12.")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As Oracle systems are widely used in many companies, it is better to support compiling Gluten on this systems.
And Oracle systems are almost similar to Centos systems. I put them into one kind of OS system.

## How was this patch tested?

The UTs have been ran on a Oracle 7/8 system.


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

