### PR TITLE
[VL] Gluten-it: New option `--collect-sql-metrics=execution-time` to collect slowest plan nodes into benchmark report

### DIFF
--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/Preset.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/Preset.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.integration;
+
+import org.apache.gluten.integration.metrics.MetricMapper;
+import org.apache.spark.SparkConf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class Preset {
+  private static final Map<String, Preset> presets = new HashMap<>();
+
+  static {
+    presets.put("vanilla", new Preset(Constants.VANILLA_CONF(), Constants.VANILLA_METRIC_MAPPER()));
+    presets.put("velox", new Preset(Constants.VELOX_CONF(), Constants.VELOX_METRIC_MAPPER()));
+    presets.put("velox-with-celeborn", new Preset(Constants.VELOX_WITH_CELEBORN_CONF(), Constants.VELOX_METRIC_MAPPER()));
+    presets.put("velox-with-uniffle", new Preset(Constants.VELOX_WITH_UNIFFLE_CONF(), Constants.VELOX_METRIC_MAPPER()));
+  }
+
+  public static Preset get(String name) {
+    if (!presets.containsKey(name)) {
+      throw new IllegalArgumentException("Non-existing preset name: " + name);
+    }
+    return presets.get(name);
+  }
+
+  private final SparkConf conf;
+  private final MetricMapper metricMapper;
+
+  public Preset(SparkConf conf, MetricMapper metricMapper) {
+    this.conf = conf;
+    this.metricMapper = metricMapper;
+  }
+
+  public SparkConf getConf() {
+    return conf;
+  }
+
+  public MetricMapper getMetricMapper() {
+    return metricMapper;
+  }
+}

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
@@ -131,7 +131,7 @@ public class Parameterized implements Callable<Integer> {
         new org.apache.gluten.integration.action.Parameterized(dataGenMixin.getScale(),
             dataGenMixin.genPartitionedData(), queriesMixin.queries(),
             queriesMixin.explain(), queriesMixin.iterations(), warmupIterations, queriesMixin.noSessionReuse(), parsedDims,
-            excludedCombinations, metrics);
+            excludedCombinations, JavaConverters.asScalaBufferConverter(Arrays.asList(metrics)).asScala());
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), parameterized));
   }
 }

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
@@ -38,11 +38,14 @@ public class Queries implements Callable<Integer> {
   @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Every single task will get killed and retried after running for some time", defaultValue = "false")
   private boolean randomKillTasks;
 
+  @CommandLine.Option(names = {"--collect-sql-metrics"}, description = "Collect SQL metrics from run queries and generate a simple report based on them", defaultValue = "false")
+  private boolean collectSqlMetrics;
+
   @Override
   public Integer call() throws Exception {
     org.apache.gluten.integration.action.Queries queries =
         new org.apache.gluten.integration.action.Queries(dataGenMixin.getScale(), dataGenMixin.genPartitionedData(), queriesMixin.queries(),
-            queriesMixin.explain(), queriesMixin.iterations(), randomKillTasks, queriesMixin.noSessionReuse());
+            queriesMixin.explain(), queriesMixin.iterations(), randomKillTasks, queriesMixin.noSessionReuse(), collectSqlMetrics);
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), queries));
   }
 }

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
@@ -18,8 +18,14 @@ package org.apache.gluten.integration.command;
 
 import org.apache.gluten.integration.BaseMixin;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.gluten.integration.metrics.PlanMetric;
 import picocli.CommandLine;
+import scala.collection.JavaConverters;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "queries", mixinStandardHelpOptions = true,
@@ -38,14 +44,18 @@ public class Queries implements Callable<Integer> {
   @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Every single task will get killed and retried after running for some time", defaultValue = "false")
   private boolean randomKillTasks;
 
-  @CommandLine.Option(names = {"--collect-sql-metrics"}, description = "Collect SQL metrics from run queries and generate a simple report based on them", defaultValue = "false")
-  private boolean collectSqlMetrics;
+  @CommandLine.Option(names = {"--collect-sql-metrics"}, description = "Collect SQL metrics from run queries and generate a simple report based on them. Available types: execution-time")
+  private Set<String> collectSqlMetrics = Collections.emptySet();
 
   @Override
   public Integer call() throws Exception {
+    final List<PlanMetric.Reporter> metricsReporters = new ArrayList<>();
+    for (String type : collectSqlMetrics) {
+      metricsReporters.add(PlanMetric.newReporter(type));
+    }
     org.apache.gluten.integration.action.Queries queries =
         new org.apache.gluten.integration.action.Queries(dataGenMixin.getScale(), dataGenMixin.genPartitionedData(), queriesMixin.queries(),
-            queriesMixin.explain(), queriesMixin.iterations(), randomKillTasks, queriesMixin.noSessionReuse(), collectSqlMetrics);
+            queriesMixin.explain(), queriesMixin.iterations(), randomKillTasks, queriesMixin.noSessionReuse(), JavaConverters.asScalaBufferConverter(metricsReporters).asScala());
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), queries));
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -89,7 +89,8 @@ object Constants {
       "BroadcastHashJoinExec" -> Set(), // No available metrics provided by vanilla Spark.
       "ColumnarToRowExec" -> Set(), // No available metrics provided by vanilla Spark.
       "ShuffleExchangeExec" -> Set("fetchWaitTime", "shuffleWriteTime"),
-      "ShuffledHashJoinExec" -> Set("buildTime")
+      "ShuffledHashJoinExec" -> Set("buildTime"),
+      "WindowGroupLimitExec" -> Set() // No available metrics provided by vanilla Spark.
     ))
 
   val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER.and(
@@ -114,7 +115,9 @@ object Constants {
         "ColumnarBroadcastExchangeExec" -> Set("broadcastTime", "collectTime"),
         "BroadcastHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos"),
         "WindowExecTransformer" -> Set("wallNanos"),
-        "WindowGroupLimitExecTransformer" -> Set("wallNanos")
+        "WindowGroupLimitExecTransformer" -> Set("wallNanos"),
+        "VeloxBroadcastNestedLoopJoinExecTransformer" -> Set("wallNanos"),
+        "ExpandExecTransformer" -> Set("wallNanos")
       )
     ))
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -16,16 +16,12 @@
  */
 package org.apache.gluten.integration
 
+import org.apache.gluten.integration.metrics.MetricMapper
+import org.apache.gluten.integration.metrics.MetricMapper.SelfTimeMapper
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.TypeUtils
-import org.apache.spark.sql.types.{
-  DateType,
-  DecimalType,
-  DoubleType,
-  IntegerType,
-  LongType,
-  StringType
-}
+import org.apache.spark.sql.types._
 
 import java.sql.Date
 
