### PR TITLE
[GLUTEN-8393][VL] Fix the smj result mismatch issue 

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -973,6 +973,70 @@ jobs:
           name: test-report-spark35-slow-ras
           path: '**/surefire-reports/TEST-*.xml'
 
+  run-spark-test-spark35-smj:
+    needs: build-native-lib-centos-7
+    runs-on: ubuntu-20.04
+    container: apache/gluten:centos-8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: velox-native-lib-centos-7-${{github.sha}}
+          path: ./cpp/build/releases
+      - name: Download Arrow Jars
+        uses: actions/download-artifact@v3
+        with:
+          name: arrow-jars-centos-7-${{github.sha}}
+          path: /root/.m2/repository/org/apache/arrow/
+      - name: Prepare
+        run: |
+          dnf module -y install python39 && \
+          alternatives --set python3 /usr/bin/python3.9 && \
+          pip3 install setuptools && \
+          pip3 install pyspark==3.5.2 cython && \
+          pip3 install pandas pyarrow
+      - name: Build and Run unit test for Spark 3.5.2 (other tests)
+        run: |
+          cd $GITHUB_WORKSPACE/
+          export SPARK_SCALA_VERSION=2.12
+          $MVN_CMD clean test -Pspark-3.5 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Pspark-ut \
+          -DargLine="-Dspark.test.home=/opt/shims/spark35/spark_home/ -Dspark.gluten.sql.columnar.forceShuffledHashJoin=false" \
+          -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark35-smj
+          path: '**/surefire-reports/TEST-*.xml'
+
+  run-spark-test-spark35-slow-smj:
+    needs: build-native-lib-centos-7
+    runs-on: ubuntu-20.04
+    container: apache/gluten:centos-8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: velox-native-lib-centos-7-${{github.sha}}
+          path: ./cpp/build/releases
+      - name: Download Arrow Jars
+        uses: actions/download-artifact@v3
+        with:
+          name: arrow-jars-centos-7-${{github.sha}}
+          path: /root/.m2/repository/org/apache/arrow/
+      - name: Build and Run unit test for Spark 3.5.2 (slow tests)
+        run: |
+          cd $GITHUB_WORKSPACE/
+          $MVN_CMD clean test -Pspark-3.5 -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Pspark-ut \
+          -DargLine="-Dspark.test.home=/opt/shims/spark35/spark_home/ -Dspark.gluten.sql.columnar.forceShuffledHashJoin=false" \
+          -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-spark35-slow-smj
+          path: '**/surefire-reports/TEST-*.xml'
+
   run-cpp-test-udf-test:
     runs-on: ubuntu-20.04
     container: apache/gluten:centos-8

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1275,12 +1275,14 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
             |select cast(id as int) as c1, cast(id as string) c2 from range(100) order by c1 desc;
             |""".stripMargin)
 
-      runQueryAndCompare(
-        """
-          |select * from t1 cross join t2 on t1.c1 = t2.c1;
-          |""".stripMargin
-      ) {
-        checkGlutenOperatorMatch[ShuffledHashJoinExecTransformer]
+      withSQLConf("spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true") {
+        runQueryAndCompare(
+          """
+            |select * from t1 cross join t2 on t1.c1 = t2.c1;
+            |""".stripMargin
+        ) {
+          checkGlutenOperatorMatch[ShuffledHashJoinExecTransformer]
+        }
       }
 
       withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "1MB") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxMetricsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxMetricsSuite.scala
@@ -101,7 +101,9 @@ class VeloxMetricsSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
   }
 
   test("test shuffle hash join metrics") {
-    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+    withSQLConf(
+      GlutenConfig.COLUMNAR_FORCE_SHUFFLED_HASH_JOIN_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
       // without preproject
       runQueryAndCompare(
         "SELECT * FROM metrics_t1 join metrics_t2 on metrics_t1.c1 = metrics_t2.c1"

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -287,7 +287,8 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
     }
 
     // Validation: ShuffledHashJoin.
-    withSQLConf("spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true",
+    withSQLConf(
+      "spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true",
       "spark.sql.autoBroadcastJoinThreshold" -> "-1") {
       runQueryAndCompare(
         "select type1.date from type1," +

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -287,7 +287,8 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
     }
 
     // Validation: ShuffledHashJoin.
-    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+    withSQLConf("spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true",
+      "spark.sql.autoBroadcastJoinThreshold" -> "-1") {
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -286,7 +286,8 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
 
     // Validation: ShuffledHashJoin.
-    withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+    withSQLConf("spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true",
+      "spark.sql.autoBroadcastJoinThreshold" -> "-1") {
       runQueryAndCompare(
         "select type1.date from type1," +
           " type2 where type1.date = type2.date") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -286,7 +286,8 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
 
     // Validation: ShuffledHashJoin.
-    withSQLConf("spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true",
+    withSQLConf(
+      "spark.gluten.sql.columnar.forceShuffledHashJoin" -> "true",
       "spark.sql.autoBroadcastJoinThreshold" -> "-1") {
       runQueryAndCompare(
         "select type1.date from type1," +

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -116,6 +116,11 @@ abstract class VeloxTPCHSuite extends VeloxTPCHTableSupport {
     }
   }
 
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(GlutenConfig.COLUMNAR_FORCE_SHUFFLED_HASH_JOIN_ENABLED.key, "true")
+  }
+
   test("TPC-H q1") {
     runTPCHQuery(1, tpchQueries, queriesResults, compareResult = false, noFallBack = true) {
       checkGoldenFile(_, 1)

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -980,6 +980,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
       SubstraitParser::configSetInOptimization(joinRel.advanced_extension(), "isSMJ=")) {
     switch (joinRel.type()) {
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_INNER:
+      case ::substrait::JoinRel_JoinType_JOIN_TYPE_OUTER:
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT:
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT:
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_SEMI:

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/JkSelf/velox.git
-VELOX_BRANCH=smj-result-mismatch
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=2025_01_03
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2025_01_03
+VELOX_REPO=https://github.com/JkSelf/velox.git
+VELOX_BRANCH=smj-result-mismatch
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/SortMergeJoinExecTransformer.scala
@@ -250,11 +250,6 @@ case class SortMergeJoinExecTransformer(
     projectList) {
 
   override protected def doValidateInternal(): ValidationResult = {
-    // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
-    if (substraitJoinType == JoinRel.JoinType.JOIN_TYPE_OUTER) {
-      return ValidationResult
-        .failed(s"Found unsupported join type of $joinType for velox smj: $substraitJoinType")
-    }
     super.doValidateInternal()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Enable full outer join in smj.
2. Fix the inner join result mismatch caused by gluten's incorrect formulation of the join condition. Specifically, gluten incorrectly reorders the condition, such as changing "A = B and C = D" to "C = D and A = B", which leads to a mismatched final join result.
3. Fix the TPC-DS and TPC-H result mismatch issue in anti, semi and full outer join in https://github.com/facebookincubator/velox/pull/11772 and https://github.com/facebookincubator/velox/pull/11771
4. Set the ci job to cover the smj unit test.

## How was this patch tested?

Existing unit tests and locally run TPC-H and TPC-DS.

