### PR TITLE
[GLUTEN-8794] Support logging as many fallback reasons as possible

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
@@ -49,8 +49,8 @@ class VeloxValidatorApi extends ValidatorApi {
     }
     ValidationResult.failed(
       String.format(
-        "Native validation failed: %n%s",
-        info.fallbackInfo.asScala.reduce[String] { case (l, r) => l + "\n" + r }))
+        "Native validation failed: %n   |- %s",
+        info.fallbackInfo.asScala.reduce[String] { case (l, r) => l + "\n   |- " + r }))
   }
 
   private def isPrimitiveType(dataType: DataType): Boolean = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -199,7 +199,7 @@ trait SparkPlanExecApi {
       substraitExprName: String,
       child: ExpressionTransformer,
       original: TryEval): ExpressionTransformer = {
-    throw new GlutenNotSupportException("try_eval is not supported")
+    throw new GlutenNotSupportException(s"try_eval(${original.child.prettyName}) is not supported")
   }
 
   def genArithmeticTransformer(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -183,10 +183,12 @@ abstract class ProjectExecTransformerBase(val list: Seq[NamedExpression], val in
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
-    val relNode =
-      getRelNode(substraitContext, list, child.output, operatorId, null, validation = true)
-    // Then, validate the generated plan in native engine.
-    doNativeValidation(substraitContext, relNode)
+    failValidationWithException {
+      val relNode =
+        getRelNode(substraitContext, list, child.output, operatorId, null, validation = true)
+      // Then, validate the generated plan in native engine.
+      doNativeValidation(substraitContext, relNode)
+    }()
   }
 
   override def isNullIntolerant(expr: Expression): Boolean = expr match {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -69,9 +69,10 @@ trait ValidatablePlan extends GlutenPlan with LogLevelUtil {
   protected lazy val validationFailFast = glutenConf.validationFailFast
 
   // Wraps a validation function f that can also throw a GlutenNotSupportException.
-  // Returns ValidationResult.failed if f throws a GlutenNotSupportException, otherwise returns the result of f.
-  protected def failValidationWithException(f: => ValidationResult)(
-      finallyBlock: => Unit = () => ()): ValidationResult = {
+  // Returns ValidationResult.failed if f throws a GlutenNotSupportException,
+  // otherwise returns the result of f.
+  protected def failValidationWithException(f: => ValidationResult)(finallyBlock: => Unit = () =>
+    ()): ValidationResult = {
     try {
       f
     } catch {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -71,8 +71,8 @@ trait ValidatablePlan extends GlutenPlan with LogLevelUtil {
   // Wraps a validation function f that can also throw a GlutenNotSupportException.
   // Returns ValidationResult.failed if f throws a GlutenNotSupportException,
   // otherwise returns the result of f.
-  protected def failValidationWithException(f: => ValidationResult)(finallyBlock: => Unit = () =>
-    ()): ValidationResult = {
+  protected def failValidationWithException(f: => ValidationResult)(
+      finallyBlock: => Unit = ()): ValidationResult = {
     try {
       f
     } catch {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -118,7 +118,8 @@ trait ValidatablePlan extends GlutenPlan with LogLevelUtil {
     if (!validationResult.ok()) {
       TestStats.addFallBackClassName(this.getClass.toString)
     }
-    if (validationFailFast) validationResult else schemaValidationResult.merge(validationResult)
+    if (validationFailFast) validationResult
+    else ValidationResult.merge(schemaValidationResult, validationResult)
   }
 
   protected def doValidateInternal(): ValidationResult = ValidationResult.succeeded

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/ValidationResult.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/ValidationResult.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNode
 sealed trait ValidationResult {
   def ok(): Boolean
   def reason(): String
+  def merge(other: ValidationResult): ValidationResult
 }
 
 object ValidationResult {
@@ -42,14 +43,28 @@ object ValidationResult {
     override def ok(): Boolean = true
     override def reason(): String = throw new UnsupportedOperationException(
       "Succeeded validation doesn't have failure details")
+
+    override def merge(other: ValidationResult): ValidationResult = {
+      if (!other.ok()) {
+        return other
+      }
+      this
+    }
   }
 
   private case class Failed(override val reason: String) extends ValidationResult {
     override def ok(): Boolean = false
+
+    override def merge(other: ValidationResult): ValidationResult = {
+      if (!other.ok()) {
+        return ValidationResult.failed(reason + other.reason(), prefix = "")
+      }
+      this
+    }
   }
 
   def succeeded: ValidationResult = Succeeded
-  def failed(reason: String): ValidationResult = Failed(reason)
+  def failed(reason: String, prefix: String = "\n - "): ValidationResult = Failed(prefix + reason)
 
   implicit class EncodeFallbackTagImplicits(result: ValidationResult) {
     def tagOnFallback(plan: TreeNode[_]): Unit = {

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -48,7 +48,7 @@ case class GlutenFallbackReporter(glutenConf: GlutenConfig, spark: SparkSession)
     val executionIdInfo = Option(spark.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY))
       .map(id => s"[QueryId=$id]")
       .getOrElse("")
-    logOnLevel(logLevel, s"Validation failed for plan: $nodeName$executionIdInfo, due to: $reason.")
+    logOnLevel(logLevel, s"Validation failed for plan: $nodeName$executionIdInfo, due to: $reason")
   }
 
   private def printFallbackReason(plan: SparkPlan): Unit = {

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -51,7 +51,7 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
         }
       }
       val msgRegex = """Validation failed for plan: Scan parquet default\.t\[QueryId=[0-9]+\],""" +
-        """ due to: \[FallbackByUserOptions\] Validation failed on node Scan parquet default\.t\."""
+        """ due to: \[FallbackByUserOptions\] Validation failed on node Scan parquet default\.t"""
       assert(testAppender.loggingEvents.exists(_.getMessage.getFormattedMessage.matches(msgRegex)))
     }
   }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -53,7 +53,7 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       val msgRegex =
         """Validation failed for plan: Scan parquet spark_catalog.default\.t\[QueryId=[0-9]+\],""" +
           """ due to: \[FallbackByUserOptions\] Validation failed on node Scan parquet""" +
-          """ spark_catalog\.default\.t\.""".stripMargin
+          """ spark_catalog\.default\.t""".stripMargin
       assert(testAppender.loggingEvents.exists(_.getMessage.getFormattedMessage.matches(msgRegex)))
     }
   }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -53,7 +53,7 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       val msgRegex =
         """Validation failed for plan: Scan parquet spark_catalog.default\.t\[QueryId=[0-9]+\],""" +
           """ due to: \[FallbackByUserOptions\] Validation failed on node Scan parquet""" +
-          """ spark_catalog\.default\.t\.""".stripMargin
+          """ spark_catalog\.default\.t""".stripMargin
       assert(testAppender.loggingEvents.exists(_.getMessage.getFormattedMessage.matches(msgRegex)))
     }
   }

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -303,6 +303,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def printStackOnValidationFailure: Boolean =
     getConf(VALIDATION_PRINT_FAILURE_STACK_)
 
+  def validationFailFast: Boolean = getConf(VALIDATION_FAIL_FAST)
+
   def enableFallbackReport: Boolean = getConf(FALLBACK_REPORTER_ENABLED)
 
   def debug: Boolean = getConf(DEBUG_ENABLED)
@@ -1309,6 +1311,12 @@ object GlutenConfig {
       .internal()
       .booleanConf
       .createWithDefault(false)
+
+  val VALIDATION_FAIL_FAST =
+    buildConf("spark.gluten.sql.validation.failFast")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 
   val SOFT_AFFINITY_LOG_LEVEL =
     buildConf("spark.gluten.soft-affinity.logLevel")


### PR DESCRIPTION
1. Add configuration `spark.gluten.sql.validation.failFast` to control whether to fail validation on the first failure or to continue verifying as much as possible. More validations can provide additional fallback reasons for a given query. `true` by default to follow the current fail-fast behaviour.

For example, with setting `spark.gluten.sql.validation.failFast=false` the log for query `SELECT convert_timezone('Europe/Moscow', 'America/Los_Angeles', timestamp_ntz'2022-01-01 00:00:00')` shows like
Before:
```
15:26:54.204 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Project[QueryId=38], due to: Found schema check failure for StructType(StructField(convert_timezone(Europe/Moscow, America/Los_Angeles, TIMESTAMP_NTZ '2022-01-01 00:00:00'),TimestampNTZType,false)), due to: Schema / data type not supported: TimestampNTZType.
```

After:
```
15:09:35.179 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Project[QueryId=38], due to: 
 - Found schema check failure for StructType(StructField(convert_timezone(Europe/Moscow, America/Los_Angeles, TIMESTAMP_NTZ '2022-01-01 00:00:00'),TimestampNTZType,false)), due to: Schema / data type not supported: TimestampNTZType
 - Validation failed with exception from: ProjectExecTransformer, reason: Not supported to map spark function name to substrait function name: convert_timezone(Europe/Moscow, America/Los_Angeles, 2022-01-01 00:00:00), class name: ConvertTimezone.
```

2. Remove duplicated log.

For example, the log for query `select timestamp_ntz'2022-01-01 00:00:00' = date'2022-01-01'`

Before:
```
15:26:53.895 WARN org.apache.gluten.execution.ProjectExecTransformer: Validation failed with exception for plan: ProjectExecTransformer, due to: Type TimestampNTZType not supported.
15:26:53.896 WARN org.apache.gluten.execution.ProjectExecTransformer: Validation failed with exception for plan: ProjectExecTransformer, due to: Type TimestampNTZType not supported.
15:26:53.896 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Project[QueryId=25], due to: Type TimestampNTZType not supported..
```

After:
```
15:31:58.753 WARN org.apache.spark.sql.execution.GlutenFallbackReporter: Validation failed for plan: Project[QueryId=44], due to: 
 - Validation failed with exception from: ProjectExecTransformer, reason: Type TimestampNTZType not supported.
```