### PR TITLE
[VL] Allow shared dependencies for s3 and abfs libs

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -112,10 +112,7 @@ macro(find_re2)
 endmacro()
 
 macro(find_awssdk)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   find_package(AWSSDK REQUIRED COMPONENTS s3;identity-management)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
 endmacro()
 
 macro(find_gcssdk)

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -122,12 +122,9 @@ endmacro()
 macro(find_azure)
   find_package(CURL REQUIRED)
   find_package(LibXml2 REQUIRED)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
   find_package(azure-storage-files-datalake-cpp CONFIG REQUIRED)
   find_package(azure-identity-cpp CONFIG REQUIRED)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
 endmacro()
 
 # Build Velox backend.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr removes the setting for CMAKE_FIND_LIBRARY_SUFFIXES 
before finding libs for s3 and abfs.
This is similar to https://github.com/apache/incubator-gluten/pull/8251
Without this change, users are forced to link statically with libcrypto, which is not feasible
with fips. https://github.com/apache/incubator-gluten/issues/8232
