### PR TITLE
[GLUTEN-8520][VL] Fix bitwise operators

### DIFF
--- a/cpp/core/shuffle/FallbackRangePartitioner.cc
+++ b/cpp/core/shuffle/FallbackRangePartitioner.cc
@@ -44,7 +44,7 @@ arrow::Status gluten::FallbackRangePartitioner::compute(
   auto index = static_cast<int64_t>(vectorIndex) << 32;
   for (auto i = 0; i < numRows; ++i) {
     auto pid = pidArr[i];
-    int64_t combined = index | (i & 0xFFFFFFFFLL);
+    int64_t combined = index | (static_cast<int64_t>(i) & 0xFFFFFFFFLL);
     auto& vec = rowVectorIndexMap[pid];
     vec.push_back(combined);
     if (pid >= numPartitions_) {

--- a/cpp/core/shuffle/HashPartitioner.cc
+++ b/cpp/core/shuffle/HashPartitioner.cc
@@ -55,7 +55,7 @@ arrow::Status gluten::HashPartitioner::compute(
   auto index = static_cast<int64_t>(vectorIndex) << 32;
   for (auto i = 0; i < numRows; ++i) {
     auto pid = computePid(pidArr, i, numPartitions_);
-    int64_t combined = index | (i & 0xFFFFFFFFLL);
+    int64_t combined = index | (static_cast<int64_t>(i) & 0xFFFFFFFFLL);
     auto& vec = rowVectorIndexMap[pid];
     vec.push_back(combined);
   }

--- a/cpp/core/shuffle/RandomPartitioner.cc
+++ b/cpp/core/shuffle/RandomPartitioner.cc
@@ -35,7 +35,7 @@ arrow::Status gluten::RandomPartitioner::compute(
     std::unordered_map<int32_t, std::vector<int64_t>>& rowVectorIndexMap) {
   auto index = static_cast<int64_t>(vectorIndex) << 32;
   for (int32_t i = 0; i < numRows; ++i) {
-    int64_t combined = index | (i & 0xFFFFFFFFLL);
+    int64_t combined = index | (static_cast<int64_t>(i) & 0xFFFFFFFFLL);
     auto& vec = rowVectorIndexMap[dist_(rng_)];
     vec.push_back(combined);
   }

--- a/cpp/core/shuffle/RoundRobinPartitioner.cc
+++ b/cpp/core/shuffle/RoundRobinPartitioner.cc
@@ -38,7 +38,7 @@ arrow::Status gluten::RoundRobinPartitioner::compute(
     std::unordered_map<int32_t, std::vector<int64_t>>& rowVectorIndexMap) {
   auto index = static_cast<int64_t>(vectorIndex) << 32;
   for (int32_t i = 0; i < numRows; ++i) {
-    int64_t combined = index | (i & 0xFFFFFFFFLL);
+    int64_t combined = index | (static_cast<int64_t>(i) & 0xFFFFFFFFLL);
     auto& vec = rowVectorIndexMap[pidSelection_];
     vec.push_back(combined);
     pidSelection_ = (pidSelection_ + 1) % numPartitions_;

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -33,8 +33,8 @@ inline int64_t getFieldOffset(int64_t nullBitsetWidthInBytes, int32_t index) {
 }
 
 inline bool isNull(uint8_t* buffer_address, int32_t index) {
-  int64_t mask = 1L << (index & 0x3f); // mod 64 and shift
-  int64_t wordOffset = (index >> 6) * 8;
+  int64_t mask = 1L << (static_cast<int64_t>(index) & 0x3f); // mod 64 and shift
+  int64_t wordOffset = (static_cast<int64_t>(index) >> 6) * 8;
   int64_t value = *((int64_t*)(buffer_address + wordOffset));
   return (value & mask) != 0;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use bitwise operators only on unsigned operands
False positives
cpp/velox/tests/[MemoryManagerTest.cc:43](http://memorymanagertest.cc:43/)
cpp/velox/benchmarks/[ColumnarToRowBenchmark.cc:215](http://columnartorowbenchmark.cc:215/)
cpp/core/shuffle/[RoundRobinPartitioner.cc:39](http://roundrobinpartitioner.cc:39/)
cpp/velox/compute/[WholeStageResultIterator.cc:255](http://wholestageresultiterator.cc:255/)
cpp/core/shuffle/[HashPartitioner.cc:55](http://hashpartitioner.cc:55/)
cpp/velox/tests/[VeloxColumnarToRowTest.cc:37](http://veloxcolumnartorowtest.cc:37/)
cpp/core/shuffle/[FallbackRangePartitioner.cc:44](http://fallbackrangepartitioner.cc:44/)
cpp/velox/benchmarks/[ColumnarToRowBenchmark.cc:160](http://columnartorowbenchmark.cc:160/)
cpp/velox/tests/[MemoryManagerTest.cc:343](http://memorymanagertest.cc:343/)
cpp/core/benchmarks/[CompressionBenchmark.cc:306](http://compressionbenchmark.cc:306/)
cpp/core/shuffle/[RandomPartitioner.cc:36](http://randompartitioner.cc:36/)
cpp/core/utils/qat/[QatCodec.cc:152](http://qatcodec.cc:152/)
cpp/velox/shuffle/[VeloxShuffleReader.cc:542](http://veloxshufflereader.cc:542/)
cpp/velox/tests/[VeloxRowToColumnarTest.cc:36](http://veloxrowtocolumnartest.cc:36/)
cpp/velox/tests/[MemoryManagerTest.cc:346](http://memorymanagertest.cc:346/)
cpp/velox/shuffle/[VeloxSortShuffleWriter.cc:366](http://veloxsortshufflewriter.cc:366/)
cpp/velox/shuffle/[VeloxSortShuffleWriter.cc:416](http://veloxsortshufflewriter.cc:416/)
cpp/velox/benchmarks/[ColumnarToRowBenchmark.cc:153](http://columnartorowbenchmark.cc:153/)
cpp/velox/benchmarks/[ParquetWriteBenchmark.cc:162](http://parquetwritebenchmark.cc:162/)
cpp/velox/benchmarks/[ParquetWriteBenchmark.cc:255](http://parquetwritebenchmark.cc:255/)
cpp/velox/shuffle/[VeloxSortShuffleWriter.cc:30](http://veloxsortshufflewriter.cc:30/)
cpp/core/utils/qpl/[QplJobPool.cc:70](http://qpljobpool.cc:70/)
cpp/velox/memory/[VeloxMemoryManager.cc:263](http://veloxmemorymanager.cc:263/)
cpp/velox/operators/serializer/[VeloxRowToColumnarConverter.cc:107](http://veloxrowtocolumnarconverter.cc:107/)
cpp/velox/memory/[VeloxMemoryManager.cc:41](http://veloxmemorymanager.cc:41/)
cpp/velox/utils/tests/[MemoryPoolUtils.cc:131](http://memorypoolutils.cc:131/)
cpp/velox/operators/serializer/[VeloxRowToColumnarConverter.cc:39](http://veloxrowtocolumnarconverter.cc:39/)
cpp/core/utils/qpl/[QplCodec.cc:206](http://qplcodec.cc:206/)
cpp/velox/operators/serializer/[VeloxRowToColumnarConverter.cc:183](http://veloxrowtocolumnarconverter.cc:183/)
cpp/velox/memory/[VeloxMemoryManager.cc:43](http://veloxmemorymanager.cc:43/)

(Fixes: \#8520)

