### PR TITLE
[GLUTEN-8704][CH] try accelerate some spark* function by optimizing tight loops

### DIFF
--- a/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.cpp
@@ -26,31 +26,31 @@ using namespace DB;
 namespace local_engine
 {
 
-struct NameToUInt8 { static constexpr auto name = "sparkCastFloatToUInt8"; };
-struct NameToUInt16 { static constexpr auto name = "sparkCastFloatToUInt16"; };
-struct NameToUInt32 { static constexpr auto name = "sparkCastFloatToUInt32"; };
-struct NameToUInt64 { static constexpr auto name = "sparkCastFloatToUInt64"; };
-struct NameToUInt128 { static constexpr auto name = "sparkCastFloatToUInt128"; };
-struct NameToUInt256 { static constexpr auto name = "sparkCastFloatToUInt256"; };
+// struct NameToUInt8 { static constexpr auto name = "sparkCastFloatToUInt8"; };
+// struct NameToUInt16 { static constexpr auto name = "sparkCastFloatToUInt16"; };
+// struct NameToUInt32 { static constexpr auto name = "sparkCastFloatToUInt32"; };
+// struct NameToUInt64 { static constexpr auto name = "sparkCastFloatToUInt64"; };
+// struct NameToUInt128 { static constexpr auto name = "sparkCastFloatToUInt128"; };
+// struct NameToUInt256 { static constexpr auto name = "sparkCastFloatToUInt256"; };
 struct NameToInt8 { static constexpr auto name = "sparkCastFloatToInt8"; };
 struct NameToInt16 { static constexpr auto name = "sparkCastFloatToInt16"; };
 struct NameToInt32 { static constexpr auto name = "sparkCastFloatToInt32"; };
 struct NameToInt64 { static constexpr auto name = "sparkCastFloatToInt64"; };
-struct NameToInt128 { static constexpr auto name = "sparkCastFloatToInt128"; };
-struct NameToInt256 { static constexpr auto name = "sparkCastFloatToInt256"; };
+// struct NameToInt128 { static constexpr auto name = "sparkCastFloatToInt128"; };
+// struct NameToInt256 { static constexpr auto name = "sparkCastFloatToInt256"; };
 
-using SparkFunctionCastFloatToInt8 = local_engine::SparkFunctionCastFloatToInt<Int8, NameToInt8, INT8_MAX, INT8_MIN>;
-using SparkFunctionCastFloatToInt16 = local_engine::SparkFunctionCastFloatToInt<Int16, NameToInt16, INT16_MAX, INT16_MIN>;
-using SparkFunctionCastFloatToInt32 = local_engine::SparkFunctionCastFloatToInt<Int32, NameToInt32, INT32_MAX, INT32_MIN>;
-using SparkFunctionCastFloatToInt64 = local_engine::SparkFunctionCastFloatToInt<Int64, NameToInt64, INT64_MAX, INT64_MIN>;
-using SparkFunctionCastFloatToInt128 = local_engine::SparkFunctionCastFloatToInt<Int128, NameToInt128, std::numeric_limits<Int128>::max(), std::numeric_limits<Int128>::min()>;
-using SparkFunctionCastFloatToInt256 = local_engine::SparkFunctionCastFloatToInt<Int256, NameToInt256, std::numeric_limits<Int256>::max(), std::numeric_limits<Int256>::min()>;
-using SparkFunctionCastFloatToUInt8 = local_engine::SparkFunctionCastFloatToInt<UInt8, NameToUInt8, UINT8_MAX, 0>;
-using SparkFunctionCastFloatToUInt16 = local_engine::SparkFunctionCastFloatToInt<UInt16, NameToUInt16, UINT16_MAX, 0>;
-using SparkFunctionCastFloatToUInt32 = local_engine::SparkFunctionCastFloatToInt<UInt32, NameToUInt32, UINT32_MAX, 0>;
-using SparkFunctionCastFloatToUInt64 = local_engine::SparkFunctionCastFloatToInt<UInt64, NameToUInt64, UINT64_MAX, 0>;
-using SparkFunctionCastFloatToUInt128 = local_engine::SparkFunctionCastFloatToInt<UInt128, NameToUInt128, std::numeric_limits<UInt128>::max(), 0>;
-using SparkFunctionCastFloatToUInt256 = local_engine::SparkFunctionCastFloatToInt<UInt256, NameToUInt256, std::numeric_limits<UInt256>::max(), 0>;
+using SparkFunctionCastFloatToInt8 = local_engine::SparkFunctionCastFloatToInt<Int8, NameToInt8>;
+using SparkFunctionCastFloatToInt16 = local_engine::SparkFunctionCastFloatToInt<Int16, NameToInt16>;
+using SparkFunctionCastFloatToInt32 = local_engine::SparkFunctionCastFloatToInt<Int32, NameToInt32>;
+using SparkFunctionCastFloatToInt64 = local_engine::SparkFunctionCastFloatToInt<Int64, NameToInt64>;
+// using SparkFunctionCastFloatToInt128 = local_engine::SparkFunctionCastFloatToInt<Int128, NameToInt128>;
+// using SparkFunctionCastFloatToInt256 = local_engine::SparkFunctionCastFloatToInt<Int256, NameToInt256>;
+// using SparkFunctionCastFloatToUInt8 = local_engine::SparkFunctionCastFloatToInt<UInt8, NameToUInt8>;
+// using SparkFunctionCastFloatToUInt16 = local_engine::SparkFunctionCastFloatToInt<UInt16, NameToUInt16>;
+// using SparkFunctionCastFloatToUInt32 = local_engine::SparkFunctionCastFloatToInt<UInt32, NameToUInt32>;
+// using SparkFunctionCastFloatToUInt64 = local_engine::SparkFunctionCastFloatToInt<UInt64, NameToUInt64>;
+// using SparkFunctionCastFloatToUInt128 = local_engine::SparkFunctionCastFloatToInt<UInt128, NameToUInt128>;
+// using SparkFunctionCastFloatToUInt256 = local_engine::SparkFunctionCastFloatToInt<UInt256, NameToUInt256>;
 
 REGISTER_FUNCTION(SparkFunctionCastToInt)
 {
@@ -58,13 +58,13 @@ REGISTER_FUNCTION(SparkFunctionCastToInt)
     factory.registerFunction<SparkFunctionCastFloatToInt16>();
     factory.registerFunction<SparkFunctionCastFloatToInt32>();
     factory.registerFunction<SparkFunctionCastFloatToInt64>();
-    factory.registerFunction<SparkFunctionCastFloatToInt128>();
-    factory.registerFunction<SparkFunctionCastFloatToInt256>();
-    factory.registerFunction<SparkFunctionCastFloatToUInt8>();
-    factory.registerFunction<SparkFunctionCastFloatToUInt16>();
-    factory.registerFunction<SparkFunctionCastFloatToUInt32>();
-    factory.registerFunction<SparkFunctionCastFloatToUInt64>();
-    factory.registerFunction<SparkFunctionCastFloatToUInt128>();
-    factory.registerFunction<SparkFunctionCastFloatToUInt256>();
+    // factory.registerFunction<SparkFunctionCastFloatToInt128>();
+    // factory.registerFunction<SparkFunctionCastFloatToInt256>();
+    // factory.registerFunction<SparkFunctionCastFloatToUInt8>();
+    // factory.registerFunction<SparkFunctionCastFloatToUInt16>();
+    // factory.registerFunction<SparkFunctionCastFloatToUInt32>();
+    // factory.registerFunction<SparkFunctionCastFloatToUInt64>();
+    // factory.registerFunction<SparkFunctionCastFloatToUInt128>();
+    // factory.registerFunction<SparkFunctionCastFloatToUInt256>();
 }
 }

