### PR TITLE
[GLUTEN-8693][VL] Disallow AVX-512 for simdjson by default

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -15,6 +15,8 @@ BUILD_BENCHMARKS=OFF
 ENABLE_JEMALLOC_STATS=OFF
 BUILD_VELOX_TESTS=OFF
 BUILD_VELOX_BENCHMARKS=OFF
+# Set to ON for machines have AVX-512 instruction.
+SIMDJSON_AVX512_ALLOWED=OFF
 ENABLE_QAT=OFF
 ENABLE_IAA=OFF
 ENABLE_HBM=OFF
@@ -124,6 +126,10 @@ do
         BUILD_VELOX_BENCHMARKS=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
+        --simdjson_avx512_allowed=*)
+        SIMDJSON_AVX512_ALLOWED=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
         --build_arrow=*)
         BUILD_ARROW=("${arg#*=}")
         shift # Remove argument name from processing
@@ -190,7 +196,7 @@ function build_velox {
   ./build_velox.sh --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
                    --enable_abfs=$ENABLE_ABFS --build_test_utils=$BUILD_TESTS \
                    --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS --num_threads=$NUM_THREADS \
-                   --velox_home=$VELOX_HOME
+                   --velox_home=$VELOX_HOME --simdjson_avx512_allowed=$SIMDJSON_AVX512_ALLOWED
 }
 
 function build_gluten_cpp {

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -15,8 +15,6 @@ BUILD_BENCHMARKS=OFF
 ENABLE_JEMALLOC_STATS=OFF
 BUILD_VELOX_TESTS=OFF
 BUILD_VELOX_BENCHMARKS=OFF
-# Set to ON for machines have AVX-512 instruction.
-SIMDJSON_AVX512_ALLOWED=OFF
 ENABLE_QAT=OFF
 ENABLE_IAA=OFF
 ENABLE_HBM=OFF
@@ -126,10 +124,6 @@ do
         BUILD_VELOX_BENCHMARKS=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
-        --simdjson_avx512_allowed=*)
-        SIMDJSON_AVX512_ALLOWED=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
         --build_arrow=*)
         BUILD_ARROW=("${arg#*=}")
         shift # Remove argument name from processing
@@ -196,7 +190,7 @@ function build_velox {
   ./build_velox.sh --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
                    --enable_abfs=$ENABLE_ABFS --build_test_utils=$BUILD_TESTS \
                    --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS --num_threads=$NUM_THREADS \
-                   --velox_home=$VELOX_HOME --simdjson_avx512_allowed=$SIMDJSON_AVX512_ALLOWED
+                   --velox_home=$VELOX_HOME
 }
 
 function build_gluten_cpp {

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -34,8 +34,6 @@ ENABLE_BENCHMARK=OFF
 ENABLE_TESTS=OFF
 # Set to ON for gluten cpp test build.
 BUILD_TEST_UTILS=OFF
-# Set to ON for machines have AVX-512 instruction.
-SIMDJSON_AVX512_ALLOWED=OFF
 # Number of threads to use for building.
 NUM_THREADS=""
 
@@ -82,10 +80,6 @@ for arg in "$@"; do
     ENABLE_BENCHMARK=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
-  --simdjson_avx512_allowed=*)
-    SIMDJSON_AVX512_ALLOWED=("${arg#*=}")
-    shift # Remove argument name from processing
-    ;;
   --num_threads=*)
     NUM_THREADS=("${arg#*=}")
     shift # Remove argument name from processing
@@ -130,7 +124,10 @@ function compile {
   if [ -n "${GLUTEN_VCPKG_ENABLED:-}" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_GFLAGS_TYPE=static"
   fi
-  if [ $SIMDJSON_AVX512_ALLOWED == "OFF" ]; then
+  CPU_CAPABILITIES=$(cat /proc/cpuinfo | grep flags | head -n 1| awk '{print tolower($0)}')
+  # Set to OFF for machines don't have AVX-512 instruction set,
+  # which is used to compile simdjson, the default value is 'ON'.
+  if [[ "$CPU_CAPABILITIES" != *"avx512"* ]]; then
       COMPILE_OPTION="$COMPILE_OPTION -DSIMDJSON_AVX512_ALLOWED=OFF"
   fi
 

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -34,6 +34,8 @@ ENABLE_BENCHMARK=OFF
 ENABLE_TESTS=OFF
 # Set to ON for gluten cpp test build.
 BUILD_TEST_UTILS=OFF
+# Set to ON for machines have AVX-512 instruction.
+SIMDJSON_AVX512_ALLOWED=OFF
 # Number of threads to use for building.
 NUM_THREADS=""
 
@@ -80,6 +82,10 @@ for arg in "$@"; do
     ENABLE_BENCHMARK=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
+  --simdjson_avx512_allowed=*)
+    SIMDJSON_AVX512_ALLOWED=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
   --num_threads=*)
     NUM_THREADS=("${arg#*=}")
     shift # Remove argument name from processing
@@ -123,6 +129,9 @@ function compile {
   fi
   if [ -n "${GLUTEN_VCPKG_ENABLED:-}" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_GFLAGS_TYPE=static"
+  fi
+  if [ $SIMDJSON_AVX512_ALLOWED == "OFF" ]; then
+      COMPILE_OPTION="$COMPILE_OPTION -DSIMDJSON_AVX512_ALLOWED=OFF"
   fi
 
   COMPILE_OPTION="$COMPILE_OPTION -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disallow AVX-512 for simdjson by default, when the machine doesn't have AVX-512

https://github.com/apache/incubator-gluten/issues/8693

## How was this patch tested?

Compile velox dynamicly


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

