### PR TITLE
[GLUTEN-8497][VL] A bad test case that fails columnar table cache query

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
@@ -24,7 +24,12 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{LongType, Metadata, MetadataBuilder, StructType}
 import org.apache.spark.storage.StorageLevel
+
+import scala.collection.JavaConverters._
 
 class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
   override protected val resourcePath: String = "/tpch-data-parquet"
@@ -55,7 +60,7 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
     )
   }
 
-  test("input columnar batch") {
+  test("Input columnar batch") {
     TPCHTables.map(_.name).foreach {
       table =>
         runQueryAndCompare(s"SELECT * FROM $table", cache = true) {
@@ -64,7 +69,7 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
     }
   }
 
-  test("input columnar batch and column pruning") {
+  test("Input columnar batch and column pruning") {
     val expected = sql("SELECT l_partkey FROM lineitem").collect()
     val cached = sql("SELECT * FROM lineitem").cache()
     try {
@@ -85,7 +90,7 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
     }
   }
 
-  test("input vanilla Spark columnar batch") {
+  test("Input vanilla Spark columnar batch") {
     withSQLConf(GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key -> "false") {
       val df = spark.table("lineitem")
       val expected = df.collect()
@@ -95,6 +100,40 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
       } finally {
         actual.unpersist()
       }
+    }
+  }
+
+  // TODO: Fix this case.
+  ignore("Input fallen back vanilla Spark columnar scan") {
+    def withId(id: Int): Metadata =
+      new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()
+
+    withTempDir {
+      dir =>
+        val readSchema =
+          new StructType()
+            .add("l_orderkey_read", LongType, true, withId(1))
+        val writeSchema =
+          new StructType()
+            .add("l_orderkey_write", LongType, true, withId(1))
+        withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
+          // Write a table with metadata information that Gluten Velox backend doesn't support,
+          // to emulate the scenario that a Spark columnar scan is not offload-able so fallen back.
+          spark
+            .createDataFrame(
+              spark.sql("select l_orderkey from lineitem").collect().toList.asJava,
+              writeSchema)
+            .write
+            .mode("overwrite")
+            .parquet(dir.getCanonicalPath)
+          val df = spark.read.schema(readSchema).parquet(dir.getCanonicalPath)
+          df.cache()
+          df.explain()
+          // FIXME: The following call will throw since the vanilla Parquet scan could confuse
+          //  ColumnarCachedBatchSerializer by calling its #convertColumnarBatchToCachedBatch
+          //  method.
+          assert(df.collect().nonEmpty)
+        }
     }
   }
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
@@ -119,7 +119,7 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
         withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
           // Write a table with metadata information that Gluten Velox backend doesn't support,
           // to emulate the scenario that a Spark columnar scan is not offload-able so fallen back,
-          // then user happens to cache it.
+          // then user tries to cache it.
           spark
             .createDataFrame(
               spark.sql("select l_orderkey from lineitem").collect().toList.asJava,

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
@@ -130,9 +130,9 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
           val df = spark.read.schema(readSchema).parquet(dir.getCanonicalPath)
           df.cache()
           df.explain()
-          // FIXME: The following call will throw since the vanilla Parquet scan could confuse
-          //  ColumnarCachedBatchSerializer by calling its #convertColumnarBatchToCachedBatch
-          //  method.
+          // FIXME: The following call will throw since ColumnarCachedBatchSerializer will be
+          //  confused by the input vanilla Parquet scan when its #convertColumnarBatchToCachedBatch
+          //  method is called.
           assert(df.collect().nonEmpty)
         }
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
@@ -119,7 +119,7 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
         withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
           // Write a table with metadata information that Gluten Velox backend doesn't support,
           // to emulate the scenario that a Spark columnar scan is not offload-able so fallen back,
-          // then user commands to cache it.
+          // then user happens to cache it.
           spark
             .createDataFrame(
               spark.sql("select l_orderkey from lineitem").collect().toList.asJava,

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
@@ -118,7 +118,8 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
             .add("l_orderkey_write", LongType, true, withId(1))
         withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
           // Write a table with metadata information that Gluten Velox backend doesn't support,
-          // to emulate the scenario that a Spark columnar scan is not offload-able so fallen back.
+          // to emulate the scenario that a Spark columnar scan is not offload-able so fallen back,
+          // then user commands to cache it.
           spark
             .createDataFrame(
               spark.sql("select l_orderkey from lineitem").collect().toList.asJava,

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -77,6 +77,7 @@ object TransitionGraph {
     }
   }
 
+  // TODO: Consolidate transition graph's cost model with RAS cost model.
   private object TransitionCostModel extends FloydWarshallGraph.CostModel[Transition] {
     override def zero(): TransitionCost = TransitionCost(0, Nil)
     override def costOf(transition: Transition): TransitionCost = {


### PR DESCRIPTION
https://github.com/apache/incubator-gluten/issues/8497

Add a bad case which is ignored at the moment to reproduce the bug described in https://github.com/apache/incubator-gluten/issues/8497.

I am still looking for a proper solution of the bug. Could merge the test code in advance so one could try with it if interested.