--- a/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.cpp
@@ -26,31 +26,15 @@ using namespace DB;
 namespace local_engine
 {
 
-// struct NameToUInt8 { static constexpr auto name = "sparkCastFloatToUInt8"; };
-// struct NameToUInt16 { static constexpr auto name = "sparkCastFloatToUInt16"; };
-// struct NameToUInt32 { static constexpr auto name = "sparkCastFloatToUInt32"; };
-// struct NameToUInt64 { static constexpr auto name = "sparkCastFloatToUInt64"; };
-// struct NameToUInt128 { static constexpr auto name = "sparkCastFloatToUInt128"; };
-// struct NameToUInt256 { static constexpr auto name = "sparkCastFloatToUInt256"; };
 struct NameToInt8 { static constexpr auto name = "sparkCastFloatToInt8"; };
 struct NameToInt16 { static constexpr auto name = "sparkCastFloatToInt16"; };
 struct NameToInt32 { static constexpr auto name = "sparkCastFloatToInt32"; };
 struct NameToInt64 { static constexpr auto name = "sparkCastFloatToInt64"; };
-// struct NameToInt128 { static constexpr auto name = "sparkCastFloatToInt128"; };
-// struct NameToInt256 { static constexpr auto name = "sparkCastFloatToInt256"; };
 
 using SparkFunctionCastFloatToInt8 = local_engine::SparkFunctionCastFloatToInt<Int8, NameToInt8>;
 using SparkFunctionCastFloatToInt16 = local_engine::SparkFunctionCastFloatToInt<Int16, NameToInt16>;
 using SparkFunctionCastFloatToInt32 = local_engine::SparkFunctionCastFloatToInt<Int32, NameToInt32>;
 using SparkFunctionCastFloatToInt64 = local_engine::SparkFunctionCastFloatToInt<Int64, NameToInt64>;
-// using SparkFunctionCastFloatToInt128 = local_engine::SparkFunctionCastFloatToInt<Int128, NameToInt128>;
-// using SparkFunctionCastFloatToInt256 = local_engine::SparkFunctionCastFloatToInt<Int256, NameToInt256>;
-// using SparkFunctionCastFloatToUInt8 = local_engine::SparkFunctionCastFloatToInt<UInt8, NameToUInt8>;
-// using SparkFunctionCastFloatToUInt16 = local_engine::SparkFunctionCastFloatToInt<UInt16, NameToUInt16>;
-// using SparkFunctionCastFloatToUInt32 = local_engine::SparkFunctionCastFloatToInt<UInt32, NameToUInt32>;
-// using SparkFunctionCastFloatToUInt64 = local_engine::SparkFunctionCastFloatToInt<UInt64, NameToUInt64>;
-// using SparkFunctionCastFloatToUInt128 = local_engine::SparkFunctionCastFloatToInt<UInt128, NameToUInt128>;
-// using SparkFunctionCastFloatToUInt256 = local_engine::SparkFunctionCastFloatToInt<UInt256, NameToUInt256>;
 
 REGISTER_FUNCTION(SparkFunctionCastToInt)
 {
@@ -58,13 +42,5 @@ REGISTER_FUNCTION(SparkFunctionCastToInt)
     factory.registerFunction<SparkFunctionCastFloatToInt16>();
     factory.registerFunction<SparkFunctionCastFloatToInt32>();
     factory.registerFunction<SparkFunctionCastFloatToInt64>();
-    // factory.registerFunction<SparkFunctionCastFloatToInt128>();
-    // factory.registerFunction<SparkFunctionCastFloatToInt256>();
-    // factory.registerFunction<SparkFunctionCastFloatToUInt8>();
-    // factory.registerFunction<SparkFunctionCastFloatToUInt16>();
-    // factory.registerFunction<SparkFunctionCastFloatToUInt32>();
-    // factory.registerFunction<SparkFunctionCastFloatToUInt64>();
-    // factory.registerFunction<SparkFunctionCastFloatToUInt128>();
-    // factory.registerFunction<SparkFunctionCastFloatToUInt256>();
 }
 }

