### PR TITLE
[VL][CI] Use a unified docker image for Spark tests

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -750,7 +750,7 @@ jobs:
   run-spark-test-spark34:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: apache/gluten:centos-8-jdk17
+    container: apache/gluten:centos-8-jdk8
     steps:
       - uses: actions/checkout@v2
       - name: Download All Artifacts
@@ -774,7 +774,10 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/
           export SPARK_SCALA_VERSION=2.12
+          yum install -y java-17-openjdk-devel
           export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+          export PATH=$JAVA_HOME/bin:$PATH
+          java -version
           export SPARK_HOME=/opt/shims/spark34/spark_home/
           ls -l /opt/shims/spark34/spark_home/
           $MVN_CMD clean test -Pspark-3.4 -Pjava-17 -Pbackends-velox -Piceberg -Pdelta -Phudi -Pspark-ut \
@@ -842,7 +845,7 @@ jobs:
   run-spark-test-spark34-slow:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: apache/gluten:centos-8-jdk17
+    container: apache/gluten:centos-8-jdk8
     steps:
       - uses: actions/checkout@v2
       - name: Download All Artifacts
@@ -859,6 +862,10 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/
           export SPARK_HOME=/opt/shims/spark34/spark_home/
+          yum install -y java-17-openjdk-devel
+          export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+          export PATH=$JAVA_HOME/bin:$PATH
+          java -version
           ls -l /opt/shims/spark34/spark_home/
           $MVN_CMD clean test -Pspark-3.4 -Pjava-17 -Pbackends-velox -Piceberg -Pdelta -Pspark-ut -Phudi \
           -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest \
@@ -948,7 +955,7 @@ jobs:
   run-spark-test-spark35-jdk17:
     needs: build-native-lib-centos-7
     runs-on: ubuntu-20.04
-    container: apache/gluten:centos-8-jdk17
+    container: apache/gluten:centos-8-jdk8
     steps:
       - uses: actions/checkout@v2
       - name: Download All Artifacts
@@ -972,7 +979,10 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/
           export SPARK_SCALA_VERSION=2.12
+          yum install -y java-17-openjdk-devel
           export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+          export PATH=$JAVA_HOME/bin:$PATH
+          java -version
           $MVN_CMD clean test -Pspark-3.5 -Pjava-17 -Pbackends-velox -Piceberg -Pdelta -Phudi -Pspark-ut \
           -DargLine="-Dspark.test.home=/opt/shims/spark35/spark_home/  ${EXTRA_FLAGS}" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.SkipTestTags

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
@@ -23,7 +23,9 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.{ArrowFileSourceScanExec, BaseArrowScanExec, ColumnarToRowExec}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-class ArrowCsvScanSuiteV1 extends ArrowCsvScanSuite {
+import org.scalatest.Ignore
+
+class ArrowCsvScanSuiteV1 extends ArrowCsvScanSuiteBase {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.sql.sources.useV1SourceList", "csv")
@@ -65,8 +67,13 @@ class ArrowCsvScanSuiteV2 extends ArrowCsvScanSuite {
     super.sparkConf
       .set("spark.sql.sources.useV1SourceList", "")
   }
+
+  test("csv scan") {
+    runAndCompare("select * from student")()
+  }
 }
 
+@Ignore
 class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
@@ -86,7 +93,9 @@ class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
 }
 
 /** Since https://github.com/apache/incubator-gluten/pull/5850. */
+@Ignore
 abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
+
   test("csv scan with option string as null") {
     val df = runAndCompare("select * from student_option_str")()
     val plan = df.queryExecution.executedPlan
@@ -139,11 +148,6 @@ abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
         checkGlutenOperatorMatch[BaseArrowScanExec]
       }
     }
-  }
-
-  test("count(1) on csv scan") {
-    val df = runAndCompare("select count(1) from student")()
-    checkLengthAndPlan(df, 1)
   }
 }
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
@@ -23,9 +23,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.{ArrowFileSourceScanExec, BaseArrowScanExec, ColumnarToRowExec}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-import org.scalatest.Ignore
-
-class ArrowCsvScanSuiteV1 extends ArrowCsvScanSuiteBase {
+class ArrowCsvScanSuiteV1 extends ArrowCsvScanSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.sql.sources.useV1SourceList", "csv")
@@ -67,13 +65,8 @@ class ArrowCsvScanSuiteV2 extends ArrowCsvScanSuite {
     super.sparkConf
       .set("spark.sql.sources.useV1SourceList", "")
   }
-
-  test("csv scan") {
-    runAndCompare("select * from student")()
-  }
 }
 
-@Ignore
 class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
@@ -93,9 +86,7 @@ class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
 }
 
 /** Since https://github.com/apache/incubator-gluten/pull/5850. */
-@Ignore
 abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
-
   test("csv scan with option string as null") {
     val df = runAndCompare("select * from student_option_str")()
     val plan = df.queryExecution.executedPlan
@@ -148,6 +139,11 @@ abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
         checkGlutenOperatorMatch[BaseArrowScanExec]
       }
     }
+  }
+
+  test("count(1) on csv scan") {
+    val df = runAndCompare("select count(1) from student")()
+    checkLengthAndPlan(df, 1)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In #7789, Spark-3.4.4 support is added and JDK-17 docker is used to avoid some issues caused by arrow. This pr changes to use the unified docker image and switches JDK version before running the test, which can reduce the efforts a bit for maintaining docker images.

I cannot figure out the reason why this way didn't pass in previous test. Maybe, we can land this pr firstly and continue observing the CI feedback while still keeping the JDK-17 docker image available in docker hub for some time.

## How was this patch tested?

CI.

