### PR TITLE
[CH][DOC] Fix Maven Build Gluten ClickHouse Command

### DIFF
--- a/docs/developers/clickhouse-backend-debug.md
+++ b/docs/developers/clickhouse-backend-debug.md
@@ -18,7 +18,7 @@ parent: /developer-overview/
 
 2. Maven Build Gluten ClickHouse with Profile
    ```
-   mvn clean install -DskipTests -Pbackends-clickhouse -Pspark-3.3 -Pspark-ut
+   mvn clean install -DskipTests -P delta -Pbackends-clickhouse -Pspark-3.3 -Pspark-ut
    ```
    
 3. Set Maven Profiles in IntelliJ IDEA


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running the maven command in `Maven Build Gluten ClickHouse with Profile`, an exception occurred, as shown in the following figure.
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/5e8bd14d-5b59-4036-b2e2-b1c8bf7d0871" />

Therefore, it is necessary to update the commands in the document.

## How was this patch tested?
- Just docs, not need add UT
- The execution result after changing the command.
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/6fa1f070-008d-4fd9-ac78-b7f915919576" />
