### PR TITLE
[GLUTEN-8471][VL] Fix usage of uninitialized variables

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -126,7 +126,7 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
   uint64_t shrinkCapacity(uint64_t targetBytes, bool allowSpill, bool allowAbort) override {
     velox::memory::ScopedMemoryArbitrationContext ctx{};
     facebook::velox::exec::MemoryReclaimer::Stats status;
-    velox::memory::MemoryPool* pool;
+    velox::memory::MemoryPool* pool = nullptr;
     {
       std::unique_lock guard{mutex_};
       VELOX_CHECK_EQ(candidates_.size(), 1, "ListenableArbitrator should only be used within a single root pool");
@@ -178,7 +178,7 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
     return freeBytes;
   }
 
-  gluten::AllocationListener* listener_;
+  gluten::AllocationListener* listener_ = nullptr;
   const uint64_t memoryPoolInitialCapacity_; // FIXME: Unused.
   const uint64_t memoryPoolTransferCapacity_;
   const uint64_t memoryReclaimMaxWaitMs_;


### PR DESCRIPTION
Use of Uninitialized Variables

false positives(mainly since the file was most likely deleted and only contains 1480 lines now. Went over that file and tried to find any other Uninitialized Variables and change them accordingly. There is 9 FP below and also 9 changes in that file after taking a look at what could have been the line numbers):
cpp/velox/substrait/[SubstraitToVeloxPlan.cc:1902](http://substraittoveloxplan.cc:1902/)
cpp/velox/substrait/SubstraitToVeloxPlan.cc:1762
cpp/velox/substrait/SubstraitToVeloxPlan.cc:1680
cpp/velox/substrait/SubstraitToVeloxPlan.cc:1653
cpp/velox/substrait/SubstraitToVeloxPlan.cc:1927
pp/velox/substrait/SubstraitToVeloxPlan.cc:2539
cpp/velox/substrait/SubstraitToVeloxPlan.cc:1960
cpp/velox/substrait/SubstraitToVeloxPlan.cc:1932
cpp/velox/substrait/SubstraitToVeloxPlan.cc:2441


(Fixes: \#8471)