### PR TITLE
[VL][MIRROR] Fix build faile don Macos with INSTALL_PREFIX not set

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -30,6 +30,7 @@ VELOX_HOME=""
 VELOX_PARAMETER=""
 BUILD_ARROW=ON
 SPARK_VERSION=ALL
+INSTALL_PREFIX=${INSTALL_PREFIX:-}
 
 # set default number of threads as cpu cores minus 2
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?
After #8627 , I met the `dev/builddeps-veloxbe.sh: line 218: INSTALL_PREFIX: unbound variable`.

## How was this patch tested?
manual test on macos

