### PR TITLE
[VL] Support read ORC using table schema by index

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
@@ -130,7 +130,8 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
       partitionSchema: StructType,
       fileFormat: ReadFileFormat,
       metadataColumnNames: Seq[String],
-      properties: Map[String, String]): SplitInfo = {
+      properties: Map[String, String],
+      dataSchema: StructType): SplitInfo = {
     partition match {
       case p: GlutenMergeTreePartition =>
         ExtensionTableBuilder

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcForcePositionalSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcForcePositionalSuite.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.config.GlutenConfig
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+class VeloxOrcForcePositionalSuite extends VeloxWholeStageTransformerSuite {
+  override protected val resourcePath: String = "/tpch-data-parquet"
+  override protected val fileFormat: String = "parquet"
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
+      .set("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel", "1")
+      .set("spark.executorEnv.GLOG_v", "1")
+      .set("spark.gluten.sql.debug", "true")
+
+  import testImplicits._
+
+  def withForcePositional(f: => Unit): Unit = {
+    withSQLConf(
+      GlutenConfig.ORC_FORCE_POSITIONAL_EVOLUTION -> "true",
+      "orc.force.positional.evolution" -> "true"
+    ) {
+      f
+    }
+  }
+
+  def testRenameRootColumn(customCheck: DataFrame => Unit): Unit = {
+    withTempPath {
+      tmp =>
+        val path = tmp.getCanonicalPath
+        val df1 = Seq((1, 2), (4, 5), (8, 9)).toDF("col1", "col2")
+        val df2 = Seq((10, 12), (15, 19), (22, 40)).toDF("col1", "col3")
+
+        val dir1 = s"file://$path/part=one"
+        val dir2 = s"file://$path/part=two"
+
+        df1.write.format("orc").save(dir1)
+        df2.write.format("orc").save(dir2)
+
+        spark.read
+          .schema(df2.schema)
+          .format("orc")
+          .load(s"file://$path")
+          .createOrReplaceTempView("test")
+
+        runQueryAndCompare("select * from test")(customCheck)
+    }
+  }
+
+  test("rename root columns") {
+    testRenameRootColumn {
+      df =>
+        checkAnswer(
+          df,
+          Seq(
+            Row(1, null, "one"),
+            Row(4, null, "one"),
+            Row(8, null, "one"),
+            Row(10, 12, "two"),
+            Row(15, 19, "two"),
+            Row(22, 40, "two")
+          ))
+    }
+  }
+
+  test("rename root columns - top level column should be replaced by index") {
+    withForcePositional {
+      testRenameRootColumn {
+        df =>
+          checkAnswer(
+            df,
+            Seq(
+              Row(1, 2, "one"),
+              Row(4, 5, "one"),
+              Row(8, 9, "one"),
+              Row(10, 12, "two"),
+              Row(15, 19, "two"),
+              Row(22, 40, "two")
+            )
+          )
+      }
+    }
+  }
+
+  def testRenameNestedColumn(customCheck: DataFrame => Unit): Unit = {
+    withTempPath {
+      tmp =>
+        val path = tmp.getCanonicalPath
+        val df1 = spark.createDataFrame(
+          spark.sparkContext.parallelize(Row(1, Row("abc", 2)) :: Nil),
+          schema = StructType(
+            Array(
+              StructField("col1", IntegerType, nullable = true),
+              StructField(
+                "col2",
+                StructType(
+                  Array(
+                    StructField("a", StringType, nullable = true),
+                    StructField("b", IntegerType, nullable = true)
+                  )))
+            ))
+        )
+        val df2 = spark.createDataFrame(
+          spark.sparkContext.parallelize(Row(20, Row("EFG", 10)) :: Nil),
+          schema = StructType(
+            Array(
+              StructField("col1", IntegerType, nullable = true),
+              StructField(
+                "col2",
+                StructType(
+                  Array(
+                    StructField("a", StringType, nullable = true),
+                    StructField("c", IntegerType, nullable = true)
+                  )))
+            ))
+        )
+
+        df1.write.mode("overwrite").format("orc").save(s"file://$path/part=one")
+        df2.write.mode("overwrite").format("orc").save(s"file://$path/part=two")
+
+        spark.read
+          .schema(df2.schema)
+          .format("orc")
+          .load(s"file://$path")
+          .createOrReplaceTempView("test")
+
+        runQueryAndCompare("select * from test")(customCheck)
+    }
+  }
+
+  test("rename nested columns") {
+    testRenameNestedColumn {
+      df =>
+        checkAnswer(
+          df,
+          Row(1, Row("abc", null), "one") :: Row(20, Row("EFG", 10), "two") :: Nil
+        )
+    }
+  }
+
+  test("rename nested columns - only top level column should be replaced") {
+    withForcePositional {
+      testRenameNestedColumn {
+        df =>
+          checkAnswer(
+            df,
+            Row(1, Row("abc", null), "one") :: Row(20, Row("EFG", 10), "two") :: Nil
+          )
+      }
+    }
+  }
+
+  def testPruneNestedSchema(customCheck: DataFrame => Unit): Unit = {
+    withTempPath {
+      tmp =>
+        val path = tmp.getCanonicalPath
+
+        val df1 = spark.createDataFrame(
+          spark.sparkContext.parallelize(Row(1, 5, Row("abc", 2)) :: Nil),
+          schema = StructType(
+            Array(
+              StructField("col1", IntegerType, nullable = true),
+              StructField("col2", IntegerType, nullable = true),
+              StructField(
+                "col3",
+                StructType(
+                  Array(
+                    StructField("a", StringType, nullable = true),
+                    StructField("b", IntegerType, nullable = true)
+                  )))
+            ))
+        )
+        df1.write.format("orc").save(s"file://$path")
+
+        spark.read
+          .format("orc")
+          .schema(StructType(Array(
+            StructField("col1", IntegerType, nullable = true),
+            StructField("col2", IntegerType, nullable = true),
+            StructField(
+              "col3",
+              StructType(Array(
+                StructField("b", IntegerType, nullable = true)
+              )))
+          )))
+          .load(s"file://$path")
+          .createOrReplaceTempView("test")
+
+        runQueryAndCompare("select * from test")(customCheck)
+    }
+  }
+
+  test("prune nested schema") {
+    testPruneNestedSchema {
+      df =>
+        checkAnswer(
+          df,
+          Row(1, 5, Row(2)) :: Nil
+        )
+    }
+  }
+
+  test("prune nested schema - only top level column should be replaced") {
+    withForcePositional {
+      testPruneNestedSchema {
+        df =>
+          checkAnswer(
+            df,
+            Row(1, 5, Row(2)) :: Nil
+          )
+      }
+    }
+  }
+}

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcSchemaEvolutionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcSchemaEvolutionSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+class VeloxOrcSchemaEvolutionSuite extends VeloxWholeStageTransformerSuite {
+  override protected val resourcePath: String = "/tpch-data-parquet"
+  override protected val fileFormat: String = "parquet"
+
+  import testImplicits._
+
+  test("read ORC with column names all starting with '_col'") {
+    withTempPath {
+      tmp =>
+        val df = Seq((1, 2, 3), (4, 5, 6), (7, 8, 9)).toDF("_col0", "_col1", "_col2")
+        df.write.format("orc").save(s"file://${tmp.getCanonicalPath}")
+
+        withTempView("test") {
+          spark.read
+            .format("orc")
+            .schema(
+              StructType(
+                Array(
+                  StructField("a", IntegerType, nullable = true),
+                  StructField("b", IntegerType, nullable = true),
+                  StructField("c", IntegerType, nullable = true)
+                )))
+            .load(s"file://${tmp.getCanonicalPath}")
+            .createOrReplaceTempView("test")
+
+          runQueryAndCompare("select a, b, c from test") {
+            df =>
+              checkAnswer(
+                df,
+                Row(1, 2, 3) ::
+                  Row(4, 5, 6) ::
+                  Row(7, 8, 9) ::
+                  Nil)
+          }
+        }
+    }
+  }
+}

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -272,6 +272,11 @@ void VeloxBackend::initConnector() {
   connectorConfMap[velox::connector::hive::HiveConfig::kFilePreloadThreshold] =
       backendConf_->get<std::string>(kFilePreloadThreshold, "1048576"); // 1M
 
+  // Map table schema to file schema using name
+  connectorConfMap[velox::connector::hive::HiveConfig::kParquetUseColumnNames] = "true";
+  connectorConfMap[velox::connector::hive::HiveConfig::kOrcUseColumnNames] = "true";
+  connectorConfMap[velox::connector::hive::HiveConfig::kOrcUseNestedColumnNames] = "true";
+
   // read as UTC
   connectorConfMap[velox::connector::hive::HiveConfig::kReadTimestampPartitionValueAsLocalTime] = "false";
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -598,7 +598,11 @@ std::shared_ptr<velox::config::ConfigBase> WholeStageResultIterator::createConne
   configs[velox::connector::hive::HiveConfig::kIgnoreMissingFilesSession] =
       std::to_string(veloxCfg_->get<bool>(kIgnoreMissingFiles, false));
   configs[velox::connector::hive::HiveConfig::kParquetUseColumnNamesSession] = "true";
-  configs[velox::connector::hive::HiveConfig::kOrcUseColumnNamesSession] = "true";
+  if (veloxCfg_->get<bool>(kOrcForcePositionalEvolution, false)) {
+    configs[velox::connector::hive::HiveConfig::kOrcUseNestedColumnNamesSession] = "true";
+  } else {
+    configs[velox::connector::hive::HiveConfig::kOrcUseColumnNamesSession] = "true";
+  }
   return std::make_shared<velox::config::ConfigBase>(std::move(configs));
 }
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -597,6 +597,8 @@ std::shared_ptr<velox::config::ConfigBase> WholeStageResultIterator::createConne
       std::to_string(veloxCfg_->get<int32_t>(kMaxPartitions, 10000));
   configs[velox::connector::hive::HiveConfig::kIgnoreMissingFilesSession] =
       std::to_string(veloxCfg_->get<bool>(kIgnoreMissingFiles, false));
+  configs[velox::connector::hive::HiveConfig::kParquetUseColumnNamesSession] = "true";
+  configs[velox::connector::hive::HiveConfig::kOrcUseColumnNamesSession] = "true";
   return std::make_shared<velox::config::ConfigBase>(std::move(configs));
 }
 

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -127,6 +127,7 @@ const std::string kLoadQuantum = "spark.gluten.sql.columnar.backend.velox.loadQu
 const std::string kMaxCoalescedDistance = "spark.gluten.sql.columnar.backend.velox.maxCoalescedDistance";
 const std::string kMaxCoalescedBytes = "spark.gluten.sql.columnar.backend.velox.maxCoalescedBytes";
 const std::string kCachePrefetchMinPct = "spark.gluten.sql.columnar.backend.velox.cachePrefetchMinPct";
+const std::string kOrcForcePositionalEvolution = "spark.hadoop.orc.force.positional.evolution";
 
 // write fies
 const std::string kMaxPartitions = "spark.gluten.sql.columnar.backend.velox.maxPartitionsPerWritersSession";

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1284,7 +1284,13 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   std::shared_ptr<connector::hive::HiveTableHandle> tableHandle;
   if (!readRel.has_filter()) {
     tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
-        kHiveConnectorId, "hive_table", filterPushdownEnabled, common::SubfieldFilters{}, nullptr);
+        kHiveConnectorId,
+        "hive_table",
+        filterPushdownEnabled,
+        common::SubfieldFilters{},
+        nullptr,
+        splitInfo->fileSchema,
+        splitInfo->properties);
   } else {
     common::SubfieldFilters subfieldFilters;
     auto names = colNameList;
@@ -1292,7 +1298,13 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     auto remainingFilter = exprConverter_->toVeloxExpr(readRel.filter(), ROW(std::move(names), std::move(types)));
 
     tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
-        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter);
+        kHiveConnectorId,
+        "hive_table",
+        filterPushdownEnabled,
+        std::move(subfieldFilters),
+        remainingFilter,
+        splitInfo->fileSchema,
+        splitInfo->properties);
   }
 
   // Get assignments and out names.

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -55,6 +55,12 @@ struct SplitInfo {
   /// The file sizes and modification times of the files to be scanned.
   std::vector<std::optional<facebook::velox::FileProperties>> properties;
 
+  /// The file read options
+  std::unordered_map<std::string, std::string> readOptions;
+
+  /// The file schema
+  RowTypePtr fileSchema;
+
   /// Make SplitInfo polymorphic
   virtual ~SplitInfo() = default;
 };

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2025_02_22
+VELOX_REPO=https://github.com/ccat3z/velox.git
+VELOX_BRANCH=feat/old-orc-oap
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/ccat3z/velox.git
-VELOX_BRANCH=feat/old-orc-oap
+VELOX_BRANCH=feat/orc-positional-oap
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -36,6 +36,8 @@ import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
 import org.apache.spark.task.TaskResources
 import org.apache.spark.util.SparkResourceUtil
 
