### PR TITLE
[VL] Fix wrong warning of "Memory overhead is set to ..." under default Spark config settings

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -67,10 +67,11 @@ class VeloxListenerApi extends ListenerApi with Logging {
         ByteUnit.BYTE.toMiB(desiredOverheadSize).toString)
     }
     val overheadSize: Long = SparkResourceUtil.getMemoryOverheadSize(conf)
-    if (overheadSize < desiredOverheadSize) {
+    if (ByteUnit.BYTE.toMiB(overheadSize) < ByteUnit.BYTE.toMiB(desiredOverheadSize)) {
       logWarning(
-        s"Memory overhead is set to $overheadSize which is smaller than the recommended size" +
-          s" $desiredOverheadSize. This may cause OOM.")
+        s"Memory overhead is set to ${ByteUnit.BYTE.toMiB(overheadSize)}MiB which is smaller than" +
+          s" the recommended size ${ByteUnit.BYTE.toMiB(desiredOverheadSize)}MiB." +
+          s" This may cause OOM.")
     }
     conf.set(GlutenConfig.GLUTEN_OVERHEAD_SIZE_IN_BYTES_KEY, overheadSize.toString)
 


### PR DESCRIPTION
This is a minor fix for warning "Memory overhead is set to ..." that is sometimes unexpectedly appearing, which is because of the incorrect precision of the overhead vs desired overhead comparison.