--- a/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.h
@@ -97,13 +97,16 @@ public:
     void executeInternal(const DB::ColumnPtr & src, DB::PaddedPODArray<T> & data, DB::PaddedPODArray<UInt8> & null_map_data) const
     {
         const DB::ColumnVector<F> * src_vec = assert_cast<const DB::ColumnVector<F> *>(src.get());
-        const auto & src_data = src_vec->getData();
-        size_t rows = src_vec->size();
 
+        size_t rows = src_vec->size();
+        const auto & src_data = src_vec->getData();
+
+        const auto int_min = static_cast<F>(std::numeric_limits<T>::min());
+        const auto int_max = static_cast<F>(std::numeric_limits<T>::max());
         for (size_t i = 0; i < rows; ++i)
         {
             null_map_data[i] = !isFinite(src_data[i]);
-            data[i] = static_cast<T>(src_data[i]);
+            data[i] = static_cast<T>(std::fmax(int_min, std::fmin(int_max, src_data[i])));
         }
     }
 

--- a/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCastFloatToInt.h
@@ -143,14 +143,6 @@ public:
         const auto & src_data = src_vec->getData();
         const auto int_min = static_cast<F>(std::numeric_limits<T>::min());
         const auto int_max = static_cast<F>(std::numeric_limits<T>::max());
-
-        /*
-        for (size_t i = 0; i < rows; ++i)
-        {
-            null_map_data[i] = !isFinite(src_data[i]);
-            data[i] = static_cast<T>(std::fmax(int_min, std::fmin(int_max, src_data[i])));
-        }
-        */
         vector(int_min, int_max, src_data, data, null_map_data, rows);
     }
 

--- a/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.cpp
@@ -16,7 +16,6 @@
  */
 #include "SparkFunctionCheckDecimalOverflow.h"
 
-#include <typeinfo>
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
@@ -28,6 +27,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
 #include "Columns/ColumnsCommon.h"
+#include <iostream>
 
 namespace DB
 {
@@ -274,8 +274,9 @@ private:
             /// signed integer to decimal
             using MaxNativeType = std::conditional_t<(sizeof(FromFieldType) > sizeof(ToNativeType)), FromFieldType, ToNativeType>;
 
-            auto converted = static_cast<MaxNativeType>(from) * static_cast<MaxNativeType>(scale_multiplier);
-            ok = converted < pow10_to_precision && converted > -pow10_to_precision;
+            MaxNativeType converted = 0;
+            ok = !common::mulOverflow(static_cast<MaxNativeType>(from), static_cast<MaxNativeType>(scale_multiplier), converted) && converted < pow10_to_precision
+                && converted > -pow10_to_precision;
             to = ok ? static_cast<ToNativeType>(converted) : static_cast<ToNativeType>(0);
         }
         return ok;

--- a/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.cpp
@@ -266,7 +266,7 @@ private:
             /// float to decimal
             auto converted = from * static_cast<FromFieldType>(scale_multiplier);
             auto float_pow10_to_precision = static_cast<FromFieldType>(pow10_to_precision);
-            ok = !isFinite(from) && converted < float_pow10_to_precision && converted > -float_pow10_to_precision;
+            ok = isFinite(from) && converted < float_pow10_to_precision && converted > -float_pow10_to_precision;
             to = ok ? static_cast<ToNativeType>(converted) : static_cast<ToNativeType>(0);
         }
         else

--- a/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionCheckDecimalOverflow.cpp
@@ -204,29 +204,25 @@ private:
 
         for (size_t i = 0; i < rows; ++i)
         {
-            ToFieldType to;
             bool success = false;
             if constexpr (IsDataTypeDecimal<FromDataType>)
             {
                 success = convertDecimalToDecimalImpl<FromDataType, ToDataType, MaxNativeType>(
-                    src_data[i], scale_direction, scale_multiplier, pow10_to_precision, to);
+                    src_data[i], scale_direction, scale_multiplier, pow10_to_precision, res_data[i]);
             }
             else
             {
                 success = convertNumberToDecimalImpl<FromDataType, ToDataType>(
-                    src_data[i], to_scale, whole_part_max, to);
+                    src_data[i], to_scale, whole_part_max, res_data[i]);
             }
 
             if constexpr (exception_mode == CheckExceptionMode::Null)
             {
-                res_data[i] = static_cast<ToFieldType>(to);
                 (*res_nullmap_data)[i] = !success;
             }
             else
             {
-                if (success)
-                    res_data[i] = static_cast<ToFieldType>(to);
-                else
+                if (!success)
                     throw Exception(ErrorCodes::DECIMAL_OVERFLOW, "Decimal value is overflow.");
             }
         }

--- a/cpp-ch/local-engine/Functions/SparkFunctionDecimalBinaryArithmetic.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDecimalBinaryArithmetic.h
@@ -422,7 +422,6 @@ private:
     }
 };
 
