### PR TITLE
[GLUTEN-8503][VL] Fix macro parenthesis CVE

### DIFF
--- a/cpp/core/benchmarks/CompressionBenchmark.cc
+++ b/cpp/core/benchmarks/CompressionBenchmark.cc
@@ -60,7 +60,7 @@ using gluten::ShuffleWriterOptions;
 
 namespace gluten {
 
-#define ALIGNMENT 2 * 1024 * 1024
+#define ALIGNMENT (2 * 1024 * 1024)
 
 const int32_t kQatGzip = 0;
 const int32_t kQatZstd = 1;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Macro replacement lists should be parenthesized@cpp/core/benchmarks/[CompressionBenchmark.cc:61](http://compressionbenchmark.cc:61/)

(Fixes: \#8503)

