### PR TITLE
[GLUTEN-8499][VL] Fix the logic of cast expression

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -1482,7 +1482,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     withTempView("try_cast_table") {
       withTempPath {
         path =>
-          Seq[(String)](("123456"), ("000A1234"), ("1.1"))
+          Seq[(String)](("123456"), ("000A1234"), ("1.1"), ("1a.1"))
             .toDF("str")
             .write
             .parquet(path.getCanonicalPath)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -1482,13 +1482,13 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     withTempView("try_cast_table") {
       withTempPath {
         path =>
-          Seq[(String)](("123456"), ("000A1234"))
+          Seq[(String)](("123456"), ("000A1234"), ("1.1"))
             .toDF("str")
             .write
             .parquet(path.getCanonicalPath)
           spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("try_cast_table")
           runQueryAndCompare("select try_cast(str as bigint) from try_cast_table") {
-            checkGlutenOperatorMatch[ProjectExecTransformer]
+            checkSparkOperatorMatch[ProjectExec]
           }
           runQueryAndCompare("select try_cast(str as double) from try_cast_table") {
             checkGlutenOperatorMatch[ProjectExecTransformer]

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -337,6 +337,9 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       case s: ScalarSubquery =>
         ScalarSubqueryTransformer(substraitExprName, s)
       case c: Cast =>
+        if (SparkShimLoader.getSparkShims.withAnsiEvalMode(c)) {
+          throw new GlutenNotSupportException(s"Cast expression does not support ANSI mode, $c")
+        }
         // Add trim node, as necessary.
         val newCast =
           BackendsApiManager.getSparkPlanExecApiInstance.genCastWithNewChild(c)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
@@ -47,7 +47,8 @@ case class CastTransformer(substraitExprName: String, child: ExpressionTransform
     ExpressionBuilder.makeCast(
       typeNode,
       child.doTransform(args),
-      !SparkShimLoader.getSparkShims.withTryEvalMode(original))
+      SparkShimLoader.getSparkShims.withAnsiEvalMode(original) &&
+        !SparkShimLoader.getSparkShims.withTryEvalMode(original))
   }
 }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
@@ -47,7 +47,7 @@ case class CastTransformer(substraitExprName: String, child: ExpressionTransform
     ExpressionBuilder.makeCast(
       typeNode,
       child.doTransform(args),
-      SparkShimLoader.getSparkShims.withTryEvalMode(original))
+      !SparkShimLoader.getSparkShims.withTryEvalMode(original))
   }
 }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
@@ -47,7 +47,7 @@ case class CastTransformer(substraitExprName: String, child: ExpressionTransform
     ExpressionBuilder.makeCast(
       typeNode,
       child.doTransform(args),
-      SparkShimLoader.getSparkShims.withAnsiEvalMode(original))
+      SparkShimLoader.getSparkShims.withTryEvalMode(original))
   }
 }
 

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -463,6 +463,7 @@ class Spark34Shims extends SparkShims {
       case s: Subtract => s.evalMode == EvalMode.ANSI
       case d: Divide => d.evalMode == EvalMode.ANSI
       case m: Multiply => m.evalMode == EvalMode.ANSI
+      case c: Cast => c.ansiEnabled
       case _ => false
     }
   }

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -453,6 +453,7 @@ class Spark34Shims extends SparkShims {
       case s: Subtract => s.evalMode == EvalMode.TRY
       case d: Divide => d.evalMode == EvalMode.TRY
       case m: Multiply => m.evalMode == EvalMode.TRY
+      case c: Cast => c.isTryCast
       case _ => false
     }
   }

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -488,6 +488,7 @@ class Spark35Shims extends SparkShims {
       case s: Subtract => s.evalMode == EvalMode.ANSI
       case d: Divide => d.evalMode == EvalMode.ANSI
       case m: Multiply => m.evalMode == EvalMode.ANSI
+      case c: Cast => c.ansiEnabled
       case _ => false
     }
   }

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -478,6 +478,7 @@ class Spark35Shims extends SparkShims {
       case s: Subtract => s.evalMode == EvalMode.TRY
       case d: Divide => d.evalMode == EvalMode.TRY
       case m: Multiply => m.evalMode == EvalMode.TRY
+      case c: Cast => c.isTryCast
       case _ => false
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The cast expression in ansi mode not only returns null on error, but also has different calculation logic from non-ansi mode, so we should fall back the cast expression in ansi mode.

Like `cast string to long`, they define different `allowDecimal`:

https://github.com/apache/spark/blob/3c831ebf7cd81c2ed774c692b2da7a35ce0fa252/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java#L1612

https://github.com/apache/spark/blob/3c831ebf7cd81c2ed774c692b2da7a35ce0fa252/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java#L1813

Closes #8499

## How was this patch tested?

unit test