-/// TODO(taiyang-li): implement JIT for binary deicmal arithmetic functions
 template <class Operation, typename Name, OpMode mode = OpMode::Default>
 class SparkFunctionDecimalBinaryArithmetic final : public IFunction
 {

--- a/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
@@ -81,114 +81,117 @@ public:
     DB::ColumnPtr
     executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        if (arguments.size() != 2)
-            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 2", name);
+        using L = Float64;
+        using R = Float64;
+        using T = Float64;
 
-        if (!isNativeNumber(arguments[0].type) || !isNativeNumber(arguments[1].type))
-            throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type must be native number", name);
+        const DB::ColumnVector<L> * col_left = nullptr;
+        const DB::ColumnVector<R> * col_right = nullptr;
+        const DB::ColumnVector<L> * const_col_left = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
+        const DB::ColumnVector<R> * const_col_right = checkAndGetColumnConstData<DB::ColumnVector<R>>(arguments[1].column.get());
 
-        using Types = TypeList<
-            DB::DataTypeFloat32,
-            DB::DataTypeFloat64,
-            DB::DataTypeUInt8,
-            DB::DataTypeUInt16,
-            DB::DataTypeUInt32,
-            DB::DataTypeUInt64,
-            DB::DataTypeInt8,
-            DB::DataTypeInt16,
-            DB::DataTypeInt32,
-            DB::DataTypeInt64>;
+        L left_const_val = 0;
+        if (const_col_left)
+            left_const_val = const_col_left->getElement(0);
+        else
+            col_left = assert_cast<const DB::ColumnVector<L> *>(arguments[0].column.get());
 
-        DB::ColumnPtr result = nullptr;
-        bool valid = castTypeToEither(
-            Types{},
-            arguments[0].type.get(),
-            [&](const auto & left_)
+        R right_const_val = 0;
+        if (const_col_right)
+        {
+            right_const_val = const_col_right->getElement(0);
+            if (right_const_val == 0)
             {
-                return castTypeToEither(
-                    Types{},
-                    arguments[1].type.get(),
-                    [&](const auto & right_)
+                auto data_col = DB::ColumnVector<T>::create(1, 0);
+                auto null_map_col = DB::ColumnVector<UInt8>::create(1, 1);
+                return DB::ColumnConst::create(DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col)), input_rows_count);
+            }
+        }
+        else
+            col_right = assert_cast<const DB::ColumnVector<R> *>(arguments[1].column.get());
+
+        auto res_col = DB::ColumnVector<T>::create(input_rows_count, 0);
+        auto res_null_map = DB::ColumnVector<UInt8>::create(input_rows_count, 0);
+        DB::PaddedPODArray<T> & res_data = res_col->getData();
+        DB::PaddedPODArray<UInt8> & res_null_map_data = res_null_map->getData();
+        vector(col_left, col_right, left_const_val, right_const_val, res_data, res_null_map_data, input_rows_count);
+        return DB::ColumnNullable::create(std::move(res_col), std::move(res_null_map));
+    }
+
+    MULTITARGET_FUNCTION_AVX2_SSE42(
+        MULTITARGET_FUNCTION_HEADER(static void NO_SANITIZE_UNDEFINED NO_INLINE),
+        vectorImpl,
+        MULTITARGET_FUNCTION_BODY(
+            (const DB::ColumnVector<Float64> * col_left,
+             const DB::ColumnVector<Float64> * col_right,
+             Float64 left_const_val,
+             Float64 right_const_val,
+             DB::PaddedPODArray<Float64> & res_data,
+             DB::PaddedPODArray<UInt8> & res_null_map_data,
+             size_t input_rows_count) /// NOLINT
+            {
+                if (col_left && col_right)
+                {
+                    const auto & ldata = col_left->getData();
+                    const auto & rdata = col_right->getData();
+
+                    for (size_t i = 0; i < input_rows_count; ++i)
                     {
-                        using L = typename std::decay_t<decltype(left_)>::FieldType;
-                        using R = typename std::decay_t<decltype(right_)>::FieldType;
-                        using T = typename DB::NumberTraits::ResultOfFloatingPointDivision<L, R>::Type;
+                        auto l = ldata[i];
+                        auto r = rdata[i];
+                        res_data[i] = SparkDivideFloatingImpl<Float64, Float64>::apply(l, r ? r : 1);
+                        res_null_map_data[i] = !rdata[i];
+                    }
+                }
+                else if (col_left)
+                {
+                    Float64 r = right_const_val;
+                    for (size_t i = 0; i < input_rows_count; ++i)
+                    {
+                        Float64 l = col_left->getData()[i];
 
-                        const DB::ColumnVector<L> * col_left = nullptr;
-                        const DB::ColumnVector<R> * col_right = nullptr;
-                        const DB::ColumnVector<L> * const_col_left
-                            = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
-                        const DB::ColumnVector<R> * const_col_right
-                            = checkAndGetColumnConstData<DB::ColumnVector<R>>(arguments[1].column.get());
+                        /// r must not be zero because r = 0 is already processed in fast path
+                        /// No need to assign null_map_data[i] = 0, because it is already 0
+                        // res_null_map_data[i] = 0;
+                        res_data[i] = SparkDivideFloatingImpl<Float64, Float64>::apply(l, r);
+                    }
+                }
+                else if (col_right)
+                {
+                    Float64 l = left_const_val;
+                    for (size_t i = 0; i < input_rows_count; ++i)
+                    {
+                        Float64 r = col_right->getData()[i];
+                        res_null_map_data[i] = !r;
+                        res_data[i] = SparkDivideFloatingImpl<Float64, Float64>::apply(l, r ? r : 1);
+                    }
+                }
+            }))
 
