### PR TITLE
[GLUTEN-8678] Fix jar name on macos

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -224,7 +224,7 @@
               <arguments>
                 <argument>target/gluten-package-${project.version}.jar</argument>
                 <argument>
-                  target/${jar.assembly.name.prefix}-${backend_type}-bundle-spark${sparkbundle.version}_${scala.binary.version}-${os.detected.release}_${os.detected.release.version}_${os.detected.arch}-${project.version}.jar
+                  target/${jar.assembly.name.prefix}-${backend_type}-bundle-spark${sparkbundle.version}_${scala.binary.version}-${os.full.name}-${project.version}.jar
                 </argument>
               </arguments>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
     <project.prefix>spark-sql-columnar</project.prefix>
     <jar.assembly.name.prefix>gluten</jar.assembly.name.prefix>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+    <!--
+    Will be overwritten by the profile on different platforms.
+    Otherwise, it is built from an unsupported platform.
+    -->
+    <os.full.name>unknown</os.full.name>
     <!-- To build built-in backend c++ codes -->
     <scala.recompile.mode>all</scala.recompile.mode>
     <!-- For unit tests -->
@@ -952,6 +957,7 @@
       <properties>
         <platform>darwin</platform>
         <arch>x86_64</arch>
+        <os.full.name>${platform}_${arch}</os.full.name>
       </properties>
     </profile>
     <profile>
@@ -965,6 +971,7 @@
       <properties>
         <platform>darwin</platform>
         <arch>aarch64</arch>
+        <os.full.name>${platform}_${arch}</os.full.name>
       </properties>
     </profile>
     <profile>
@@ -978,6 +985,7 @@
       <properties>
         <platform>linux</platform>
         <arch>amd64</arch>
+        <os.full.name>${os.detected.release}_${os.detected.release.version}_${os.detected.arch}</os.full.name>
       </properties>
     </profile>
     <profile>
@@ -991,6 +999,7 @@
       <properties>
         <platform>linux</platform>
         <arch>aarch64</arch>
+        <os.full.name>${os.detected.release}_${os.detected.release.version}_${os.detected.arch}</os.full.name>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -985,7 +985,7 @@
       <properties>
         <platform>linux</platform>
         <arch>amd64</arch>
-        <os.full.name>${os.detected.release}_${os.detected.release.version}_${os.detected.arch}</os.full.name>
+        <os.full.name>${platform}_${arch}</os.full.name>
       </properties>
     </profile>
     <profile>
@@ -999,7 +999,7 @@
       <properties>
         <platform>linux</platform>
         <arch>aarch64</arch>
-        <os.full.name>${os.detected.release}_${os.detected.release.version}_${os.detected.arch}</os.full.name>
+        <os.full.name>${platform}_${arch}</os.full.name>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
After this fix, the jar name on macOS will be like:
gluten-velox-bundle-spark3.5_2.12-darwin_aarch64-1.4.0-SNAPSHOT.jar
gluten-velox-bundle-spark3.5_2.12-darwin_x86_64-1.4.0-SNAPSHOT.jar

Fixes: #8678 