### PR TITLE
[GLUTEN-8749][CH] Explicitly cast input data type for std::min

### DIFF
--- a/cpp-ch/local-engine/AggregateFunctions/AggregateFunctionUniqHyperLogLogPlusPlus.h
+++ b/cpp-ch/local-engine/AggregateFunctions/AggregateFunctionUniqHyperLogLogPlusPlus.h
@@ -216,7 +216,7 @@ private:
 
         // Adjust bounds
         size_t low = nearest_estimate_index + 1 > K ? nearest_estimate_index - K + 1 : 0;
-        size_t high = std::min(low + K, num_estimates);
+        size_t high = std::min(static_cast<size_t>(low + K), num_estimates);
         while (high < num_estimates && distance(high) < distance(low))
         {
             ++low;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Issue: The argument types passed to std::min do not match in a way that the template can resolve. Specifically:

- ow + K is of type size_t
- num_estimates is of type size_t, but the error message shows it being deduced as UInt64, which is likely an alias for unsigned long long.

Solution: Use static_cast to explicitly cast the types and resolve the mismatch.

## How was this patch tested?
rebuild