-                        L left_const_val = 0;
-                        if (const_col_left)
-                            left_const_val = const_col_left->getElement(0);
-                        else
-                            col_left = assert_cast<const DB::ColumnVector<L> *>(arguments[0].column.get());
+    static void NO_INLINE vector(
+        const DB::ColumnVector<Float64> * col_left,
+        const DB::ColumnVector<Float64> * col_right,
+        Float64 left_const_val,
+        Float64 right_const_val,
+        DB::PaddedPODArray<Float64> & res_data,
+        DB::PaddedPODArray<UInt8> & res_null_map_data,
+        size_t input_rows_count)
+    {
+#if USE_MULTITARGET_CODE
+        if (isArchSupported(DB::TargetArch::AVX2))
+        {
+            vectorImplAVX2(col_left, col_right, left_const_val, right_const_val, res_data, res_null_map_data, input_rows_count);
+            return;
+        }
 
-                        R right_const_val = 0;
-                        if (const_col_right)
-                        {
-                            right_const_val = const_col_right->getElement(0);
-                            if (right_const_val == 0)
-                            {
-                                auto data_col = DB::ColumnVector<T>::create(1, 0);
-                                auto null_map_col = DB::ColumnVector<UInt8>::create(1, 1);
-                                result = DB::ColumnConst::create(DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col)), input_rows_count);
-                                return true;
-                            }
-                        }
-                        else
-                            col_right = assert_cast<const DB::ColumnVector<R> *>(arguments[1].column.get());
+        if (isArchSupported(DB::TargetArch::SSE42))
+        {
+            vectorImplSSE42(col_left, col_right, left_const_val, right_const_val, res_data, res_null_map_data, input_rows_count);
+            return;
+        }
+#endif
 
-                        auto res_col = DB::ColumnVector<T>::create(input_rows_count, 0);
-                        auto res_null_map = DB::ColumnVector<UInt8>::create(input_rows_count, 0);
-                        DB::PaddedPODArray<T> & res_data = res_col->getData();
-                        DB::PaddedPODArray<UInt8> & res_null_map_data = res_null_map->getData();
-
-                        if (col_left && col_right)
-                        {
-                            auto & ldata = col_left->getData();
-                            auto & rdata = col_right->getData();
-                            for (size_t i = 0; i < input_rows_count; ++i)
-                            {
-                                L l = ldata[i];
-                                R r = rdata[i];
-
-                                res_null_map_data[i] = !r;
-                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r ? r : 1);
-                            }
-                        }
-                        else if (col_left)
-                        {
-                            R r = right_const_val;
-                            for (size_t i = 0; i < input_rows_count; ++i)
-                            {
-                                L l = col_left->getData()[i];
-                                res_null_map_data[i] = 0; /// r = 0 is already processed in fast path
-                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r);
-                            }
-                        }
-                        else if (col_right)
-                        {
-                            L l = left_const_val;
-                            for (size_t i = 0; i < input_rows_count; ++i)
-                            {
-                                R r = col_right->getData()[i];
-                                res_null_map_data[i] = !r;
-                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r ? r : 1);
-                            }
-                        }
-
-                        result = DB::ColumnNullable::create(std::move(res_col), std::move(res_null_map));
-                        return true;
-                    });
-            });
-
-        if (!valid)
-            throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s arguments type is not valid", name);
-        return result;
+        vectorImpl(col_left, col_right, left_const_val, right_const_val, res_data, res_null_map_data, input_rows_count);
     }
 
 #if USE_EMBEDDED_COMPILER

--- a/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
@@ -116,8 +116,7 @@ public:
 
                         const DB::ColumnVector<L> * col_left = nullptr;
                         const DB::ColumnVector<R> * col_right = nullptr;
-                        const DB::ColumnVector<L> * const_col_left
-                            = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
+                        const DB::ColumnVector<L> * const_col_left = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
                         const DB::ColumnVector<R> * const_col_right
                             = checkAndGetColumnConstData<DB::ColumnVector<R>>(arguments[1].column.get());
 
@@ -133,65 +132,33 @@ public:
                             right_const_val = const_col_right->getElement(0);
                             if (right_const_val == 0)
                             {
-                                auto data_col = DB::ColumnVector<T>::create(1, 0);
-                                auto null_map_col = DB::ColumnVector<UInt8>::create(1, 1);
-                                result = DB::ColumnConst::create(DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col)), input_rows_count);
+                                /// TODO(taiyang-li): return const column instead
+                                auto data_col = DB::ColumnVector<T>::create(arguments[0].column->size(), 0);
+                                auto null_map_col = DB::ColumnVector<UInt8>::create(arguments[0].column->size(), 1);
+                                result = DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col));
                                 return true;
                             }
                         }
                         else
                             col_right = assert_cast<const DB::ColumnVector<R> *>(arguments[1].column.get());
 
-                        if (const_col_left && const_col_right)
-                        {
-                            L l = left_const_val;
-                            R r = right_const_val;
-                            T v = SparkDivideFloatingImpl<L, R>::apply(l, r);
-
-                            auto data_col = DB::ColumnVector<T>::create(1, v);
-                            auto null_map_col = DB::ColumnVector<UInt8>::create(1, !r);
-                            result = DB::ColumnConst::create(
-                                DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col)), input_rows_count);
-                            return true;
-                        }
-
-                        auto res_col = DB::ColumnVector<T>::create(input_rows_count, 0);
+                        auto res_values = DB::ColumnVector<T>::create(input_rows_count, 0);
                         auto res_null_map = DB::ColumnVector<UInt8>::create(input_rows_count, 0);
-                        DB::PaddedPODArray<T> & res_data = res_col->getData();
+                        DB::PaddedPODArray<T> & res_data = res_values->getData();
                         DB::PaddedPODArray<UInt8> & res_null_map_data = res_null_map->getData();
