### PR TITLE
[VL] nit: gluten-it: Fix non-POSIX shell warnings in centos-7-deps.sh

### DIFF
--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -48,15 +48,14 @@ pip3 install --upgrade pip
 pip3 install cmake==3.28.3
 
 # git >= 2.7.4
-case "$(git --version)" in "git version 2."*)
+if [[ "$(git --version)" != "git version 2."* ]]; then
   [ -f /etc/yum.repos.d/ius.repo ] || yum -y install https://repo.ius.io/ius-release-el7.rpm
   yum -y remove git
   yum -y install git236
-  ;;
-esac
+fi
 
 # flex>=2.6.0
-case "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" in "flex 2.6."*)
+if [[ "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" != "flex 2.6."* ]]; then
   yum -y install gettext-devel
   FLEX_URL="https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz"
   mkdir -p /tmp/flex
@@ -67,8 +66,7 @@ case "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" in "flex 2.6."*)
   make install
   cd
   rm -rf /tmp/flex
-  ;;
-esac
+fi
 
 # automake>=1.14
 installed_automake_version="$(aclocal --version | sed -En "1s/^.* ([1-9\.]*)$/\1/p")"

--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -48,14 +48,15 @@ pip3 install --upgrade pip
 pip3 install cmake==3.28.3
 
 # git >= 2.7.4
-if [[ "$(git --version)" != "git version 2."* ]]; then
+case "$(git --version)" in "git version 2."*)
   [ -f /etc/yum.repos.d/ius.repo ] || yum -y install https://repo.ius.io/ius-release-el7.rpm
   yum -y remove git
   yum -y install git236
-fi
+  ;;
+esac
 
 # flex>=2.6.0
-if [[ "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" != "flex 2.6."* ]]; then
+case "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" in "flex 2.6."*)
   yum -y install gettext-devel
   FLEX_URL="https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz"
   mkdir -p /tmp/flex
@@ -66,7 +67,8 @@ if [[ "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" != "flex 2.6."* ]]; t
   make install
   cd
   rm -rf /tmp/flex
-fi
+  ;;
+esac
 
 # automake>=1.14
 installed_automake_version="$(aclocal --version | sed -En "1s/^.* ([1-9\.]*)$/\1/p")"

--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -49,9 +49,6 @@ pip3 install cmake==3.28.3
 
 # git >= 2.7.4
 case "$(git --version)" in "git version 2."*)
-  true
-  ;;
-  *)
   [ -f /etc/yum.repos.d/ius.repo ] || yum -y install https://repo.ius.io/ius-release-el7.rpm
   yum -y remove git
   yum -y install git236
@@ -60,9 +57,6 @@ esac
 
 # flex>=2.6.0
 case "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" in "flex 2.6."*)
-  true
-  ;;
-  *)
   yum -y install gettext-devel
   FLEX_URL="https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz"
   mkdir -p /tmp/flex

--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -49,6 +49,9 @@ pip3 install cmake==3.28.3
 
 # git >= 2.7.4
 case "$(git --version)" in "git version 2."*)
+  true
+  ;;
+  *)
   [ -f /etc/yum.repos.d/ius.repo ] || yum -y install https://repo.ius.io/ius-release-el7.rpm
   yum -y remove git
   yum -y install git236
@@ -57,6 +60,9 @@ esac
 
 # flex>=2.6.0
 case "$(PATH="/usr/local/bin:$PATH" flex --version 2>&1)" in "flex 2.6."*)
+  true
+  ;;
+  *)
   yum -y install gettext-devel
   FLEX_URL="https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz"
   mkdir -p /tmp/flex

--- a/tools/gluten-te/centos/centos-8-deps.sh
+++ b/tools/gluten-te/centos/centos-8-deps.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
The following is reported by `shellcheck`:

```
In POSIX sh, [[ ]] is undefined.
See SC2039.
```

Fix by changing to `#/bin/bash`