### PR TITLE
[GLUTEN-8779][VL][Minor] Code cleanup for native validation

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -141,9 +141,6 @@ class SubstraitToVeloxPlanValidator {
   /// Validate Substrait expression.
   bool validateExpression(const ::substrait::Expression& expression, const RowTypePtr& inputType);
 
-  /// Validate Substrait literal.
-  bool validateLiteral(const ::substrait::Expression_Literal& literal, const RowTypePtr& inputType);
-
   /// Validate Substrait if-then expression.
   bool validateIfThen(const ::substrait::Expression_IfThen& ifThen, const RowTypePtr& inputType);
 


### PR DESCRIPTION
`SubstraitToVeloxPlanValidator::validateLiteral` allows all literals to pass, so it should be removed