+                        for (size_t i = 0; i < input_rows_count; ++i)
+                        {
+                            L l = col_left ? col_left->getElement(i) : left_const_val;
+                            R r = col_right ? col_right->getElement(i) : right_const_val;
 
-                        if (col_left && col_right)
-                        {
-                            for (size_t i = 0; i < input_rows_count; ++i)
-                            {
-                                L l = col_left->getData()[i];
-                                R r = col_right->getData()[i];
-                                res_null_map_data[i] = !r;
-                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r ? r : 1);
-                            }
-                        }
-                        else if (col_left)
-                        {
-                            R r = right_const_val;
-                            for (size_t i = 0; i < input_rows_count; ++i)
-                            {
-                                L l = col_left->getData()[i];
-                                res_null_map_data[i] = 0; /// r = 0 is already processed in fast path
+                            /// TODO(taiyang-li): try to vectorize it
+                            if (r == 0)
+                                res_null_map_data[i] = 1;
+                            else
                                 res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r);
-                            }
-                        }
-                        else if (col_right)
-                        {
-                            L l = left_const_val;
-                            for (size_t i = 0; i < input_rows_count; ++i)
-                            {
-                                R r = col_right->getData()[i];
-                                res_null_map_data[i] = !r;
-                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r ? r : 1);
-                            }
                         }
 
-                        result = DB::ColumnNullable::create(std::move(res_col), std::move(res_null_map));
+                        result = DB::ColumnNullable::create(std::move(res_values), std::move(res_null_map));
                         return true;
                     });
             });

--- a/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionDivide.h
@@ -116,7 +116,8 @@ public:
 
                         const DB::ColumnVector<L> * col_left = nullptr;
                         const DB::ColumnVector<R> * col_right = nullptr;
-                        const DB::ColumnVector<L> * const_col_left = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
+                        const DB::ColumnVector<L> * const_col_left
+                            = checkAndGetColumnConstData<DB::ColumnVector<L>>(arguments[0].column.get());
                         const DB::ColumnVector<R> * const_col_right
                             = checkAndGetColumnConstData<DB::ColumnVector<R>>(arguments[1].column.get());
 
@@ -132,33 +133,65 @@ public:
                             right_const_val = const_col_right->getElement(0);
                             if (right_const_val == 0)
                             {
-                                /// TODO(taiyang-li): return const column instead
-                                auto data_col = DB::ColumnVector<T>::create(arguments[0].column->size(), 0);
-                                auto null_map_col = DB::ColumnVector<UInt8>::create(arguments[0].column->size(), 1);
-                                result = DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col));
+                                auto data_col = DB::ColumnVector<T>::create(1, 0);
+                                auto null_map_col = DB::ColumnVector<UInt8>::create(1, 1);
+                                result = DB::ColumnConst::create(DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col)), input_rows_count);
                                 return true;
                             }
                         }
                         else
                             col_right = assert_cast<const DB::ColumnVector<R> *>(arguments[1].column.get());
 
-                        auto res_values = DB::ColumnVector<T>::create(input_rows_count, 0);
-                        auto res_null_map = DB::ColumnVector<UInt8>::create(input_rows_count, 0);
-                        DB::PaddedPODArray<T> & res_data = res_values->getData();
-                        DB::PaddedPODArray<UInt8> & res_null_map_data = res_null_map->getData();
-                        for (size_t i = 0; i < input_rows_count; ++i)
+                        if (const_col_left && const_col_right)
                         {
-                            L l = col_left ? col_left->getElement(i) : left_const_val;
-                            R r = col_right ? col_right->getElement(i) : right_const_val;
+                            L l = left_const_val;
+                            R r = right_const_val;
+                            T v = SparkDivideFloatingImpl<L, R>::apply(l, r);
 
-                            /// TODO(taiyang-li): try to vectorize it
-                            if (r == 0)
-                                res_null_map_data[i] = 1;
-                            else
-                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r);
+                            auto data_col = DB::ColumnVector<T>::create(1, v);
+                            auto null_map_col = DB::ColumnVector<UInt8>::create(1, !r);
+                            result = DB::ColumnConst::create(
+                                DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col)), input_rows_count);
+                            return true;
                         }
 
-                        result = DB::ColumnNullable::create(std::move(res_values), std::move(res_null_map));
+                        auto res_col = DB::ColumnVector<T>::create(input_rows_count, 0);
+                        auto res_null_map = DB::ColumnVector<UInt8>::create(input_rows_count, 0);
+                        DB::PaddedPODArray<T> & res_data = res_col->getData();
+                        DB::PaddedPODArray<UInt8> & res_null_map_data = res_null_map->getData();
+
+                        if (col_left && col_right)
+                        {
+                            for (size_t i = 0; i < input_rows_count; ++i)
+                            {
+                                L l = col_left->getData()[i];
+                                R r = col_right->getData()[i];
+                                res_null_map_data[i] = !r;
+                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r ? r : 1);
+                            }
+                        }
+                        else if (col_left)
+                        {
+                            R r = right_const_val;
+                            for (size_t i = 0; i < input_rows_count; ++i)
+                            {
+                                L l = col_left->getData()[i];
+                                res_null_map_data[i] = 0; /// r = 0 is already processed in fast path
+                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r);
+                            }
+                        }
+                        else if (col_right)
+                        {
+                            L l = left_const_val;
+                            for (size_t i = 0; i < input_rows_count; ++i)
+                            {
+                                R r = col_right->getData()[i];
+                                res_null_map_data[i] = !r;
+                                res_data[i] = SparkDivideFloatingImpl<L, R>::apply(l, r ? r : 1);
+                            }
+                        }
+
+                        result = DB::ColumnNullable::create(std::move(res_col), std::move(res_null_map));
                         return true;
                     });
             });

