### PR TITLE
[VL] Remove resolving ViewFs file path from scan validation

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -51,9 +51,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.SerializableConfiguration
 
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.fs.viewfs.ViewFileSystemUtils
 
-import scala.collection.mutable
 import scala.util.control.Breaks.breakable
 
 class VeloxBackend extends SubstraitBackend {
@@ -109,25 +107,12 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
     def validateScheme(): Option[String] = {
       val filteredRootPaths = distinctRootPaths(rootPaths)
-      if (filteredRootPaths.nonEmpty) {
-        val resolvedPaths =
-          if (GlutenConfig.get.enableHdfsViewfs) {
-            ViewFileSystemUtils.convertViewfsToHdfs(
-              filteredRootPaths,
-              mutable.Map.empty[String, String],
-              serializableHadoopConf.get.value)
-          } else {
-            filteredRootPaths
-          }
-
-        if (
-          !VeloxFileSystemValidationJniWrapper.allSupportedByRegisteredFileSystems(
-            resolvedPaths.toArray)
-        ) {
-          Some(s"Scheme of [$filteredRootPaths] is not supported by registered file systems.")
-        } else {
-          None
-        }
+      if (
+        filteredRootPaths.nonEmpty &&
+        !VeloxFileSystemValidationJniWrapper.allSupportedByRegisteredFileSystems(
+          filteredRootPaths.toArray)
+      ) {
+        Some(s"Scheme of [$filteredRootPaths] is not supported by registered file systems.")
       } else {
         None
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I note Velox's HDFS filesystem allows ViewFs scheme. 
https://github.com/facebookincubator/velox/blob/main/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp#L112.

Then, we can just rely on the uniform JNI call through `allSupportedByRegisteredFileSystems`, instead of resolving the ViewFS file path in Gluten scan validation.


## How was this patch tested?

Customer validation.

