### PR TITLE
[CORE][VL] Cost model code refactors

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -24,6 +24,7 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.columnar.cost.{LegacyCoster, LongCoster}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc}
 import org.apache.gluten.substrait.rel.LocalFilesNode
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
@@ -54,7 +55,6 @@ class CHBackend extends SubstraitBackend {
   override def name(): String = CHConf.BACKEND_NAME
   override def buildInfo(): BuildInfo =
     BuildInfo("ClickHouse", CH_BRANCH, CH_COMMIT, "UNKNOWN")
-  override def convFuncOverride(): ConventionFunc.Override = new ConvFunc()
   override def iteratorApi(): IteratorApi = new CHIteratorApi
   override def sparkPlanExecApi(): SparkPlanExecApi = new CHSparkPlanExecApi
   override def transformerApi(): TransformerApi = new CHTransformerApi
@@ -63,6 +63,8 @@ class CHBackend extends SubstraitBackend {
   override def listenerApi(): ListenerApi = new CHListenerApi
   override def ruleApi(): RuleApi = new CHRuleApi
   override def settings(): BackendSettingsApi = CHBackendSettings
+  override def convFuncOverride(): ConventionFunc.Override = new ConvFunc()
+  override def costers(): Seq[LongCoster] = Seq(LegacyCoster)
 }
 
 object CHBackend {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -22,7 +22,6 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.extension._
 import org.apache.gluten.extension.columnar._
 import org.apache.gluten.extension.columnar.MiscColumnarRules.{RemoveGlutenTableCacheColumnarToRow, RemoveTopmostColumnarToRow, RewriteSubqueryBroadcast}
-import org.apache.gluten.extension.columnar.enumerated.planner.cost.LegacyCoster
 import org.apache.gluten.extension.columnar.heuristic.{ExpandFallbackPolicy, HeuristicTransform}
 import org.apache.gluten.extension.columnar.offload.{OffloadExchange, OffloadJoin, OffloadOthers}
 import org.apache.gluten.extension.columnar.rewrite._
@@ -143,9 +142,6 @@ object CHRuleApi {
   }
 
   private def injectRas(injector: RasInjector): Unit = {
-    // Register legacy coster for transition planner.
-    injector.injectCoster(_ => LegacyCoster)
-
     // CH backend doesn't work with RAS at the moment. Inject a rule that aborts any
     // execution calls.
     injector.injectPreTransform(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -25,6 +25,7 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.ValidationResult
+import org.apache.gluten.extension.columnar.cost.{LegacyCoster, LongCoster, RoughCoster}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc}
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.LocalFilesNode
@@ -61,7 +62,6 @@ class VeloxBackend extends SubstraitBackend {
   override def name(): String = VeloxBackend.BACKEND_NAME
   override def buildInfo(): BuildInfo =
     BuildInfo("Velox", VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME)
-  override def convFuncOverride(): ConventionFunc.Override = new ConvFunc()
   override def iteratorApi(): IteratorApi = new VeloxIteratorApi
   override def sparkPlanExecApi(): SparkPlanExecApi = new VeloxSparkPlanExecApi
   override def transformerApi(): TransformerApi = new VeloxTransformerApi
@@ -70,6 +70,8 @@ class VeloxBackend extends SubstraitBackend {
   override def listenerApi(): ListenerApi = new VeloxListenerApi
   override def ruleApi(): RuleApi = new VeloxRuleApi
   override def settings(): BackendSettingsApi = VeloxBackendSettings
+  override def convFuncOverride(): ConventionFunc.Override = new ConvFunc()
+  override def costers(): Seq[LongCoster] = Seq(LegacyCoster, RoughCoster)
 }
 
 object VeloxBackend {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -23,7 +23,6 @@ import org.apache.gluten.extension._
 import org.apache.gluten.extension.columnar._
 import org.apache.gluten.extension.columnar.MiscColumnarRules.{RemoveGlutenTableCacheColumnarToRow, RemoveTopmostColumnarToRow, RewriteSubqueryBroadcast}
 import org.apache.gluten.extension.columnar.enumerated.{RasOffload, RemoveSort}
-import org.apache.gluten.extension.columnar.enumerated.planner.cost.{LegacyCoster, RoughCoster}
 import org.apache.gluten.extension.columnar.heuristic.{ExpandFallbackPolicy, HeuristicTransform}
 import org.apache.gluten.extension.columnar.offload.{OffloadExchange, OffloadJoin, OffloadOthers}
 import org.apache.gluten.extension.columnar.rewrite._
@@ -120,10 +119,6 @@ object VeloxRuleApi {
   }
 
   private def injectRas(injector: RasInjector): Unit = {
-    // Gluten RAS: Costers.
-    injector.injectCoster(_ => LegacyCoster)
-    injector.injectCoster(_ => RoughCoster)
-
     // Gluten RAS: Pre rules.
     injector.injectPreTransform(_ => RemoveTransitions)
     injector.injectPreTransform(_ => PushDownInputFileExpression.PreOffload)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters
 
 class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
-
   protected val rootPath: String = getClass.getResource("/").getPath
   override protected val resourcePath: String = "/tpch-data-parquet"
   override protected val fileFormat: String = "parquet"

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
@@ -17,11 +17,11 @@
 package org.apache.gluten.extension.columnar.enumerated.planner
 
 import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.extension.columnar.cost.{GlutenCost, GlutenCostModel, LegacyCoster, LongCostModel}
 import org.apache.gluten.extension.columnar.enumerated.EnumeratedTransform
-import org.apache.gluten.extension.columnar.enumerated.planner.cost.{GlutenCostModel, LegacyCoster, LongCostModel}
 import org.apache.gluten.extension.columnar.enumerated.planner.property.Conv
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
-import org.apache.gluten.ras.{Cost, Ras}
+import org.apache.gluten.ras.Ras
 import org.apache.gluten.ras.RasSuiteBase._
 import org.apache.gluten.ras.path.RasPath
 import org.apache.gluten.ras.property.PropertySet
@@ -152,7 +152,7 @@ object VeloxRasSuite {
   def newRas(rasRules: Seq[RasRule[SparkPlan]]): Ras[SparkPlan] = {
     GlutenOptimization
       .builder()
-      .costModel(sessionCostModel())
+      .costModel(EnumeratedTransform.asRasCostModel(sessionCostModel()))
       .addRules(rasRules)
       .create()
       .asInstanceOf[Ras[SparkPlan]]
@@ -205,27 +205,27 @@ object VeloxRasSuite {
 
   class UserCostModel1 extends GlutenCostModel {
     private val base = legacyCostModel()
-    override def costOf(node: SparkPlan): Cost = node match {
+    override def costOf(node: SparkPlan): GlutenCost = node match {
       case _: RowUnary => base.makeInfCost()
       case other => base.costOf(other)
     }
-    override def costComparator(): Ordering[Cost] = base.costComparator()
-    override def makeInfCost(): Cost = base.makeInfCost()
-    override def sum(one: Cost, other: Cost): Cost = base.sum(one, other)
-    override def diff(one: Cost, other: Cost): Cost = base.diff(one, other)
-    override def makeZeroCost(): Cost = base.makeZeroCost()
+    override def costComparator(): Ordering[GlutenCost] = base.costComparator()
+    override def makeInfCost(): GlutenCost = base.makeInfCost()
+    override def sum(one: GlutenCost, other: GlutenCost): GlutenCost = base.sum(one, other)
+    override def diff(one: GlutenCost, other: GlutenCost): GlutenCost = base.diff(one, other)
+    override def makeZeroCost(): GlutenCost = base.makeZeroCost()
   }
 
   class UserCostModel2 extends GlutenCostModel {
     private val base = legacyCostModel()
-    override def costOf(node: SparkPlan): Cost = node match {
+    override def costOf(node: SparkPlan): GlutenCost = node match {
       case _: ColumnarUnary => base.makeInfCost()
       case other => base.costOf(other)
     }
-    override def costComparator(): Ordering[Cost] = base.costComparator()
-    override def makeInfCost(): Cost = base.makeInfCost()
-    override def sum(one: Cost, other: Cost): Cost = base.sum(one, other)
-    override def diff(one: Cost, other: Cost): Cost = base.diff(one, other)
-    override def makeZeroCost(): Cost = base.makeZeroCost()
+    override def costComparator(): Ordering[GlutenCost] = base.costComparator()
+    override def makeInfCost(): GlutenCost = base.makeInfCost()
+    override def sum(one: GlutenCost, other: GlutenCost): GlutenCost = base.sum(one, other)
+    override def diff(one: GlutenCost, other: GlutenCost): GlutenCost = base.diff(one, other)
+    override def makeZeroCost(): GlutenCost = base.makeZeroCost()
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
@@ -74,7 +74,7 @@ trait Component {
    * A sequence of [[org.apache.gluten.extension.columnar.cost.LongCoster]] Gluten is using for cost
    * evaluation.
    */
-  def costers(): Seq[LongCoster]
+  def costers(): Seq[LongCoster] = Nil
 
   /** Query planner rules. */
   def injectRules(injector: Injector): Unit

--- a/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.component
 
+import org.apache.gluten.extension.columnar.cost.LongCoster
 import org.apache.gluten.extension.columnar.transition.ConventionFunc
 import org.apache.gluten.extension.injector.Injector
 
@@ -68,6 +69,12 @@ trait Component {
    * and input conventions it requires.
    */
   def convFuncOverride(): ConventionFunc.Override = ConventionFunc.Override.Empty
+
+  /**
+   * A sequence of [[org.apache.gluten.extension.columnar.cost.LongCoster]] Gluten is using for cost
+   * evaluation.
+   */
+  def costers(): Seq[LongCoster]
 
   /** Query planner rules. */
   def injectRules(injector: Injector): Unit

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/GlutenCost.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/GlutenCost.scala
@@ -14,17 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.extension.columnar.enumerated.planner.cost
+package org.apache.gluten.extension.columnar.cost
 
-import org.apache.gluten.ras.{Cost, CostModel}
-
-import org.apache.spark.sql.execution.SparkPlan
-
-trait GlutenCostModel extends CostModel[SparkPlan] {
-  // Returns cost value of one + other.
-  def sum(one: Cost, other: Cost): Cost
-  // Returns cost value of one - other.
-  def diff(one: Cost, other: Cost): Cost
-
-  def makeZeroCost(): Cost
-}
+trait GlutenCost

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/GlutenCostModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/GlutenCostModel.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar.cost
+
+import org.apache.gluten.component.Component
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.util.SparkReflectionUtil
+
+/**
+ * The cost model API of Gluten. Used by:
+ *   1. RAS planner for cost-based optimization; 2. Transition graph for choosing transition paths.
+ */
+trait GlutenCostModel {
+  def costOf(node: SparkPlan): GlutenCost
+  def costComparator(): Ordering[GlutenCost]
+  def makeZeroCost(): GlutenCost
+  def makeInfCost(): GlutenCost
+  // Returns cost value of one + other.
+  def sum(one: GlutenCost, other: GlutenCost): GlutenCost
+  // Returns cost value of one - other.
+  def diff(one: GlutenCost, other: GlutenCost): GlutenCost
+}
+
+object GlutenCostModel extends Logging {
+  def find(aliasOrClass: String): GlutenCostModel = {
+    val costModelRegistry = LongCostModel.registry()
+    // Components should override Backend's costers. Hence, reversed registration order is applied.
+    Component
+      .sorted()
+      .reverse
+      .flatMap(_.costers())
+      .foreach(coster => costModelRegistry.register(coster))
+    val costModel = find(costModelRegistry, aliasOrClass)
+    costModel
+  }
+
+  private def find(registry: LongCostModel.Registry, aliasOrClass: String): GlutenCostModel = {
+    if (LongCostModel.Kind.values().contains(aliasOrClass)) {
+      val kind = LongCostModel.Kind.values()(aliasOrClass)
+      val model = registry.get(kind)
+      return model
+    }
+    val clazz = SparkReflectionUtil.classForName(aliasOrClass)
+    logInfo(s"Using user cost model: $aliasOrClass")
+    val ctor = clazz.getDeclaredConstructor()
+    ctor.setAccessible(true)
+    val model: GlutenCostModel = ctor.newInstance().asInstanceOf[GlutenCostModel]
+    model
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCost.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCost.scala
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.extension.columnar.enumerated.planner.cost
+package org.apache.gluten.extension.columnar.cost
 
-import org.apache.gluten.ras.Cost
-
-case class LongCost(value: Long) extends Cost
+case class LongCost(value: Long) extends GlutenCost

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCostModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCostModel.scala
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.extension.columnar.enumerated.planner.cost
+package org.apache.gluten.extension.columnar.cost
 
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.columnar.enumerated.planner.plan.GlutenPlanModel.GroupLeafExec
-import org.apache.gluten.ras.Cost
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
@@ -39,15 +38,15 @@ abstract class LongCostModel extends GlutenCostModel {
     assert(a >= 0)
     assert(b >= 0)
     val sum = a + b
-    if (sum < a || sum < b) Long.MaxValue else sum
+    if (sum < a || sum < b) infLongCost else sum
   }
 
-  override def sum(one: Cost, other: Cost): LongCost = (one, other) match {
+  override def sum(one: GlutenCost, other: GlutenCost): LongCost = (one, other) match {
     case (LongCost(value), LongCost(otherValue)) => LongCost(safeSum(value, otherValue))
   }
 
   // Returns cost value of one - other.
-  override def diff(one: Cost, other: Cost): Cost = (one, other) match {
+  override def diff(one: GlutenCost, other: GlutenCost): GlutenCost = (one, other) match {
     case (LongCost(value), LongCost(otherValue)) =>
       val d = Math.subtractExact(value, otherValue)
       require(d >= zeroLongCost, s"Difference between cost $one and $other should not be negative")
@@ -62,13 +61,13 @@ abstract class LongCostModel extends GlutenCostModel {
 
   def selfLongCostOf(node: SparkPlan): Long
 
-  override def costComparator(): Ordering[Cost] = Ordering.Long.on {
+  override def costComparator(): Ordering[GlutenCost] = Ordering.Long.on {
     case LongCost(value) => value
     case _ => throw new IllegalStateException("Unexpected cost type")
   }
 
-  override def makeInfCost(): Cost = LongCost(infLongCost)
-  override def makeZeroCost(): Cost = LongCost(zeroLongCost)
+  override def makeInfCost(): GlutenCost = LongCost(infLongCost)
+  override def makeZeroCost(): GlutenCost = LongCost(zeroLongCost)
 }
 
 object LongCostModel extends Logging {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCoster.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCoster.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.extension.columnar.enumerated.planner.cost
+package org.apache.gluten.extension.columnar.cost
 
 import org.apache.spark.sql.execution.SparkPlan
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCosterChain.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/cost/LongCosterChain.scala
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.extension.columnar.enumerated.planner.cost
+package org.apache.gluten.extension.columnar.cost
+
 import org.apache.gluten.exception.GlutenException
 
 import org.apache.spark.sql.execution.SparkPlan

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/property/Conv.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/property/Conv.scala
@@ -46,7 +46,7 @@ sealed trait Conv extends Property[SparkPlan] {
       return true
     }
     val prop = this.asInstanceOf[Prop]
-    val out = Transition.factory().satisfies(prop.prop, req.req)
+    val out = Transition.factory.satisfies(prop.prop, req.req)
     out
   }
 }
@@ -64,7 +64,7 @@ object Conv {
   def findTransition(from: Conv, to: Conv): Transition = {
     val prop = from.asInstanceOf[Prop]
     val req = to.asInstanceOf[Req]
-    val out = Transition.factory().findTransition(prop.prop, req.req, new IllegalStateException())
+    val out = Transition.factory.findTransition(prop.prop, req.req, new IllegalStateException())
     out
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -116,21 +116,21 @@ object Convention {
     protected[this] def registerTransitions(): Unit
 
     final protected[this] def fromRow(transition: Transition): Unit = {
-      Transition.graph.addEdge(RowType.VanillaRow, this, transition)
+      Transition.factory.update(graph => graph.addEdge(RowType.VanillaRow, this, transition))
     }
 
     final protected[this] def toRow(transition: Transition): Unit = {
-      Transition.graph.addEdge(this, RowType.VanillaRow, transition)
+      Transition.factory.update(graph => graph.addEdge(this, RowType.VanillaRow, transition))
     }
 
     final protected[this] def fromBatch(from: BatchType, transition: Transition): Unit = {
       assert(from != this)
-      Transition.graph.addEdge(from, this, transition)
+      Transition.factory.update(graph => graph.addEdge(from, this, transition))
     }
 
     final protected[this] def toBatch(to: BatchType, transition: Transition): Unit = {
       assert(to != this)
-      Transition.graph.addEdge(this, to, transition)
+      Transition.factory.update(graph => graph.addEdge(this, to, transition))
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
@@ -87,19 +87,18 @@ object FloydWarshallGraph {
   }
 
   private object Builder {
-    // Thread safe.
     private class Impl[V <: AnyRef, E <: AnyRef]() extends Builder[V, E] {
       private val pathTable: mutable.Map[V, mutable.Map[V, Path[E]]] = mutable.Map()
       private var graph: Option[FloydWarshallGraph[V, E]] = None
 
-      override def addVertex(v: V): Builder[V, E] = synchronized {
+      override def addVertex(v: V): Builder[V, E] = {
         assert(!pathTable.contains(v), s"Vertex $v already exists in graph")
         pathTable.getOrElseUpdate(v, mutable.Map()).getOrElseUpdate(v, Path(Nil))
         graph = None
         this
       }
 
-      override def addEdge(from: V, to: V, edge: E): Builder[V, E] = synchronized {
+      override def addEdge(from: V, to: V, edge: E): Builder[V, E] = {
         assert(from != to, s"Input vertices $from and $to should be different")
         assert(pathTable.contains(from), s"Vertex $from not exists in graph")
         assert(pathTable.contains(to), s"Vertex $to not exists in graph")
@@ -109,7 +108,7 @@ object FloydWarshallGraph {
         this
       }
 
-      override def build(costModel: CostModel[E]): FloydWarshallGraph[V, E] = synchronized {
+      override def build(costModel: CostModel[E]): FloydWarshallGraph[V, E] = {
         val vertices = pathTable.keys
         for (k <- vertices) {
           for (i <- vertices) {
@@ -137,7 +136,7 @@ object FloydWarshallGraph {
         new FloydWarshallGraph.Impl(pathTable.map { case (k, m) => (k, m.toMap) }.toMap)
       }
 
-      private def hasPath(from: V, to: V): Boolean = synchronized {
+      private def hasPath(from: V, to: V): Boolean = {
         if (!pathTable.contains(from)) {
           return false
         }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
@@ -44,8 +44,8 @@ object FloydWarshallGraph {
     def cost(costModel: CostModel[E]): Cost
   }
 
-  def builder[V <: AnyRef, E <: AnyRef](costModelFactory: () => CostModel[E]): Builder[V, E] = {
-    Builder.create(costModelFactory)
+  def builder[V <: AnyRef, E <: AnyRef](): Builder[V, E] = {
+    Builder.create()
   }
 
   private object Path {
@@ -83,13 +83,12 @@ object FloydWarshallGraph {
   trait Builder[V <: AnyRef, E <: AnyRef] {
     def addVertex(v: V): Builder[V, E]
     def addEdge(from: V, to: V, edge: E): Builder[V, E]
-    def build(): FloydWarshallGraph[V, E]
+    def build(costModel: CostModel[E]): FloydWarshallGraph[V, E]
   }
 
   private object Builder {
     // Thread safe.
-    private class Impl[V <: AnyRef, E <: AnyRef](costModelFactory: () => CostModel[E])
-      extends Builder[V, E] {
+    private class Impl[V <: AnyRef, E <: AnyRef]() extends Builder[V, E] {
       private val pathTable: mutable.Map[V, mutable.Map[V, Path[E]]] = mutable.Map()
       private var graph: Option[FloydWarshallGraph[V, E]] = None
 
@@ -110,26 +109,7 @@ object FloydWarshallGraph {
         this
       }
 
-      override def build(): FloydWarshallGraph[V, E] = synchronized {
-        if (graph.isEmpty) {
-          graph = Some(compile())
-        }
-        return graph.get
-      }
-
-      private def hasPath(from: V, to: V): Boolean = {
-        if (!pathTable.contains(from)) {
-          return false
-        }
-        val vec = pathTable(from)
-        if (!vec.contains(to)) {
-          return false
-        }
-        true
-      }
-
-      private def compile(): FloydWarshallGraph[V, E] = {
-        val costModel = costModelFactory()
+      override def build(costModel: CostModel[E]): FloydWarshallGraph[V, E] = synchronized {
         val vertices = pathTable.keys
         for (k <- vertices) {
           for (i <- vertices) {
@@ -156,10 +136,21 @@ object FloydWarshallGraph {
         }
         new FloydWarshallGraph.Impl(pathTable.map { case (k, m) => (k, m.toMap) }.toMap)
       }
+
+      private def hasPath(from: V, to: V): Boolean = synchronized {
+        if (!pathTable.contains(from)) {
+          return false
+        }
+        val vec = pathTable(from)
+        if (!vec.contains(to)) {
+          return false
+        }
+        true
+      }
     }
 
-    def create[V <: AnyRef, E <: AnyRef](costModelFactory: () => CostModel[E]): Builder[V, E] = {
-      new Impl(costModelFactory)
+    def create[V <: AnyRef, E <: AnyRef](): Builder[V, E] = {
+      new Impl()
     }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
@@ -99,7 +99,7 @@ object Transition {
         graphCache.getOrElseUpdate(
           aliasOrClass, {
             val base = GlutenCostModel.find(aliasOrClass)
-            graphBuilder.build(TransitionGraph.newCostModel(base))
+            graphBuilder.build(TransitionGraph.asTransitionCostModel(base))
           })
       }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -39,7 +39,7 @@ object TransitionGraph {
     }
 
     final private def register(): Unit = BatchType.synchronized {
-      Transition.graph.addVertex(this)
+      Transition.factory.update(graph => graph.addVertex(this))
       register0()
     }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -54,7 +54,7 @@ object TransitionGraph {
     FloydWarshallGraph.builder()
   }
 
-  private[transition] def newCostModel(
+  private[transition] def asTransitionCostModel(
       base: GlutenCostModel): FloydWarshallGraph.CostModel[Transition] = {
     new TransitionCostModel(base)
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
@@ -52,7 +52,7 @@ case class InsertTransitions(convReq: ConventionReq) extends Rule[SparkPlan] {
           child
         } else {
           val transition =
-            Transition.factory().findTransition(from, convReq, Transition.notFound(node))
+            Transition.factory.findTransition(from, convReq, Transition.notFound(node))
           val newChild = transition.apply(child)
           newChild
         }
@@ -100,8 +100,7 @@ object Transitions {
   def enforceReq(plan: SparkPlan, req: ConventionReq): SparkPlan = {
     val convFunc = ConventionFunc.create()
     val removed = RemoveTransitions.removeForNode(plan)
-    val transition = Transition
-      .factory()
+    val transition = Transition.factory
       .findTransition(convFunc.conventionOf(removed), req, Transition.notFound(removed, req))
     val out = transition.apply(removed)
     out

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -62,7 +62,6 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_BACKEND_A", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
-    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyBackendB extends Backend {
@@ -70,7 +69,6 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_BACKEND_B", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
-    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyComponentC extends Component {
@@ -80,7 +78,6 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_COMPONENT_C", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
-    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyComponentD extends Component {
@@ -91,7 +88,6 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_COMPONENT_D", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
-    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyComponentE extends Component {
@@ -102,6 +98,5 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_COMPONENT_E", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
-    override def costers(): Seq[LongCoster] = Nil
   }
 }

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.component
 
 import org.apache.gluten.backend.Backend
+import org.apache.gluten.extension.columnar.cost.LongCoster
 import org.apache.gluten.extension.injector.Injector
 
 import org.scalatest.BeforeAndAfterAll
@@ -61,6 +62,7 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_BACKEND_A", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
+    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyBackendB extends Backend {
@@ -68,6 +70,7 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_BACKEND_B", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
+    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyComponentC extends Component {
@@ -77,6 +80,7 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_COMPONENT_C", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
+    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyComponentD extends Component {
@@ -87,6 +91,7 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_COMPONENT_D", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
+    override def costers(): Seq[LongCoster] = Nil
   }
 
   private class DummyComponentE extends Component {
@@ -97,5 +102,6 @@ object ComponentSuite {
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_COMPONENT_E", "N/A", "N/A", "N/A")
     override def injectRules(injector: Injector): Unit = {}
+    override def costers(): Seq[LongCoster] = Nil
   }
 }

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.component
 
 import org.apache.gluten.backend.Backend
-import org.apache.gluten.extension.columnar.cost.LongCoster
 import org.apache.gluten.extension.injector.Injector
 
 import org.scalatest.BeforeAndAfterAll

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraphSuite.scala
@@ -36,7 +36,7 @@ class FloydWarshallGraphSuite extends AnyFunSuite {
     val e42 = Edge(3)
 
     val graph = FloydWarshallGraph
-      .builder(() => CostModel)
+      .builder()
       .addVertex(v0)
       .addVertex(v1)
       .addVertex(v2)
@@ -47,7 +47,7 @@ class FloydWarshallGraphSuite extends AnyFunSuite {
       .addEdge(v0, v3, e03)
       .addEdge(v3, v4, e34)
       .addEdge(v4, v2, e42)
-      .build()
+      .build(CostModel)
 
     assert(graph.hasPath(v0, v1))
     assert(graph.hasPath(v0, v2))

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/cost/RoughCoster.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/cost/RoughCoster.scala
@@ -14,37 +14,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gluten.extension.columnar.enumerated.planner.cost
+package org.apache.gluten.extension.columnar.cost
 
+import org.apache.gluten.execution.RowToColumnarExecBase
 import org.apache.gluten.extension.columnar.transition.{ColumnarToColumnarLike, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
 
-import org.apache.spark.sql.execution.{ColumnarWriteFilesExec, ProjectExec, SparkPlan}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 
-object LegacyCoster extends LongCoster {
-  override def kind(): LongCostModel.Kind = LongCostModel.Legacy
+object RoughCoster extends LongCoster {
+  override def kind(): LongCostModel.Kind = LongCostModel.Rough
 
   override def selfCostOf(node: SparkPlan): Option[Long] = {
     Some(selfCostOf0(node))
   }
 
-  // A very rough estimation as of now. The cost model basically considers any
-  // fallen back ops as having extreme high cost so offloads computations as
-  // much as possible.
   private def selfCostOf0(node: SparkPlan): Long = {
     node match {
       case ColumnarWriteFilesExec.OnNoopLeafPath(_) => 0
+      case ProjectExec(projectList, _) if projectList.forall(isCheapExpression) =>
+        // Make trivial ProjectExec has the same cost as ProjectExecTransform to reduce unnecessary
+        // c2r and r2c.
+        10L
+      case r2c: RowToColumnarExecBase if hasComplexTypes(r2c.schema) =>
+        // Avoid moving computation back to native when transition has complex types in schema.
+        // Such transitions are observed to be extremely expensive as of now.
+        Long.MaxValue
       case ColumnarToRowLike(_) => 10L
       case RowToColumnarLike(_) => 10L
       case ColumnarToColumnarLike(_) => 5L
       case p if PlanUtil.isGlutenColumnarOp(p) => 10L
-      // 1. 100L << 1000L, to keep the pulled out non-offload-able projects if the main op
-      // turns into offload-able after pulling.
-      // 2. 100L >> 10L, to offload project op itself eagerly.
-      case ProjectExec(_, _) => 100L
       case p if PlanUtil.isVanillaColumnarOp(p) => 1000L
       // Other row ops. Usually a vanilla row op.
       case _ => 1000L
     }
+  }
+
+  private def isCheapExpression(ne: NamedExpression): Boolean = ne match {
+    case Alias(_: Attribute, _) => true
+    case _: Attribute => true
+    case _ => false
+  }
+
+  private def hasComplexTypes(schema: StructType): Boolean = {
+    schema.exists(_.dataType match {
+      case _: StructType => true
+      case _: ArrayType => true
+      case _: MapType => true
+      case _ => false
+    })
   }
 }

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.backend.Backend
 import org.apache.gluten.component.Component
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.execution.{ColumnarToColumnarExec, GlutenPlan}
-import org.apache.gluten.extension.columnar.enumerated.planner.cost.LegacyCoster
+import org.apache.gluten.extension.columnar.cost.{LegacyCoster, LongCoster}
 import org.apache.gluten.extension.injector.Injector
 
 import org.apache.spark.rdd.RDD
@@ -152,8 +152,7 @@ object TransitionSuite extends TransitionSuiteBase {
     override def name(): String = "dummy-backend"
     override def buildInfo(): Component.BuildInfo =
       Component.BuildInfo("DUMMY_BACKEND", "N/A", "N/A", "N/A")
-    override def injectRules(injector: Injector): Unit = {
-      injector.gluten.ras.injectCoster(_ => LegacyCoster)
-    }
+    override def injectRules(injector: Injector): Unit = {}
+    override def costers(): Seq[LongCoster] = Seq(LegacyCoster)
   }
 }

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -1450,12 +1450,15 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(false)
 
+  // FIXME: This option is no longer only used by RAS. Should change key to
+  //  `spark.gluten.costModel` or something similar.
   val RAS_COST_MODEL =
     buildConf("spark.gluten.ras.costModel")
       .doc(
         "The class name of user-defined cost model that will be used by Gluten's transition " +
-          "planner as well as by RAS. If not specified, a legacy built-in cost model that " +
-          "exhaustively offloads computations will be used.")
+          "planner as well as by RAS. If not specified, a legacy built-in cost model will be " +
+          "used. The legacy cost model helps RAS planner exhaustively offload computations, and " +
+          "helps transition planner choose columnar-to-columnar transition over others.")
       .stringConf
       .createWithDefaultString("legacy")
 


### PR DESCRIPTION
Add new independent trait `GlutenCostModel` so legacy transition planner's cost model code doesn't have to depend on RAS cost model code.

After the change, both legacy transition planner and RAS optimizer will rely on `GlutenCostModel` through their own API adapters.

Also, make costers be registered directly through a individual API of `Component`. This will enable the code to create cost model from anywhere without having a Spark session started in advance.