### PR TITLE
[GLUTEN-8462][CORE] Raise a meaningful error when no component is found from classpath

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -39,7 +39,7 @@ package object component extends Logging {
     val components = Component.sortedUnsafe()
     require(
       components.nonEmpty,
-      s"No component found in container directories named with " +
+      s"No component files found in container directories named with " +
         s"'META-INF/gluten-components' from classpath. JVM classpath value " +
         s"is: ${System.getProperty("java.class.path")}"
     )

--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -37,9 +37,12 @@ package object component extends Logging {
     // Output log so user could view the component loading order.
     // Call #sortedUnsafe than on #sorted to avoid unnecessary recursion.
     val components = Component.sortedUnsafe()
-    require(components.nonEmpty, s"No component found in container directories named with " +
-      s"\"META-INF/gluten-components\" from classpath. JVM classpath value " +
-      s"is: ${System.getProperty("java.class.path")}")
+    require(
+      components.nonEmpty,
+      s"No component found in container directories named with " +
+        s"\"META-INF/gluten-components\" from classpath. JVM classpath value " +
+        s"is: ${System.getProperty("java.class.path")}"
+    )
     logInfo(s"Components registered within order: ${components.map(_.name()).mkString(", ")}")
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -40,7 +40,7 @@ package object component extends Logging {
     require(
       components.nonEmpty,
       s"No component found in container directories named with " +
-        s"\"META-INF/gluten-components\" from classpath. JVM classpath value " +
+        s"'META-INF/gluten-components' from classpath. JVM classpath value " +
         s"is: ${System.getProperty("java.class.path")}"
     )
     logInfo(s"Components registered within order: ${components.map(_.name()).mkString(", ")}")

--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -37,6 +37,9 @@ package object component extends Logging {
     // Output log so user could view the component loading order.
     // Call #sortedUnsafe than on #sorted to avoid unnecessary recursion.
     val components = Component.sortedUnsafe()
+    require(components.nonEmpty, s"No component found in container directories named with " +
+      s"\"META-INF/gluten-components\" from classpath. JVM classpath value " +
+      s"is: ${System.getProperty("java.class.path")}")
     logInfo(s"Components registered within order: ${components.map(_.name()).mkString(", ")}")
   }
 }


### PR DESCRIPTION
When no component files (with name `META-INF/gluten-components/<classname>`) found from classpath, raise an error instead of running into UB.