### PR TITLE
[CORE] Make scalatest.testFailureIgnore configurable for convenience

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1354,7 +1354,7 @@
           <version>${scalatest-maven-plugin.version}</version>
           <configuration>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <testFailureIgnore>false</testFailureIgnore>
+            <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
             <junitxml>.</junitxml>
             <argLine>${argLine} ${extraJavaTestArgs}</argLine>
           </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make testFailureIgnore configurable for local tests.

## How was this patch tested?

`mvn ... -Dmaven.test.failure.ignore=true`