--- a/cpp-ch/local-engine/Parser/ExpressionParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpressionParser.cpp
@@ -337,11 +337,12 @@ ExpressionParser::NodeRawConstPtr ExpressionParser::parseExpression(ActionsDAG &
             }
             else if ((isDecimal(denull_input_type) || isNativeNumber(denull_input_type)) && substrait_type.has_decimal())
             {
-                int decimal_precision = substrait_type.decimal().precision();
-                if (decimal_precision)
+                int precision = substrait_type.decimal().precision();
+                int scale = substrait_type.decimal().scale();
+                if (precision)
                 {
-                    args.emplace_back(addConstColumn(actions_dag, std::make_shared<DataTypeInt32>(), decimal_precision));
-                    args.emplace_back(addConstColumn(actions_dag, std::make_shared<DataTypeInt32>(), substrait_type.decimal().scale()));
+                    args.emplace_back(addConstColumn(actions_dag, std::make_shared<DataTypeInt32>(), precision));
+                    args.emplace_back(addConstColumn(actions_dag, std::make_shared<DataTypeInt32>(), scale));
                     result_node = toFunctionNode(actions_dag, "checkDecimalOverflowSparkOrNull", args);
                 }
             }

--- a/cpp-ch/local-engine/tests/CMakeLists.txt
+++ b/cpp-ch/local-engine/tests/CMakeLists.txt
@@ -97,7 +97,7 @@ if(ENABLE_BENCHMARKS)
     benchmark_parquet_read.cpp
     benchmark_spark_row.cpp
     benchmark_unix_timestamp_function.cpp
-    benchmark_spark_floor_function.cpp
+    benchmark_spark_functions.cpp
     benchmark_cast_float_function.cpp
     benchmark_to_datetime_function.cpp
     benchmark_spark_divide_function.cpp

--- a/cpp-ch/local-engine/tests/benchmark_spark_functions.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_functions.cpp
@@ -32,7 +32,7 @@
 #include <benchmark/benchmark.h>
 #include <Common/QueryContext.h>
 #include <Common/TargetSpecific.h>
-#include "DataTypes/DataTypeNullable.h"
+#include <DataTypes/DataTypeNullable.h>
 
 #if USE_MULTITARGET_CODE
 #include <immintrin.h>

--- a/cpp-ch/local-engine/tests/benchmark_spark_functions.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_functions.cpp
@@ -18,10 +18,7 @@
 #if defined(__x86_64__)
 
 #include <cstddef>
-#if USE_MULTITARGET_CODE
-#include <immintrin.h>
-#endif
-
+#include <Columns/ColumnsCommon.h>
 #include <Columns/IColumn.h>
 #include <Core/Block.h>
 #include <DataTypes/DataTypeArray.h>
@@ -35,7 +32,11 @@
 #include <benchmark/benchmark.h>
 #include <Common/QueryContext.h>
 #include <Common/TargetSpecific.h>
-#include <Columns/ColumnsCommon.h>
+#include "DataTypes/DataTypeNullable.h"
+
+#if USE_MULTITARGET_CODE
+#include <immintrin.h>
+#endif
 
 using namespace DB;
 
@@ -44,7 +45,7 @@ static IColumn::Offsets createOffsets(size_t rows)
     IColumn::Offsets offsets(rows, 0);
     for (size_t i = 0; i < rows; ++i)
         offsets[i] = offsets[i-1] + (rand() % 10);
-    return std::move(offsets);
+    return offsets;
 }
 
 static ColumnPtr createColumn(const DataTypePtr & type, size_t rows)
@@ -158,6 +159,68 @@ static void BM_SparkFloorFunction_For_Float64(benchmark::State & state)
     }
 }
 
