### PR TITLE
[GLUTEN-8705][CH] Enable MemorySpillScheduler

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
@@ -93,11 +93,13 @@ class CHListenerApi extends ListenerApi with Logging {
       "timezone" -> conf.get("spark.sql.session.timeZone", TimeZone.getDefault.getID),
       "local_engine.settings.log_processors_profiles" -> "true")
     conf.setCHSettings("spark_version", SPARK_VERSION)
-    if (!conf.contains(CHConf.runtimeSettings("enable_adaptive_memory_spill_scheduler")))
-    {
+    if (!conf.contains(RuntimeSettings.ENABLE_MEMORY_SPILL_SCHEDULER.key)) {
       // Enable adaptive memory spill scheduler for native by default
-      conf.setCHSettings("enable_adaptive_memory_spill_scheduler", "true")
+      conf.set(
+        RuntimeSettings.ENABLE_MEMORY_SPILL_SCHEDULER.key,
+        RuntimeSettings.ENABLE_MEMORY_SPILL_SCHEDULER.defaultValueString)
     }
+
     // add memory limit for external sort
     if (conf.getLong(RuntimeSettings.MAX_BYTES_BEFORE_EXTERNAL_SORT.key, -1) < 0) {
       if (conf.getBoolean("spark.memory.offHeap.enabled", defaultValue = false)) {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
@@ -93,6 +93,11 @@ class CHListenerApi extends ListenerApi with Logging {
       "timezone" -> conf.get("spark.sql.session.timeZone", TimeZone.getDefault.getID),
       "local_engine.settings.log_processors_profiles" -> "true")
     conf.setCHSettings("spark_version", SPARK_VERSION)
+    if (!conf.contains(CHConf.runtimeSettings("enable_adaptive_memory_spill_scheduler")))
+    {
+      // Enable adaptive memory spill scheduler for native by default
+      conf.setCHSettings("enable_adaptive_memory_spill_scheduler", "true")
+    }
     // add memory limit for external sort
     if (conf.getLong(RuntimeSettings.MAX_BYTES_BEFORE_EXTERNAL_SORT.key, -1) < 0) {
       if (conf.getBoolean("spark.memory.offHeap.enabled", defaultValue = false)) {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/RuntimeSettings.scala
@@ -96,4 +96,10 @@ object RuntimeSettings {
       .doc("The bucket directory for writing data")
       .stringConf
       .createWithDefault("")
+
+  val ENABLE_MEMORY_SPILL_SCHEDULER =
+    buildConf(runtimeSettings("enable_adaptive_memory_spill_scheduler"))
+      .doc("Enable memory spill scheduler")
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/cpp-ch/local-engine/Common/QueryContext.cpp
+++ b/cpp-ch/local-engine/Common/QueryContext.cpp
@@ -99,7 +99,6 @@ int64_t QueryContext::initializeQuery(const String & task_id)
     // Notice:
     // this generated random query id a qualified global queryid for the spark query
     query_context->query_context->setCurrentQueryId(toString(UUIDHelpers::generateV4()) + "_" + task_id);
-    query_context->query_context->setSetting("enable_adaptive_memory_spill_scheduler", true);
     auto config = MemoryConfig::loadFromContext(query_context->query_context);
     query_context->thread_status = std::make_shared<ThreadStatus>(false);
     query_context->thread_group = std::make_shared<ThreadGroup>(query_context->query_context);

--- a/cpp-ch/local-engine/Common/QueryContext.cpp
+++ b/cpp-ch/local-engine/Common/QueryContext.cpp
@@ -99,6 +99,7 @@ int64_t QueryContext::initializeQuery(const String & task_id)
     // Notice:
     // this generated random query id a qualified global queryid for the spark query
     query_context->query_context->setCurrentQueryId(toString(UUIDHelpers::generateV4()) + "_" + task_id);
+    query_context->query_context->setSetting("enable_adaptive_memory_spill_scheduler", true);
     auto config = MemoryConfig::loadFromContext(query_context->query_context);
     query_context->thread_status = std::make_shared<ThreadStatus>(false);
     query_context->thread_group = std::make_shared<ThreadGroup>(query_context->query_context);

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
@@ -479,6 +479,7 @@ void GraceAggregatingTransform::mergeOneBlock(const DB::Block & block, bool is_o
     {
         rehashDataVariants();
     }
+    // reset the flag
     force_spill = false;
 
     LOG_DEBUG(

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.cpp
@@ -60,6 +60,9 @@ GraceAggregatingTransform::GraceAggregatingTransform(
     if (enable_spill_test)
         buckets.emplace(1, BufferFileStream());
     current_data_variants = std::make_shared<DB::AggregatedDataVariants>();
+
+    // IProcessor::spillable, MemorySpillScheduler will trigger the spill by enable this flag.
+    spillable = true;
 }
 
 GraceAggregatingTransform::~GraceAggregatingTransform()
@@ -476,6 +479,7 @@ void GraceAggregatingTransform::mergeOneBlock(const DB::Block & block, bool is_o
     {
         rehashDataVariants();
     }
+    force_spill = false;
 
     LOG_DEBUG(
         logger,
@@ -534,6 +538,13 @@ void GraceAggregatingTransform::mergeOneBlock(const DB::Block & block, bool is_o
 
 bool GraceAggregatingTransform::isMemoryOverflow()
 {
+    if (force_spill)
+    {
+        auto stats = getMemoryStats();
+        if (stats.spillable_memory_bytes > force_spill_on_bytes * 0.8)
+            return true;
+    }
+
     /// More greedy memory usage strategy.
     if (!current_data_variants)
         return false;
@@ -578,6 +589,43 @@ bool GraceAggregatingTransform::isMemoryOverflow()
         }
     }
     return false;
+}
+
+DB::ProcessorMemoryStats GraceAggregatingTransform::getMemoryStats()
+{
+    DB::ProcessorMemoryStats stats;
+    if (!current_data_variants)
+        return stats;
+
+    stats.need_reserved_memory_bytes = current_data_variants->aggregates_pool->allocatedBytes();
+    for (size_t i = current_bucket_index + 1; i < getBucketsNum(); ++i)
+    {
+        auto & file_stream = buckets[i];
+        stats.spillable_memory_bytes += file_stream.pending_bytes;
+    }
+
+    if (per_key_memory_usage > 0)
+    {
+        auto current_result_rows = current_data_variants->size();
+        stats.need_reserved_memory_bytes += current_result_rows * per_key_memory_usage;
+        stats.spillable_memory_bytes += current_result_rows * per_key_memory_usage;
+    }
+    else
+    {
+        // This is a rough estimation, we don't know the exact memory usage for each key.
+        stats.spillable_memory_bytes += current_data_variants->aggregates_pool->allocatedBytes();
+    }
+    return stats;
+}
+
+bool GraceAggregatingTransform::spillOnSize(size_t bytes)
+{
+    auto stats = getMemoryStats();
+    if (stats.spillable_memory_bytes < bytes * 0.8)
+        return false;
+    force_spill = true;
+    force_spill_on_bytes = bytes;
+    return true;
 }
 
 }

--- a/cpp-ch/local-engine/Operator/GraceAggregatingTransform.h
+++ b/cpp-ch/local-engine/Operator/GraceAggregatingTransform.h
@@ -23,6 +23,7 @@
 #include <Processors/IProcessor.h>
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Poco/Logger.h>
+#include <Common/MemorySpillScheduler.h>
 #include <Common/AggregateUtil.h>
 
 
@@ -106,7 +107,13 @@ private:
     void checkAndSetupCurrentDataVariants();
     /// Merge one block into current_data_variants.
     void mergeOneBlock(const DB::Block & block, bool is_original_block);
+
+    // spill control
     bool isMemoryOverflow();
+    DB::ProcessorMemoryStats getMemoryStats() override;
+    bool spillOnSize(size_t bytes) override;
+    bool force_spill = false; // a force flag to trigger spill
+    bool force_spill_on_bytes = 0;
 
     bool input_finished = false;
     bool has_input = false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #8705

It's a common case that there are multiple join steps in a subplan.  A previous solution, each join operator spills when its memory usage is over limit,unable to sense the exisitence of other operators. It's easy to cause OOM, even there is no any join operator reach the limit.

`MemorySpillScheduler` chooses one operator to  trigger it spill based on total memory usage and each operator's memory usage. It could avoid the above cases.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

 manual tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

