### PR TITLE
[GLUTEN-8534][VL] Fix allowing loops to iterate beyond end of array

### DIFF
--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -108,6 +108,7 @@ VectorPtr createFlatVector<TypeKind::HUGEINT>(
       uint8_t bytesValue[length];
       memcpy(bytesValue, memoryAddress + offsets[pos] + wordoffset, length);
       uint8_t bytesValue2[16]{};
+      GLUTEN_CHECK(length <= 16, "array out of bounds exception");
       for (int k = length - 1; k >= 0; k--) {
         bytesValue2[length - 1 - k] = bytesValue[k];
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allowing loops to iterate beyond the end of an array
Since we know bytesValue2 is size 16 the length needs to also be 16 or less so we do not iterate before(beyond) the size of that bytesValue2 array

(Fixes: \#8534)

