### PR TITLE
[GLUTEN-8532][VL] Fix parenthesis within macro

### DIFF
--- a/cpp/core/utils/qat/QatCodec.cc
+++ b/cpp/core/utils/qat/QatCodec.cc
@@ -26,9 +26,9 @@
 
 #include "QatCodec.h"
 
-#define QZ_INIT_FAIL(rc) (QZ_OK != rc && QZ_DUPLICATE != rc)
+#define QZ_INIT_FAIL(rc) ((QZ_OK != (rc)) && (QZ_DUPLICATE != (rc)))
 
-#define QZ_SETUP_SESSION_FAIL(rc) (QZ_PARAMS == rc || QZ_NOSW_NO_HW == rc || QZ_NOSW_LOW_MEM == rc)
+#define QZ_SETUP_SESSION_FAIL(rc) (QZ_PARAMS == (rc) || QZ_NOSW_NO_HW == (rc) || QZ_NOSW_LOW_MEM == (rc))
 
 namespace gluten {
 namespace qat {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use parentheses within macros around parameter names

False Positive:
cpp/velox/substrait/[SubstraitToVeloxPlanValidator.cc:37](http://substraittoveloxplanvalidator.cc:37/)
cpp/velox/substrait/[SubstraitToVeloxPlanValidator.cc:48](http://substraittoveloxplanvalidator.cc:48/)

(Fixes: \#8532)