+BENCHMARK(BM_CHFloorFunction_For_Int64);
+BENCHMARK(BM_CHFloorFunction_For_Float64);
+BENCHMARK(BM_SparkFloorFunction_For_Int64);
+BENCHMARK(BM_SparkFloorFunction_For_Float64);
+
+static void BM_SparkDivide_VectorVector(benchmark::State & state)
+{
+    using namespace DB;
+    auto & factory = FunctionFactory::instance();
+    auto function = factory.get("sparkDivide", local_engine::QueryContext::globalContext());
+    auto type = DataTypeFactory::instance().get("Nullable(Float64)");
+    auto left = createColumn(type, 65536);
+    auto right = createColumn(type, 65536);
+    auto block = Block({ColumnWithTypeAndName(left, type, "left"), ColumnWithTypeAndName(right, type, "right")});
+    auto executable = function->build(block.getColumnsWithTypeAndName());
+    for (auto _ : state)
+    {
+        auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows(), false);
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+static void BM_SparkDivide_VectorConstant(benchmark::State & state)
+{
+    using namespace DB;
+    auto & factory = FunctionFactory::instance();
+    auto function = factory.get("sparkDivide", local_engine::QueryContext::globalContext());
+    auto type = DataTypeFactory::instance().get("Nullable(Float64)");
+    auto left = createColumn(type, 65536);
+    auto right = createColumn(type, 1);
+    auto const_right = ColumnConst::create(std::move(right), 65536);
+    auto block = Block({ColumnWithTypeAndName(left, type, "left"), ColumnWithTypeAndName(std::move(const_right), type, "right")});
+    auto executable = function->build(block.getColumnsWithTypeAndName());
+    for (auto _ : state)
+    {
+        auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows(), false);
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+static void BM_SparkDivide_ConstantVector(benchmark::State & state)
+{
+    using namespace DB;
+    auto & factory = FunctionFactory::instance();
+    auto function = factory.get("sparkDivide", local_engine::QueryContext::globalContext());
+    auto type = DataTypeFactory::instance().get("Nullable(Float64)");
+    auto left = createColumn(type, 1);
+    auto const_left = ColumnConst::create(std::move(left), 65536);
+    auto right = createColumn(type, 65536);
+    auto block = Block({ColumnWithTypeAndName(std::move(const_left), type, "left"), ColumnWithTypeAndName(std::move(right), type, "right")});
+    auto executable = function->build(block.getColumnsWithTypeAndName());
+    for (auto _ : state)
+    {
+        auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows(), false);
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(BM_SparkDivide_VectorVector);
+BENCHMARK(BM_SparkDivide_VectorConstant);
+BENCHMARK(BM_SparkDivide_ConstantVector);
+
 static void nanInfToNullAutoOpt(float * data, uint8_t * null_map, size_t size)
 {
     for (size_t i = 0; i < size; ++i)
@@ -267,10 +330,6 @@ static void BMNanInfToNull(benchmark::State & state)
 }
 BENCHMARK(BMNanInfToNull);
 
-BENCHMARK(BM_CHFloorFunction_For_Int64);
-BENCHMARK(BM_CHFloorFunction_For_Float64);
-BENCHMARK(BM_SparkFloorFunction_For_Int64);
-BENCHMARK(BM_SparkFloorFunction_For_Float64);
 
 
 /*
@@ -1277,5 +1336,6 @@ BENCHMARK_TEMPLATE(BM_myFilterToIndicesDefault, UInt64);
 BENCHMARK_TEMPLATE(BM_myFilterToIndicesAVX512, UInt32);
 BENCHMARK_TEMPLATE(BM_myFilterToIndicesAVX512, UInt64);
 */
+
 
 #endif

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -540,6 +540,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     )
     // test for sort node not present but gluten uses shuffle hash join
     .exclude("SPARK-41048: Improve output partitioning and ordering with AQE cache")
+    .exclude("SPARK-28224: Aggregate sum big decimal overflow")
     // Rewrite this test since it checks the physical operator which is changed in Gluten
     .excludeCH("SPARK-27439: Explain result should match collected result after view change")
     .excludeCH("SPARK-28067: Aggregate sum should not return wrong results for decimal overflow")


### PR DESCRIPTION
## What changes were proposed in this pull request?

try accelerate some spark* function through vectorization
- sparkDivide: 
   - vectorVector(1.09x)
   - vectorConstant(25x) 
- castFloatToInt*: 2.67x
- checkDecimalOverflowSparkOrNull:
   - decimal to decimal, scale up: 1.47x
   - decimal to decimal, scale down: 1.94x
   - decimal to decimal, no scale change: 274x
   - int to decimal: 3.07x
   - float to decimal: 10.98x


spark ut "SPARK-28224: Aggregate sum big decimal overflow" was excluded from spark3.5 because it runs in ansi mode, which is not fully supported in gluten currently. 

(Fixes: \#8704)

## How was this patch tested?

existing uts


## performance tests
baseline version
```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
BM_OptSparkDivide_VectorVector                   133184 ns       133174 ns         5328
BM_OptSparkDivide_VectorConstant                  34535 ns        34534 ns        19413
BM_OptSparkDivide_ConstantVector                 106590 ns       106575 ns         6717
BM_OptSparkCastFloatToInt                        185191 ns       185165 ns         3536
BM_OptCheckDecimalOverflowSparkFromDecimal1      737342 ns       737312 ns          951
BM_OptCheckDecimalOverflowSparkFromDecimal2      653192 ns       653165 ns         1073
BM_OptCheckDecimalOverflowSparkFromDecimal3      463498 ns       463486 ns         1511
BM_OptCheckDecimalOverflowSparkFromInt          1025330 ns      1025289 ns          682
BM_OptCheckDecimalOverflowSparkFromFloat        2084486 ns      2084187 ns          330
```

optimized version
```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
BM_OptSparkDivide_VectorVector                   117474 ns       117468 ns         5913
BM_OptSparkDivide_VectorConstant                   1393 ns         1393 ns       503263
BM_OptSparkDivide_ConstantVector                 101636 ns       101634 ns         6890
BM_OptSparkCastFloatToInt                         70839 ns        70836 ns         9840
BM_OptCheckDecimalOverflowSparkFromDecimal1      500702 ns       500677 ns         1000
BM_OptCheckDecimalOverflowSparkFromDecimal2      335018 ns       334988 ns         2091
BM_OptCheckDecimalOverflowSparkFromDecimal3        1690 ns         1690 ns       411554
BM_OptCheckDecimalOverflowSparkFromInt           333732 ns       333702 ns         2092
BM_OptCheckDecimalOverflowSparkFromFloat         189853 ns       189838 ns         3665 
```


speedups
``` txt
BM_OptSparkDivide_VectorVector 133184 117474 1.13373
BM_OptSparkDivide_VectorConstant 34535 1393 24.7918
BM_OptSparkDivide_ConstantVector 106590 101636 1.04874
BM_OptSparkCastFloatToInt 185191 70839 2.61425
BM_OptCheckDecimalOverflowSparkFromDecimal1 737342 500702 1.47262
BM_OptCheckDecimalOverflowSparkFromDecimal2 653192 335018 1.94972
BM_OptCheckDecimalOverflowSparkFromDecimal3 463498 1690 274.259
BM_OptCheckDecimalOverflowSparkFromInt 1025330 333732 3.07232
BM_OptCheckDecimalOverflowSparkFromFloat 2084486 189853 10.9795
```



