### PR TITLE
[GLUTEN-8479][CORE][Part-3] Split backend configs to its corresponding modules

### DIFF
--- a/backends-clickhouse/src-celeborn/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src-celeborn/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriter.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.clickhouse.CHBackendSettings
+import org.apache.gluten.backendsapi.clickhouse.{CHBackendSettings, CHConfig}
 import org.apache.gluten.execution.ColumnarNativeIterator
 import org.apache.gluten.memory.CHThreadGroup
 import org.apache.gluten.vectorized._
@@ -29,7 +29,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.protocol.ShuffleMode
-import org.apache.gluten.config.GlutenConfig
 
 import java.io.IOException
 import java.util.Locale
@@ -80,10 +79,10 @@ class CHCelebornColumnarShuffleWriter[K, V](
       nativeBufferSize,
       capitalizedCompressionCodec,
       compressionLevel,
-      GlutenConfig.get.chColumnarShuffleSpillThreshold,
+      CHConfig.get.chColumnarShuffleSpillThreshold,
       CHBackendSettings.shuffleHashAlgorithm,
       celebornPartitionPusher,
-      GlutenConfig.get.chColumnarForceMemorySortShuffle
+      CHConfig.get.chColumnarForceMemorySortShuffle
         || ShuffleMode.SORT.name.equalsIgnoreCase(shuffleWriterType)
     )
 