@@ -40,16 +36,17 @@ object Constants {
     .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
     .set("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")
     .set("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "0")
-    .set("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false") // q72 slow if false, q64 fails if true
+    .set(
+      "spark.gluten.sql.columnar.physicalJoinOptimizeEnable",
+      "false"
+    ) // q72 slow if false, q64 fails if true
 
   val VELOX_WITH_CELEBORN_CONF: SparkConf = new SparkConf(false)
     .set("spark.gluten.sql.columnar.forceShuffledHashJoin", "true")
     .set("spark.gluten.sql.columnar.shuffle.celeborn.fallback.enabled", "false")
     .set("spark.sql.parquet.enableVectorizedReader", "true")
     .set("spark.plugins", "org.apache.gluten.GlutenPlugin")
-    .set(
-      "spark.shuffle.manager",
-      "org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager")
+    .set("spark.shuffle.manager", "org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager")
     .set("spark.celeborn.shuffle.writer", "hash")
     .set("spark.celeborn.push.replicate.enabled", "false")
     .set("spark.celeborn.client.shuffle.compression.codec", "none")
@@ -58,7 +55,10 @@ object Constants {
     .set("spark.dynamicAllocation.enabled", "false")
     .set("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")
     .set("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "0")
-    .set("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false") // q72 slow if false, q64 fails if true
+    .set(
+      "spark.gluten.sql.columnar.physicalJoinOptimizeEnable",
+      "false"
+    ) // q72 slow if false, q64 fails if true
     .set("spark.celeborn.push.data.timeout", "600s")
     .set("spark.celeborn.push.limit.inFlight.timeout", "1200s")
 
@@ -77,6 +77,25 @@ object Constants {
     .set("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")
     .set("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "0")
     .set("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false")
+
+  val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(Map()) // TODO
+
+  val VELOX_METRIC_MAPPER: MetricMapper = SelfTimeMapper(
+    Map(
+      "FileSourceScanExecTransformer" -> Set("scanTime", "pruningTime", "remainingFilterTime"),
+      "ProjectExecTransformer" -> Set("wallNanos"),
+      "FilterExecTransformer" -> Set("wallNanos"),
+      "SortExecTransformer" -> Set("wallNanos"),
+      "RegularHashAggregateExecTransformer" -> Set("aggWallNanos", "rowConstructionWallNanos"),
+      "FlushableHashAggregateExecTransformer" -> Set("aggWallNanos", "rowConstructionWallNanos"),
+      "VeloxColumnarToRowExec" -> Set("convertTime"),
+      "VeloxResizeBatchesExec" -> Set("selfTime"),
+      "ColumnarShuffleExchangeExec" -> Set("splitTime", "shuffleWallTime", "fetchWaitTime", "decompressTime", "deserializeTime"),
+      "ShuffledHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos"),
+      "ColumnarBroadcastExchangeExec" -> Set("broadcastTime", "collectTime"),
+      "BroadcastHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos")
+    )
+  ) // TODO
 
   @deprecated
   val TYPE_MODIFIER_DATE_AS_DOUBLE: TypeModifier =

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -80,7 +80,7 @@ object Constants {
 
   val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(Map()) // TODO
 
-  val VELOX_METRIC_MAPPER: MetricMapper = SelfTimeMapper(
+  val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER + SelfTimeMapper(
     Map(
       "FileSourceScanExecTransformer" -> Set("scanTime", "pruningTime", "remainingFilterTime"),
       "ProjectExecTransformer" -> Set("wallNanos"),

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -78,34 +78,45 @@ object Constants {
     .set("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "0")
     .set("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false")
 
-  val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(Map(
-    "FileSourceScanExec" -> Set("metadataTime", "scanTime"),
-    "HashAggregateExec" -> Set("aggTime"),
-    "ProjectExec" -> Set(), // No available metrics provided by vanilla Spark.
-    "FilterExec" -> Set(), // No available metrics provided by vanilla Spark.
-    "BroadcastExchangeExec" -> Set("broadcastTime", "buildTime", "collectTime"),
-    "BroadcastHashJoinExec" -> Set(), // No available metrics provided by vanilla Spark.
-    "ColumnarToRowExec" -> Set(), // No available metrics provided by vanilla Spark.
-    "ShuffleExchangeExec" -> Set("fetchWaitTime", "shuffleWriteTime"),
-    "ShuffledHashJoinExec" -> Set("buildTime")
-  ))
-
-  val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER and SelfTimeMapper(
+  val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(
     Map(
-      "FileSourceScanExecTransformer" -> Set("scanTime", "pruningTime", "remainingFilterTime"),
-      "ProjectExecTransformer" -> Set("wallNanos"),
-      "FilterExecTransformer" -> Set("wallNanos"),
-      "SortExecTransformer" -> Set("wallNanos"),
-      "RegularHashAggregateExecTransformer" -> Set("aggWallNanos", "rowConstructionWallNanos"),
-      "FlushableHashAggregateExecTransformer" -> Set("aggWallNanos", "rowConstructionWallNanos"),
-      "VeloxColumnarToRowExec" -> Set("convertTime"),
-      "VeloxResizeBatchesExec" -> Set("selfTime"),
-      "ColumnarShuffleExchangeExec" -> Set("splitTime", "shuffleWallTime", "fetchWaitTime", "decompressTime", "deserializeTime"),
-      "ShuffledHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos"),
-      "ColumnarBroadcastExchangeExec" -> Set("broadcastTime", "collectTime"),
-      "BroadcastHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos")
-    )
-  )
+      "FileSourceScanExec" -> Set("metadataTime", "scanTime"),
+      "HashAggregateExec" -> Set("aggTime"),
+      "ProjectExec" -> Set(), // No available metrics provided by vanilla Spark.
+      "FilterExec" -> Set(), // No available metrics provided by vanilla Spark.
+      "WindowExec" -> Set(), // No available metrics provided by vanilla Spark.
+      "BroadcastExchangeExec" -> Set("broadcastTime", "buildTime", "collectTime"),
+      "BroadcastHashJoinExec" -> Set(), // No available metrics provided by vanilla Spark.
+      "ColumnarToRowExec" -> Set(), // No available metrics provided by vanilla Spark.
+      "ShuffleExchangeExec" -> Set("fetchWaitTime", "shuffleWriteTime"),
+      "ShuffledHashJoinExec" -> Set("buildTime")
+    ))
+
+  val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER.and(
+    SelfTimeMapper(
+      Map(
+        "FileSourceScanExecTransformer" -> Set("scanTime", "pruningTime", "remainingFilterTime"),
+        "ProjectExecTransformer" -> Set("wallNanos"),
+        "FilterExecTransformer" -> Set("wallNanos"),
+        "SortExecTransformer" -> Set("wallNanos"),
+        "RegularHashAggregateExecTransformer" -> Set("aggWallNanos", "rowConstructionWallNanos"),
+        "FlushableHashAggregateExecTransformer" -> Set("aggWallNanos", "rowConstructionWallNanos"),
+        "VeloxColumnarToRowExec" -> Set("convertTime"),
+        "RowToVeloxColumnarExec" -> Set("convertTime"),
+        "VeloxResizeBatchesExec" -> Set("selfTime"),
+        "ColumnarShuffleExchangeExec" -> Set(
+          "splitTime",
+          "shuffleWallTime",
+          "fetchWaitTime",
+          "decompressTime",
+          "deserializeTime"),
+        "ShuffledHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos"),
+        "ColumnarBroadcastExchangeExec" -> Set("broadcastTime", "collectTime"),
+        "BroadcastHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos"),
+        "WindowExecTransformer" -> Set("wallNanos"),
+        "WindowGroupLimitExecTransformer" -> Set("wallNanos")
+      )
+    ))
 
   @deprecated
   val TYPE_MODIFIER_DATE_AS_DOUBLE: TypeModifier =

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -80,7 +80,7 @@ object Constants {
 
   val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(Map()) // TODO
 
-  val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER + SelfTimeMapper(
+  val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER and SelfTimeMapper(
     Map(
       "FileSourceScanExecTransformer" -> Set("scanTime", "pruningTime", "remainingFilterTime"),
       "ProjectExecTransformer" -> Set("wallNanos"),

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -78,7 +78,17 @@ object Constants {
     .set("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "0")
     .set("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false")
 
-  val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(Map()) // TODO
+  val VANILLA_METRIC_MAPPER: MetricMapper = SelfTimeMapper(Map(
+    "FileSourceScanExec" -> Set("metadataTime", "scanTime"),
+    "HashAggregateExec" -> Set("aggTime"),
+    "ProjectExec" -> Set(), // No available metrics provided by vanilla Spark.
+    "FilterExec" -> Set(), // No available metrics provided by vanilla Spark.
+    "BroadcastExchangeExec" -> Set("broadcastTime", "buildTime", "collectTime"),
+    "BroadcastHashJoinExec" -> Set(), // No available metrics provided by vanilla Spark.
+    "ColumnarToRowExec" -> Set(), // No available metrics provided by vanilla Spark.
+    "ShuffleExchangeExec" -> Set("fetchWaitTime", "shuffleWriteTime"),
+    "ShuffledHashJoinExec" -> Set("buildTime")
+  ))
 
   val VELOX_METRIC_MAPPER: MetricMapper = VANILLA_METRIC_MAPPER and SelfTimeMapper(
     Map(
@@ -95,7 +105,7 @@ object Constants {
       "ColumnarBroadcastExchangeExec" -> Set("broadcastTime", "collectTime"),
       "BroadcastHashJoinExecTransformer" -> Set("hashBuildWallNanos", "hashProbeWallNanos")
     )
-  ) // TODO
+  )
 
   @deprecated
   val TYPE_MODIFIER_DATE_AS_DOUBLE: TypeModifier =

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/QueryRunner.scala
@@ -16,9 +16,12 @@
  */
 package org.apache.gluten.integration
 
+import org.apache.gluten.integration.metrics.MetricMapper
+
+import org.apache.spark.sql.{RunResult, SparkQueryRunner, SparkSession}
+
 import com.google.common.base.Preconditions
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.apache.spark.sql.{RunResult, SparkQueryRunner, SparkSession}
 
 import java.io.File
 
@@ -39,11 +42,20 @@ class QueryRunner(val queryResourceFolder: String, val dataPath: String) {
       desc: String,
       caseId: String,
       explain: Boolean = false,
-      metrics: Array[String] = Array(),
+      sqlMetricMapper: MetricMapper = MetricMapper.dummy,
+      executorMetrics: Seq[String] = Nil,
       randomKillTasks: Boolean = false): QueryResult = {
     val path = "%s/%s.sql".format(queryResourceFolder, caseId)
     try {
-      val r = SparkQueryRunner.runQuery(spark, desc, path, explain, metrics, randomKillTasks)
+      val r =
+        SparkQueryRunner.runQuery(
+          spark,
+          desc,
+          path,
+          explain,
+          sqlMetricMapper,
+          executorMetrics,
+          randomKillTasks)
       println(s"Successfully ran query $caseId. Returned row count: ${r.rows.length}")
       Success(caseId, r)
     } catch {

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ShimUtils.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ShimUtils.scala
@@ -17,25 +17,25 @@
 
 package org.apache.gluten.integration
 
+import org.apache.spark.VersionUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.types.StructType
 
 object ShimUtils {
-
   def getExpressionEncoder(schema: StructType): ExpressionEncoder[Row] = {
-    try {
+    val sparkVersion = VersionUtils.majorMinorVersion()
+    if (VersionUtils.compareMajorMinorVersion(sparkVersion, (3, 5)) < 0) {
       RowEncoder.getClass
         .getMethod("apply", classOf[StructType])
         .invoke(RowEncoder, schema)
         .asInstanceOf[ExpressionEncoder[Row]]
-    } catch {
-      case _: Exception =>
-        // to be compatible with Spark 3.5 and later
-        ExpressionEncoder.getClass
-          .getMethod("apply", classOf[StructType])
-          .invoke(ExpressionEncoder, schema)
-          .asInstanceOf[ExpressionEncoder[Row]]
+    } else {
+      // to be compatible with Spark 3.5 and later
+      ExpressionEncoder.getClass
+        .getMethod("apply", classOf[StructType])
+        .invoke(ExpressionEncoder, schema)
+        .asInstanceOf[ExpressionEncoder[Row]]
     }
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Suite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Suite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.integration
 
 import org.apache.gluten.integration.action.Action
+import org.apache.gluten.integration.metrics.MetricMapper
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.history.HistoryServerHelper
@@ -44,7 +45,9 @@ abstract class Suite(
     private val disableBhj: Boolean,
     private val disableWscg: Boolean,
     private val shufflePartitions: Int,
-    private val scanPartitions: Int) {
+    private val scanPartitions: Int,
+    private val baselineMetricMapper: MetricMapper,
+    private val testMetricMapper: MetricMapper) {
 
   resetLogLevel()
 
@@ -174,6 +177,14 @@ abstract class Suite(
     testConf.clone()
   }
 
+  private[integration] def getBaselineMetricMapper(): MetricMapper = {
+    baselineMetricMapper
+  }
+
+  private[integration] def getTestMetricMapper(): MetricMapper = {
+    testMetricMapper
+  }
+
   protected def historyWritePath(): String
 
   private[integration] def dataWritePath(scale: Double, genPartitionedData: Boolean): String
@@ -185,7 +196,6 @@ abstract class Suite(
   private[integration] def allQueryIds(): Array[String]
 
   private[integration] def desc(): String
-
 }
 
 object Suite {}

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -40,7 +40,7 @@ class Parameterized(
     noSessionReuse: Boolean,
     configDimensions: Seq[Parameterized.Dim],
     excludedCombinations: Seq[Set[Parameterized.DimKv]],
-    metrics: Array[String])
+    metrics: Seq[String])
     extends Action {
   import Parameterized._
 
@@ -301,7 +301,7 @@ object Parameterized {
           coords.foreach(coord =>
             inc
               .next()
-              .write(coord.queryResult.asSuccessOption().map(_.runResult.metrics(metricName)))))
+              .write(coord.queryResult.asSuccessOption().map(_.runResult.executorMetrics(metricName)))))
         coords.foreach(coord =>
           inc
             .next()
@@ -346,9 +346,9 @@ object Parameterized {
       coordinate: Coordinate,
       desc: String,
       explain: Boolean,
-      metrics: Array[String]): TestResultLine.Coord = {
+      metrics: Seq[String]): TestResultLine.Coord = {
     val testDesc = "Query %s [%s] %s".format(desc, id, coordinate)
-    val result = runner.runQuery(spark, testDesc, id, explain, metrics)
+    val result = runner.runQuery(spark, testDesc, id, explain, executorMetrics = metrics)
     TestResultLine.Coord(coordinate, result)
   }
 
@@ -358,6 +358,6 @@ object Parameterized {
       id: String,
       coordinate: Coordinate,
       desc: String): Unit = {
-    runQuery(runner, session, id, coordinate, desc, explain = false, Array.empty)
+    runQuery(runner, session, id, coordinate, desc, explain = false, Nil)
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
@@ -16,13 +16,13 @@
  */
 package org.apache.gluten.integration.action
 
+import org.apache.gluten.integration.{QueryRunner, Suite, TableCreator}
 import org.apache.gluten.integration.QueryRunner.QueryResult
 import org.apache.gluten.integration.action.Actions.QuerySelector
 import org.apache.gluten.integration.action.TableRender.RowParser.FieldAppender.RowAppender
 import org.apache.gluten.integration.metrics.{MetricMapper, PlanMetric}
-import org.apache.gluten.integration.metrics.PlanMetric.SelfTimeReporter
 import org.apache.gluten.integration.stat.RamStat
-import org.apache.gluten.integration.{QueryRunner, Suite, TableCreator}
+
 import org.apache.spark.sql.SparkSession
 
 case class Queries(
@@ -34,7 +34,7 @@ case class Queries(
     randomKillTasks: Boolean,
     noSessionReuse: Boolean,
     metricsReporters: Seq[PlanMetric.Reporter])
-    extends Action {
+  extends Action {
   import Queries._
 
   override def execute(suite: Suite): Boolean = {
@@ -78,7 +78,8 @@ case class Queries(
       "RAM statistics: JVM Heap size: %d KiB (total %d KiB), Process RSS: %d KiB\n",
       RamStat.getJvmHeapUsed(),
       RamStat.getJvmHeapTotal(),
-      RamStat.getProcessRamUsed())
+      RamStat.getProcessRamUsed()
+    )
     println("")
 
     val sqlMetrics = succeeded.flatMap(_.queryResult.asSuccess().runResult.sqlMetrics)
@@ -145,26 +146,30 @@ object Queries {
       "Plan Time (Millis)",
       "Query Time (Millis)")
 
-    results.foreach { line =>
-      render.appendRow(line)
-    }
+    results.foreach(line => render.appendRow(line))
 
     render.print(System.out)
   }
 
   private def runQuery(
-                        runner: QueryRunner,
-                        creator: TableCreator,
-                        session: SparkSession,
-                        id: String,
-                        desc: String,
-                        explain: Boolean,
-                        metricMapper: MetricMapper,
-                        randomKillTasks: Boolean): TestResultLine = {
+      runner: QueryRunner,
+      creator: TableCreator,
+      session: SparkSession,
+      id: String,
+      desc: String,
+      explain: Boolean,
+      metricMapper: MetricMapper,
+      randomKillTasks: Boolean): TestResultLine = {
     println(s"Running query: $id...")
     val testDesc = "Query %s [%s]".format(desc, id)
     val result =
-      runner.runQuery(session, testDesc, id, explain = explain, sqlMetricMapper = metricMapper, randomKillTasks = randomKillTasks)
+      runner.runQuery(
+        session,
+        testDesc,
+        id,
+        explain = explain,
+        sqlMetricMapper = metricMapper,
+        randomKillTasks = randomKillTasks)
     TestResultLine(result)
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/TableRender.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/TableRender.scala
@@ -213,8 +213,16 @@ object TableRender {
   }
 
   object RowParser {
+    implicit object StringSeqParser extends RowParser[Seq[String]] {
+      override def parse(rowFactory: RowAppender, row: Seq[String]): Unit = {
+        val inc = rowFactory.incremental()
+        row.foreach(ceil => inc.next().write(ceil))
+      }
+    }
+
     trait FieldAppender {
       def child(name: String): FieldAppender
+
       def write(value: Any): Unit
     }
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/package.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/package.scala
@@ -40,7 +40,8 @@ package object action {
             c1.runResult.rows ++ c2.runResult.rows,
             c1.runResult.planningTimeMillis + c2.runResult.planningTimeMillis,
             c1.runResult.executionTimeMillis + c2.runResult.executionTimeMillis,
-            (c1.runResult.metrics, c2.runResult.metrics).sumUp))
+            c1.runResult.sqlMetrics ++ c2.runResult.sqlMetrics,
+            (c1.runResult.executorMetrics, c2.runResult.executorMetrics).sumUp))
       }
     }
   }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchSuite.scala
@@ -16,57 +16,59 @@
  */
 package org.apache.gluten.integration.clickbench
 
+import org.apache.gluten.integration.{DataGen, Suite, TableCreator}
 import org.apache.gluten.integration.action.Action
 import org.apache.gluten.integration.metrics.MetricMapper
-import org.apache.gluten.integration.{DataGen, Suite, TableCreator}
-import org.apache.log4j.Level
+
 import org.apache.spark.SparkConf
+
+import org.apache.log4j.Level
 
 import java.io.File
 
 /**
  * ClickBench: a Benchmark For Analytical Databases
  *
- * See the project: https://github.com/ClickHouse/ClickBench
- * Site: https://benchmark.clickhouse.com/
+ * See the project: https://github.com/ClickHouse/ClickBench Site: https://benchmark.clickhouse.com/
  */
 class ClickBenchSuite(
-                       val masterUrl: String,
-                       val actions: Array[Action],
-                       val testConf: SparkConf,
-                       val baselineConf: SparkConf,
-                       val extraSparkConf: Map[String, String],
-                       val logLevel: Level,
-                       val errorOnMemLeak: Boolean,
-                       val dataDir: String,
-                       val enableUi: Boolean,
-                       val enableHsUi: Boolean,
-                       val hsUiPort: Int,
-                       val disableAqe: Boolean,
-                       val disableBhj: Boolean,
-                       val disableWscg: Boolean,
-                       val shufflePartitions: Int,
-                       val scanPartitions: Int,
-                       val baselineMetricMapper: MetricMapper,
-                       val testMetricMapper: MetricMapper)
-    extends Suite(
-      masterUrl,
-      actions,
-      testConf,
-      baselineConf,
-      extraSparkConf,
-      logLevel,
-      errorOnMemLeak,
-      enableUi,
-      enableHsUi,
-      hsUiPort,
-      disableAqe,
-      disableBhj,
-      disableWscg,
-      shufflePartitions,
-      scanPartitions,
-      baselineMetricMapper,
-      testMetricMapper) {
+    val masterUrl: String,
+    val actions: Array[Action],
+    val testConf: SparkConf,
+    val baselineConf: SparkConf,
+    val extraSparkConf: Map[String, String],
+    val logLevel: Level,
+    val errorOnMemLeak: Boolean,
+    val dataDir: String,
+    val enableUi: Boolean,
+    val enableHsUi: Boolean,
+    val hsUiPort: Int,
+    val disableAqe: Boolean,
+    val disableBhj: Boolean,
+    val disableWscg: Boolean,
+    val shufflePartitions: Int,
+    val scanPartitions: Int,
+    val baselineMetricMapper: MetricMapper,
+    val testMetricMapper: MetricMapper)
+  extends Suite(
+    masterUrl,
+    actions,
+    testConf,
+    baselineConf,
+    extraSparkConf,
+    logLevel,
+    errorOnMemLeak,
+    enableUi,
+    enableHsUi,
+    hsUiPort,
+    disableAqe,
+    disableBhj,
+    disableWscg,
+    shufflePartitions,
+    scanPartitions,
+    baselineMetricMapper,
+    testMetricMapper
+  ) {
   import ClickBenchSuite._
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH
@@ -99,7 +101,7 @@ private object ClickBenchSuite {
   private val ALL_QUERY_IDS = (1 to 43).map(i => s"q$i").toArray
 
   private def checkDataGenArgs(scale: Double, genPartitionedData: Boolean): Unit = {
-    assert(scale == 1.0D, "ClickBench suite doesn't support scale factor other than 1")
+    assert(scale == 1.0d, "ClickBench suite doesn't support scale factor other than 1")
     assert(!genPartitionedData, "ClickBench suite doesn't support generating partitioned data")
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.integration.clickbench
 
 import org.apache.gluten.integration.action.Action
+import org.apache.gluten.integration.metrics.MetricMapper
 import org.apache.gluten.integration.{DataGen, Suite, TableCreator}
 import org.apache.log4j.Level
 import org.apache.spark.SparkConf
@@ -30,22 +31,24 @@ import java.io.File
  * Site: https://benchmark.clickhouse.com/
  */
 class ClickBenchSuite(
-    val masterUrl: String,
-    val actions: Array[Action],
-    val testConf: SparkConf,
-    val baselineConf: SparkConf,
-    val extraSparkConf: Map[String, String],
-    val logLevel: Level,
-    val errorOnMemLeak: Boolean,
-    val dataDir: String,
-    val enableUi: Boolean,
-    val enableHsUi: Boolean,
-    val hsUiPort: Int,
-    val disableAqe: Boolean,
-    val disableBhj: Boolean,
-    val disableWscg: Boolean,
-    val shufflePartitions: Int,
-    val scanPartitions: Int)
+                       val masterUrl: String,
+                       val actions: Array[Action],
+                       val testConf: SparkConf,
+                       val baselineConf: SparkConf,
+                       val extraSparkConf: Map[String, String],
+                       val logLevel: Level,
+                       val errorOnMemLeak: Boolean,
+                       val dataDir: String,
+                       val enableUi: Boolean,
+                       val enableHsUi: Boolean,
+                       val hsUiPort: Int,
+                       val disableAqe: Boolean,
+                       val disableBhj: Boolean,
+                       val disableWscg: Boolean,
+                       val shufflePartitions: Int,
+                       val scanPartitions: Int,
+                       val baselineMetricMapper: MetricMapper,
+                       val testMetricMapper: MetricMapper)
     extends Suite(
       masterUrl,
       actions,
@@ -61,7 +64,9 @@ class ClickBenchSuite(
       disableBhj,
       disableWscg,
       shufflePartitions,
-      scanPartitions) {
+      scanPartitions,
+      baselineMetricMapper,
+      testMetricMapper) {
   import ClickBenchSuite._
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsSuite.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.integration.ds
 
 import org.apache.gluten.integration.action.Action
 import org.apache.gluten.integration.ds.TpcdsSuite.{ALL_QUERY_IDS, HISTORY_WRITE_PATH, TPCDS_WRITE_RELATIVE_PATH}
+import org.apache.gluten.integration.metrics.MetricMapper
 import org.apache.gluten.integration.{DataGen, Suite, TableCreator, TypeModifier}
 import org.apache.log4j.Level
 import org.apache.spark.SparkConf
@@ -25,22 +26,24 @@ import org.apache.spark.SparkConf
 import java.io.File
 
 class TpcdsSuite(
-    val masterUrl: String,
-    val actions: Array[Action],
-    val testConf: SparkConf,
-    val baselineConf: SparkConf,
-    val extraSparkConf: Map[String, String],
-    val logLevel: Level,
-    val errorOnMemLeak: Boolean,
-    val dataDir: String,
-    val enableUi: Boolean,
-    val enableHsUi: Boolean,
-    val hsUiPort: Int,
-    val disableAqe: Boolean,
-    val disableBhj: Boolean,
-    val disableWscg: Boolean,
-    val shufflePartitions: Int,
-    val scanPartitions: Int)
+                  val masterUrl: String,
+                  val actions: Array[Action],
+                  val testConf: SparkConf,
+                  val baselineConf: SparkConf,
+                  val extraSparkConf: Map[String, String],
+                  val logLevel: Level,
+                  val errorOnMemLeak: Boolean,
+                  val dataDir: String,
+                  val enableUi: Boolean,
+                  val enableHsUi: Boolean,
+                  val hsUiPort: Int,
+                  val disableAqe: Boolean,
+                  val disableBhj: Boolean,
+                  val disableWscg: Boolean,
+                  val shufflePartitions: Int,
+                  val scanPartitions: Int,
+                  val baselineMetricMapper: MetricMapper,
+                  val testMetricMapper: MetricMapper)
     extends Suite(
       masterUrl,
       actions,
@@ -56,7 +59,9 @@ class TpcdsSuite(
       disableBhj,
       disableWscg,
       shufflePartitions,
-      scanPartitions) {
+      scanPartitions,
+      baselineMetricMapper,
+      testMetricMapper) {
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsSuite.scala
@@ -16,52 +16,55 @@
  */
 package org.apache.gluten.integration.ds
 
+import org.apache.gluten.integration.{DataGen, Suite, TableCreator, TypeModifier}
 import org.apache.gluten.integration.action.Action
 import org.apache.gluten.integration.ds.TpcdsSuite.{ALL_QUERY_IDS, HISTORY_WRITE_PATH, TPCDS_WRITE_RELATIVE_PATH}
 import org.apache.gluten.integration.metrics.MetricMapper
-import org.apache.gluten.integration.{DataGen, Suite, TableCreator, TypeModifier}
-import org.apache.log4j.Level
+
 import org.apache.spark.SparkConf
+
+import org.apache.log4j.Level
 
 import java.io.File
 
 class TpcdsSuite(
-                  val masterUrl: String,
-                  val actions: Array[Action],
-                  val testConf: SparkConf,
-                  val baselineConf: SparkConf,
-                  val extraSparkConf: Map[String, String],
-                  val logLevel: Level,
-                  val errorOnMemLeak: Boolean,
-                  val dataDir: String,
-                  val enableUi: Boolean,
-                  val enableHsUi: Boolean,
-                  val hsUiPort: Int,
-                  val disableAqe: Boolean,
-                  val disableBhj: Boolean,
-                  val disableWscg: Boolean,
-                  val shufflePartitions: Int,
-                  val scanPartitions: Int,
-                  val baselineMetricMapper: MetricMapper,
-                  val testMetricMapper: MetricMapper)
-    extends Suite(
-      masterUrl,
-      actions,
-      testConf,
-      baselineConf,
-      extraSparkConf,
-      logLevel,
-      errorOnMemLeak,
-      enableUi,
-      enableHsUi,
-      hsUiPort,
-      disableAqe,
-      disableBhj,
-      disableWscg,
-      shufflePartitions,
-      scanPartitions,
-      baselineMetricMapper,
-      testMetricMapper) {
+    val masterUrl: String,
+    val actions: Array[Action],
+    val testConf: SparkConf,
+    val baselineConf: SparkConf,
+    val extraSparkConf: Map[String, String],
+    val logLevel: Level,
+    val errorOnMemLeak: Boolean,
+    val dataDir: String,
+    val enableUi: Boolean,
+    val enableHsUi: Boolean,
+    val hsUiPort: Int,
+    val disableAqe: Boolean,
+    val disableBhj: Boolean,
+    val disableWscg: Boolean,
+    val shufflePartitions: Int,
+    val scanPartitions: Int,
+    val baselineMetricMapper: MetricMapper,
+    val testMetricMapper: MetricMapper)
+  extends Suite(
+    masterUrl,
+    actions,
+    testConf,
+    baselineConf,
+    extraSparkConf,
+    logLevel,
+    errorOnMemLeak,
+    enableUi,
+    enableHsUi,
+    hsUiPort,
+    disableAqe,
+    disableBhj,
+    disableWscg,
+    shufflePartitions,
+    scanPartitions,
+    baselineMetricMapper,
+    testMetricMapper
+  ) {
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH
 
@@ -201,6 +204,7 @@ object TpcdsSuite {
     "q96",
     "q97",
     "q98",
-    "q99")
+    "q99"
+  )
   private val HISTORY_WRITE_PATH = "/tmp/tpcds-history"
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/h/TpchSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/h/TpchSuite.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.integration.h
 
 import org.apache.gluten.integration.action.Action
 import org.apache.gluten.integration.h.TpchSuite.{HISTORY_WRITE_PATH, TPCH_WRITE_RELATIVE_PATH}
+import org.apache.gluten.integration.metrics.MetricMapper
 import org.apache.gluten.integration.{DataGen, Suite, TableCreator, TypeModifier}
 import org.apache.log4j.Level
 import org.apache.spark.SparkConf
@@ -25,22 +26,24 @@ import org.apache.spark.SparkConf
 import java.io.File
 
 class TpchSuite(
-    val masterUrl: String,
-    val actions: Array[Action],
-    val testConf: SparkConf,
-    val baselineConf: SparkConf,
-    val extraSparkConf: Map[String, String],
-    val logLevel: Level,
-    val errorOnMemLeak: Boolean,
-    val dataDir: String,
-    val enableUi: Boolean,
-    val enableHsUi: Boolean,
-    val hsUiPort: Int,
-    val disableAqe: Boolean,
-    val disableBhj: Boolean,
-    val disableWscg: Boolean,
-    val shufflePartitions: Int,
-    val scanPartitions: Int)
+                 val masterUrl: String,
+                 val actions: Array[Action],
+                 val testConf: SparkConf,
+                 val baselineConf: SparkConf,
+                 val extraSparkConf: Map[String, String],
+                 val logLevel: Level,
+                 val errorOnMemLeak: Boolean,
+                 val dataDir: String,
+                 val enableUi: Boolean,
+                 val enableHsUi: Boolean,
+                 val hsUiPort: Int,
+                 val disableAqe: Boolean,
+                 val disableBhj: Boolean,
+                 val disableWscg: Boolean,
+                 val shufflePartitions: Int,
+                 val scanPartitions: Int,
+                 val baselineMetricMapper: MetricMapper,
+                 val testMetricMapper: MetricMapper)
     extends Suite(
       masterUrl,
       actions,
@@ -56,7 +59,9 @@ class TpchSuite(
       disableBhj,
       disableWscg,
       shufflePartitions,
-      scanPartitions) {
+      scanPartitions,
+      baselineMetricMapper,
+      testMetricMapper) {
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricMapper.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricMapper.scala
@@ -48,7 +48,7 @@ object MetricMapper {
         case other => Seq(other)
       }
 
-    def andThen(
+    def +(
         other: MetricMapper): MetricMapper = {
       new ChainedTypeMetricMapper(unwrap(mapper) ++ unwrap(other))
     }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricMapper.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricMapper.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gluten.integration.metrics
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+trait MetricMapper {
+  def map(node: SparkPlan, key: String, metric: SQLMetric): Seq[MetricTag[_]]
+}
+
+object MetricMapper {
+  val dummy: MetricMapper = (node: SparkPlan, key: String, metric: SQLMetric) => Nil
+
+  case class SelfTimeMapper(selfTimeKeys: Map[String, Set[String]])
+    extends MetricMapper {
+    override def map(node: SparkPlan, key: String, metric: SQLMetric): Seq[MetricTag[_]] = {
+      val className = node.getClass.getSimpleName
+      if (selfTimeKeys.contains(className)) {
+        if (selfTimeKeys(className).contains(key)) {
+          return Seq(MetricTag.IsSelfTime())
+        }
+      }
+      Nil
+    }
+  }
+
+  implicit class TypedMetricMapperOps(mapper: MetricMapper) {
+    private def unwrap(
+        mapper: MetricMapper): Seq[MetricMapper] =
+      mapper match {
+        case c: ChainedTypeMetricMapper => c.mappers
+        case other => Seq(other)
+      }
+
+    def andThen(
+        other: MetricMapper): MetricMapper = {
+      new ChainedTypeMetricMapper(unwrap(mapper) ++ unwrap(other))
+    }
+  }
+
+  private class ChainedTypeMetricMapper(val mappers: Seq[MetricMapper])
+    extends MetricMapper {
+    assert(!mappers.exists(_.isInstanceOf[ChainedTypeMetricMapper]))
+    override def map(node: SparkPlan, key: String, metric: SQLMetric): Seq[MetricTag[_]] = {
+      mappers.flatMap(m => m.map(node, key, metric))
+    }
+  }
+}

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricMapper.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricMapper.scala
@@ -48,7 +48,7 @@ object MetricMapper {
         case other => Seq(other)
       }
 
-    def +(
+    def and(
         other: MetricMapper): MetricMapper = {
       new ChainedTypeMetricMapper(unwrap(mapper) ++ unwrap(other))
     }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricTag.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricTag.scala
@@ -1,0 +1,22 @@
+package org.apache.gluten.integration.metrics
+
+import scala.reflect.{ClassTag, classTag}
+
+trait MetricTag[T] {
+  import MetricTag._
+  final def name(): String = nameOf(ClassTag(this.getClass))
+  def value(): T
+}
+
+object MetricTag {
+  def nameOf[T <: MetricTag[_]: ClassTag]: String = {
+    val clazz = classTag[T].runtimeClass
+    assert(classOf[MetricTag[_]].isAssignableFrom(clazz))
+    clazz.getSimpleName
+  }
+  case class IsSelfTime() extends MetricTag[Nothing] {
+    override def value(): Nothing = {
+      throw new UnsupportedOperationException()
+    }
+  }
+}

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricTag.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/MetricTag.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gluten.integration.metrics
 
 import scala.reflect.{ClassTag, classTag}

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -49,6 +49,11 @@ case class PlanMetric(
 }
 
 object PlanMetric {
+  def newReporter(`type`: String): Reporter = `type` match {
+    case "execution-time" => new SelfTimeReporter(10)
+    case other => throw new IllegalArgumentException(s"Metric reporter type $other not defined")
+  }
+
   sealed trait Reporter {
     def toString(metrics: Seq[PlanMetric]): String
   }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gluten.integration.metrics
+
+import org.apache.gluten.integration.action.TableRender
+import org.apache.gluten.integration.action.TableRender.Field.Leaf
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+import org.apache.commons.io.output.ByteArrayOutputStream
+
+import java.io.File
+import java.nio.charset.Charset
+
+import scala.reflect.{classTag, ClassTag}
+
+case class PlanMetric(
+    queryPath: String,
+    plan: SparkPlan,
+    key: String,
+    metric: SQLMetric,
+    tags: Map[String, Seq[MetricTag[_]]]) {
+
+  def containsTags[T <: MetricTag[_]: ClassTag]: Boolean = {
+    val name = MetricTag.nameOf[T]
+    tags.contains(name)
+  }
+  def getTags[T <: MetricTag[_]: ClassTag]: Seq[T] = {
+    require(containsTags[T])
+    val name = MetricTag.nameOf[T]
+    tags(name).asInstanceOf[Seq[T]]
+  }
+}
+
+object PlanMetric {
+  sealed trait Reporter {
+    def toString(metrics: Seq[PlanMetric]): String
+  }
+
+  class SelfTimeReporter(topN: Int) extends Reporter {
+    override def toString(metrics: Seq[PlanMetric]): String = {
+      val sb = new StringBuilder()
+      val selfTimes = metrics
+        .filter(_.containsTags[MetricTag.IsSelfTime])
+      val sorted = selfTimes.sortBy(_.metric.value)(Ordering.Long.reverse)
+      sb.append(s"Top $topN plan nodes that took longest time to execute: ")
+      sb.append(System.lineSeparator())
+      sb.append(System.lineSeparator())
+      val tr: TableRender[Seq[String]] =
+        TableRender.create(
+          Leaf("Query"),
+          Leaf("Node ID"),
+          Leaf("Node Name"),
+          Leaf("Execution Time (ms)"))
+      for (i <- 0 until (topN.min(sorted.size))) {
+        val m = sorted(i)
+        val f = new File(m.queryPath).toPath.getFileName.toString
+        tr.appendRow(
+          Seq(
+            f,
+            m.plan.id.toString,
+            m.plan.nodeName,
+            s"[${m.metric.name.getOrElse("")}] ${m.metric.value.toString}"))
+      }
+      val out = new ByteArrayOutputStream()
+      tr.print(out)
+      sb.append(out.toString(Charset.defaultCharset))
+      sb.toString()
+    }
+  }
+}

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -65,7 +65,6 @@ object PlanMetric {
     }
 
     override def toString(metrics: Seq[PlanMetric]): String = {
-
       val sb = new StringBuilder()
       val selfTimes = metrics
         .filter(_.containsTags[MetricTag.IsSelfTime])

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -59,11 +59,12 @@ object PlanMetric {
   }
 
   class SelfTimeReporter(topN: Int) extends Reporter {
+    private def toNanoTime(m: SQLMetric): Long = m.metricType match {
+      case "nsTiming" => m.value
+      case "timing" => m.value * 1000000
+    }
+
     override def toString(metrics: Seq[PlanMetric]): String = {
-      def toNanoTime(m: SQLMetric): Long = m.metricType match {
-        case "nsTiming" => m.value
-        case "timing" => m.value * 1000000
-      }
 
       val sb = new StringBuilder()
       val selfTimes = metrics

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -72,7 +72,7 @@ object PlanMetric {
           Leaf("Query"),
           Leaf("Node ID"),
           Leaf("Node Name"),
-          Leaf("Execution Time (ms)"))
+          Leaf("Execution Time (ns)"))
       for (i <- 0 until (topN.min(sorted.size))) {
         val m = sorted(i)
         val f = new File(m.queryPath).toPath.getFileName.toString

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -28,7 +28,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream
 import java.io.File
 import java.nio.charset.Charset
 
-import scala.reflect.{classTag, ClassTag}
+import scala.reflect.ClassTag
 
 case class PlanMetric(
     queryPath: String,

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/VersionUtils.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/VersionUtils.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+object VersionUtils {
+  def majorMinorVersion(): (Int, Int) = {
+    org.apache.spark.util.VersionUtils.majorMinorVersion(org.apache.spark.SPARK_VERSION)
+  }
+
+  // Returns X. X < 0 if one < other, x == 0 if one == other, x > 0 if one > other.
+  def compareMajorMinorVersion(one: (Int, Int), other: (Int, Int)): Int = {
+    val base = 1000
+    assert(one._2 < base && other._2 < base)
+    one._1 * base + one._2 - (other._1 * base + other._2)
+  }
+}

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/deploy/history/GlutenItHistoryServerPlugin.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/deploy/history/GlutenItHistoryServerPlugin.scala
@@ -117,7 +117,7 @@ class GlutenItHistoryServerPlugin extends AppHistoryServerPlugin {
     Seq()
   }
 
-  override def setupUI(ui: _root_.org.apache.spark.ui.SparkUI): Unit = {
+  override def setupUI(ui: org.apache.spark.ui.SparkUI): Unit = {
     // no-op
   }
 }

--- a/tools/gluten-it/common/src/test/java/org/apache/gluten/integration/action/TableRenderTest.scala
+++ b/tools/gluten-it/common/src/test/java/org/apache/gluten/integration/action/TableRenderTest.scala
@@ -26,12 +26,7 @@ object TableRenderTest {
   def case0(): Unit = {
     val render: TableRender[Seq[String]] = TableRender.create(
       Branch("ABC", List(Branch("AB", List(Leaf("A"), Leaf("B"))), Leaf("C"))),
-      Branch("DE", List(Leaf("D"), Leaf("E"))))(new RowParser[Seq[String]] {
-      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
-        val inc = rowFactory.incremental()
-        row.foreach(ceil => inc.next().write(ceil))
-      }
-    })
+      Branch("DE", List(Leaf("D"), Leaf("E"))))
     render.print(Console.out)
     Console.out.println()
   }
@@ -39,12 +34,7 @@ object TableRenderTest {
   def case1(): Unit = {
     val render: TableRender[Seq[String]] = TableRender.create(
       Branch("ABC", List(Branch("AB", List(Leaf("A"), Leaf("B"))), Leaf("C"))),
-      Branch("DE", List(Leaf("D"), Leaf("E"))))(new RowParser[Seq[String]] {
-      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
-        val inc = rowFactory.incremental()
-        row.foreach(ceil => inc.next().write(ceil))
-      }
-    })
+      Branch("DE", List(Leaf("D"), Leaf("E"))))
 
     render.appendRow(List("aaaa", "b", "cccccc", "d", "eeeee"))
     render.print(Console.out)
@@ -54,12 +44,7 @@ object TableRenderTest {
   def case2(): Unit = {
     val render: TableRender[Seq[String]] = TableRender.create(
       Branch("ABC", List(Branch("AAAAAAAAABBBBBB", List(Leaf("A"), Leaf("B"))), Leaf("C"))),
-      Branch("DE", List(Leaf("D"), Leaf("E"))))(new RowParser[Seq[String]] {
-      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
-        val inc = rowFactory.incremental()
-        row.foreach(ceil => inc.next().write(ceil))
-      }
-    })
+      Branch("DE", List(Leaf("D"), Leaf("E"))))
 
     render.appendRow(List("aaaa", "b", "cccccc", "d", "eeeee"))
     render.print(Console.out)
@@ -69,12 +54,7 @@ object TableRenderTest {
   def case3(): Unit = {
     val render: TableRender[Seq[String]] = TableRender.create(
       Branch("ABC", List(Branch("AB", List(Leaf("A"), Leaf("B"))), Leaf("CCCCCCCCCCCCC"))),
-      Branch("DE", List(Leaf("D"), Leaf("E"))))(new RowParser[Seq[String]] {
-      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
-        val inc = rowFactory.incremental()
-        row.foreach(ceil => inc.next().write(ceil))
-      }
-    })
+      Branch("DE", List(Leaf("D"), Leaf("E"))))
 
     render.appendRow(List("aaaa", "b", "cccccc", "d", "eeeee"))
     render.appendRow(List("aaaaaaaaaaaaa", "b", "cccccc", "ddddddddddd", "eeeee"))
@@ -87,12 +67,7 @@ object TableRenderTest {
       Branch(
         "ABBBBBBBBBBBBBBBBBBBBBBBBBBBBC",
         List(Branch("AB", List(Leaf("A"), Leaf("B"))), Leaf("C"))),
-      Branch("DE", List(Leaf("D"), Leaf("E"))))(new RowParser[Seq[String]] {
-      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
-        val inc = rowFactory.incremental()
-        row.foreach(ceil => inc.next().write(ceil))
-      }
-    })
+      Branch("DE", List(Leaf("D"), Leaf("E"))))
 
     render.appendRow(List("aaaa", "b", "cccccc", "d", "eeeee"))
     render.print(Console.out)
@@ -104,12 +79,7 @@ object TableRenderTest {
     val render: TableRender[Seq[String]] = TableRender.create(
       Leaf("Query ID"),
       Branch("Succeeded", leafs),
-      Branch("Row Count", leafs))(new RowParser[Seq[String]] {
-      override def parse(rowFactory: FieldAppender.RowAppender, row: Seq[String]): Unit = {
-        val inc = rowFactory.incremental()
-        row.foreach(ceil => inc.next().write(ceil))
-      }
-    })
+      Branch("Row Count", leafs))
 
     render.appendRow(
       List("q1", "true", "true", "true && true && true && true", "true", "1", "1", "1", "1"))


### PR DESCRIPTION
New option `--collect-sql-metrics=execution-time` to make user be able to find out the top 10 query plan nodes that took longest time to execute in the benchmark report.

The option is only available with subcommand `gluten-it queries` at the moment.

For example, run:
```
<gluten-it> queries --local --data-gen=once --enable-history --collect-sql-metrics=execution-time
```

The test report will include:
```
Top 10 plan nodes that took longest time to execute: 

|  Query  | Node ID |         Node Name         |     Execution Time (ns)     |
|---------|---------|---------------------------|-----------------------------|
|   q1.sql|      573|     ProjectExecTransformer|  [time of project] 776031999|
|   q2.sql|     1299|  ColumnarBroadcastExchange|  [time to collect] 769000000|
|   q2.sql|     1241|  ColumnarBroadcastExchange|  [time to collect] 457000000|
|   q3.sql|     3327|  ColumnarBroadcastExchange|  [time to collect] 401000000|
|  q21.sql|    20047|  ColumnarBroadcastExchange|  [time to collect] 396000000|
|   q3.sql|     3272|  ColumnarBroadcastExchange|  [time to collect] 373000000|
|  q21.sql|    19991|  ColumnarBroadcastExchange|  [time to collect] 357000000|
|   q2.sql|     1001|  ColumnarBroadcastExchange|  [time to collect] 328000000|
|  q18.sql|    17275|  ColumnarBroadcastExchange|  [time to collect] 326000000|
|   q9.sql|     9866|  ColumnarBroadcastExchange|  [time to collect] 322000000|
```

