### PR TITLE
[DOC] fix Gluten UI page title not correct

### DIFF
--- a/docs/get-started/VeloxGlutenUI.md
+++ b/docs/get-started/VeloxGlutenUI.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Gluten with Velox Backend
+title: Gluten UI
 nav_order: 1
 parent: Getting-Started
 ---


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now the document title under https://apache.github.io/incubator-gluten/Getting-Started/ is duplicated, this MR aims to fix this.
![image](https://github.com/user-attachments/assets/cec51582-e901-4749-8e07-7bcedf9bafb3)




