### PR TITLE
[GLUTEN-8475][VL] Fix C-style casts to C++-style

### DIFF
--- a/cpp/core/benchmarks/CompressionBenchmark.cc
+++ b/cpp/core/benchmarks/CompressionBenchmark.cc
@@ -114,7 +114,7 @@ class BenchmarkCompression {
     setCpu(state.range(2) + state.thread_index());
     auto ipcWriteOptions = arrow::ipc::IpcWriteOptions::Defaults();
     ipcWriteOptions.use_threads = false;
-    auto compressBufferSize = (uint32_t)state.range(1);
+    auto compressBufferSize = static_cast<uint32_t>(state.range(1));
     auto compressionType = state.range(0);
     switch (compressionType) {
       case gluten::kLZ4: {
@@ -253,7 +253,7 @@ class BenchmarkCompression {
           GLUTEN_ASSIGN_OR_THROW(
               auto len,
               codec->Decompress(buffers[j]->size() - 8, buffers[j]->data() + 8, outputSize, out->mutable_data()));
-          (void)len;
+          static_cast<void>(len);
         }
       }
     }

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -162,7 +162,7 @@ bool StdMemoryAllocator::reallocateAligned(void* p, uint64_t alignment, int64_t 
     return false;
   }
   if (newSize <= size) {
-    auto aligned = ROUND_TO_LINE(newSize, alignment);
+    auto aligned = ROUND_TO_LINE(static_cast<uint64_t>(newSize), alignment);
     if (aligned <= size) {
       // shrink-to-fit
       return reallocate(p, size, aligned, out);

--- a/cpp/core/shuffle/Spill.cc
+++ b/cpp/core/shuffle/Spill.cc
@@ -25,7 +25,7 @@ Spill::Spill(Spill::SpillType type) : type_(type) {}
 
 Spill::~Spill() {
   if (is_) {
-    (void)is_->Close();
+    static_cast<void>(is_->Close());
   }
 }
 

--- a/cpp/core/utils/qat/QatCodec.cc
+++ b/cpp/core/utils/qat/QatCodec.cc
@@ -38,8 +38,8 @@ class QatZipCodec : public arrow::util::Codec {
   explicit QatZipCodec(int compressionLevel) : compressionLevel_(compressionLevel) {}
 
   ~QatZipCodec() {
-    (void)qzTeardownSession(&qzSession_);
-    (void)qzClose(&qzSession_);
+    static_cast<void>(qzTeardownSession(&qzSession_));
+    static_cast<void>(qzClose(&qzSession_));
   }
 
   arrow::Result<int64_t> Decompress(int64_t inputLen, const uint8_t* input, int64_t outputLen, uint8_t* output)

--- a/cpp/core/utils/qpl/QplCodec.cc
+++ b/cpp/core/utils/qpl/QplCodec.cc
@@ -203,7 +203,7 @@ class QplGzipCodec final : public arrow::util::Codec {
   int64_t MaxCompressedLen(int64_t input_len, const uint8_t* ARROW_ARG_UNUSED(input)) override {
     ARROW_DCHECK_GE(input_len, 0);
     /// Aligned with ZLIB
-    return ((input_len) + ((input_len) >> 12) + ((input_len) >> 14) + ((input_len) >> 25) + 13);
+    return ((input_len) + ((input_len) >> 12) + ((input_len) >> 14) + ((input_len) >> 25) + 13LL);
   }
 
   arrow::Result<std::shared_ptr<arrow::util::Compressor>> MakeCompressor() override {

--- a/cpp/velox/jni/JniFileSystem.cc
+++ b/cpp/velox/jni/JniFileSystem.cc
@@ -338,11 +338,12 @@ class JniFileSystem : public facebook::velox::filesystems::FileSystem {
     JNIEnv* env = nullptr;
     attachCurrentThreadAsDaemonOrThrow(vm, &env);
     std::vector<std::string> out;
-    jobjectArray jarray = (jobjectArray)env->CallObjectMethod(obj_, jniFileSystemList, createJString(env, path));
+    jobjectArray jarray =
+        static_cast<jobjectArray>(env->CallObjectMethod(obj_, jniFileSystemList, createJString(env, path)));
     checkException(env);
     jsize length = env->GetArrayLength(jarray);
     for (jsize i = 0; i < length; ++i) {
-      jstring element = (jstring)env->GetObjectArrayElement(jarray, i);
+      jstring element = static_cast<jstring>(env->GetObjectArrayElement(jarray, i));
       std::string cElement = jStringToCString(env, element);
       out.push_back(cElement);
     }

--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -80,7 +80,7 @@ void VeloxColumnarToRowConverter::convert(std::shared_ptr<ColumnarBatch> cb, int
 
   size_t offset = 0;
   for (auto i = 0; i < numRows_; ++i) {
-    auto rowSize = fast_->serialize(startRow + i, (char*)(bufferAddress_ + offset));
+    auto rowSize = fast_->serialize(startRow + i, reinterpret_cast<char*>(bufferAddress_ + offset));
     lengths_[i] = rowSize;
     if (i > 0) {
       offsets_[i] = offsets_[i - 1] + lengths_[i - 1];

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -35,7 +35,7 @@ inline int64_t getFieldOffset(int64_t nullBitsetWidthInBytes, int32_t index) {
 inline bool isNull(uint8_t* buffer_address, int32_t index) {
   int64_t mask = 1L << (static_cast<int64_t>(index) & 0x3f); // mod 64 and shift
   int64_t wordOffset = (static_cast<int64_t>(index) >> 6) * 8;
-  int64_t value = *((int64_t*)(buffer_address + wordOffset));
+  int64_t value = *reinterpret_cast<int64_t*>(buffer_address + wordOffset);
   return (value & mask) != 0;
 }
 
@@ -51,7 +51,7 @@ int32_t getTotalStringSize(
       continue;
     }
 
-    int64_t offsetAndSize = *(int64_t*)(memoryAddress + offsets[pos] + fieldOffset);
+    int64_t offsetAndSize = *(reinterpret_cast<int64_t*>(memoryAddress + offsets[pos] + fieldOffset));
     int32_t length = static_cast<int32_t>(offsetAndSize);
     if (!StringView::isInline(length)) {
       size += length;
@@ -98,11 +98,11 @@ VectorPtr createFlatVector<TypeKind::HUGEINT>(
   auto column = BaseVector::create<FlatVector<int128_t>>(type, numRows, pool);
   auto rawValues = column->mutableRawValues<uint8_t>();
   auto typeWidth = sizeof(int128_t);
-  auto shift = __builtin_ctz((uint32_t)typeWidth);
+  auto shift = __builtin_ctz(static_cast<uint32_t>(typeWidth));
   for (auto pos = 0; pos < numRows; pos++) {
     if (!isNull(memoryAddress + offsets[pos], columnIdx)) {
       uint8_t* destptr = rawValues + (pos << shift);
-      int64_t offsetAndSize = *(int64_t*)(memoryAddress + offsets[pos] + fieldOffset);
+      int64_t offsetAndSize = *reinterpret_cast<int64_t*>(memoryAddress + offsets[pos] + fieldOffset);
       int32_t length = static_cast<int32_t>(offsetAndSize);
       int32_t wordoffset = static_cast<int32_t>(offsetAndSize >> 32);
       uint8_t bytesValue[length];
@@ -111,7 +111,7 @@ VectorPtr createFlatVector<TypeKind::HUGEINT>(
       for (int k = length - 1; k >= 0; k--) {
         bytesValue2[length - 1 - k] = bytesValue[k];
       }
-      if (int8_t(bytesValue[0]) < 0) {
+      if (static_cast<int8_t>(bytesValue[0]) < 0) {
         memset(bytesValue2 + length, 255, 16 - length);
       }
       memcpy(destptr, bytesValue2, typeWidth);
@@ -135,7 +135,7 @@ VectorPtr createFlatVector<TypeKind::BOOLEAN>(
   auto rawValues = column->mutableRawValues<uint64_t>();
   for (auto pos = 0; pos < numRows; pos++) {
     if (!isNull(memoryAddress + offsets[pos], columnIdx)) {
-      bool value = *(bool*)(memoryAddress + offsets[pos] + fieldOffset);
+      bool value = *(reinterpret_cast<bool*>(memoryAddress + offsets[pos] + fieldOffset));
       bits::setBit(rawValues, pos, value);
     } else {
       column->setNull(pos, true);
@@ -156,7 +156,7 @@ VectorPtr createFlatVector<TypeKind::TIMESTAMP>(
   auto column = BaseVector::create<FlatVector<Timestamp>>(type, numRows, pool);
   for (auto pos = 0; pos < numRows; pos++) {
     if (!isNull(memoryAddress + offsets[pos], columnIdx)) {
-      int64_t value = *(int64_t*)(memoryAddress + offsets[pos] + fieldOffset);
+      int64_t value = *reinterpret_cast<int64_t*>(memoryAddress + offsets[pos] + fieldOffset);
       column->set(pos, Timestamp::fromMicros(value));
     } else {
       column->setNull(pos, true);
@@ -178,7 +178,7 @@ VectorPtr createFlatVectorStringView(
   char* rawBuffer = column->getRawStringBufferWithSpace(size, true);
   for (auto pos = 0; pos < numRows; pos++) {
     if (!isNull(memoryAddress + offsets[pos], columnIdx)) {
-      int64_t offsetAndSize = *(int64_t*)(memoryAddress + offsets[pos] + fieldOffset);
+      int64_t offsetAndSize = *(reinterpret_cast<int64_t*>(memoryAddress + offsets[pos] + fieldOffset));
       int32_t length = static_cast<int32_t>(offsetAndSize);
       int32_t wordoffset = static_cast<int32_t>(offsetAndSize >> 32);
       auto valueSrcPtr = memoryAddress + offsets[pos] + wordoffset;

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -440,7 +440,7 @@ std::shared_ptr<ColumnarBatch> VeloxSortShuffleReaderDeserializer::deserializeTo
     auto buffer = cur->second;
     const auto* rawBuffer = buffer->as<char>();
     while (rowOffset_ < cur->first && readRows < batchSize_) {
-      auto rowSize = *(RowSizeType*)(rawBuffer + byteOffset_) - sizeof(RowSizeType);
+      auto rowSize = *(reinterpret_cast<const RowSizeType*>(rawBuffer + byteOffset_)) - sizeof(RowSizeType);
       byteOffset_ += sizeof(RowSizeType);
       data.push_back(std::string_view(rawBuffer + byteOffset_, rowSize));
       byteOffset_ += rowSize;

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -327,7 +327,7 @@ int16_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal&
 template <>
 int32_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
   if (literal.has_date()) {
-    return int32_t(literal.date());
+    return static_cast<int32_t>(literal.date());
   }
   return literal.i32();
 }

--- a/cpp/velox/tests/FunctionTest.cc
+++ b/cpp/velox/tests/FunctionTest.cc
@@ -153,11 +153,13 @@ TEST_F(FunctionTest, setVectorFromVariants) {
 
   // Floats are harder to compare because of low-precision. Just making sure
   // they don't throw.
-  EXPECT_NO_THROW(setVectorFromVariants(REAL(), {variant(float(0.99L)), variant(float(-1.99L))}, pool_.get()));
+  EXPECT_NO_THROW(setVectorFromVariants(
+      REAL(), {variant(static_cast<float>(0.99L)), variant(static_cast<float>(-1.99L))}, pool_.get()));
 
-  resultVec = setVectorFromVariants(DOUBLE(), {variant(double(0.99L)), variant(double(-1.99L))}, pool_.get());
-  ASSERT_EQ(double(0.99L), resultVec->asFlatVector<double>()->valueAt(0));
-  ASSERT_EQ(double(-1.99L), resultVec->asFlatVector<double>()->valueAt(1));
+  resultVec = setVectorFromVariants(
+      DOUBLE(), {variant(static_cast<double>(0.99L)), variant(static_cast<double>(-1.99L))}, pool_.get());
+  ASSERT_EQ(static_cast<double>(0.99L), resultVec->asFlatVector<double>()->valueAt(0));
+  ASSERT_EQ(static_cast<double>(-1.99L), resultVec->asFlatVector<double>()->valueAt(1));
 
   resultVec = setVectorFromVariants(VARCHAR(), {variant(""), variant("asdf")}, pool_.get());
   ASSERT_EQ("", resultVec->asFlatVector<StringView>()->valueAt(0).str());

--- a/cpp/velox/tests/VeloxSubstraitRoundTripTest.cc
+++ b/cpp/velox/tests/VeloxSubstraitRoundTripTest.cc
@@ -371,10 +371,10 @@ TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {
                         makeConstantExpr(BOOLEAN(), static_cast<bool>(1)),
                         makeConstantExpr(TINYINT(), static_cast<int8_t>(23)),
                         makeConstantExpr(SMALLINT(), static_cast<int16_t>(45)),
-                        makeConstantExpr(INTEGER(), static_cast<int32_t>(678)),
+                        makeConstantExpr(INTEGER(), 678),
                         makeConstantExpr(BIGINT(), static_cast<int64_t>(910)),
                         makeConstantExpr(REAL(), static_cast<float>(1.23)),
-                        makeConstantExpr(DOUBLE(), static_cast<double>(4.56)),
+                        makeConstantExpr(DOUBLE(), 4.56),
                         makeConstantExpr(VARCHAR(), "789")};
                     return std::make_shared<core::ProjectNode>(
                         id, std::move(projectNames), std::move(projectExpressions), input);


### PR DESCRIPTION
## What changes were proposed in this pull request?
False positives for Do not Cast
cpp/velox/compute/[WholeStageResultIterator.cc:461](http://wholestageresultiterator.cc:461/)
cpp/velox/compute/WholeStageResultIterator.cc:463](http://wholestageresultiterator.cc:463/)
cpp/velox/shuffle/[VeloxSortShuffleWriter.cc:219](http://veloxsortshufflewriter.cc:219/)
cpp/velox/tests/[FunctionTest.cc:157](http://functiontest.cc:157/)
cpp/velox/shuffle/[VeloxShuffleReader.cc:437](http://veloxshufflereader.cc:437/)
cpp/velox/shuffle/[VeloxSortShuffleWriter.cc:347](http://veloxsortshufflewriter.cc:347/)
cpp/velox/substrait/[SubstraitToVeloxPlan.cc:1049](http://substraittoveloxplan.cc:1049/)
cpp/velox/substrait/[SubstraitToVeloxPlan.cc:1](http://substraittoveloxplan.cc:1102/)040
cpp/velox/substrait/[SubstraitToVeloxPlan.cc:1102](http://substraittoveloxplan.cc:1102/)
cpp/velox/substrait/[SubstraitToVeloxPlan.cc:1095](http://substraittoveloxplan.cc:1095/)
cpp/velox/tests/[VeloxSubstraitRoundTripTest.cc:370](http://veloxsubstraitroundtriptest.cc:370/) -> and below test would fail at BaseVector.cpp comparing the VELOX_CHECK_EQ(type->kind(), value.kind()); if it is not casted correctly so leaving as is
cpp/velox/tests/[VeloxSubstraitRoundTripTest.cc:371](http://veloxsubstraitroundtriptest.cc:371/)
cpp/velox/tests/[VeloxSubstraitRoundTripTest.cc:372](http://veloxsubstraitroundtriptest.cc:372/)
cpp/velox/tests/[VeloxSubstraitRoundTripTest.cc:374](http://veloxsubstraitroundtriptest.cc:374/)
cpp/velox/tests/[VeloxSubstraitRoundTripTest.cc:375](http://veloxsubstraitroundtriptest.cc:375/)

(Please fill in changes proposed in this fix)

(Fixes: \#8475)