+import org.apache.orc.OrcConf
+
 import java.util
 import java.util.Collections
 
@@ -259,6 +261,10 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
       conf.set(SQLConf.ORC_VECTORIZED_READER_ENABLED.key, "false")
       conf.set(SQLConf.CACHE_VECTORIZED_READER_ENABLED.key, "false")
     }
+
+    conf.set(
+      GlutenConfig.ORC_FORCE_POSITIONAL_EVOLUTION,
+      conf.get(OrcConf.FORCE_POSITIONAL_EVOLUTION.getAttribute, "false"))
   }
 }
 

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
@@ -151,15 +151,17 @@ public class LocalFilesNode implements SplitInfo {
       if (index != null) {
         fileBuilder.setPartitionIndex(index);
       }
-      Map<String, String> partitionColumn = partitionColumns.get(i);
-      if (!partitionColumn.isEmpty()) {
-        partitionColumn.forEach(
-            (key, value) -> {
-              ReadRel.LocalFiles.FileOrFiles.partitionColumn.Builder pcBuilder =
-                  ReadRel.LocalFiles.FileOrFiles.partitionColumn.newBuilder();
-              pcBuilder.setKey(key).setValue(value);
-              fileBuilder.addPartitionColumns(pcBuilder.build());
-            });
+      if (partitionColumns != null && partitionColumns.size() == paths.size()) {
+        Map<String, String> partitionColumn = partitionColumns.get(i);
+        if (!partitionColumn.isEmpty()) {
+          partitionColumn.forEach(
+              (key, value) -> {
+                ReadRel.LocalFiles.FileOrFiles.partitionColumn.Builder pcBuilder =
+                    ReadRel.LocalFiles.FileOrFiles.partitionColumn.newBuilder();
+                pcBuilder.setKey(key).setValue(value);
+                fileBuilder.addPartitionColumns(pcBuilder.build());
+              });
+        }
       }
       fileBuilder.setLength(lengths.get(i));
       fileBuilder.setStart(starts.get(i));
@@ -237,6 +239,14 @@ public class LocalFilesNode implements SplitInfo {
                   .setMaxBlockSize(GlutenConfig.get().textInputMaxBlockSize())
                   .build();
           fileBuilder.setJson(jsonReadOptions);
+          break;
+        case HidiReadFormat:
+          String compatValues = fileReadProperties.getOrDefault("compact_values", "true");
+          ReadRel.LocalFiles.FileOrFiles.HidiReadOptions hidiReadOptions =
+              ReadRel.LocalFiles.FileOrFiles.HidiReadOptions.newBuilder()
+                  .setCompactValues(compatValues)
+                  .build();
+          fileBuilder.setHidi(hidiReadOptions);
           break;
         default:
           break;

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/IteratorApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/IteratorApi.scala
@@ -37,7 +37,8 @@ trait IteratorApi {
       partitionSchema: StructType,
       fileFormat: ReadFileFormat,
       metadataColumnNames: Seq[String],
-      properties: Map[String, String]): SplitInfo
+      properties: Map[String, String],
+      dataSchema: StructType): SplitInfo
 
   def genSplitInfoForPartitions(
       partitionIndex: Int,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -74,8 +74,9 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
           _,
           getPartitionSchema,
           fileFormat,
-          getMetadataColumns().map(_.name),
-          getProperties))
+          getMetadataColumns.map(_.name),
+          getProperties,
+          getDataSchema))
   }
 
   val serializableHadoopConf: SerializableConfiguration = new SerializableConfiguration(

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -375,6 +375,7 @@ object GlutenConfig {
   val PARQUET_GZIP_WINDOW_SIZE: String = "parquet.gzip.windowSize"
   // Hadoop config
   val HADOOP_PREFIX = "spark.hadoop."
+  val ORC_FORCE_POSITIONAL_EVOLUTION = HADOOP_PREFIX + "orc.force.positional.evolution"
 
   // S3 config
   val S3A_PREFIX = "fs.s3a."
@@ -466,6 +467,7 @@ object GlutenConfig {
       "spark.gluten.sql.columnar.backend.velox.bloomFilter.expectedNumItems",
       "spark.gluten.sql.columnar.backend.velox.bloomFilter.numBits",
       "spark.gluten.sql.columnar.backend.velox.bloomFilter.maxNumBits",
+      ORC_FORCE_POSITIONAL_EVOLUTION,
       // s3 config
       SPARK_S3_ACCESS_KEY,
       SPARK_S3_SECRET_KEY,


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `orc.force.positional.evolution` is enabled (https://github.com/apache/spark/commit/00d43b1f829fb5f79f0355afbbacc804162648e5) or the orc file has no column names, vanilla spark read orc file using table schema by index.

1. Passthrough `ScanTransformer#getDataColumns` as table schema to Velox.
2. Enable `k{Parquet,Orc}UseColumnNames` in Velox to match spark default behavior, which always map table schema to physical file schema using name. 

This PR depends on https://github.com/facebookincubator/velox/pull/12489 (old orc file).

Fixed https://github.com/apache/incubator-gluten/issues/5638.

## How was this patch tested?

Unit tests.