--- a/backends-clickhouse/src-delta-20/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
+++ b/backends-clickhouse/src-delta-20/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.delta
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Dataset
@@ -110,7 +110,7 @@ class ClickhouseOptimisticTransaction(
         spark.conf.getAll.foreach(
           entry => {
             if (
-              CHConf.startWithSettingsPrefix(entry._1)
+              CHConfig.startWithSettingsPrefix(entry._1)
               || entry._1.equalsIgnoreCase(DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE.key)
             ) {
               options += (entry._1 -> entry._2)

--- a/backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
+++ b/backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.delta
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Dataset
@@ -111,7 +111,7 @@ class ClickhouseOptimisticTransaction(
         spark.conf.getAll.foreach(
           entry => {
             if (
-              CHConf.startWithSettingsPrefix(entry._1)
+              CHConfig.startWithSettingsPrefix(entry._1)
               || entry._1.equalsIgnoreCase(DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE.key)
             ) {
               options += (entry._1 -> entry._2)

--- a/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
+++ b/backends-clickhouse/src-delta-32/main/scala/org/apache/spark/sql/delta/ClickhouseOptimisticTransaction.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.delta
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Dataset
@@ -71,7 +71,7 @@ class ClickhouseOptimisticTransaction(
     val nativeWrite = GlutenConfig.get.enableNativeWriter.getOrElse(false)
     if (writingMergeTree) {
       // TODO: update FallbackByBackendSettings for mergetree always return true
-      val onePipeline = nativeWrite && CHConf.get.enableOnePipelineMergeTreeWrite
+      val onePipeline = nativeWrite && CHConfig.get.enableOnePipelineMergeTreeWrite
       if (onePipeline)
         pipelineWriteFiles(inputData, writeOptions, isOptimize, additionalConstraints)
       else {
@@ -155,7 +155,7 @@ class ClickhouseOptimisticTransaction(
       spark.conf.getAll.foreach(
         entry => {
           if (
-            CHConf.startWithSettingsPrefix(entry._1)
+            CHConfig.startWithSettingsPrefix(entry._1)
             || entry._1.equalsIgnoreCase(DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE.key)
           ) {
             options += (entry._1 -> entry._2)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -52,7 +52,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 class CHBackend extends SubstraitBackend {
   import CHBackend._
-  override def name(): String = CHConf.BACKEND_NAME
+  override def name(): String = CHConfig.BACKEND_NAME
   override def buildInfo(): BuildInfo =
     BuildInfo("ClickHouse", CH_BRANCH, CH_COMMIT, "UNKNOWN")
   override def iteratorApi(): IteratorApi = new CHIteratorApi
@@ -85,11 +85,11 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   // experimental: when the files count per partition exceeds this threshold,
   // it will put the files into one partition.
   val GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD: String =
-    CHConf.prefixOf("files.per.partition.threshold")
+    CHConfig.prefixOf("files.per.partition.threshold")
   val GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD_DEFAULT = "-1"
 
   private val GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE: String =
-    CHConf.prefixOf("customized.shuffle.codec.enable")
+    CHConfig.prefixOf("customized.shuffle.codec.enable")
   private val GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE_DEFAULT = false
   lazy val useCustomizedShuffleCodec: Boolean = SparkEnv.get.conf.getBoolean(
     CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE,
@@ -97,7 +97,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   )
 
   private val GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE: String =
-    CHConf.prefixOf("customized.buffer.size")
+    CHConfig.prefixOf("customized.buffer.size")
   private val GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE_DEFAULT = 4096
   lazy val customizeBufferSize: Int = SparkEnv.get.conf.getInt(
     CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE,
@@ -105,7 +105,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   )
 
   val GLUTEN_CLICKHOUSE_BROADCAST_CACHE_EXPIRED_TIME: String =
-    CHConf.prefixOf("broadcast.cache.expired.time")
+    CHConfig.prefixOf("broadcast.cache.expired.time")
   // unit: SECONDS, default 1 day
   val GLUTEN_CLICKHOUSE_BROADCAST_CACHE_EXPIRED_TIME_DEFAULT: Int = 86400
 
@@ -113,7 +113,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
 
   // The algorithm for hash partition of the shuffle
   private val GLUTEN_CLICKHOUSE_SHUFFLE_HASH_ALGORITHM: String =
-    CHConf.prefixOf("shuffle.hash.algorithm")
+    CHConfig.prefixOf("shuffle.hash.algorithm")
   // valid values are: cityHash64 or sparkMurmurHash3_32
   private val GLUTEN_CLICKHOUSE_SHUFFLE_HASH_ALGORITHM_DEFAULT = "sparkMurmurHash3_32"
   def shuffleHashAlgorithm: String = {
@@ -128,32 +128,32 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
     }
   }
 
-  private val GLUTEN_CLICKHOUSE_AFFINITY_MODE: String = CHConf.prefixOf("affinity.mode")
+  private val GLUTEN_CLICKHOUSE_AFFINITY_MODE: String = CHConfig.prefixOf("affinity.mode")
   val SOFT: String = "soft"
   val FORCE: String = "force"
   private val GLUTEN_CLICKHOUSE_AFFINITY_MODE_DEFAULT = SOFT
 
-  private val GLUTEN_MAX_BLOCK_SIZE: String = CHConf.runtimeSettings("max_block_size")
+  private val GLUTEN_MAX_BLOCK_SIZE: String = CHConfig.runtimeSettings("max_block_size")
   // Same as default value in clickhouse
   private val GLUTEN_MAX_BLOCK_SIZE_DEFAULT = 65409
   private val GLUTEN_MAX_SHUFFLE_READ_BYTES: String =
-    CHConf.runtimeConfig("max_source_concatenate_bytes")
+    CHConfig.runtimeConfig("max_source_concatenate_bytes")
   private val GLUTEN_MAX_SHUFFLE_READ_BYTES_DEFAULT = GLUTEN_MAX_BLOCK_SIZE_DEFAULT * 256
 
-  val GLUTEN_AQE_PROPAGATEEMPTY: String = CHConf.prefixOf("aqe.propagate.empty.relation")
+  val GLUTEN_AQE_PROPAGATEEMPTY: String = CHConfig.prefixOf("aqe.propagate.empty.relation")
 
-  val GLUTEN_CLICKHOUSE_DELTA_SCAN_CACHE_SIZE: String = CHConf.prefixOf("deltascan.cache.size")
+  val GLUTEN_CLICKHOUSE_DELTA_SCAN_CACHE_SIZE: String = CHConfig.prefixOf("deltascan.cache.size")
   val GLUTEN_CLICKHOUSE_ADDFILES_TO_MTPS_CACHE_SIZE: String =
-    CHConf.prefixOf("addfiles.to.mtps.cache.size")
+    CHConfig.prefixOf("addfiles.to.mtps.cache.size")
   val GLUTEN_CLICKHOUSE_TABLE_PATH_TO_MTPS_CACHE_SIZE: String =
-    CHConf.prefixOf("table.path.to.mtps.cache.size")
+    CHConfig.prefixOf("table.path.to.mtps.cache.size")
 
   val GLUTEN_CLICKHOUSE_DELTA_METADATA_OPTIMIZE: String =
-    CHConf.prefixOf("delta.metadata.optimize")
+    CHConfig.prefixOf("delta.metadata.optimize")
   val GLUTEN_CLICKHOUSE_DELTA_METADATA_OPTIMIZE_DEFAULT_VALUE: String = "true"
 
   val GLUTEN_CLICKHOUSE_CONVERT_LEFT_ANTI_SEMI_TO_RIGHT: String =
-    CHConf.prefixOf("convert.left.anti_semi.to.right")
+    CHConfig.prefixOf("convert.left.anti_semi.to.right")
   val GLUTEN_CLICKHOUSE_CONVERT_LEFT_ANTI_SEMI_TO_RIGHT_DEFAULT_VALUE: String = "false"
 
   def affinityMode: String = {
@@ -363,7 +363,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   // for example, select a, b, sum(c+d) from t group by a, b with cube
   def enablePushdownPreProjectionAheadExpand(): Boolean = {
     SparkEnv.get.conf.getBoolean(
-      CHConf.prefixOf("enable_pushdown_preprojection_ahead_expand"),
+      CHConfig.prefixOf("enable_pushdown_preprojection_ahead_expand"),
       defaultValue = true
     )
   }
@@ -375,14 +375,14 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   // It could reduce the overhead of pre-aggregate node.
   def enableLazyAggregateExpand(): Boolean = {
     SparkEnv.get.conf.getBoolean(
-      CHConf.runtimeConfig("enable_lazy_aggregate_expand"),
+      CHConfig.runtimeConfig("enable_lazy_aggregate_expand"),
       defaultValue = true
     )
   }
 
   def enablePreProjectionForJoinConditions(): Boolean = {
     SparkEnv.get.conf.getBoolean(
-      CHConf.runtimeConfig("enable_pre_projection_for_join_conditions"),
+      CHConfig.runtimeConfig("enable_pre_projection_for_join_conditions"),
       defaultValue = true
     )
   }
@@ -390,14 +390,14 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   // If the partition keys are high cardinality, the aggregation method is slower.
   def enableConvertWindowGroupLimitToAggregate(): Boolean = {
     SparkEnv.get.conf.getBoolean(
-      CHConf.runtimeConfig("enable_window_group_limit_to_aggregate"),
+      CHConfig.runtimeConfig("enable_window_group_limit_to_aggregate"),
       defaultValue = true
     )
   }
 
   def enableReplaceFromJsonWithGetJsonObject(): Boolean = {
     SparkEnv.get.conf.getBoolean(
-      CHConf.runtimeConfig("enable_replace_from_json_with_get_json_object"),
+      CHConfig.runtimeConfig("enable_replace_from_json_with_get_json_object"),
       defaultValue = true
     )
   }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
@@ -88,7 +88,7 @@ class CHListenerApi extends ListenerApi with Logging {
       JniLibLoader.loadFromPath(executorLibPath, true)
     }
     // Add configs
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
     conf.setCHConfig(
       "timezone" -> conf.get("spark.sql.session.timeZone", TimeZone.getDefault.getID),
       "local_engine.settings.log_processors_profiles" -> "true")

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
@@ -94,32 +94,32 @@ class CHTransformerApi extends TransformerApi with Logging {
       nativeConfMap: util.Map[String, String],
       backendPrefix: String): Unit = {
 
-    require(backendPrefix == CHConf.CONF_PREFIX)
+    require(backendPrefix == CHConfig.CONF_PREFIX)
     if (nativeConfMap.getOrDefault("spark.memory.offHeap.enabled", "false").toBoolean) {
       val offHeapSize =
         nativeConfMap.getOrDefault("spark.gluten.memory.offHeap.size.in.bytes", "0").toLong
       if (offHeapSize > 0) {
 
         // Only set default max_bytes_before_external_group_by for CH when it is not set explicitly.
-        val groupBySpillKey = CHConf.runtimeSettings("max_bytes_before_external_group_by")
+        val groupBySpillKey = CHConfig.runtimeSettings("max_bytes_before_external_group_by")
         if (!nativeConfMap.containsKey(groupBySpillKey)) {
           val groupBySpillValue = offHeapSize * 0.5
           nativeConfMap.put(groupBySpillKey, groupBySpillValue.toLong.toString)
         }
 
-        val maxMemoryUsageKey = CHConf.runtimeSettings("max_memory_usage")
+        val maxMemoryUsageKey = CHConfig.runtimeSettings("max_memory_usage")
         if (!nativeConfMap.containsKey(maxMemoryUsageKey)) {
           val maxMemoryUsageValue = offHeapSize
           nativeConfMap.put(maxMemoryUsageKey, maxMemoryUsageValue.toString)
         }
 
         // Only set default max_bytes_before_external_join for CH when join_algorithm is grace_hash
-        val joinAlgorithmKey = CHConf.runtimeSettings("join_algorithm")
+        val joinAlgorithmKey = CHConfig.runtimeSettings("join_algorithm")
         if (
           nativeConfMap.containsKey(joinAlgorithmKey) &&
           nativeConfMap.get(joinAlgorithmKey) == "grace_hash"
         ) {
-          val joinSpillKey = CHConf.runtimeSettings("max_bytes_in_join")
+          val joinSpillKey = CHConfig.runtimeSettings("max_bytes_in_join")
           if (!nativeConfMap.containsKey(joinSpillKey)) {
             val joinSpillValue = offHeapSize * 0.7
             nativeConfMap.put(joinSpillKey, joinSpillValue.toLong.toString)
@@ -134,7 +134,7 @@ class CHTransformerApi extends TransformerApi with Logging {
       }
     }
 
-    val hdfsConfigPrefix = CHConf.runtimeConfig("hdfs")
+    val hdfsConfigPrefix = CHConfig.runtimeConfig("hdfs")
     injectConfig("spark.hadoop.input.connect.timeout", s"$hdfsConfigPrefix.input_connect_timeout")
     injectConfig("spark.hadoop.input.read.timeout", s"$hdfsConfigPrefix.input_read_timeout")
     injectConfig("spark.hadoop.input.write.timeout", s"$hdfsConfigPrefix.input_write_timeout")
@@ -144,7 +144,7 @@ class CHTransformerApi extends TransformerApi with Logging {
 
     // Respect spark config spark.sql.orc.compression.codec for CH backend
     // TODO: consider compression or orc.compression in table options.
-    val orcCompressionKey = CHConf.runtimeSettings("output_format_orc_compression_method")
+    val orcCompressionKey = CHConfig.runtimeSettings("output_format_orc_compression_method")
     if (!nativeConfMap.containsKey(orcCompressionKey)) {
       if (nativeConfMap.containsKey("spark.sql.orc.compression.codec")) {
         val compression = nativeConfMap.get("spark.sql.orc.compression.codec").toLowerCase()

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeConfig.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeConfig.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.backendsapi.clickhouse
 import org.apache.spark.sql.internal.SQLConf
 
 object RuntimeConfig {
-  import CHConf.runtimeConfig
+  import CHConfig.runtimeConfig
   import SQLConf._
 
   /** Clickhouse Configuration */

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.internal.SQLConf
 
 object RuntimeSettings {
 
-  import CHConf.runtimeSettings
+  import CHConfig.runtimeSettings
   import SQLConf._
 
   /** Clickhouse settings */

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.expression
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.expression.ConverterUtils.FunctionConfig
 import org.apache.gluten.substrait.expression._
@@ -70,7 +70,7 @@ case class CHTruncTimestampTransformer(
     if (
       timeZoneIgnore && timeZoneId.nonEmpty &&
       !timeZoneId.get.equalsIgnoreCase(
-        SQLConf.get.getConfString(s"${CHConf.runtimeConfig("timezone")}")
+        SQLConf.get.getConfString(s"${CHConfig.runtimeConfig("timezone")}")
       )
     ) {
       throw new GlutenNotSupportException(

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/RewriteToDateExpresstionRule.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.extension
 
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.config.GlutenConfig
 
 import org.apache.spark.internal.Logging
@@ -43,7 +44,7 @@ class RewriteToDateExpresstionRule(spark: SparkSession) extends Rule[LogicalPlan
     if (
       plan.resolved &&
       GlutenConfig.get.enableGluten &&
-      GlutenConfig.get.enableCHRewriteDateConversion
+      CHConfig.get.enableCHRewriteDateConversion
     ) {
       visitPlan(plan)
     } else {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/vectorized/NativeExpressionEvaluator.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/vectorized/NativeExpressionEvaluator.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.vectorized
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.utils.ConfigUtil
 
 import scala.collection.JavaConverters._
@@ -29,10 +29,10 @@ object NativeExpressionEvaluator {
     ExpressionEvaluatorJniWrapper.updateQueryRuntimeSettings(
       ConfigUtil.serialize(
         settings
-          .filter(t => CHConf.startWithSettingsPrefix(t._1) && t._2.nonEmpty)
+          .filter(t => CHConfig.startWithSettingsPrefix(t._1) && t._2.nonEmpty)
           .map {
             case (k, v) =>
-              (CHConf.removeSettingsPrefix(k), v)
+              (CHConfig.removeSettingsPrefix(k), v)
           }
           .asJava))
   }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.clickhouse.CHBackendSettings
+import org.apache.gluten.backendsapi.clickhouse.{CHBackendSettings, CHConfig}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.ColumnarNativeIterator
 import org.apache.gluten.memory.CHThreadGroup
@@ -59,9 +59,9 @@ class CHColumnarShuffleWriter[K, V](
       conf,
       compressionCodec,
       GlutenConfig.get.columnarShuffleCodecBackend.orNull)
-  private val maxSortBufferSize = GlutenConfig.get.chColumnarMaxSortBufferSize
-  private val forceMemorySortShuffle = GlutenConfig.get.chColumnarForceMemorySortShuffle
-  private val spillThreshold = GlutenConfig.get.chColumnarShuffleSpillThreshold
+  private val maxSortBufferSize = CHConfig.get.chColumnarMaxSortBufferSize
+  private val forceMemorySortShuffle = CHConfig.get.chColumnarForceMemorySortShuffle
+  private val spillThreshold = CHConfig.get.chColumnarShuffleSpillThreshold
   private val jniWrapper = new CHShuffleSplitterJniWrapper
   // Are we in the process of stopping? Because map tasks can call stop() with success = true
   // and then call stop() with success = false if they get an exception, we want to make sure

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/MergeTreeConf.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/MergeTreeConf.scala
@@ -16,16 +16,16 @@
  */
 package org.apache.spark.sql.delta
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.internal.config.ConfigBuilder
 import org.apache.spark.sql.internal.SQLConf
 
-/** [[CHConf]] entries for MergeTree features. */
+/** [[CHConfig]] entries for MergeTree features. */
 trait MergeTreeConfBase {
 
-  private val CH_PREFIX: String = CHConf.runtimeSettings("merge_tree")
-  private val GLUTEN_PREFIX: String = CHConf.runtimeSettings("mergetree")
+  private val CH_PREFIX: String = CHConfig.runtimeSettings("merge_tree")
+  private val GLUTEN_PREFIX: String = CHConfig.runtimeSettings("mergetree")
 
   private def buildCHConf(key: String): ConfigBuilder = SQLConf.buildConf(s"$CH_PREFIX.$key")
   private def buildGLUTENConf(key: String): ConfigBuilder =

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/commands/GlutenCacheFilesCommand.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/commands/GlutenCacheFilesCommand.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.commands
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.substrait.rel.LocalFilesBuilder
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
@@ -53,7 +53,7 @@ case class GlutenCacheFilesCommand(
   override def run(session: SparkSession): Seq[Row] = {
     if (
       !session.sparkContext.getConf.getBoolean(
-        CHConf.runtimeConfig("gluten_cache.local.enabled"),
+        CHConfig.runtimeConfig("gluten_cache.local.enabled"),
         defaultValue = false)
     ) {
       return Seq(Row(false, "Config `gluten_cache.local.enabled` is disabled."))

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/clickhouse/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/clickhouse/utils/MergeTreePartsPartitionsUtil.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.clickhouse.utils
 
-import org.apache.gluten.backendsapi.clickhouse.{CHBackendSettings, CHConf}
+import org.apache.gluten.backendsapi.clickhouse.{CHBackendSettings, CHConfig}
 import org.apache.gluten.execution.{GlutenMergeTreePartition, MergeTreePartRange, MergeTreePartSplit}
 import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter}
 import org.apache.gluten.softaffinity.SoftAffinityManager
@@ -555,7 +555,7 @@ object MergeTreePartsPartitionsUtil extends Logging {
   }
 
   private def useDriverFilter(filterExprs: Seq[Expression], sparkSession: SparkSession): Boolean = {
-    val enableDriverFilterKey = CHConf.runtimeSettings("enabled_driver_filter_mergetree_index")
+    val enableDriverFilterKey = CHConfig.runtimeSettings("enabled_driver_filter_mergetree_index")
 
     // When using soft affinity, disable driver filter
     filterExprs.nonEmpty && sparkSession.sessionState.conf.getConfString(

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v1/CHMergeTreeWriterInjects.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v1/CHMergeTreeWriterInjects.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.v1
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.execution.ColumnarToRowExecBase
 import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.substrait.`type`.ColumnTypeNode
@@ -88,7 +88,7 @@ class CHMergeTreeWriterInjects extends CHFormatWriterInjects {
       context: TaskAttemptContext,
       nativeConf: ju.Map[String, String]): OutputWriter = {
 
-    val wrapper = if (CHConf.get.enableOnePipelineMergeTreeWrite) {
+    val wrapper = if (CHConfig.get.enableOnePipelineMergeTreeWrite) {
 
       /**
        * In pipeline mode, CHColumnarWriteFilesRDD.writeFilesForEmptyIterator will create a JNI

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseConfig.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseConfig.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.clickhouse
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.execution.datasources.mergetree.StorageMeta
@@ -35,7 +35,7 @@ object ClickHouseConfig {
   private val DEFAULT_ENGINE = "mergetree"
   private val OPT_NAME_PREFIX = "clickhouse."
 
-  val CLICKHOUSE_WORKER_ID: String = CHConf.prefixOf("worker.id")
+  val CLICKHOUSE_WORKER_ID: String = CHConfig.prefixOf("worker.id")
 
   /** Create a mergetree configurations and returns the normalized key -> value map. */
   def createMergeTreeConfigurations(

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseColumnarMemorySortShuffleSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseColumnarMemorySortShuffleSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -37,7 +37,7 @@ class GlutenClickHouseColumnarMemorySortShuffleSuite
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.sql.adaptive.enabled", "true")
-      .set(CHConf.prefixOf("forceMemorySortShuffle"), "true")
+      .set(CHConfig.prefixOf("forceMemorySortShuffle"), "true")
 
     // TODO: forceMemorySortShuffle
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseColumnarShuffleAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseColumnarShuffleAQESuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -179,7 +179,7 @@ class GlutenClickHouseColumnarShuffleAQESuite
 
   test("GLUTEN-6768 rerorder hash join") {
     withSQLConf(
-      (CHConf.prefixOf("enable_reorder_hash_join_tables"), "true"),
+      (CHConfig.prefixOf("enable_reorder_hash_join_tables"), "true"),
       ("spark.sql.adaptive.enabled", "true")) {
       spark.sql("create table t1(a int, b int) using parquet")
       spark.sql("create table t2(a int, b int) using parquet")
@@ -265,8 +265,8 @@ class GlutenClickHouseColumnarShuffleAQESuite
 
   test("GLUTEN-6768 change mixed join condition into multi join on clauses") {
     withSQLConf(
-      (CHConf.runtimeConfig("prefer_multi_join_on_clauses"), "true"),
-      (CHConf.runtimeConfig("multi_join_on_clauses_build_side_row_limit"), "1000000")
+      (CHConfig.runtimeConfig("prefer_multi_join_on_clauses"), "true"),
+      (CHConfig.runtimeConfig("multi_join_on_clauses_build_side_row_limit"), "1000000")
     ) {
 
       spark.sql("create table t1(a int, b int, c int, d int) using parquet")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseDeltaParquetWriteSuite.scala
@@ -41,7 +41,7 @@ class GlutenClickHouseDeltaParquetWriteSuite
   override protected val tpchQueries: String = rootPath + "queries/tpch-queries-ch"
   override protected val queriesResults: String = rootPath + "mergetree-queries-output"
 
-  import org.apache.gluten.backendsapi.clickhouse.CHConf._
+  import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseExcelFormatSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseExcelFormatSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 
 import org.apache.spark.SparkConf
@@ -67,7 +67,7 @@ class GlutenClickHouseExcelFormatSuite
   override protected def createTPCHNotNullTables(): Unit = {}
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.sql.adaptive.enabled", "true")
@@ -881,7 +881,7 @@ class GlutenClickHouseExcelFormatSuite
       .toDF()
       .createTempView("no_quote_table")
 
-    withSQLConf((CHConf.runtimeSettings("use_excel_serialization.quote_strict"), "true")) {
+    withSQLConf((CHConfig.runtimeSettings("use_excel_serialization.quote_strict"), "true")) {
       compareResultsAgainstVanillaSpark(
         "select * from no_quote_table",
         compareResult = true,
@@ -1187,7 +1187,7 @@ class GlutenClickHouseExcelFormatSuite
   }
 
   test("issue-2881 null string test") {
-    withSQLConf((CHConf.runtimeSettings("use_excel_serialization.empty_as_null"), "true")) {
+    withSQLConf((CHConfig.runtimeSettings("use_excel_serialization.empty_as_null"), "true")) {
       val file_path = csvDataPath + "/null_string.csv"
       val schema = StructType.apply(
         Seq(
@@ -1220,7 +1220,7 @@ class GlutenClickHouseExcelFormatSuite
   }
 
   test("issue-3542 null string test") {
-    withSQLConf((CHConf.runtimeSettings("use_excel_serialization.empty_as_null"), "false")) {
+    withSQLConf((CHConfig.runtimeSettings("use_excel_serialization.empty_as_null"), "false")) {
       val file_path = csvDataPath + "/null_string.csv"
       val schema = StructType.apply(
         Seq(
@@ -1358,7 +1358,7 @@ class GlutenClickHouseExcelFormatSuite
       .createTempView("TEST_MEASURE1")
 
     withSQLConf(
-      (CHConf.runtimeSettings("use_excel_serialization"), "false"),
+      (CHConfig.runtimeSettings("use_excel_serialization"), "false"),
       ("spark.gluten.sql.text.input.empty.as.default", "true")) {
       compareResultsAgainstVanillaSpark(
         """
@@ -1394,7 +1394,7 @@ class GlutenClickHouseExcelFormatSuite
   }
 
   test("issues-3609 int read test") {
-    withSQLConf((CHConf.runtimeSettings("use_excel_serialization.number_force"), "false")) {
+    withSQLConf((CHConfig.runtimeSettings("use_excel_serialization.number_force"), "false")) {
       val csv_path = csvDataPath + "/int_special.csv"
       val options = new util.HashMap[String, String]()
       options.put("delimiter", ",")
@@ -1423,7 +1423,7 @@ class GlutenClickHouseExcelFormatSuite
       checkAnswer(df, expectedAnswer)
     }
 
-    withSQLConf((CHConf.runtimeSettings("use_excel_serialization.number_force"), "true")) {
+    withSQLConf((CHConfig.runtimeSettings("use_excel_serialization.number_force"), "true")) {
       val csv_path = csvDataPath + "/int_special.csv"
       val options = new util.HashMap[String, String]()
       options.put("delimiter", ",")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseJoinSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseJoinSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
@@ -31,7 +31,7 @@ class GlutenClickHouseJoinSuite extends GlutenClickHouseWholeStageTransformerSui
     rootPath + "../../../../tools/gluten-it/common/src/main/resources/tpch-queries"
   protected val queriesResults: String = rootPath + "queries-output"
 
-  private val joinAlgorithm = CHConf.runtimeSettings("join_algorithm")
+  private val joinAlgorithm = CHConfig.runtimeSettings("join_algorithm")
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseS3SourceSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseS3SourceSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkConf
 
@@ -33,7 +33,7 @@ class GlutenClickHouseS3SourceSuite extends GlutenClickHouseTPCHAbstractSuite {
   override protected val queriesResults: String = rootPath + "queries-output"
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -95,7 +95,7 @@ class GlutenClickHouseS3SourceSuite extends GlutenClickHouseTPCHAbstractSuite {
     println(s"currTime=$currTime")
     // scalastyle:on println
     spark.sparkContext.setLocalProperty(
-      CHConf.runtimeSettings("spark.kylin.local-cache.accept-cache-time"),
+      CHConfig.runtimeSettings("spark.kylin.local-cache.accept-cache-time"),
       currTime.toString)
     spark
       .sql("""
@@ -109,7 +109,7 @@ class GlutenClickHouseS3SourceSuite extends GlutenClickHouseTPCHAbstractSuite {
     println(s"currTime=$currTime")
     // scalastyle:on println
     spark.sparkContext.setLocalProperty(
-      CHConf.runtimeSettings("spark.kylin.local-cache.accept-cache-time"),
+      CHConfig.runtimeSettings("spark.kylin.local-cache.accept-cache-time"),
       currTime.toString)
     spark
       .sql("""
@@ -123,7 +123,7 @@ class GlutenClickHouseS3SourceSuite extends GlutenClickHouseTPCHAbstractSuite {
     println(s"currTime=$currTime")
     // scalastyle:on println
     spark.sparkContext.setLocalProperty(
-      CHConf.runtimeSettings("spark.kylin.local-cache.accept-cache-time"),
+      CHConfig.runtimeSettings("spark.kylin.local-cache.accept-cache-time"),
       currTime.toString)
     spark
       .sql("""

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseSyntheticDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseSyntheticDataSuite.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.GlutenConfig
-
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -68,8 +66,6 @@ class GlutenClickHouseSyntheticDataSuite
   override protected def afterAll(): Unit = {
     DeltaLog.clearCache()
     super.afterAll()
-    // init GlutenConfig in the next beforeAll
-    GlutenConfig.ins = null
   }
 
   test("test all data types all agg") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.benchmarks.GenTPCDSTableScripts
-import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.utils.{Arm, UTSystemParameters}
 
 import org.apache.spark.SparkConf
@@ -164,8 +163,6 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
     }
 
     FileUtils.forceDelete(new File(basePath))
-    // init GlutenConfig in the next beforeAll
-    GlutenConfig.ins = null
   }
 
   protected def runTPCDSQuery(

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHAbstractSuite.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.GlutenConfig
-
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.DataFrame
@@ -589,8 +587,6 @@ abstract class GlutenClickHouseTPCHAbstractSuite
     ClickhouseSnapshot.clearAllFileStatusCache()
     DeltaLog.clearCache()
     super.afterAll()
-    // init GlutenConfig in the next beforeAll
-    GlutenConfig.ins = null
   }
 
   override protected def runTPCHQuery(

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHBucketSuite.scala
@@ -39,7 +39,7 @@ class GlutenClickHouseTPCHBucketSuite
   override protected val queriesResults: String = rootPath + "bucket-queries-output"
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.io.compression.codec", "LZ4")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Alias
@@ -233,7 +233,7 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
 
     Seq(("true", false), ("false", true)).foreach(
       conf => {
-        withSQLConf((GlutenConfig.ENABLE_CH_REWRITE_DATE_CONVERSION.key, conf._1)) {
+        withSQLConf((CHConfig.ENABLE_CH_REWRITE_DATE_CONVERSION.key, conf._1)) {
           runSql(sqlStr)(
             df => {
               val project = df.queryExecution.executedPlan.collect {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseWholeStageTransformerSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseWholeStageTransformerSuite.scala
@@ -75,7 +75,7 @@ class GlutenClickHouseWholeStageTransformerSuite extends WholeStageTransformerSu
   }
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     val conf = super.sparkConf
       .set("spark.gluten.sql.enable.native.validation", "false")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseHiveTableSuite.scala
@@ -40,7 +40,7 @@ class GlutenClickHouseHiveTableSuite
   with AdaptiveSparkPlanHelper {
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     new SparkConf()
       .set("spark.plugins", "org.apache.gluten.GlutenPlugin")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseTableAfterRestart.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseTableAfterRestart.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.hive
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
@@ -48,7 +48,7 @@ class GlutenClickHouseTableAfterRestart
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -61,7 +61,7 @@ class GlutenClickHouseTableAfterRestart
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.ui.enabled", "true")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeCacheDataSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeConfig}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -48,7 +48,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
   }
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -59,7 +59,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set("spark.gluten.soft-affinity.enabled", "true")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -595,7 +595,7 @@ class GlutenClickHouseMergeTreeCacheDataSuite
   }
 
   test("test disable cache files return") {
-    withSQLConf(CHConf.runtimeConfig("gluten_cache.local.enabled") -> "false") {
+    withSQLConf(CHConfig.runtimeConfig("gluten_cache.local.enabled") -> "false") {
       runSql(
         s"CACHE FILES select * from '$HDFS_URL_ENDPOINT/tpch-data/lineitem'",
         noFallBack = false) {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeOptimizeSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeOptimizeSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -43,7 +43,7 @@ class GlutenClickHouseMergeTreeOptimizeSuite
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -53,7 +53,7 @@ class GlutenClickHouseMergeTreeOptimizeSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "10000")
       .set(
         "spark.databricks.delta.retentionDurationCheck.enabled",
@@ -494,7 +494,7 @@ class GlutenClickHouseMergeTreeOptimizeSuite
   test("test mergetree insert with optimize basic") {
     withSQLConf(
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
-      CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true"
+      CHConfig.runtimeSettings("mergetree.merge_after_insert") -> "true"
     ) {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS lineitem_mergetree_insert_optimize_basic;

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreePathBasedWriteSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.utils.Arm
@@ -50,7 +50,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -61,7 +61,7 @@ class GlutenClickHouseMergeTreePathBasedWriteSuite
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.ui.enabled", "true")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -51,7 +51,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
   }
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -61,7 +61,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -497,8 +497,8 @@ class GlutenClickHouseMergeTreeWriteOnHDFSSuite
 
     withSQLConf(
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
-      CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true",
-      CHConf.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
+      CHConfig.runtimeSettings("mergetree.merge_after_insert") -> "true",
+      CHConfig.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
       RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key -> "10000"
     ) {
       spark.sql(s"""

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -51,7 +51,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
   }
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -61,7 +61,7 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .setCHSettings("mergetree.merge_after_insert", false)
   }
 
@@ -496,8 +496,8 @@ class GlutenClickHouseMergeTreeWriteOnHDFSWithRocksDBMetaSuite
 
     withSQLConf(
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
-      CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true",
-      CHConf.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
+      CHConfig.runtimeSettings("mergetree.merge_after_insert") -> "true",
+      CHConfig.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
       RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key -> "10000"
     ) {
       spark.sql(s"""

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteOnS3Suite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeConfig}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeConfig}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{BasicScanExecTransformer, FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
@@ -66,7 +66,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
       .set("spark.sql.adaptive.enabled", "true")
       .set(RuntimeConfig.LOGGER_LEVEL.key, "error")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
   }
 
   override protected def beforeEach(): Unit = {
@@ -557,8 +557,8 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
 
     withSQLConf(
       "spark.databricks.delta.optimize.minFileSize" -> "200000000",
-      CHConf.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
-      CHConf.runtimeSettings("mergetree.merge_after_insert") -> "true"
+      CHConfig.runtimeSettings("mergetree.insert_without_local_storage") -> "true",
+      CHConfig.runtimeSettings("mergetree.merge_after_insert") -> "true"
     ) {
       spark.sql(s"""
                    |DROP TABLE IF EXISTS $tableName;
@@ -617,7 +617,7 @@ class GlutenClickHouseMergeTreeWriteOnS3Suite
 
     FileUtils.forceDelete(new File(S3_METADATA_PATH))
 
-    withSQLConf(CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> "true") {
+    withSQLConf(CHConfig.runtimeSettings("enabled_driver_filter_mergetree_index") -> "true") {
       runTPCHQueryBySQL(6, q6(tableName)) {
         df =>
           val scanExec = collect(df.queryExecution.executedPlan) {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.utils.Arm
@@ -46,7 +46,7 @@ class GlutenClickHouseMergeTreeWriteSuite
   override protected val tpchQueries: String = rootPath + "queries/tpch-queries-ch"
   override protected val queriesResults: String = rootPath + "mergetree-queries-output"
 
-  import org.apache.gluten.backendsapi.clickhouse.CHConf._
+  import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
@@ -58,7 +58,7 @@ class GlutenClickHouseMergeTreeWriteSuite
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
       .set(RuntimeSettings.MIN_INSERT_BLOCK_SIZE_ROWS.key, "100000")
       .setCHSettings("mergetree.merge_after_insert", false)
       .setCHSettings("input_format_parquet_max_block_size", 8192)
@@ -1571,7 +1571,7 @@ class GlutenClickHouseMergeTreeWriteSuite
 
     Seq(("true", 2), ("false", 3)).foreach(
       conf => {
-        withSQLConf(CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> conf._1) {
+        withSQLConf(CHConfig.runtimeSettings("enabled_driver_filter_mergetree_index") -> conf._1) {
           runTPCHQueryBySQL(6, q6("lineitem_mergetree_pk_pruning_by_driver")) {
             df =>
               val scanExec = collect(df.queryExecution.executedPlan) {
@@ -1593,8 +1593,8 @@ class GlutenClickHouseMergeTreeWriteSuite
 
     // GLUTEN-7670: fix enable 'files.per.partition.threshold'
     withSQLConf(
-      CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> "true",
-      CHConf.prefixOf("files.per.partition.threshold") -> "10"
+      CHConfig.runtimeSettings("enabled_driver_filter_mergetree_index") -> "true",
+      CHConfig.prefixOf("files.per.partition.threshold") -> "10"
     ) {
       runTPCHQueryBySQL(6, q6("lineitem_mergetree_pk_pruning_by_driver")) {
         df =>
@@ -1711,7 +1711,7 @@ class GlutenClickHouseMergeTreeWriteSuite
 
     Seq(("true", 2), ("false", 2)).foreach(
       conf => {
-        withSQLConf(CHConf.runtimeSettings("enabled_driver_filter_mergetree_index") -> conf._1) {
+        withSQLConf(CHConfig.runtimeSettings("enabled_driver_filter_mergetree_index") -> conf._1) {
           runTPCHQueryBySQL(12, sqlStr) {
             df =>
               val scanExec = collect(df.queryExecution.executedPlan) {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/mergetree/GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.mergetree
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.GlutenClickHouseTPCHAbstractSuite
 
@@ -44,7 +44,7 @@ class GlutenClickHouseMergeTreeWriteTaskNotSerializableSuite
       .set("spark.sql.files.maxPartitionBytes", "20000000")
       .set("spark.memory.offHeap.size", "4G")
       .set(GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")
-      .set(CHConf.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
+      .set(CHConfig.ENABLE_ONEPIPELINE_MERGETREE_WRITE.key, spark35.toString)
   }
 
   override protected def createTPCHNotNullTables(): Unit = {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -43,7 +43,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
   // scalastyle:off line.size.limit
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/parquet/GlutenParquetColumnIndexSuite.scala
@@ -109,7 +109,7 @@ class GlutenParquetColumnIndexSuite
     assertResult(scanOutput)(chFileScan.longMetric("numOutputRows").value)
   }
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetGraceHashJoinSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetGraceHashJoinSuite.scala
@@ -26,7 +26,7 @@ class GlutenClickHouseTPCDSParquetGraceHashJoinSuite extends GlutenClickHouseTPC
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "sort")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpcds/GlutenClickHouseTPCDSParquetSuite.scala
@@ -30,7 +30,7 @@ class GlutenClickHouseTPCDSParquetSuite extends GlutenClickHouseTPCDSAbstractSui
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
     super.sparkConf
       .set("spark.shuffle.manager", "sort")
       .set("spark.io.compression.codec", "snappy")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseHDFSSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseHDFSSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.tpch
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf._
+import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 import org.apache.gluten.execution.{CHNativeCacheManager, FileSourceScanExecTransformer, GlutenClickHouseTPCHAbstractSuite}
 
 import org.apache.spark.SparkConf

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.execution.tpch
 
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.utils.Arm
@@ -41,7 +42,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
@@ -51,7 +52,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.gluten.sql.columnar.backend.ch.shuffle.hash.algorithm", "sparkMurmurHash3_32")
       .setCHConfig("enable_streaming_aggregating", true)
-      .set(GlutenConfig.COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD.key, (1024 * 1024).toString)
+      .set(CHConfig.COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD.key, (1024 * 1024).toString)
   }
 
   override protected def createTPCHNotNullTables(): Unit = {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQESuite.scala
@@ -39,7 +39,7 @@ class GlutenClickHouseTPCHParquetAQESuite
 
   /** Run Gluten + ClickHouse Backend with SortShuffleManager */
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
 
     super.sparkConf
       .set("spark.shuffle.manager", "sort")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -46,7 +46,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
   protected val bucketTableDataPath: String = basePath + "/tpch-parquet-bucket"
 
   override protected def sparkConf: SparkConf = {
-    import org.apache.gluten.backendsapi.clickhouse.CHConf._
+    import org.apache.gluten.backendsapi.clickhouse.CHConfig._
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.io.compression.codec", "LZ4")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution.tpch
 
-import org.apache.gluten.backendsapi.clickhouse.{CHConf, RuntimeSettings}
+import org.apache.gluten.backendsapi.clickhouse.{CHConfig, RuntimeSettings}
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.execution.GlutenPlan
@@ -2621,7 +2621,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite extends GlutenClickHouseTPCHAbstr
 
   test("GLUTEN-4521: Invalid result from grace mergeing aggregation with spill") {
     withSQLConf(
-      (CHConf.runtimeConfig("max_allowed_memory_usage_ratio_for_aggregate_merging"), "0.0001")) {
+      (CHConfig.runtimeConfig("max_allowed_memory_usage_ratio_for_aggregate_merging"), "0.0001")) {
       val sql =
         """
           |select count(l_orderkey, l_partkey) from (

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/test/GlutenSQLTestUtils.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/test/GlutenSQLTestUtils.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.test
 
-import org.apache.gluten.config.GlutenConfig
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.test.SharedSparkSession
@@ -26,7 +24,5 @@ trait GlutenSQLTestUtils extends SparkFunSuite with SharedSparkSession {
   override protected def afterAll(): Unit = {
     DeltaLog.clearCache()
     super.afterAll()
-    // init GlutenConfig in the next beforeAll
-    GlutenConfig.ins = null
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHOptimizeRuleBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHOptimizeRuleBenchmark.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.benchmarks
 
-import org.apache.gluten.backendsapi.clickhouse.CHConf
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
 
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.SparkSession
@@ -62,7 +62,7 @@ object CHOptimizeRuleBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmar
   }
 
   def testToDateOptimize(parquetDir: String, enable: String): Unit = {
-    withSQLConf((CHConf.prefixOf("rewrite.dateConversion"), enable)) {
+    withSQLConf((CHConfig.prefixOf("rewrite.dateConversion"), enable)) {
       spark
         .sql(s"""
                 |select

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.GlutenBuildInfo._
 import org.apache.gluten.backendsapi._
 import org.apache.gluten.columnarbatch.VeloxBatch
 import org.apache.gluten.component.Component.BuildInfo
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.{GlutenConfig, VeloxConfig}
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
@@ -166,8 +166,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
           }
         case DwrfReadFormat => None
         case OrcReadFormat =>
-          if (!GlutenConfig.get.veloxOrcScanEnabled) {
-            Some(s"Velox ORC scan is turned off, ${GlutenConfig.VELOX_ORC_SCAN_ENABLED.key}")
+          if (!VeloxConfig.get.veloxOrcScanEnabled) {
+            Some(s"Velox ORC scan is turned off, ${VeloxConfig.VELOX_ORC_SCAN_ENABLED.key}")
           } else {
             val typeValidator: PartialFunction[StructField, String] = {
               case StructField(_, arrayType: ArrayType, _, _)
@@ -543,7 +543,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
   override def alwaysFailOnMapExpression(): Boolean = true
 
   override def requiredChildOrderingForWindow(): Boolean = {
-    GlutenConfig.get.veloxColumnarWindowType.equals("streaming")
+    VeloxConfig.get.veloxColumnarWindowType.equals("streaming")
   }
 
   override def requiredChildOrderingForWindowGroupLimit(): Boolean = false

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.config
+
+import org.apache.gluten.config.GlutenConfig.{buildConf, buildStaticConf, COLUMNAR_MAX_BATCH_SIZE}
+
+import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.sql.internal.SQLConf
+
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+class VeloxConfig(conf: SQLConf) extends GlutenConfig(conf) {
+  import VeloxConfig._
+
+  def veloxColumnarWindowType: String = getConf(COLUMNAR_VELOX_WINDOW_TYPE)
+
+  def veloxSpillFileSystem: String = getConf(COLUMNAR_VELOX_SPILL_FILE_SYSTEM)
+
+  def veloxResizeBatchesShuffleInput: Boolean =
+    getConf(COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT)
+
+  case class ResizeRange(min: Int, max: Int) {
+    assert(max >= min)
+    assert(min > 0, "Min batch size should be larger than 0")
+    assert(max > 0, "Max batch size should be larger than 0")
+  }
+
+  def veloxResizeBatchesShuffleInputRange: ResizeRange = {
+    val standardSize = getConf(COLUMNAR_MAX_BATCH_SIZE)
+    val defaultMinSize: Int = (0.25 * standardSize).toInt.max(1)
+    val minSize = getConf(COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT_MIN_SIZE)
+      .getOrElse(defaultMinSize)
+    ResizeRange(minSize, Int.MaxValue)
+  }
+
+  def veloxBloomFilterMaxNumBits: Long = getConf(COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS)
+
+  def castFromVarcharAddTrimNode: Boolean = getConf(CAST_FROM_VARCHAR_ADD_TRIM_NODE)
+
+  def enableVeloxFlushablePartialAggregation: Boolean =
+    getConf(VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED)
+
+  def enableBroadcastBuildRelationInOffheap: Boolean =
+    getConf(VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP)
+
+  def veloxOrcScanEnabled: Boolean =
+    getConf(VELOX_ORC_SCAN_ENABLED)
+}
+
+object VeloxConfig {
+
+  def get: VeloxConfig = {
+    new VeloxConfig(SQLConf.get)
+  }
+
+  val COLUMNAR_VELOX_WINDOW_TYPE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.window.type")
+      .internal()
+      .doc(
+        "Velox backend supports both SortWindow and" +
+          " StreamingWindow operators." +
+          " The StreamingWindow operator skips the sorting step" +
+          " in the input but does not support spill." +
+          " On the other hand, the SortWindow operator is " +
+          "responsible for sorting the input data within the" +
+          " Window operator and also supports spill.")
+      .stringConf
+      .checkValues(Set("streaming", "sort"))
+      .createWithDefault("streaming")
+
+  // velox caching options.
+  val COLUMNAR_VELOX_CACHE_ENABLED =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.cacheEnabled")
+      .internal()
+      .doc("Enable Velox cache, default off")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_VELOX_MEM_CACHE_SIZE =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.memCacheSize")
+      .internal()
+      .doc("The memory cache size")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1GB")
+
+  val COLUMNAR_VELOX_MEM_INIT_CAPACITY =
+    buildConf("spark.gluten.sql.columnar.backend.velox.memInitCapacity")
+      .internal()
+      .doc("The initial memory capacity to reserve for a newly created Velox query memory pool.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("8MB")
+
+  val COLUMNAR_VELOX_MEM_RECLAIM_MAX_WAIT_MS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.reclaimMaxWaitMs")
+      .internal()
+      .doc("The max time in ms to wait for memory reclaim.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(TimeUnit.MINUTES.toMillis(60))
+
+  val COLUMNAR_VELOX_SSD_CACHE_PATH =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCachePath")
+      .internal()
+      .doc("The folder to store the cache files, better on SSD")
+      .stringConf
+      .createWithDefault("/tmp")
+
+  val COLUMNAR_VELOX_SSD_CACHE_SIZE =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCacheSize")
+      .internal()
+      .doc("The SSD cache size, will do memory caching only if this value = 0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1GB")
+
+  val COLUMNAR_VELOX_SSD_CACHE_SHARDS =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCacheShards")
+      .internal()
+      .doc("The cache shards")
+      .intConf
+      .createWithDefault(1)
+
+  val COLUMNAR_VELOX_SSD_CACHE_IO_THREADS =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCacheIOThreads")
+      .internal()
+      .doc("The IO threads for cache promoting")
+      .intConf
+      .createWithDefault(1)
+
+  val COLUMNAR_VELOX_SSD_ODIRECT_ENABLED =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdODirect")
+      .internal()
+      .doc("The O_DIRECT flag for cache writing")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.IOThreads")
+      .internal()
+      .doc(
+        "The Size of the IO thread pool in the Connector. " +
+          "This thread pool is used for split preloading and DirectBufferedInput. " +
+          "By default, the value is the same as the maximum task slots per Spark executor.")
+      .intConf
+      .createOptional
+
+  val COLUMNAR_VELOX_ASYNC_TIMEOUT =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.asyncTimeoutOnTaskStopping")
+      .internal()
+      .doc(
+        "Timeout for asynchronous execution when task is being stopped in Velox backend. " +
+          "It's recommended to set to a number larger than network connection timeout that the " +
+          "possible aysnc tasks are relying on.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(30000)
+
+  val COLUMNAR_VELOX_SPLIT_PRELOAD_PER_DRIVER =
+    buildConf("spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver")
+      .internal()
+      .doc("The split preload per task")
+      .intConf
+      .createWithDefault(2)
+
+  val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
+    buildConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
+      .internal()
+      .doc("Set glog verbose level in Velox backend, same as FLAGS_v.")
+      .intConf
+      .createWithDefault(0)
+
+  val COLUMNAR_VELOX_GLOG_SEVERITY_LEVEL =
+    buildConf("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel")
+      .internal()
+      .doc("Set glog severity level in Velox backend, same as FLAGS_minloglevel.")
+      .intConf
+      .createWithDefault(1)
+
+  val COLUMNAR_VELOX_SPILL_STRATEGY =
+    buildConf("spark.gluten.sql.columnar.backend.velox.spillStrategy")
+      .internal()
+      .doc("none: Disable spill on Velox backend; " +
+        "auto: Let Spark memory manager manage Velox's spilling")
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValues(Set("none", "auto"))
+      .createWithDefault("auto")
+
+  val COLUMNAR_VELOX_MAX_SPILL_LEVEL =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillLevel")
+      .internal()
+      .doc("The max allowed spilling level with zero being the initial spilling level")
+      .intConf
+      .createWithDefault(4)
+
+  val COLUMNAR_VELOX_MAX_SPILL_FILE_SIZE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillFileSize")
+      .internal()
+      .doc("The maximum size of a single spill file created")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1GB")
+
+  val COLUMNAR_VELOX_SPILL_FILE_SYSTEM =
+    buildConf("spark.gluten.sql.columnar.backend.velox.spillFileSystem")
+      .internal()
+      .doc(
+        "The filesystem used to store spill data. local: The local file system. " +
+          "heap-over-local: Write file to JVM heap if having extra heap space. " +
+          "Otherwise write to local file system.")
+      .stringConf
+      .checkValues(Set("local", "heap-over-local"))
+      .createWithDefaultString("local")
+
+  val COLUMNAR_VELOX_MAX_SPILL_RUN_ROWS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillRunRows")
+      .internal()
+      .doc("The maximum row size of a single spill run")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("3M")
+
+  val COLUMNAR_VELOX_MAX_SPILL_BYTES =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillBytes")
+      .internal()
+      .doc("The maximum file size of a query")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("100G")
+
+  val MAX_PARTITION_PER_WRITERS_SESSION =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxPartitionsPerWritersSession")
+      .internal()
+      .doc("Maximum number of partitions per a single table writer instance.")
+      .intConf
+      .checkValue(_ > 0, "must be a positive number")
+      .createWithDefault(10000)
+
+  val COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT =
+    buildConf("spark.gluten.sql.columnar.backend.velox.resizeBatches.shuffleInput")
+      .internal()
+      .doc(s"If true, combine small columnar batches together before sending to shuffle. " +
+        s"The default minimum output batch size is equal to 0.8 * ${COLUMNAR_MAX_BATCH_SIZE.key}")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT_MIN_SIZE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.resizeBatches.shuffleInput.minSize")
+      .internal()
+      .doc(
+        s"The minimum batch size for shuffle. If size of an input batch is " +
+          s"smaller than the value, it will be combined with other " +
+          s"batches before sending to shuffle. Only functions when " +
+          s"${COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT.key} is set to true. " +
+          s"Default value: 0.25 * <max batch size>")
+      .intConf
+      .createOptional
+
+  val COLUMNAR_VELOX_ENABLE_USER_EXCEPTION_STACKTRACE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.enableUserExceptionStacktrace")
+      .internal()
+      .doc("Enable the stacktrace for user type of VeloxException")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COLUMNAR_VELOX_SHOW_TASK_METRICS_WHEN_FINISHED =
+    buildConf("spark.gluten.sql.columnar.backend.velox.showTaskMetricsWhenFinished")
+      .internal()
+      .doc("Show velox full task metrics when finished.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_VELOX_MEMORY_USE_HUGE_PAGES =
+    buildConf("spark.gluten.sql.columnar.backend.velox.memoryUseHugePages")
+      .internal()
+      .doc("Use explicit huge pages for Velox memory allocation.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_VELOX_ENABLE_SYSTEM_EXCEPTION_STACKTRACE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace")
+      .internal()
+      .doc("Enable the stacktrace for system type of VeloxException")
+      .booleanConf
+      .createWithDefault(true)
+
+  val VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED =
+    buildConf("spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation")
+      .internal()
+      .doc(
+        "Enable flushable aggregation. If true, Gluten will try converting regular aggregation " +
+          "into Velox's flushable aggregation when applicable. A flushable aggregation could " +
+          "emit intermediate result at anytime when memory is full / data reduction ratio is low."
+      )
+      .booleanConf
+      .createWithDefault(true)
+
+  val MAX_PARTIAL_AGGREGATION_MEMORY_RATIO =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio")
+      .internal()
+      .doc(
+        "Set the max memory of partial aggregation as "
+          + "maxPartialAggregationMemoryRatio of offheap size. Note: this option only works when " +
+          "flushable partial aggregation is enabled. Ignored when " +
+          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false."
+      )
+      .doubleConf
+      .createWithDefault(0.1)
+
+  val MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY_RATIO =
+    buildConf("spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio")
+      .internal()
+      .doc(
+        "Set the max extended memory of partial aggregation as "
+          + "maxExtendedPartialAggregationMemoryRatio of offheap size. Note: this option only " +
+          "works when flushable partial aggregation is enabled. Ignored when " +
+          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false."
+      )
+      .doubleConf
+      .createWithDefault(0.15)
+
+  val ABANDON_PARTIAL_AGGREGATION_MIN_PCT =
+    buildConf("spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct")
+      .internal()
+      .doc(
+        "If partial aggregation aggregationPct greater than this value, "
+          + "partial aggregation may be early abandoned. Note: this option only works when " +
+          "flushable partial aggregation is enabled. Ignored when " +
+          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false.")
+      .intConf
+      .createWithDefault(90)
+
+  val ABANDON_PARTIAL_AGGREGATION_MIN_ROWS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows")
+      .internal()
+      .doc(
+        "If partial aggregation input rows number greater than this value, "
+          + " partial aggregation may be early abandoned. Note: this option only works when " +
+          "flushable partial aggregation is enabled. Ignored when " +
+          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false.")
+      .intConf
+      .createWithDefault(100000)
+
+  val COLUMNAR_VELOX_BLOOM_FILTER_EXPECTED_NUM_ITEMS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.bloomFilter.expectedNumItems")
+      .internal()
+      .doc("The default number of expected items for the velox bloomfilter: " +
+        "'spark.bloom_filter.expected_num_items'")
+      .longConf
+      .createWithDefault(1000000L)
+
+  val COLUMNAR_VELOX_BLOOM_FILTER_NUM_BITS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.bloomFilter.numBits")
+      .internal()
+      .doc("The default number of bits to use for the velox bloom filter: " +
+        "'spark.bloom_filter.num_bits'")
+      .longConf
+      .createWithDefault(8388608L)
+
+  val COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.bloomFilter.maxNumBits")
+      .internal()
+      .doc("The max number of bits to use for the velox bloom filter: " +
+        "'spark.bloom_filter.max_num_bits'")
+      .longConf
+      .createWithDefault(4194304L)
+
+  val COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.fileHandleCacheEnabled")
+      .internal()
+      .doc("Disables caching if false. File handle cache should be disabled " +
+        "if files are mutable, i.e. file content may change while file path stays the same.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DIRECTORY_SIZE_GUESS =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.directorySizeGuess")
+      .internal()
+      .doc("Set the directory size guess for velox file scan")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("32KB")
+
+  val FILE_PRELOAD_THRESHOLD =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.filePreloadThreshold")
+      .internal()
+      .doc("Set the file preload threshold for velox file scan")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("1MB")
+
+  val PREFETCH_ROW_GROUPS =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.prefetchRowGroups")
+      .internal()
+      .doc("Set the prefetch row groups for velox file scan")
+      .intConf
+      .createWithDefault(1)
+
+  val LOAD_QUANTUM =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.loadQuantum")
+      .internal()
+      .doc("Set the load quantum for velox file scan, recommend to use the default value (256MB) " +
+        "for performance consideration. If Velox cache is enabled, it can be 8MB at most.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("256MB")
+
+  val MAX_COALESCED_DISTANCE_BYTES =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.maxCoalescedDistance")
+      .internal()
+      .doc(" Set the max coalesced distance bytes for velox file scan")
+      .stringConf
+      .createWithDefaultString("512KB")
+
+  val MAX_COALESCED_BYTES =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.maxCoalescedBytes")
+      .internal()
+      .doc("Set the max coalesced bytes for velox file scan")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("64MB")
+
+  val CACHE_PREFETCH_MINPCT =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.cachePrefetchMinPct")
+      .internal()
+      .doc("Set prefetch cache min pct for velox file scan")
+      .intConf
+      .createWithDefault(0)
+
+  val AWS_SDK_LOG_LEVEL =
+    buildConf("spark.gluten.velox.awsSdkLogLevel")
+      .internal()
+      .doc("Log granularity of AWS C++ SDK in velox.")
+      .stringConf
+      .createWithDefault("FATAL")
+
+  val AWS_S3_RETRY_MODE =
+    buildConf("spark.gluten.velox.fs.s3a.retry.mode")
+      .internal()
+      .doc("Retry mode for AWS s3 connection error: legacy, standard and adaptive.")
+      .stringConf
+      .createWithDefault("legacy")
+
+  val AWS_S3_CONNECT_TIMEOUT =
+    buildConf("spark.gluten.velox.fs.s3a.connect.timeout")
+      .internal()
+      .doc("Timeout for AWS s3 connection.")
+      .stringConf
+      .createWithDefault("200s")
+
+  val VELOX_ORC_SCAN_ENABLED =
+    buildConf("spark.gluten.sql.columnar.backend.velox.orc.scan.enabled")
+      .internal()
+      .doc("Enable velox orc scan. If disabled, vanilla spark orc scan will be used.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val CAST_FROM_VARCHAR_ADD_TRIM_NODE =
+    buildConf("spark.gluten.velox.castFromVarcharAddTrimNode")
+      .internal()
+      .doc(
+        "If true, will add a trim node " +
+          "which has the same sementic as vanilla Spark to CAST-from-varchar." +
+          "Otherwise, do nothing.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP =
+    buildConf("spark.gluten.velox.offHeapBroadcastBuildRelation.enabled")
+      .internal()
+      .doc("Experimental: If enabled, broadcast build relation will use offheap memory. " +
+        "Otherwise, broadcast build relation will use onheap memory.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val QUERY_TRACE_ENABLED = buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceEnabled")
+    .doc("Enable query tracing flag.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+
+  val QUERY_TRACE_DIR = buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceDir")
+    .doc("Base dir of a query to store tracing data.")
+    .internal()
+    .stringConf
+    .createWithDefault("")
+
+  val QUERY_TRACE_NODE_IDS = buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceNodeIds")
+    .doc("A comma-separated list of plan node ids whose input data will be traced. " +
+      "Empty string if only want to trace the query metadata.")
+    .internal()
+    .stringConf
+    .createWithDefault("")
+
+  val QUERY_TRACE_MAX_BYTES =
+    buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceMaxBytes")
+      .doc("The max trace bytes limit. Tracing is disabled if zero.")
+      .internal()
+      .longConf
+      .createWithDefault(0)
+
+  val QUERY_TRACE_TASK_REG_EXP =
+    buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceTaskRegExp")
+      .doc("The regexp of traced task id. We only enable trace on a task if its id matches.")
+      .internal()
+      .stringConf
+      .createWithDefault("")
+
+  val OP_TRACE_DIRECTORY_CREATE_CONFIG =
+    buildConf("spark.gluten.sql.columnar.backend.velox.opTraceDirectoryCreateConfig")
+      .doc(
+        "Config used to create operator trace directory. This config is provided to" +
+          " underlying file system and the config is free form. The form should be " +
+          "defined by the underlying file system.")
+      .internal()
+      .stringConf
+      .createWithDefault("")
+}

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.extension
 
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.execution._
 
 import org.apache.spark.sql.SparkSession
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
 case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkPlan] {
   import FlushableHashAggregateRule._
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!GlutenConfig.get.enableVeloxFlushablePartialAggregation) {
+    if (!VeloxConfig.get.enableVeloxFlushablePartialAggregation) {
       return plan
     }
     plan.transformUpWithPruning(_.containsPattern(EXCHANGE)) {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.vectorized.{ColumnarBatchSerializeResult, ColumnarBatchSerializerJniWrapper}
@@ -93,7 +93,7 @@ object BroadcastUtils {
       schema: StructType,
       from: Broadcast[F],
       fn: Iterator[InternalRow] => Iterator[ColumnarBatch]): Broadcast[T] = {
-    val useOffheapBuildRelation = GlutenConfig.get.enableBroadcastBuildRelationInOffheap
+    val useOffheapBuildRelation = VeloxConfig.get.enableBroadcastBuildRelationInOffheap
     mode match {
       case HashedRelationBroadcastMode(_, _) =>
         // HashedRelation to ColumnarBuildSideRelation.

--- a/backends-velox/src/test/java/org/apache/gluten/test/MockVeloxBackend.java
+++ b/backends-velox/src/test/java/org/apache/gluten/test/MockVeloxBackend.java
@@ -17,7 +17,7 @@
 package org.apache.gluten.test;
 
 import org.apache.gluten.config.GlutenConfig;
-import org.apache.gluten.config.GlutenConfig$;
+import org.apache.gluten.config.VeloxConfig$;
 
 import com.codahale.metrics.MetricRegistry;
 import org.apache.spark.SparkConf;
@@ -72,7 +72,7 @@ public final class MockVeloxBackend {
   private static SparkConf newSparkConf() {
     final SparkConf conf = new SparkConf();
     conf.set(GlutenConfig.SPARK_OFFHEAP_SIZE_KEY(), "1g");
-    conf.set(GlutenConfig$.MODULE$.COLUMNAR_VELOX_CONNECTOR_IO_THREADS().key(), "0");
+    conf.set(VeloxConfig$.MODULE$.COLUMNAR_VELOX_CONNECTOR_IO_THREADS().key(), "0");
     return conf;
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.extension.columnar.validator.FallbackInjects
 
 import org.apache.spark.SparkConf
@@ -1178,7 +1178,7 @@ class VeloxAggregateFunctionsDefaultSuite extends VeloxAggregateFunctionsSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       // Disable flush. This may cause spilling to happen on partial aggregations.
-      .set(GlutenConfig.VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED.key, "false")
+      .set(VeloxConfig.VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED.key, "false")
   }
 
   test("flushable aggregate rule") {
@@ -1199,9 +1199,9 @@ class VeloxAggregateFunctionsFlushSuite extends VeloxAggregateFunctionsSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       // To test flush behaviors, set low flush threshold to ensure flush happens.
-      .set(GlutenConfig.VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED.key, "true")
-      .set(GlutenConfig.ABANDON_PARTIAL_AGGREGATION_MIN_PCT.key, "1")
-      .set(GlutenConfig.ABANDON_PARTIAL_AGGREGATION_MIN_ROWS.key, "10")
+      .set(VeloxConfig.VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED.key, "true")
+      .set(VeloxConfig.ABANDON_PARTIAL_AGGREGATION_MIN_PCT.key, "1")
+      .set(VeloxConfig.ABANDON_PARTIAL_AGGREGATION_MIN_ROWS.key, "10")
   }
 
   test("flushable aggregate rule") {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxHashJoinSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxHashJoinSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
@@ -118,7 +118,7 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
     Seq("true", "false").foreach(
       enabledOffheapBroadcast =>
         withSQLConf(
-          GlutenConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key -> enabledOffheapBroadcast) {
+          VeloxConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key -> enabledOffheapBroadcast) {
           withTable("t1", "t2") {
             spark.sql("""
                         |CREATE TABLE t1 USING PARQUET
@@ -158,7 +158,7 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
     Seq("true", "false").foreach(
       enabledOffheapBroadcast =>
         withSQLConf(
-          GlutenConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key -> enabledOffheapBroadcast) {
+          VeloxConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key -> enabledOffheapBroadcast) {
           withTable("t1", "t2") {
             val df1 =
               (0 until 50)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxTPCHSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, TestUtils}
@@ -344,7 +345,7 @@ class VeloxTPCHV1BhjOffheapSuite extends VeloxTPCHSuite {
     super.sparkConf
       .set("spark.sql.sources.useV1SourceList", "parquet")
       .set("spark.sql.autoBroadcastJoinThreshold", "30M")
-      .set(GlutenConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key, "true")
+      .set(VeloxConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key, "true")
   }
 }
 

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetReadSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetReadSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.execution.{BasicScanExecTransformer, VeloxWholeStageTransformerSuite}
 
 import org.apache.spark.SparkConf
@@ -29,7 +29,7 @@ class VeloxParquetReadSuite extends VeloxWholeStageTransformerSuite {
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set(GlutenConfig.LOAD_QUANTUM.key, "256m")
+      .set(VeloxConfig.LOAD_QUANTUM.key, "256m")
   }
 
   testWithSpecifiedSparkVersion("read example parquet files", Some("3.5"), Some("3.5")) {

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -259,26 +259,6 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
       conf.set(SQLConf.ORC_VECTORIZED_READER_ENABLED.key, "false")
       conf.set(SQLConf.CACHE_VECTORIZED_READER_ENABLED.key, "false")
     }
-    // When the Velox cache is enabled, the Velox file handle cache should also be enabled.
-    // Otherwise, a 'reference id not found' error may occur.
-    if (
-      conf.getBoolean(COLUMNAR_VELOX_CACHE_ENABLED.key, false) &&
-      !conf.getBoolean(COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.key, false)
-    ) {
-      throw new IllegalArgumentException(
-        s"${COLUMNAR_VELOX_CACHE_ENABLED.key} and " +
-          s"${COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.key} should be enabled together.")
-    }
-
-    if (
-      conf.getBoolean(COLUMNAR_VELOX_CACHE_ENABLED.key, false) &&
-      conf.getSizeAsBytes(LOAD_QUANTUM.key, LOAD_QUANTUM.defaultValueString) > 8 * 1024 * 1024
-    ) {
-      throw new IllegalArgumentException(
-        s"Velox currently only support up to 8MB load quantum size " +
-          s"on SSD cache enabled by ${COLUMNAR_VELOX_CACHE_ENABLED.key}, " +
-          s"User can set ${LOAD_QUANTUM.key} <= 8MB skip this error.")
-    }
   }
 }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WindowExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WindowExecTransformer.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.expression._
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.metrics.MetricsUpdater
@@ -87,7 +86,7 @@ case class WindowExecTransformer(
     val windowParametersStr = new StringBuffer("WindowParameters:")
     // isStreaming: 1 for streaming, 0 for sort
     val isStreaming: Int =
-      if (GlutenConfig.get.veloxColumnarWindowType.equals("streaming")) 1 else 0
+      if (BackendsApiManager.getSettings.requiredChildOrderingForWindow()) 1 else 0
 
     windowParametersStr
       .append("isStreaming=")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -30,19 +30,19 @@ class GlutenBloomFilterAggregateQuerySuite
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 
+  val veloxBloomFilterMaxNumBits = 4194304L
+
   testGluten("Test bloom_filter_agg with big RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS") {
     val table = "bloom_filter_test"
     withSQLConf(
-      SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key -> "5000000",
-      GlutenConfig.COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS.key -> "4194304"
+      SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key -> "5000000"
     ) {
       val numEstimatedItems = 5000000L
-      val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
       val sqlString = s"""
                          |SELECT every(might_contain(
                          |            (SELECT bloom_filter_agg(col,
                          |              cast($numEstimatedItems as long),
-                         |              cast($numBits as long))
+                         |              cast($veloxBloomFilterMaxNumBits as long))
                          |             FROM $table),
                          |            col)) positive_membership_test
                          |FROM $table
@@ -72,14 +72,13 @@ class GlutenBloomFilterAggregateQuerySuite
   testGluten("Test bloom_filter_agg filter fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
-    val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
     val sqlString = s"""
                        |SELECT col positive_membership_test
                        |FROM $table
                        |WHERE might_contain(
                        |            (SELECT bloom_filter_agg(col,
                        |              cast($numEstimatedItems as long),
-                       |              cast($numBits as long))
+                       |              cast($veloxBloomFilterMaxNumBits as long))
                        |             FROM $table), col)
                       """.stripMargin
     withTempView(table) {
@@ -118,14 +117,13 @@ class GlutenBloomFilterAggregateQuerySuite
   testGluten("Test bloom_filter_agg agg fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
-    val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
     val sqlString = s"""
                        |SELECT col positive_membership_test
                        |FROM $table
                        |WHERE might_contain(
                        |            (SELECT bloom_filter_agg(col,
                        |              cast($numEstimatedItems as long),
-                       |              cast($numBits as long))
+                       |              cast($veloxBloomFilterMaxNumBits as long))
                        |             FROM $table), col)
                       """.stripMargin
 

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -29,19 +29,19 @@ class GlutenBloomFilterAggregateQuerySuite
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 
+  val veloxBloomFilterMaxNumBits = 4194304L
+
   testGluten("Test bloom_filter_agg with big RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS") {
     val table = "bloom_filter_test"
     withSQLConf(
-      SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key -> "5000000",
-      GlutenConfig.COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS.key -> "4194304"
+      SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key -> "5000000"
     ) {
       val numEstimatedItems = 5000000L
-      val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
       val sqlString = s"""
                          |SELECT every(might_contain(
                          |            (SELECT bloom_filter_agg(col,
                          |              cast($numEstimatedItems as long),
-                         |              cast($numBits as long))
+                         |              cast($veloxBloomFilterMaxNumBits as long))
                          |             FROM $table),
                          |            col)) positive_membership_test
                          |FROM $table
@@ -71,14 +71,13 @@ class GlutenBloomFilterAggregateQuerySuite
   testGluten("Test bloom_filter_agg filter fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
-    val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
     val sqlString = s"""
                        |SELECT col positive_membership_test
                        |FROM $table
                        |WHERE might_contain(
                        |            (SELECT bloom_filter_agg(col,
                        |              cast($numEstimatedItems as long),
-                       |              cast($numBits as long))
+                       |              cast($veloxBloomFilterMaxNumBits as long))
                        |             FROM $table), col)
                       """.stripMargin
     withTempView(table) {
@@ -117,14 +116,13 @@ class GlutenBloomFilterAggregateQuerySuite
   testGluten("Test bloom_filter_agg agg fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
-    val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
     val sqlString = s"""
                        |SELECT col positive_membership_test
                        |FROM $table
                        |WHERE might_contain(
                        |            (SELECT bloom_filter_agg(col,
                        |              cast($numEstimatedItems as long),
-                       |              cast($numBits as long))
+                       |              cast($veloxBloomFilterMaxNumBits as long))
                        |             FROM $table), col)
                       """.stripMargin
 

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -30,19 +30,17 @@ class GlutenBloomFilterAggregateQuerySuite
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 
+  val veloxBloomFilterMaxNumBits = 4194304L
+
   testGluten("Test bloom_filter_agg with big RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS") {
     val table = "bloom_filter_test"
-    withSQLConf(
-      SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key -> "5000000",
-      GlutenConfig.COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS.key -> "4194304"
-    ) {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key -> "5000000") {
       val numEstimatedItems = 5000000L
-      val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
       val sqlString = s"""
                          |SELECT every(might_contain(
                          |            (SELECT bloom_filter_agg(col,
                          |              cast($numEstimatedItems as long),
-                         |              cast($numBits as long))
+                         |              cast($veloxBloomFilterMaxNumBits as long))
                          |             FROM $table),
                          |            col)) positive_membership_test
                          |FROM $table
@@ -72,14 +70,13 @@ class GlutenBloomFilterAggregateQuerySuite
   testGluten("Test bloom_filter_agg filter fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
-    val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
     val sqlString = s"""
                        |SELECT col positive_membership_test
                        |FROM $table
                        |WHERE might_contain(
                        |            (SELECT bloom_filter_agg(col,
                        |              cast($numEstimatedItems as long),
-                       |              cast($numBits as long))
+                       |              cast($veloxBloomFilterMaxNumBits as long))
                        |             FROM $table), col)
                       """.stripMargin
     withTempView(table) {
@@ -118,14 +115,13 @@ class GlutenBloomFilterAggregateQuerySuite
   testGluten("Test bloom_filter_agg agg fallback") {
     val table = "bloom_filter_test"
     val numEstimatedItems = 5000000L
-    val numBits = GlutenConfig.get.veloxBloomFilterMaxNumBits
     val sqlString = s"""
                        |SELECT col positive_membership_test
                        |FROM $table
                        |WHERE might_contain(
                        |            (SELECT bloom_filter_agg(col,
                        |              cast($numEstimatedItems as long),
-                       |              cast($numBits as long))
+                       |              cast($veloxBloomFilterMaxNumBits as long))
                        |             FROM $table), col)
                       """.stripMargin
 

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql
 
-import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{ProjectExecTransformer, WholeStageTransformer}
 
 import org.apache.spark.SparkException
@@ -324,7 +323,7 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
   }
 
   testGluten("Allow leading/trailing whitespace in string before casting") {
-    withSQLConf(GlutenConfig.CAST_FROM_VARCHAR_ADD_TRIM_NODE.key -> "true") {
+    withSQLConf("spark.gluten.velox.castFromVarcharAddTrimNode" -> "true") {
       def checkResult(df: DataFrame, expectedResult: Seq[Row]): Unit = {
         checkAnswer(df, expectedResult)
         assert(

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import java.util
 import java.util.Locale
-import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
@@ -60,8 +59,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableColumnarHiveTableScanNestedColumnPruning: Boolean =
     getConf(COLUMNAR_HIVETABLESCAN_NESTED_COLUMN_PRUNING_ENABLED)
 
-  def enableVanillaVectorizedReaders: Boolean = getConf(VANILLA_VECTORIZED_READERS_ENABLED)
-
   def enableColumnarHashAgg: Boolean = getConf(COLUMNAR_HASHAGG_ENABLED)
 
   def forceToUseHashAgg: Boolean = getConf(COLUMNAR_FORCE_HASHAGG_ENABLED)
@@ -77,8 +74,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableColumnarWindow: Boolean = getConf(COLUMNAR_WINDOW_ENABLED)
 
   def enableColumnarWindowGroupLimit: Boolean = getConf(COLUMNAR_WINDOW_GROUP_LIMIT_ENABLED)
-
-  def veloxColumnarWindowType: String = getConf(COLUMNAR_VELOX_WINDOW_TYPE)
 
   def enableColumnarShuffledHashJoin: Boolean = getConf(COLUMNAR_SHUFFLED_HASH_JOIN_ENABLED)
 
@@ -105,16 +100,11 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableColumnarCoalesce: Boolean = getConf(COLUMNAR_COALESCE_ENABLED)
 
-  def columnarTableCacheEnabled: Boolean = getConf(COLUMNAR_TABLE_CACHE_ENABLED)
-
   def enableRewriteDateTimestampComparison: Boolean =
     getConf(ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON)
 
   def enableCollapseNestedGetJsonObject: Boolean =
     getConf(ENABLE_COLLAPSE_GET_JSON_OBJECT)
-
-  def enableCHRewriteDateConversion: Boolean =
-    getConf(ENABLE_CH_REWRITE_DATE_CONVERSION)
 
   def enableCommonSubexpressionEliminate: Boolean =
     getConf(ENABLE_COMMON_SUBEXPRESSION_ELIMINATE)
@@ -124,9 +114,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableExtendedColumnPruning: Boolean =
     getConf(ENABLE_EXTENDED_COLUMN_PRUNING)
-
-  def veloxOrcScanEnabled: Boolean =
-    getConf(VELOX_ORC_SCAN_ENABLED)
 
   def forceOrcCharTypeScanFallbackEnabled: Boolean =
     getConf(VELOX_FORCE_ORC_CHAR_TYPE_SCAN_FALLBACK)
@@ -177,8 +164,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableScanOnly: Boolean = getConf(COLUMNAR_SCAN_ONLY_ENABLED)
 
-  def tmpFile: Option[String] = getConf(COLUMNAR_TEMP_DIR)
-
   def columnarShuffleSortPartitionsThreshold: Int =
     getConf(COLUMNAR_SHUFFLE_SORT_PARTITIONS_THRESHOLD)
 
@@ -210,9 +195,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
     getConf(COLUMNAR_SHUFFLE_READER_BUFFER_SIZE)
 
   def maxBatchSize: Int = getConf(COLUMNAR_MAX_BATCH_SIZE)
-
-  def columnarToRowMemThreshold: Long =
-    getConf(GLUTEN_COLUMNAR_TO_ROW_MEM_THRESHOLD)
 
   def shuffleWriterBufferSize: Int = getConf(SHUFFLE_WRITER_BUFFER_SIZE)
     .getOrElse(maxBatchSize)
@@ -264,14 +246,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def memoryIsolation: Boolean = getConf(COLUMNAR_MEMORY_ISOLATION)
 
-  def memoryBacktraceAllocation: Boolean = getConf(COLUMNAR_MEMORY_BACKTRACE_ALLOCATION)
-
-  def numTaskSlotsPerExecutor: Int = {
-    val numSlots = getConf(NUM_TASK_SLOTS_PER_EXECUTOR)
-    assert(numSlots > 0, s"Number of task slot not found. This should not happen.")
-    numSlots
-  }
-
   def offHeapMemorySize: Long = getConf(COLUMNAR_OFFHEAP_SIZE_IN_BYTES)
 
   def taskOffHeapMemorySize: Long = getConf(COLUMNAR_TASK_OFFHEAP_SIZE_IN_BYTES)
@@ -287,87 +261,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableRas: Boolean = getConf(RAS_ENABLED)
 
   def rasCostModel: String = getConf(RAS_COST_MODEL)
-
-  def enableVeloxCache: Boolean = getConf(COLUMNAR_VELOX_CACHE_ENABLED)
-
-  def veloxMemCacheSize: Long = getConf(COLUMNAR_VELOX_MEM_CACHE_SIZE)
-
-  def veloxSsdCachePath: String = getConf(COLUMNAR_VELOX_SSD_CACHE_PATH)
-
-  def veloxSsdCacheSize: Long = getConf(COLUMNAR_VELOX_SSD_CACHE_SIZE)
-
-  def veloxSsdCacheShards: Integer = getConf(COLUMNAR_VELOX_SSD_CACHE_SHARDS)
-
-  def veloxSsdCacheIOThreads: Integer = getConf(COLUMNAR_VELOX_SSD_CACHE_IO_THREADS)
-
-  def veloxSsdODirectEnabled: Boolean = getConf(COLUMNAR_VELOX_SSD_ODIRECT_ENABLED)
-
-  def veloxConnectorIOThreads: Int = {
-    getConf(COLUMNAR_VELOX_CONNECTOR_IO_THREADS).getOrElse(numTaskSlotsPerExecutor)
-  }
-
-  def veloxSplitPreloadPerDriver: Integer = getConf(COLUMNAR_VELOX_SPLIT_PRELOAD_PER_DRIVER)
-
-  def veloxSpillStrategy: String = getConf(COLUMNAR_VELOX_SPILL_STRATEGY)
-
-  def veloxMaxSpillLevel: Int = getConf(COLUMNAR_VELOX_MAX_SPILL_LEVEL)
-
-  def veloxMaxSpillFileSize: Long = getConf(COLUMNAR_VELOX_MAX_SPILL_FILE_SIZE)
-
-  def veloxSpillFileSystem: String = getConf(COLUMNAR_VELOX_SPILL_FILE_SYSTEM)
-
-  def veloxMaxSpillRunRows: Long = getConf(COLUMNAR_VELOX_MAX_SPILL_RUN_ROWS)
-
-  def veloxMaxSpillBytes: Long = getConf(COLUMNAR_VELOX_MAX_SPILL_BYTES)
-
-  def veloxBloomFilterExpectedNumItems: Long =
-    getConf(COLUMNAR_VELOX_BLOOM_FILTER_EXPECTED_NUM_ITEMS)
-
-  def veloxBloomFilterNumBits: Long = getConf(COLUMNAR_VELOX_BLOOM_FILTER_NUM_BITS)
-
-  def veloxBloomFilterMaxNumBits: Long = getConf(COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS)
-
-  def castFromVarcharAddTrimNode: Boolean = getConf(CAST_FROM_VARCHAR_ADD_TRIM_NODE)
-
-  case class ResizeRange(min: Int, max: Int) {
-    assert(max >= min)
-    assert(min > 0, "Min batch size should be larger than 0")
-    assert(max > 0, "Max batch size should be larger than 0")
-  }
-
-  private object ResizeRange {
-    def parse(pattern: String): ResizeRange = {
-      assert(pattern.count(_ == '~') == 1, s"Invalid range pattern for batch resizing: $pattern")
-      val splits = pattern.split('~')
-      assert(splits.length == 2)
-      ResizeRange(splits(0).toInt, splits(1).toInt)
-    }
-  }
-
-  def veloxResizeBatchesShuffleInput: Boolean =
-    getConf(COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT)
-
-  def veloxResizeBatchesShuffleInputRange: ResizeRange = {
-    val standardSize = getConf(COLUMNAR_MAX_BATCH_SIZE)
-    val defaultMinSize: Int = (0.25 * standardSize).toInt.max(1)
-    val minSize = getConf(COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT_MIN_SIZE)
-      .getOrElse(defaultMinSize)
-    ResizeRange(minSize, Int.MaxValue)
-  }
-
-  def chColumnarShuffleSpillThreshold: Long = {
-    val threshold = getConf(COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD)
-    if (threshold == 0) {
-      (taskOffHeapMemorySize * 0.9).toLong
-    } else {
-      threshold
-    }
-  }
-
-  def chColumnarMaxSortBufferSize: Long = getConf(COLUMNAR_CH_MAX_SORT_BUFFER_SIZE)
-
-  def chColumnarForceMemorySortShuffle: Boolean =
-    getConf(COLUMNAR_CH_FORCE_MEMORY_SORT_SHUFFLE)
 
   def cartesianProductTransformerEnabled: Boolean =
     getConf(CARTESIAN_PRODUCT_TRANSFORMER_ENABLED)
@@ -412,15 +305,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableFallbackReport: Boolean = getConf(FALLBACK_REPORTER_ENABLED)
 
-  def enableVeloxUserExceptionStacktrace: Boolean =
-    getConf(COLUMNAR_VELOX_ENABLE_USER_EXCEPTION_STACKTRACE)
-
-  def memoryUseHugePages: Boolean =
-    getConf(COLUMNAR_VELOX_MEMORY_USE_HUGE_PAGES)
-
   def debug: Boolean = getConf(DEBUG_ENABLED)
-
-  def debugKeepJniWorkspace: Boolean = getConf(DEBUG_KEEP_JNI_WORKSPACE)
 
   def collectUtStats: Boolean = getConf(UT_STATISTIC)
 
@@ -439,46 +324,14 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableParquetRowGroupMaxMinIndex: Boolean =
     getConf(ENABLE_PARQUET_ROW_GROUP_MAX_MIN_INDEX)
 
-  def enableVeloxFlushablePartialAggregation: Boolean =
-    getConf(VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED)
-
-  def maxFlushableAggregationMemoryRatio: Double = getConf(MAX_PARTIAL_AGGREGATION_MEMORY_RATIO)
-
-  def maxExtendedFlushableAggregationMemoryRatio: Double = getConf(
-    MAX_PARTIAL_AGGREGATION_MEMORY_RATIO)
-
-  def abandonFlushableAggregationMinPct: Int = getConf(ABANDON_PARTIAL_AGGREGATION_MIN_PCT)
-
-  def abandonFlushableAggregationMinRows: Int = getConf(ABANDON_PARTIAL_AGGREGATION_MIN_ROWS)
-
   // Please use `BackendsApiManager.getSettings.enableNativeWriteFiles()` instead
   def enableNativeWriter: Option[Boolean] = getConf(NATIVE_WRITER_ENABLED)
 
   def enableNativeArrowReader: Boolean = getConf(NATIVE_ARROW_READER_ENABLED)
 
-  def directorySizeGuess: Long = getConf(DIRECTORY_SIZE_GUESS)
-
-  def filePreloadThreshold: Long = getConf(FILE_PRELOAD_THRESHOLD)
-
-  def prefetchRowGroups: Int = getConf(PREFETCH_ROW_GROUPS)
-
-  def loadQuantum: Long = getConf(LOAD_QUANTUM)
-
-  def maxCoalescedDistance: String = getConf(MAX_COALESCED_DISTANCE_BYTES)
-
-  def maxCoalescedBytes: Long = getConf(MAX_COALESCED_BYTES)
-
-  def cachePrefetchMinPct: Int = getConf(CACHE_PREFETCH_MINPCT)
-
   def enableColumnarProjectCollapse: Boolean = getConf(ENABLE_COLUMNAR_PROJECT_COLLAPSE)
 
   def enableColumnarPartialProject: Boolean = getConf(ENABLE_COLUMNAR_PARTIAL_PROJECT)
-
-  def awsSdkLogLevel: String = getConf(AWS_SDK_LOG_LEVEL)
-
-  def awsS3RetryMode: String = getConf(AWS_S3_RETRY_MODE)
-
-  def awsConnectionTimeout: String = getConf(AWS_S3_CONNECT_TIMEOUT)
 
   def enableCastAvgAggregateFunction: Boolean = getConf(COLUMNAR_NATIVE_CAST_AGGREGATE_ENABLED)
 
@@ -490,9 +343,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableCelebornFallback: Boolean = getConf(CELEBORN_FALLBACK_ENABLED)
 
   def enableHdfsViewfs: Boolean = getConf(HDFS_VIEWFS_ENABLED)
-
-  def enableBroadcastBuildRelationInOffheap: Boolean =
-    getConf(VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP)
 
   def parquetEncryptionValidationEnabled: Boolean = getConf(ENCRYPTED_PARQUET_FALLBACK_ENABLED)
 
@@ -584,8 +434,6 @@ object GlutenConfig {
   val SPARK_SHUFFLE_SPILL_COMPRESS = "spark.shuffle.spill.compress"
   val SPARK_SHUFFLE_SPILL_COMPRESS_DEFAULT: Boolean = true
 
-  var ins: GlutenConfig = _
-
   def get: GlutenConfig = {
     new GlutenConfig(SQLConf.get)
   }
@@ -594,7 +442,11 @@ object GlutenConfig {
     GLUTEN_CONFIG_PREFIX + backendName
   }
 
-  /** Get dynamic configs. */
+  /**
+   * Get dynamic configs.
+   *
+   * TODO: Improve the get native conf logic.
+   */
   def getNativeSessionConf(
       backendName: String,
       conf: scala.collection.Map[String, String]): util.Map[String, String] = {
@@ -611,9 +463,9 @@ object GlutenConfig {
       SQLConf.LEGACY_TIME_PARSER_POLICY.key,
       "spark.io.compression.codec",
       "spark.sql.decimalOperations.allowPrecisionLoss",
-      COLUMNAR_VELOX_BLOOM_FILTER_EXPECTED_NUM_ITEMS.key,
-      COLUMNAR_VELOX_BLOOM_FILTER_NUM_BITS.key,
-      COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS.key,
+      "spark.gluten.sql.columnar.backend.velox.bloomFilter.expectedNumItems",
+      "spark.gluten.sql.columnar.backend.velox.bloomFilter.numBits",
+      "spark.gluten.sql.columnar.backend.velox.bloomFilter.maxNumBits",
       // s3 config
       SPARK_S3_ACCESS_KEY,
       SPARK_S3_SECRET_KEY,
@@ -625,20 +477,20 @@ object GlutenConfig {
       SPARK_S3_IAM_SESSION_NAME,
       SPARK_S3_RETRY_MAX_ATTEMPTS,
       SPARK_S3_CONNECTION_MAXIMUM,
-      AWS_S3_CONNECT_TIMEOUT.key,
-      AWS_S3_RETRY_MODE.key,
-      AWS_SDK_LOG_LEVEL.key,
+      "spark.gluten.velox.fs.s3a.connect.timeout",
+      "spark.gluten.velox.fs.s3a.retry.mode",
+      "spark.gluten.velox.awsSdkLogLevel",
       // gcs config
       SPARK_GCS_STORAGE_ROOT_URL,
       SPARK_GCS_AUTH_TYPE,
       SPARK_GCS_AUTH_SERVICE_ACCOUNT_JSON_KEYFILE,
       SPARK_REDACTION_REGEX,
-      QUERY_TRACE_ENABLED,
-      QUERY_TRACE_DIR,
-      QUERY_TRACE_NODE_IDS,
-      QUERY_TRACE_MAX_BYTES,
-      QUERY_TRACE_TASK_REG_EXP,
-      OP_TRACE_DIRECTORY_CREATE_CONFIG
+      "spark.gluten.sql.columnar.backend.velox.queryTraceEnabled",
+      "spark.gluten.sql.columnar.backend.velox.queryTraceDir",
+      "spark.gluten.sql.columnar.backend.velox.queryTraceNodeIds",
+      "spark.gluten.sql.columnar.backend.velox.queryTraceMaxBytes",
+      "spark.gluten.sql.columnar.backend.velox.queryTraceTaskRegExp",
+      "spark.gluten.sql.columnar.backend.velox.opTraceDirectoryCreateConfig"
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 
@@ -701,6 +553,8 @@ object GlutenConfig {
   /**
    * Get static and dynamic configs. Some of the config is dynamic in spark, but is static in
    * gluten, these will be used to construct HiveConnector which intends reused in velox
+   *
+   * TODO: Improve the get native conf logic.
    */
   def getNativeBackendConf(
       backendName: String,
@@ -715,10 +569,10 @@ object GlutenConfig {
       (SPARK_S3_USE_INSTANCE_CREDENTIALS, "false"),
       (SPARK_S3_RETRY_MAX_ATTEMPTS, "20"),
       (SPARK_S3_CONNECTION_MAXIMUM, "15"),
-      (AWS_S3_CONNECT_TIMEOUT.key, AWS_S3_CONNECT_TIMEOUT.defaultValueString),
-      (AWS_S3_RETRY_MODE.key, AWS_S3_RETRY_MODE.defaultValueString),
+      ("spark.gluten.velox.fs.s3a.connect.timeout", "200s"),
+      ("spark.gluten.velox.fs.s3a.retry.mode", "legacy"),
       (
-        COLUMNAR_VELOX_CONNECTOR_IO_THREADS.key,
+        "spark.gluten.sql.columnar.backend.velox.IOThreads",
         conf.getOrElse(
           NUM_TASK_SLOTS_PER_EXECUTOR.key,
           NUM_TASK_SLOTS_PER_EXECUTOR.defaultValueString)),
@@ -730,10 +584,8 @@ object GlutenConfig {
       ("spark.hadoop.dfs.client.log.severity", "INFO"),
       ("spark.sql.orc.compression.codec", "snappy"),
       ("spark.sql.decimalOperations.allowPrecisionLoss", "true"),
-      (
-        COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.key,
-        COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.defaultValueString),
-      (AWS_SDK_LOG_LEVEL.key, AWS_SDK_LOG_LEVEL.defaultValueString)
+      ("spark.gluten.sql.columnar.backend.velox.fileHandleCacheEnabled", "false"),
+      ("spark.gluten.velox.awsSdkLogLevel", "FATAL")
     )
     keyWithDefault.forEach(e => nativeConfMap.put(e._1, conf.getOrElse(e._1, e._2)))
 
@@ -991,21 +843,6 @@ object GlutenConfig {
       .doc("Enable or disable columnar window group limit.")
       .booleanConf
       .createWithDefault(true)
-
-  val COLUMNAR_VELOX_WINDOW_TYPE =
-    buildConf("spark.gluten.sql.columnar.backend.velox.window.type")
-      .internal()
-      .doc(
-        "Velox backend supports both SortWindow and" +
-          " StreamingWindow operators." +
-          " The StreamingWindow operator skips the sorting step" +
-          " in the input but does not support spill." +
-          " On the other hand, the SortWindow operator is " +
-          "responsible for sorting the input data within the" +
-          " Window operator and also supports spill.")
-      .stringConf
-      .checkValues(Set("streaming", "sort"))
-      .createWithDefault("streaming")
 
   val COLUMNAR_PREFER_STREAMING_AGGREGATE =
     buildConf("spark.gluten.sql.columnar.preferStreamingAggregate")
@@ -1443,209 +1280,6 @@ object GlutenConfig {
       .stringConf
       .createWithDefaultString("legacy")
 
-  // velox caching options.
-  val COLUMNAR_VELOX_CACHE_ENABLED =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.cacheEnabled")
-      .internal()
-      .doc("Enable Velox cache, default off")
-      .booleanConf
-      .createWithDefault(false)
-
-  val COLUMNAR_VELOX_MEM_CACHE_SIZE =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.memCacheSize")
-      .internal()
-      .doc("The memory cache size")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("1GB")
-
-  val COLUMNAR_VELOX_MEM_INIT_CAPACITY =
-    buildConf("spark.gluten.sql.columnar.backend.velox.memInitCapacity")
-      .internal()
-      .doc("The initial memory capacity to reserve for a newly created Velox query memory pool.")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("8MB")
-
-  val COLUMNAR_VELOX_MEM_RECLAIM_MAX_WAIT_MS =
-    buildConf("spark.gluten.sql.columnar.backend.velox.reclaimMaxWaitMs")
-      .internal()
-      .doc("The max time in ms to wait for memory reclaim.")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefault(TimeUnit.MINUTES.toMillis(60))
-
-  val COLUMNAR_VELOX_SSD_CACHE_PATH =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCachePath")
-      .internal()
-      .doc("The folder to store the cache files, better on SSD")
-      .stringConf
-      .createWithDefault("/tmp")
-
-  val COLUMNAR_VELOX_SSD_CACHE_SIZE =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCacheSize")
-      .internal()
-      .doc("The SSD cache size, will do memory caching only if this value = 0")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("1GB")
-
-  val COLUMNAR_VELOX_SSD_CACHE_SHARDS =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCacheShards")
-      .internal()
-      .doc("The cache shards")
-      .intConf
-      .createWithDefault(1)
-
-  val COLUMNAR_VELOX_SSD_CACHE_IO_THREADS =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCacheIOThreads")
-      .internal()
-      .doc("The IO threads for cache promoting")
-      .intConf
-      .createWithDefault(1)
-
-  val COLUMNAR_VELOX_SSD_ODIRECT_ENABLED =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdODirect")
-      .internal()
-      .doc("The O_DIRECT flag for cache writing")
-      .booleanConf
-      .createWithDefault(false)
-
-  val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.IOThreads")
-      .internal()
-      .doc(
-        "The Size of the IO thread pool in the Connector. " +
-          "This thread pool is used for split preloading and DirectBufferedInput. " +
-          "By default, the value is the same as the maximum task slots per Spark executor.")
-      .intConf
-      .createOptional
-
-  val COLUMNAR_VELOX_ASYNC_TIMEOUT =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.asyncTimeoutOnTaskStopping")
-      .internal()
-      .doc(
-        "Timeout for asynchronous execution when task is being stopped in Velox backend. " +
-          "It's recommended to set to a number larger than network connection timeout that the " +
-          "possible aysnc tasks are relying on.")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefault(30000)
-
-  val COLUMNAR_VELOX_SPLIT_PRELOAD_PER_DRIVER =
-    buildConf("spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver")
-      .internal()
-      .doc("The split preload per task")
-      .intConf
-      .createWithDefault(2)
-
-  val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
-    buildConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
-      .internal()
-      .doc("Set glog verbose level in Velox backend, same as FLAGS_v.")
-      .intConf
-      .createWithDefault(0)
-
-  val COLUMNAR_VELOX_GLOG_SEVERITY_LEVEL =
-    buildConf("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel")
-      .internal()
-      .doc("Set glog severity level in Velox backend, same as FLAGS_minloglevel.")
-      .intConf
-      .createWithDefault(1)
-
-  val COLUMNAR_VELOX_SPILL_STRATEGY =
-    buildConf("spark.gluten.sql.columnar.backend.velox.spillStrategy")
-      .internal()
-      .doc("none: Disable spill on Velox backend; " +
-        "auto: Let Spark memory manager manage Velox's spilling")
-      .stringConf
-      .transform(_.toLowerCase(Locale.ROOT))
-      .checkValues(Set("none", "auto"))
-      .createWithDefault("auto")
-
-  val COLUMNAR_VELOX_MAX_SPILL_LEVEL =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillLevel")
-      .internal()
-      .doc("The max allowed spilling level with zero being the initial spilling level")
-      .intConf
-      .createWithDefault(4)
-
-  val COLUMNAR_VELOX_MAX_SPILL_FILE_SIZE =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillFileSize")
-      .internal()
-      .doc("The maximum size of a single spill file created")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("1GB")
-
-  val COLUMNAR_VELOX_SPILL_FILE_SYSTEM =
-    buildConf("spark.gluten.sql.columnar.backend.velox.spillFileSystem")
-      .internal()
-      .doc(
-        "The filesystem used to store spill data. local: The local file system. " +
-          "heap-over-local: Write file to JVM heap if having extra heap space. " +
-          "Otherwise write to local file system.")
-      .stringConf
-      .checkValues(Set("local", "heap-over-local"))
-      .createWithDefaultString("local")
-
-  val COLUMNAR_VELOX_MAX_SPILL_RUN_ROWS =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillRunRows")
-      .internal()
-      .doc("The maximum row size of a single spill run")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("3M")
-
-  val COLUMNAR_VELOX_MAX_SPILL_BYTES =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxSpillBytes")
-      .internal()
-      .doc("The maximum file size of a query")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("100G")
-
-  val MAX_PARTITION_PER_WRITERS_SESSION =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxPartitionsPerWritersSession")
-      .internal()
-      .doc("Maximum number of partitions per a single table writer instance.")
-      .intConf
-      .checkValue(_ > 0, "must be a positive number")
-      .createWithDefault(10000)
-
-  val COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT =
-    buildConf("spark.gluten.sql.columnar.backend.velox.resizeBatches.shuffleInput")
-      .internal()
-      .doc(s"If true, combine small columnar batches together before sending to shuffle. " +
-        s"The default minimum output batch size is equal to 0.8 * ${COLUMNAR_MAX_BATCH_SIZE.key}")
-      .booleanConf
-      .createWithDefault(true)
-
-  val COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT_MIN_SIZE =
-    buildConf("spark.gluten.sql.columnar.backend.velox.resizeBatches.shuffleInput.minSize")
-      .internal()
-      .doc(
-        s"The minimum batch size for shuffle. If size of an input batch is " +
-          s"smaller than the value, it will be combined with other " +
-          s"batches before sending to shuffle. Only functions when " +
-          s"${COLUMNAR_VELOX_RESIZE_BATCHES_SHUFFLE_INPUT.key} is set to true. " +
-          s"Default value: 0.25 * <max batch size>")
-      .intConf
-      .createOptional
-
-  val COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD =
-    buildConf("spark.gluten.sql.columnar.backend.ch.spillThreshold")
-      .internal()
-      .doc("Shuffle spill threshold on ch backend")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("0MB")
-
-  val COLUMNAR_CH_MAX_SORT_BUFFER_SIZE =
-    buildConf("spark.gluten.sql.columnar.backend.ch.maxSortBufferSize")
-      .internal()
-      .doc("The maximum size of sort shuffle buffer in CH backend.")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("0")
-
-  val COLUMNAR_CH_FORCE_MEMORY_SORT_SHUFFLE =
-    buildConf("spark.gluten.sql.columnar.backend.ch.forceMemorySortShuffle")
-      .internal()
-      .doc("Whether to force to use memory sort shuffle in CH backend. ")
-      .booleanConf
-      .createWithDefault(false)
-
   val TRANSFORM_PLAN_LOG_LEVEL =
     buildConf("spark.gluten.sql.transform.logLevel")
       .internal()
@@ -1823,34 +1457,6 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
-  val COLUMNAR_VELOX_ENABLE_USER_EXCEPTION_STACKTRACE =
-    buildConf("spark.gluten.sql.columnar.backend.velox.enableUserExceptionStacktrace")
-      .internal()
-      .doc("Enable the stacktrace for user type of VeloxException")
-      .booleanConf
-      .createWithDefault(true)
-
-  val COLUMNAR_VELOX_SHOW_TASK_METRICS_WHEN_FINISHED =
-    buildConf("spark.gluten.sql.columnar.backend.velox.showTaskMetricsWhenFinished")
-      .internal()
-      .doc("Show velox full task metrics when finished.")
-      .booleanConf
-      .createWithDefault(false)
-
-  val COLUMNAR_VELOX_MEMORY_USE_HUGE_PAGES =
-    buildConf("spark.gluten.sql.columnar.backend.velox.memoryUseHugePages")
-      .internal()
-      .doc("Use explicit huge pages for Velox memory allocation.")
-      .booleanConf
-      .createWithDefault(false)
-
-  val COLUMNAR_VELOX_ENABLE_SYSTEM_EXCEPTION_STACKTRACE =
-    buildConf("spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace")
-      .internal()
-      .doc("Enable the stacktrace for system type of VeloxException")
-      .booleanConf
-      .createWithDefault(true)
-
   val TEXT_INPUT_ROW_MAX_BLOCK_SIZE =
     buildConf("spark.gluten.sql.text.input.max.block.size")
       .internal()
@@ -1872,63 +1478,6 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(false)
 
-  val VELOX_FLUSHABLE_PARTIAL_AGGREGATION_ENABLED =
-    buildConf("spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation")
-      .internal()
-      .doc(
-        "Enable flushable aggregation. If true, Gluten will try converting regular aggregation " +
-          "into Velox's flushable aggregation when applicable. A flushable aggregation could " +
-          "emit intermediate result at anytime when memory is full / data reduction ratio is low."
-      )
-      .booleanConf
-      .createWithDefault(true)
-
-  val MAX_PARTIAL_AGGREGATION_MEMORY_RATIO =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxPartialAggregationMemoryRatio")
-      .internal()
-      .doc(
-        "Set the max memory of partial aggregation as "
-          + "maxPartialAggregationMemoryRatio of offheap size. Note: this option only works when " +
-          "flushable partial aggregation is enabled. Ignored when " +
-          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false."
-      )
-      .doubleConf
-      .createWithDefault(0.1)
-
-  val MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY_RATIO =
-    buildConf("spark.gluten.sql.columnar.backend.velox.maxExtendedPartialAggregationMemoryRatio")
-      .internal()
-      .doc(
-        "Set the max extended memory of partial aggregation as "
-          + "maxExtendedPartialAggregationMemoryRatio of offheap size. Note: this option only " +
-          "works when flushable partial aggregation is enabled. Ignored when " +
-          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false."
-      )
-      .doubleConf
-      .createWithDefault(0.15)
-
-  val ABANDON_PARTIAL_AGGREGATION_MIN_PCT =
-    buildConf("spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinPct")
-      .internal()
-      .doc(
-        "If partial aggregation aggregationPct greater than this value, "
-          + "partial aggregation may be early abandoned. Note: this option only works when " +
-          "flushable partial aggregation is enabled. Ignored when " +
-          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false.")
-      .intConf
-      .createWithDefault(90)
-
-  val ABANDON_PARTIAL_AGGREGATION_MIN_ROWS =
-    buildConf("spark.gluten.sql.columnar.backend.velox.abandonPartialAggregationMinRows")
-      .internal()
-      .doc(
-        "If partial aggregation input rows number greater than this value, "
-          + " partial aggregation may be early abandoned. Note: this option only works when " +
-          "flushable partial aggregation is enabled. Ignored when " +
-          "spark.gluten.sql.columnar.backend.velox.flushablePartialAggregation=false.")
-      .intConf
-      .createWithDefault(100000)
-
   val ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON =
     buildConf("spark.gluten.sql.rewrite.dateTimestampComparison")
       .internal()
@@ -1943,16 +1492,6 @@ object GlutenConfig {
       .doc("Collapse nested get_json_object functions as one for optimization.")
       .booleanConf
       .createWithDefault(false)
-
-  val ENABLE_CH_REWRITE_DATE_CONVERSION =
-    buildConf("spark.gluten.sql.columnar.backend.ch.rewrite.dateConversion")
-      .internal()
-      .doc(
-        "Rewrite the conversion between date and string."
-          + "For example `to_date(from_unixtime(unix_timestamp(stringType, 'yyyyMMdd')))`"
-          + " will be rewritten to `to_date(stringType)`")
-      .booleanConf
-      .createWithDefault(true)
 
   val ENABLE_COLUMNAR_PROJECT_COLLAPSE =
     buildConf("spark.gluten.sql.columnar.project.collapse")
@@ -1998,38 +1537,6 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
-  val COLUMNAR_VELOX_BLOOM_FILTER_EXPECTED_NUM_ITEMS =
-    buildConf("spark.gluten.sql.columnar.backend.velox.bloomFilter.expectedNumItems")
-      .internal()
-      .doc("The default number of expected items for the velox bloomfilter: " +
-        "'spark.bloom_filter.expected_num_items'")
-      .longConf
-      .createWithDefault(1000000L)
-
-  val COLUMNAR_VELOX_BLOOM_FILTER_NUM_BITS =
-    buildConf("spark.gluten.sql.columnar.backend.velox.bloomFilter.numBits")
-      .internal()
-      .doc("The default number of bits to use for the velox bloom filter: " +
-        "'spark.bloom_filter.num_bits'")
-      .longConf
-      .createWithDefault(8388608L)
-
-  val COLUMNAR_VELOX_BLOOM_FILTER_MAX_NUM_BITS =
-    buildConf("spark.gluten.sql.columnar.backend.velox.bloomFilter.maxNumBits")
-      .internal()
-      .doc("The max number of bits to use for the velox bloom filter: " +
-        "'spark.bloom_filter.max_num_bits'")
-      .longConf
-      .createWithDefault(4194304L)
-
-  val COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.fileHandleCacheEnabled")
-      .internal()
-      .doc("Disables caching if false. File handle cache should be disabled " +
-        "if files are mutable, i.e. file content may change while file path stays the same.")
-      .booleanConf
-      .createWithDefault(false)
-
   val CARTESIAN_PRODUCT_TRANSFORMER_ENABLED =
     buildConf("spark.gluten.sql.cartesianProductTransformerEnabled")
       .internal()
@@ -2066,84 +1573,6 @@ object GlutenConfig {
         "`WholeStageTransformerContext`.")
       .booleanConf
       .createWithDefault(false)
-
-  val DIRECTORY_SIZE_GUESS =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.directorySizeGuess")
-      .internal()
-      .doc("Set the directory size guess for velox file scan")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("32KB")
-
-  val FILE_PRELOAD_THRESHOLD =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.filePreloadThreshold")
-      .internal()
-      .doc("Set the file preload threshold for velox file scan")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("1MB")
-
-  val PREFETCH_ROW_GROUPS =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.prefetchRowGroups")
-      .internal()
-      .doc("Set the prefetch row groups for velox file scan")
-      .intConf
-      .createWithDefault(1)
-
-  val LOAD_QUANTUM =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.loadQuantum")
-      .internal()
-      .doc("Set the load quantum for velox file scan, recommend to use the default value (256MB) " +
-        "for performance consideration. If Velox cache is enabled, it can be 8MB at most.")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("256MB")
-
-  val MAX_COALESCED_DISTANCE_BYTES =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.maxCoalescedDistance")
-      .internal()
-      .doc(" Set the max coalesced distance bytes for velox file scan")
-      .stringConf
-      .createWithDefaultString("512KB")
-
-  val MAX_COALESCED_BYTES =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.maxCoalescedBytes")
-      .internal()
-      .doc("Set the max coalesced bytes for velox file scan")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("64MB")
-
-  val CACHE_PREFETCH_MINPCT =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.cachePrefetchMinPct")
-      .internal()
-      .doc("Set prefetch cache min pct for velox file scan")
-      .intConf
-      .createWithDefault(0)
-
-  val AWS_SDK_LOG_LEVEL =
-    buildConf("spark.gluten.velox.awsSdkLogLevel")
-      .internal()
-      .doc("Log granularity of AWS C++ SDK in velox.")
-      .stringConf
-      .createWithDefault("FATAL")
-
-  val AWS_S3_RETRY_MODE =
-    buildConf("spark.gluten.velox.fs.s3a.retry.mode")
-      .internal()
-      .doc("Retry mode for AWS s3 connection error: legacy, standard and adaptive.")
-      .stringConf
-      .createWithDefault("legacy")
-
-  val AWS_S3_CONNECT_TIMEOUT =
-    buildConf("spark.gluten.velox.fs.s3a.connect.timeout")
-      .internal()
-      .doc("Timeout for AWS s3 connection.")
-      .stringConf
-      .createWithDefault("200s")
-
-  val VELOX_ORC_SCAN_ENABLED =
-    buildConf("spark.gluten.sql.columnar.backend.velox.orc.scan.enabled")
-      .internal()
-      .doc("Enable velox orc scan. If disabled, vanilla spark orc scan will be used.")
-      .booleanConf
-      .createWithDefault(true)
 
   val VELOX_FORCE_ORC_CHAR_TYPE_SCAN_FALLBACK =
     buildConf("spark.gluten.sql.orc.charType.scan.fallback.enabled")
@@ -2215,28 +1644,10 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
-  val CAST_FROM_VARCHAR_ADD_TRIM_NODE =
-    buildConf("spark.gluten.velox.castFromVarcharAddTrimNode")
-      .internal()
-      .doc(
-        "If true, will add a trim node " +
-          "which has the same sementic as vanilla Spark to CAST-from-varchar." +
-          "Otherwise, do nothing.")
-      .booleanConf
-      .createWithDefault(false)
-
   val HDFS_VIEWFS_ENABLED =
     buildStaticConf("spark.gluten.storage.hdfsViewfs.enabled")
       .internal()
       .doc("If enabled, gluten will convert the viewfs path to hdfs path in scala side")
-      .booleanConf
-      .createWithDefault(false)
-
-  val VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP =
-    buildConf("spark.gluten.velox.offHeapBroadcastBuildRelation.enabled")
-      .internal()
-      .doc("Experimental: If enabled, broadcast build relation will use offheap memory. " +
-        "Otherwise, broadcast build relation will use onheap memory.")
       .booleanConf
       .createWithDefault(false)
 
@@ -2246,49 +1657,6 @@ object GlutenConfig {
       .doc("If enabled, gluten will not offload scan when encrypted parquet files are detected")
       .booleanConf
       .createWithDefault(false)
-
-  val QUERY_TRACE_ENABLED = buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceEnabled")
-    .doc("Enable query tracing flag.")
-    .internal()
-    .booleanConf
-    .createWithDefault(false)
-
-  val QUERY_TRACE_DIR = buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceDir")
-    .doc("Base dir of a query to store tracing data.")
-    .internal()
-    .stringConf
-    .createWithDefault("")
-
-  val QUERY_TRACE_NODE_IDS = buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceNodeIds")
-    .doc("A comma-separated list of plan node ids whose input data will be traced. " +
-      "Empty string if only want to trace the query metadata.")
-    .internal()
-    .stringConf
-    .createWithDefault("")
-
-  val QUERY_TRACE_MAX_BYTES =
-    buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceMaxBytes")
-      .doc("The max trace bytes limit. Tracing is disabled if zero.")
-      .internal()
-      .longConf
-      .createWithDefault(0)
-
-  val QUERY_TRACE_TASK_REG_EXP =
-    buildConf("spark.gluten.sql.columnar.backend.velox.queryTraceTaskRegExp")
-      .doc("The regexp of traced task id. We only enable trace on a task if its id matches.")
-      .internal()
-      .stringConf
-      .createWithDefault("")
-
-  val OP_TRACE_DIRECTORY_CREATE_CONFIG =
-    buildConf("spark.gluten.sql.columnar.backend.velox.opTraceDirectoryCreateConfig")
-      .doc(
-        "Config used to create operator trace directory. This config is provided to" +
-          " underlying file system and the config is free form. The form should be " +
-          "defined by the underlying file system.")
-      .internal()
-      .stringConf
-      .createWithDefault("")
 
   val AUTO_ADJUST_STAGE_RESOURCE_PROFILE_ENABLED =
     buildStaticConf("spark.gluten.auto.adjustStageResource.enabled")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix https://github.com/apache/incubator-gluten/issues/8479, This PR aims to split the backend configurations into individual modules that belong to each other.

This PR mainly accomplishes two things: 
1. It splits the configurations defined in GlutenConfig, moving Velox-related configurations to VeloxConfig and CH-related configurations to CHConf. 
3. It deletes the configuration retrieval methods that are not in use.

## How was this patch tested?

GA.

