### PR TITLE
[VL] Remove an out-of-date warning message

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -280,10 +280,6 @@ void VeloxBackend::initConnector() {
       ioThreads >= 0,
       kVeloxIOThreads + " was set to negative number " + std::to_string(ioThreads) + ", this should not happen.");
   if (ioThreads > 0) {
-    LOG(WARNING)
-        << "Velox background IO threads is enabled. Which is highly unrecommended as of now, since it may cause"
-        << " some unexpected issues like query crash or hanging. Please turn it off if you are unsure about"
-        << " this option.";
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads);
   }
   velox::connector::registerConnector(std::make_shared<velox::connector::hive::HiveConnector>(

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
@@ -46,7 +46,7 @@ public class Parameterized implements Callable<Integer> {
   @CommandLine.Option(names = {"--warmup-iterations"}, description = "Dry-run iterations before actually run the test", defaultValue = "0")
   private int warmupIterations;
 
-  @CommandLine.Option(names = {"-m", "--metric"}, description = "Specify a series of metrics to collect during execution")
+  @CommandLine.Option(names = {"-m", "--metric"}, description = "Specify a series of executor metrics to collect during execution")
   private String[] metrics = new String[0];
 
   @CommandLine.Option(names = {"-d", "--dim"}, description = "Set a series of dimensions consisting of possible config options, example: -d=offheap:1g,spark.memory.offHeap.enabled=true,spark.memory.offHeap.size=1g")

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
@@ -44,7 +44,7 @@ public class Queries implements Callable<Integer> {
   @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Every single task will get killed and retried after running for some time", defaultValue = "false")
   private boolean randomKillTasks;
 
-  @CommandLine.Option(names = {"--collect-sql-metrics"}, description = "Collect SQL metrics from run queries and generate a simple report based on them. Available types: execution-time")
+  @CommandLine.Option(names = {"--sql-metrics"}, description = "Collect SQL metrics from run queries and generate a simple report based on them. Available types: execution-time")
   private Set<String> collectSqlMetrics = Collections.emptySet();
 
   @Override


### PR DESCRIPTION
This is a follow-up minor fix for https://github.com/apache/incubator-gluten/pull/7845.

Enabling Velox background IO thread now no longer causes hanging or dead lock issues. Remove the related warning message which could be misleading for users.

Also, simplify gluten-it option `--collect-sql-metrics` which is introduced in https://github.com/apache/incubator-gluten/pull/8445 to `--sql-metrics`.