### PR TITLE
[GLUTEN-8811][VL]Fix bucket scan when some partitionValue is empty

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/IteratorApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/IteratorApi.scala
@@ -39,6 +39,14 @@ trait IteratorApi {
       metadataColumnNames: Seq[String],
       properties: Map[String, String]): SplitInfo
 
+  def genSplitInfoForPartitions(
+      partitionIndex: Int,
+      partition: Seq[InputPartition],
+      partitionSchema: StructType,
+      fileFormat: ReadFileFormat,
+      metadataColumnNames: Seq[String],
+      properties: Map[String, String]): SplitInfo = throw new UnsupportedOperationException()
+
   /** Generate native row partition. */
   def genPartitions(
       wsCtx: WholeStageTransformContext,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -354,6 +354,153 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
     allLeafTransformers.toSeq
   }
 
+  private def generateWholeStageRDD(
+      leafTransformers: Seq[LeafTransformSupport],
+      wsCtx: WholeStageTransformContext,
+      inputRDDs: ColumnarInputRDDsWrapper,
+      pipelineTime: SQLMetric): RDD[ColumnarBatch] = {
+
+    /**
+     * If containing leaf exec transformer this "whole stage" generates a RDD which itself takes
+     * care of [[LeafTransformSupport]] there won't be any other RDD for leaf operator. As a result,
+     * genFirstStageIterator rather than genFinalStageIterator will be invoked
+     */
+    val allInputPartitions = leafTransformers.map(_.getPartitions.toIndexedSeq)
+    val allSplitInfos = getSplitInfosFromPartitions(leafTransformers)
+
+    if (GlutenConfig.get.enableHdfsViewfs) {
+      val viewfsToHdfsCache: mutable.Map[String, String] = mutable.Map.empty
+      allSplitInfos.foreach {
+        splitInfos =>
+          splitInfos.foreach {
+            case splitInfo: LocalFilesNode =>
+              val newPaths = ViewFileSystemUtils.convertViewfsToHdfs(
+                splitInfo.getPaths.asScala.toSeq,
+                viewfsToHdfsCache,
+                serializableHadoopConf.value)
+              splitInfo.setPaths(newPaths.asJava)
+          }
+      }
+    }
+
+    val inputPartitions =
+      BackendsApiManager.getIteratorApiInstance.genPartitions(
+        wsCtx,
+        allSplitInfos,
+        leafTransformers)
+
+    val rdd = new GlutenWholeStageColumnarRDD(
+      sparkContext,
+      inputPartitions,
+      inputRDDs,
+      pipelineTime,
+      leafInputMetricsUpdater(),
+      BackendsApiManager.getMetricsApiInstance.metricsUpdatingFunction(
+        child,
+        wsCtx.substraitContext.registeredRelMap,
+        wsCtx.substraitContext.registeredJoinParams,
+        wsCtx.substraitContext.registeredAggregationParams
+      )
+    )
+
+    allInputPartitions.head.indices.foreach(
+      i => {
+        val currentPartitions = allInputPartitions.map(_(i))
+        currentPartitions.indices.foreach(
+          i =>
+            currentPartitions(i) match {
+              case f: FilePartition =>
+                SoftAffinity.updateFilePartitionLocations(f, rdd.id)
+              case _ =>
+            })
+      })
+
+    rdd
+  }
+
+  private def getSplitInfosFromPartitionSeqs(
+      leafTransformers: Seq[BatchScanExecTransformerBase]): Seq[Seq[SplitInfo]] = {
+    // If these are two batch scan transformer with keyGroupPartitioning,
+    // they have same partitionValues,
+    // but some partitions maybe empty for those partition values that are not present,
+    // otherwise, exchange will be inserted. We should combine the two leaf
+    // transformers' partitions with same index, and set them together in
+    // the substraitContext. We use transpose to do that, You can refer to
+    // the diagram below.
+    // leaf1  Seq(p11) Seq(p12, p13) Seq(p14) ... Seq(p1n)
+    // leaf2  Seq(p21) Seq(p22)      Seq()    ... Seq(p2n)
+    // transpose =>
+    // leaf1 | leaf2
+    //  Seq(p11)       |  Seq(p21)    => substraitContext.setSplitInfo([Seq(p11), Seq(p21)])
+    //  Seq(p12, p13)  |  Seq(p22)    => substraitContext.setSplitInfo([Seq(p12, p13), Seq(p22)])
+    //  Seq(p14)       |  Seq()    ...
+    //                ...
+    //  Seq(p1n)       |  Seq(p2n)    => substraitContext.setSplitInfo([Seq(p1n), Seq(p2n)])
+
+    val allSplitInfos = leafTransformers.map(_.getSplitInfosWithIndex)
+    val partitionLength = allSplitInfos.head.size
+    if (allSplitInfos.exists(_.size != partitionLength)) {
+      throw new GlutenException(
+        "The partition length of all the leaf transformer are not the same.")
+    }
+    if (GlutenConfig.get.enableHdfsViewfs) {
+      val viewfsToHdfsCache: mutable.Map[String, String] = mutable.Map.empty
+      allSplitInfos.foreach {
+        case splitInfo: LocalFilesNode =>
+          val newPaths = ViewFileSystemUtils.convertViewfsToHdfs(
+            splitInfo.getPaths.asScala.toSeq,
+            viewfsToHdfsCache,
+            serializableHadoopConf.value)
+          splitInfo.setPaths(newPaths.asJava)
+      }
+    }
+
+    allSplitInfos.transpose
+  }
+
+  private def generateWholeStageDatasourceRDD(
+      leafTransformers: Seq[BatchScanExecTransformerBase],
+      wsCtx: WholeStageTransformContext,
+      inputRDDs: ColumnarInputRDDsWrapper,
+      pipelineTime: SQLMetric): RDD[ColumnarBatch] = {
+
+    /**
+     * If containing leaf exec transformer this "whole stage" generates a RDD which itself takes
+     * care of [[LeafTransformSupport]] there won't be any other RDD for leaf operator. As a result,
+     * genFirstStageIterator rather than genFinalStageIterator will be invoked
+     */
+    val allInputPartitions = leafTransformers.map(_.getPartitionsWithIndex)
+    val allSplitInfos = getSplitInfosFromPartitionSeqs(leafTransformers)
+
+    val inputPartitions =
+      BackendsApiManager.getIteratorApiInstance.genPartitions(
+        wsCtx,
+        allSplitInfos,
+        leafTransformers)
+
+    val rdd = new GlutenWholeStageColumnarRDD(
+      sparkContext,
+      inputPartitions,
+      inputRDDs,
+      pipelineTime,
+      leafInputMetricsUpdater(),
+      BackendsApiManager.getMetricsApiInstance.metricsUpdatingFunction(
+        child,
+        wsCtx.substraitContext.registeredRelMap,
+        wsCtx.substraitContext.registeredJoinParams,
+        wsCtx.substraitContext.registeredAggregationParams
+      )
+    )
+
+    allInputPartitions.foreach(_.foreach(_.foreach {
+      case f: FilePartition =>
+        SoftAffinity.updateFilePartitionLocations(f, rdd.id)
+      case _ =>
+    }))
+
+    rdd
+  }
+
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     assert(child.isInstanceOf[TransformSupport])
     val pipelineTime: SQLMetric = longMetric("pipelineTime")
