### PR TITLE
[GLUTEN-8453] [VL] Allow Heavy Batch to be Processed by ColumnarCachedBatchSerializer

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -17,8 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.columnarbatch.{ColumnarBatches, VeloxColumnarBatches}
 import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
@@ -171,11 +170,24 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with Logging {
       conf: SQLConf): RDD[CachedBatch] = {
     input.mapPartitions {
       it =>
+        val lightBatches = it.map {
+          /* Native code needs a Velox offloaded batch, making sure to offload
+             if heavy batch is encountered */
+          batch =>
+            val heavy = ColumnarBatches.isHeavyBatch(batch)
+            if (heavy) {
+              val offloaded = VeloxColumnarBatches.toVeloxBatch(
+                ColumnarBatches.offload(ArrowBufferAllocators.contextInstance(), batch))
+              offloaded
+            } else {
+              batch
+            }
+        }
         new Iterator[CachedBatch] {
-          override def hasNext: Boolean = it.hasNext
+          override def hasNext: Boolean = lightBatches.hasNext
 
           override def next(): CachedBatch = {
-            val batch = it.next()
+            val batch = lightBatches.next()
             val results =
               ColumnarBatchSerializerJniWrapper
                 .create(

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.{ColumnarBatches, VeloxColumnarBatches}
+import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators

--- a/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
@@ -85,8 +85,7 @@ public final class ColumnarBatches {
   }
 
   /** Heavy batch: Data is readable from JVM and formatted as Arrow data. */
-  @VisibleForTesting
-  static boolean isHeavyBatch(ColumnarBatch batch) {
+  public static boolean isHeavyBatch(ColumnarBatch batch) {
     return identifyBatchType(batch) == BatchType.HEAVY;
   }
 
@@ -94,8 +93,7 @@ public final class ColumnarBatches {
    * Light batch: Data is not readable from JVM, a long int handle (which is a pointer usually) is
    * used to bind the batch to a native side implementation.
    */
-  @VisibleForTesting
-  static boolean isLightBatch(ColumnarBatch batch) {
+  public static boolean isLightBatch(ColumnarBatch batch) {
     return identifyBatchType(batch) == BatchType.LIGHT;
   }
 
@@ -230,7 +228,8 @@ public final class ColumnarBatches {
     if (input.numCols() == 0) {
       throw new IllegalArgumentException("batch with zero columns cannot be offloaded");
     }
-    // Batch-offloading doesn't involve any backend-specific native code. Use the internal
+    // Batch-offloading doesn't involve any backend-specific native code. Use the
+    // internal
     // backend to store native batch references only.
     final Runtime runtime =
         Runtimes.contextInstance(INTERNAL_BACKEND_KIND, "ColumnarBatches#offload");


### PR DESCRIPTION
 - Currently the ColumnarCachedBatchSerializer does not support Arrow Heavy Batch.
 - ColumnarCachedBatchSerializer expects light batch to offload to native. (In most cases it receives an already offloaded, however fails when the input is a heavy batch).
 - Added conversion to offload it if the upstream operator produced an ArrowJavaBatch.
 - Also makes the check light/heavy batch public, since they can be good utility functions and don't have critical logic inside.
 - Note: This is a fix which will make it work, but ideally it should work with RAS and be compatible with the transitions added, to do this we can wrap the InMemoryTableScanExec and register as a Gluten operator to elegantly offload. I'll investigate as part 2
 