### PR TITLE
[GLUTEN-8455][VL] Support encrypted parquet fallback for 3.5

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/utils/ParquetEncryptionDetectionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/utils/ParquetEncryptionDetectionSuite.scala
@@ -112,7 +112,7 @@ class ParquetEncryptionDetectionSuite extends GlutenQueryTest {
 
   testWithSpecifiedSparkVersion(
     "Detect encrypted Parquet with encrypted footer",
-    Array("3.2", "3.3", "3.4")) {
+    Array("3.2", "3.3", "3.4", "3.5")) {
     withTempDir {
       tempDir =>
         val filePath = s"${tempDir.getAbsolutePath}/encrypted_footer.parquet"
@@ -136,7 +136,7 @@ class ParquetEncryptionDetectionSuite extends GlutenQueryTest {
 
   testWithSpecifiedSparkVersion(
     "Detect encrypted Parquet without encrypted footer (plaintext footer)",
-    Array("3.2", "3.3", "3.4")) {
+    Array("3.2", "3.3", "3.4", "3.5")) {
     withTempDir {
       tempDir =>
         val filePath = s"${tempDir.getAbsolutePath}/plaintext_footer.parquet"
@@ -160,7 +160,7 @@ class ParquetEncryptionDetectionSuite extends GlutenQueryTest {
 
   testWithSpecifiedSparkVersion(
     "Detect plain (unencrypted) Parquet file",
-    Array("3.2", "3.3", "3.4")) {
+    Array("3.2", "3.3", "3.4", "3.5")) {
     withTempDir {
       tempDir =>
         val filePath = s"${tempDir.getAbsolutePath}/plain.parquet"

--- a/backends-velox/src/test/scala/org/apache/gluten/utils/ParquetEncryptionDetectionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/utils/ParquetEncryptionDetectionSuite.scala
@@ -110,9 +110,7 @@ class ParquetEncryptionDetectionSuite extends GlutenQueryTest {
     fs.listFiles(new Path(path), false).next()
   }
 
-  testWithSpecifiedSparkVersion(
-    "Detect encrypted Parquet with encrypted footer",
-    Array("3.2", "3.3", "3.4", "3.5")) {
+  test("Detect encrypted Parquet with encrypted footer") {
     withTempDir {
       tempDir =>
         val filePath = s"${tempDir.getAbsolutePath}/encrypted_footer.parquet"
@@ -134,9 +132,7 @@ class ParquetEncryptionDetectionSuite extends GlutenQueryTest {
     }
   }
 
-  testWithSpecifiedSparkVersion(
-    "Detect encrypted Parquet without encrypted footer (plaintext footer)",
-    Array("3.2", "3.3", "3.4", "3.5")) {
+  test("Detect encrypted Parquet without encrypted footer (plaintext footer)") {
     withTempDir {
       tempDir =>
         val filePath = s"${tempDir.getAbsolutePath}/plaintext_footer.parquet"
@@ -158,9 +154,7 @@ class ParquetEncryptionDetectionSuite extends GlutenQueryTest {
     }
   }
 
-  testWithSpecifiedSparkVersion(
-    "Detect plain (unencrypted) Parquet file",
-    Array("3.2", "3.3", "3.4", "3.5")) {
+  test("Detect plain (unencrypted) Parquet file") {
     withTempDir {
       tempDir =>
         val filePath = s"${tempDir.getAbsolutePath}/plain.parquet"

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -564,7 +564,8 @@ class Spark35Shims extends SparkShims {
         ParquetFileReader.readFooter(conf, fileStatus.getPath, ParquetMetadataConverter.NO_FILTER)
       val fileMetaData = footer.getFileMetaData
       fileMetaData.getEncryptionType match {
-        // UNENCRYPTED file has a plaintext footer and no file encryption, return unencrypted.
+        // UNENCRYPTED file has a plaintext footer and no file encryption,
+        // We can leverage file metadata for this check and return unencrypted.
         case EncryptionType.UNENCRYPTED =>
           false
         // PLAINTEXT_FOOTER has a plaintext footer however the file is encrypted.

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -58,8 +58,8 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, LocatedFileStatus, Path}
-import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException
+import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.metadata.FileMetaData.EncryptionType
 import org.apache.parquet.schema.MessageType
@@ -572,7 +572,8 @@ class Spark35Shims extends SparkShims {
           false
       }
     } catch {
-      case e: Exception if ExceptionUtils.hasCause(e, classOf[ParquetCryptoRuntimeException]) => true
+      case e: Exception if ExceptionUtils.hasCause(e, classOf[ParquetCryptoRuntimeException]) =>
+        true
       case e: Exception => false
     }
   }

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.sql.shims.spark35
 
 import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.{ShimDescriptor, SparkShims}
+
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -53,6 +54,7 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, LocatedFileStatus, Path}
 import org.apache.parquet.format.converter.ParquetMetadataConverter
@@ -61,7 +63,8 @@ import org.apache.parquet.hadoop.metadata.FileMetaData.EncryptionType
 import org.apache.parquet.schema.MessageType
 
 import java.time.ZoneOffset
-import java.util.{Properties, HashMap => JHashMap, Map => JMap}
+import java.util.{HashMap => JHashMap, Map => JMap, Properties}
+
 import scala.reflect.ClassTag
 
 class Spark35Shims extends SparkShims {
@@ -555,7 +558,8 @@ class Spark35Shims extends SparkShims {
       fileStatus: LocatedFileStatus,
       conf: Configuration): Boolean = {
     try {
-      val footer = ParquetFileReader.readFooter(conf, fileStatus.getPath, ParquetMetadataConverter.NO_FILTER)
+      val footer =
+        ParquetFileReader.readFooter(conf, fileStatus.getPath, ParquetMetadataConverter.NO_FILTER)
       val fileMetaData = footer.getFileMetaData
       fileMetaData.getEncryptionType match {
         case EncryptionType.UNENCRYPTED =>
@@ -567,8 +571,7 @@ class Spark35Shims extends SparkShims {
         case _ =>
           false
       }
-    }
-    catch {
+    } catch {
       case _: Exception => false
     }
   }


### PR DESCRIPTION
 - Adds support for encrypted parquet fallback for Spark 3.5.
 - Previous Spark versions use an older parquet dependency which does not provide direct metadata to check encryption.
 - Using `EncryptionType` provided by Parquet 1.13 for Spark 3.5.