### PR TITLE
[GLUTEN-8531] Remove cmake version overwrite in vcpkg tool metadata file

### DIFF
--- a/dev/vcpkg/init.sh
+++ b/dev/vcpkg/init.sh
@@ -57,9 +57,6 @@ if [ ! -d "$VCPKG_ROOT" ] || [ -z "$(ls "$VCPKG_ROOT")" ]; then
 fi
 [ -f "$VCPKG" ] || "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
 
-sed -i "s/3.27.1/3.28.3/g" $VCPKG_ROOT/scripts/vcpkgTools.xml
-sed -i "s/192374a68e2971f04974a194645726196d9b8ee7abd650d1e6f65f7aa2ccc9b186c3edb473bb4958c764532edcdd42f4182ee1fcb86b17d78b0bcd6305ce3df1/bd311ca835ef0914952f21d70d1753564d58de2ede02e80ede96e78cd2f40b4189e006007643ebb37792e13edd97eb4a33810bc8aca1eab6dd428eaffe1d2e38/g" $VCPKG_ROOT/scripts/vcpkgTools.xml
-
 EXTRA_FEATURES=""
 if [ "$BUILD_TESTS" = "ON" ]; then
   EXTRA_FEATURES+="--x-feature=duckdb "


### PR DESCRIPTION
## What changes were proposed in this pull request?

The latest release of vcpkg has migrated metadata from XML to JSON https://github.com/microsoft/vcpkg-tool/releases/tag/2025-01-11. `init.sh` will fail with `sed: can't read /Gluten/dev/vcpkg/.vcpkg/scripts/vcpkgTools.xml: No such file or directory`. 

Additionally, the version of cmake is 3.30.1 and does not need to be manually updated https://github.com/microsoft/vcpkg/blob/master/scripts/vcpkg-tools.json#L64. This PR will fix the build issue.

Addresses https://github.com/apache/incubator-gluten/issues/8531
## How was this patch tested?
vcpkg build.

