### PR TITLE
[GLUTEN-8414][VL] Override doCanonicalize in ColumnarPartialProjectEx…

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -30,6 +30,7 @@ import org.apache.gluten.vectorized.{ArrowColumnarRow, ArrowWritableColumnVector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, Coalesce, Expression, If, LambdaFunction, NamedExpression, NaNvl, ScalaUDF}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.execution.{ExplainUtils, ProjectExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.hive.HiveUdfUtil
@@ -74,6 +75,14 @@ case class ColumnarPartialProjectExec(original: ProjectExec, child: SparkPlan)(
   )
 
   override def output: Seq[Attribute] = child.output ++ replacedAliasUdf.map(_.toAttribute)
+
+  override def doCanonicalize(): ColumnarPartialProjectExec = {
+    val canonicalized = original.canonicalized.asInstanceOf[ProjectExec]
+    this.copy(
+      original = canonicalized,
+      child = child.canonicalized
+    )(replacedAliasUdf.map(QueryPlan.normalizeExpressions(_, child.output)))
+  }gggg
 
   override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
 


### PR DESCRIPTION
…ec node

## What changes were proposed in this pull request?

implement doCanonicalize in ColumnarPartialProjectExec node, for reuse exchange contains ColumnarPartialProjectExec
(same kind problem as https://github.com/apache/incubator-gluten/issues/3154)
(Fixes: \#8414)

## How was this patch tested?

manual test in our product env

<img width="610" alt="image" src="https://github.com/user-attachments/assets/264c7c99-5fe9-4fbc-8945-fe726b17b7f0" />

the biggest table read four times before implement doCanonicalize in ColumnarPartialProjectExec

<img width="633" alt="image" src="https://github.com/user-attachments/assets/2cdb045a-81a2-4129-8cca-6061029f3fec" />

the biggest table read one times before implement doCanonicalize in ColumnarPartialProjectExec


<img width="650" alt="image" src="https://github.com/user-attachments/assets/1d54f48d-49b4-405b-a142-7918b7dee87a" />

we can also see the stage reuse multi times after implement doCanonicalize in ColumnarPartialProjectExec in spark plan


