### PR TITLE
[VL] nit: Remove shadowed variables in SubstraitToVeloxPlan.cc

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -667,8 +667,6 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     }
   }
 
-  // Do not hard-code connector ID and allow for connectors other than Hive.
-  static const std::string kHiveConnectorId = "test-hive";
   // Currently only support parquet format.
   dwio::common::FileFormat fileFormat = dwio::common::FileFormat::PARQUET;
 
@@ -1272,9 +1270,6 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     veloxTypeList = SubstraitParser::parseNamedStruct(baseSchema, asLowerCase);
     SubstraitParser::parseColumnTypes(baseSchema, columnTypes);
   }
-
-  // Do not hard-code connector ID and allow for connectors other than Hive.
-  static const std::string kHiveConnectorId = "test-hive";
 
   // Velox requires Filter Pushdown must being enabled.
   bool filterPushdownEnabled = true;


### PR DESCRIPTION
`gluten::kHiveConnectorId` was defined as const so no need to define `kHiveConnectorId` locally in the function bodies.