### PR TITLE
[VL] Skip the velox download if velox_repo not accessable

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -145,26 +145,36 @@ if [ "$VELOX_HOME" == "" ]; then
 fi
 VELOX_SOURCE_DIR="${VELOX_HOME}"
 
-# checkout code
-TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}' | head -n 1)"
-if [ -d $VELOX_SOURCE_DIR ]; then
-  echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
-  cd $VELOX_SOURCE_DIR
-  git init .
-  EXISTS=$(git show-ref refs/tags/build_$TARGET_BUILD_COMMIT || true)
-  if [ -z "$EXISTS" ]; then
-    git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:refs/tags/build_$TARGET_BUILD_COMMIT
+if git ls-remote $VELOX_REPO $VELOX_BRANCH &> /dev/null; then
+  # checkout code
+  TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}' | head -n 1)"
+  if [ -d $VELOX_SOURCE_DIR ]; then
+    echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
+    cd $VELOX_SOURCE_DIR
+    git init .
+    EXISTS=$(git show-ref refs/tags/build_$TARGET_BUILD_COMMIT || true)
+    if [ -z "$EXISTS" ]; then
+      git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:refs/tags/build_$TARGET_BUILD_COMMIT
+    fi
+    git reset --hard HEAD
+    git checkout refs/tags/build_$TARGET_BUILD_COMMIT
+  else
+    git clone $VELOX_REPO -b $VELOX_BRANCH $VELOX_SOURCE_DIR
+    cd $VELOX_SOURCE_DIR
+    git checkout $TARGET_BUILD_COMMIT
   fi
-  git reset --hard HEAD
-  git checkout refs/tags/build_$TARGET_BUILD_COMMIT
+  #sync submodules
+  git submodule sync --recursive
+  git submodule update --init --recursive
 else
-  git clone $VELOX_REPO -b $VELOX_BRANCH $VELOX_SOURCE_DIR
-  cd $VELOX_SOURCE_DIR
-  git checkout $TARGET_BUILD_COMMIT
+  if [ -d $VELOX_SOURCE_DIR ]; then
+    # if velox repo isn't accessable and velox_home is set
+    cd $VELOX_SOURCE_DIR
+  else
+    echo "download from $VELOX_REPO failed"
+    exit 1
+  fi
 fi
-#sync submodules
-git submodule sync --recursive
-git submodule update --init --recursive
 
 function apply_compilation_fixes {
   current_dir=$1


### PR DESCRIPTION
When velox_home is specified and velox_repo:velox_branch doesn't exists, it means user prepared the customized Velox. We can skip the velox download and continue the build. It's user's responsibility to make sure the velox has correct version.