### PR TITLE
[CORE] Add iceberg equality delete file proto definition

### DIFF
--- a/gluten-iceberg/src-iceberg/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
+++ b/gluten-iceberg/src-iceberg/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
@@ -117,6 +117,9 @@ public class IcebergLocalFilesNode extends LocalFilesNode {
           throw new UnsupportedOperationException(
               "Unsupported format " + delete.format().name() + " for delete file.");
       }
+      if (delete.equalityFieldIds() != null && !delete.equalityFieldIds().isEmpty()) {
+        deleteFileBuilder.addAllEqualityFieldIds(delete.equalityFieldIds());
+      }
       icebergBuilder.addDeleteFiles(deleteFileBuilder);
     }
     fileBuilder.setIceberg(icebergBuilder);

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -173,6 +173,13 @@ message ReadRel {
           EQUALITY_DELETES = 2;
         }
         message DeleteFile {
+          message Map {
+            message KeyValue {
+              int32 key = 1;
+              string value = 2;
+            }
+            repeated KeyValue key_values = 1;
+          }
           FileContent fileContent = 1;
           string filePath = 2;
           uint64 fileSize = 3;
@@ -181,6 +188,9 @@ message ReadRel {
             ParquetReadOptions parquet = 5;
             OrcReadOptions orc = 6;
           }
+          repeated int32 equalityFieldIds = 7;
+          Map lowerBounds = 8;
+          Map upperBounds = 9;
         }
         oneof file_format {
           ParquetReadOptions parquet = 1;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since the PR for Iceberg support of equality delete files in the Velox community has not been merged for a long time, ClickHouse backend needs to add support for equality delete files. We will first merge the protobuf definitions to facilitate ClickHouse's subsequent development.

## How was this patch tested?

N/A