@@ -369,63 +516,20 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
 
     val leafTransformers = findAllLeafTransformers()
     if (leafTransformers.nonEmpty) {
-
-      /**
-       * If containing leaf exec transformer this "whole stage" generates a RDD which itself takes
-       * care of [[LeafTransformSupport]] there won't be any other RDD for leaf operator. As a
-       * result, genFirstStageIterator rather than genFinalStageIterator will be invoked
-       */
-      val allInputPartitions = leafTransformers.map(_.getPartitions.toIndexedSeq)
-      val allSplitInfos = getSplitInfosFromPartitions(leafTransformers)
-
-      if (GlutenConfig.get.enableHdfsViewfs) {
-        val viewfsToHdfsCache: mutable.Map[String, String] = mutable.Map.empty
-        allSplitInfos.foreach {
-          splitInfos =>
-            splitInfos.foreach {
-              case splitInfo: LocalFilesNode =>
-                val newPaths = ViewFileSystemUtils.convertViewfsToHdfs(
-                  splitInfo.getPaths.asScala.toSeq,
-                  viewfsToHdfsCache,
-                  serializableHadoopConf.value)
-                splitInfo.setPaths(newPaths.asJava)
-            }
-        }
+      val isKeyGroupPartition: Boolean = leafTransformers.exists {
+        // TODO: May can apply to BatchScanExecTransformer without key group partitioning
+        case b: BatchScanExecTransformerBase if b.keyGroupedPartitioning.isDefined => true
+        case _ => false
       }
-
-      val inputPartitions =
-        BackendsApiManager.getIteratorApiInstance.genPartitions(
+      if (!isKeyGroupPartition) {
+        generateWholeStageRDD(leafTransformers, wsCtx, inputRDDs, pipelineTime)
+      } else {
+        generateWholeStageDatasourceRDD(
+          leafTransformers.map(_.asInstanceOf[BatchScanExecTransformerBase]),
           wsCtx,
-          allSplitInfos,
-          leafTransformers)
-
-      val rdd = new GlutenWholeStageColumnarRDD(
-        sparkContext,
-        inputPartitions,
-        inputRDDs,
-        pipelineTime,
-        leafInputMetricsUpdater(),
-        BackendsApiManager.getMetricsApiInstance.metricsUpdatingFunction(
-          child,
-          wsCtx.substraitContext.registeredRelMap,
-          wsCtx.substraitContext.registeredJoinParams,
-          wsCtx.substraitContext.registeredAggregationParams
-        )
-      )
-
-      allInputPartitions.head.indices.foreach(
-        i => {
-          val currentPartitions = allInputPartitions.map(_(i))
-          currentPartitions.indices.foreach(
-            i =>
-              currentPartitions(i) match {
-                case f: FilePartition =>
-                  SoftAffinity.updateFilePartitionLocations(f, rdd.id)
-                case _ =>
-              })
-        })
-
-      rdd
+          inputRDDs,
+          pipelineTime)
+      }
     } else {
 
       /**

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.{FileSourceScanExec, GlobalLimitExec, Spar
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanExecBase}
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
 import org.apache.spark.sql.internal.SQLConf
@@ -223,15 +223,20 @@ trait SparkShims {
   // For compatibility with Spark-3.5.
   def getAnalysisExceptionPlan(ae: AnalysisException): Option[LogicalPlan]
 
-  def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]]
+  def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = Option(Seq())
 
-  def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]]
+  def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] =
+    Option(Seq())
 
   def orderPartitions(
+      batchScan: DataSourceV2ScanExecBase,
       scan: Scan,
       keyGroupedPartitioning: Option[Seq[Expression]],
       filteredPartitions: Seq[Seq[InputPartition]],
-      outputPartitioning: Partitioning): Seq[InputPartition] = filteredPartitions.flatten
+      outputPartitioning: Partitioning,
+      commonPartitionValues: Option[Seq[(InternalRow, Int)]],
+      applyPartialClustering: Boolean,
+      replicatePartitions: Boolean): Seq[Seq[InputPartition]] = filteredPartitions
 
   def extractExpressionTimestampAddUnit(timestampAdd: Expression): Option[Seq[String]] =
     Option.empty

--- a/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
@@ -252,11 +252,6 @@ class Spark32Shims extends SparkShims {
     ae.plan
   }
 
-  override def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = null
-
-  override def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] =
-    null
-
   override def dateTimestampFormatInReadIsDefaultValue(
       csvOptions: CSVOptions,
       timeZone: String): Boolean = {

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -332,8 +332,6 @@ class Spark33Shims extends SparkShims {
   override def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
     batchScan.keyGroupedPartitioning
   }
-  override def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] =
-    null
 
   override def extractExpressionTimestampAddUnit(exp: Expression): Option[Seq[String]] = {
     exp match {

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters}
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanExecBase}
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
@@ -446,36 +446,120 @@ class Spark35Shims extends SparkShims {
   }
 
   override def orderPartitions(
+      batchScan: DataSourceV2ScanExecBase,
       scan: Scan,
       keyGroupedPartitioning: Option[Seq[Expression]],
       filteredPartitions: Seq[Seq[InputPartition]],
-      outputPartitioning: Partitioning): Seq[InputPartition] = {
+      outputPartitioning: Partitioning,
+      commonPartitionValues: Option[Seq[(InternalRow, Int)]],
+      applyPartialClustering: Boolean,
+      replicatePartitions: Boolean): Seq[Seq[InputPartition]] = {
     scan match {
       case _ if keyGroupedPartitioning.isDefined =>
-        var newPartitions = filteredPartitions
+        var finalPartitions = filteredPartitions
+
         outputPartitioning match {
           case p: KeyGroupedPartitioning =>
-            val partitionMapping = newPartitions
-              .map(
-                s =>
-                  InternalRowComparableWrapper(
-                    s.head.asInstanceOf[HasPartitionKey],
-                    p.expressions) -> s)
-              .toMap
-            newPartitions = p.partitionValues.map {
-              partValue =>
-                // Use empty partition for those partition values that are not present
-                partitionMapping.getOrElse(
-                  InternalRowComparableWrapper(partValue, p.expressions),
-                  Seq.empty)
+            if (
+              SQLConf.get.v2BucketingPushPartValuesEnabled &&
+              SQLConf.get.v2BucketingPartiallyClusteredDistributionEnabled
+            ) {
+              assert(
+                filteredPartitions.forall(_.size == 1),
+                "Expect partitions to be not grouped when " +
+                  s"${SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key} " +
+                  "is enabled"
+              )
+
+              val groupedPartitions = batchScan
+                .groupPartitions(finalPartitions.map(_.head), true)
+                .getOrElse(Seq.empty)
+
+              // This means the input partitions are not grouped by partition values. We'll need to
+              // check `groupByPartitionValues` and decide whether to group and replicate splits
+              // within a partition.
+              if (commonPartitionValues.isDefined && applyPartialClustering) {
+                // A mapping from the common partition values to how many splits the partition
+                // should contain. Note this no longer maintain the partition key ordering.
+                val commonPartValuesMap = commonPartitionValues.get
+                  .map(t => (InternalRowComparableWrapper(t._1, p.expressions), t._2))
+                  .toMap
+                val nestGroupedPartitions = groupedPartitions.map {
+                  case (partValue, splits) =>
+                    // `commonPartValuesMap` should contain the part value since it's the super set.
+                    val numSplits = commonPartValuesMap
+                      .get(InternalRowComparableWrapper(partValue, p.expressions))
+                    assert(
+                      numSplits.isDefined,
+                      s"Partition value $partValue does not exist in " +
+                        "common partition values from Spark plan")
+
+                    val newSplits = if (replicatePartitions) {
+                      // We need to also replicate partitions according to the other side of join
+                      Seq.fill(numSplits.get)(splits)
+                    } else {
+                      // Not grouping by partition values: this could be the side with partially
+                      // clustered distribution. Because of dynamic filtering, we'll need to check
+                      // if the final number of splits of a partition is smaller than the original
+                      // number, and fill with empty splits if so. This is necessary so that both
+                      // sides of a join will have the same number of partitions & splits.
+                      splits.map(Seq(_)).padTo(numSplits.get, Seq.empty)
+                    }
+                    (InternalRowComparableWrapper(partValue, p.expressions), newSplits)
+                }
+
+                // Now fill missing partition keys with empty partitions
+                val partitionMapping = nestGroupedPartitions.toMap
+                finalPartitions = commonPartitionValues.get.flatMap {
+                  case (partValue, numSplits) =>
+                    // Use empty partition for those partition values that are not present.
+                    partitionMapping.getOrElse(
+                      InternalRowComparableWrapper(partValue, p.expressions),
+                      Seq.fill(numSplits)(Seq.empty))
+                }
+              } else {
+                // either `commonPartitionValues` is not defined, or it is defined but
+                // `applyPartialClustering` is false.
+                val partitionMapping = groupedPartitions.map {
+                  case (row, parts) =>
+                    InternalRowComparableWrapper(row, p.expressions) -> parts
+                }.toMap
+
+                // In case `commonPartitionValues` is not defined (e.g., SPJ is not used), there
+                // could exist duplicated partition values, as partition grouping is not done
+                // at the beginning and postponed to this method. It is important to use unique
+                // partition values here so that grouped partitions won't get duplicated.
+                finalPartitions = p.uniquePartitionValues.map {
+                  partValue =>
+                    // Use empty partition for those partition values that are not present
+                    partitionMapping.getOrElse(
+                      InternalRowComparableWrapper(partValue, p.expressions),
+                      Seq.empty)
+                }
+              }
+            } else {
+              val partitionMapping = finalPartitions.map {
+                parts =>
+                  val row = parts.head.asInstanceOf[HasPartitionKey].partitionKey()
+                  InternalRowComparableWrapper(row, p.expressions) -> parts
+              }.toMap
+              finalPartitions = p.partitionValues.map {
+                partValue =>
+                  // Use empty partition for those partition values that are not present
+                  partitionMapping.getOrElse(
+                    InternalRowComparableWrapper(partValue, p.expressions),
+                    Seq.empty)
+              }
             }
+
           case _ =>
         }
-        newPartitions.flatten
+        finalPartitions
       case _ =>
-        filteredPartitions.flatten
+        filteredPartitions
     }
   }
+
   override def supportsRowBased(plan: SparkPlan): Boolean = plan.supportsRowBased
 
   override def withTryEvalMode(expr: Expression): Boolean = {


### PR DESCRIPTION
With storage partition join, suppose the left leaf partition is [1, 2], the right partition is [1, 2, 10], the number of partitions is not equal, use empty partition for those partition values that are not present.
```
index | left | right
0 | Seq(1) | Seq(1)
1 | Seq(2) | Seq(2)
2 |  Seq() | Seq(10)
```
Relevant Spark PR: 
https://github.com/apache/spark/pull/35657
