### PR TITLE
[GLUTEN-5884][VL] change default load quantum to 8M for local SSD cache

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -406,10 +406,10 @@ object VeloxConfig {
   val LOAD_QUANTUM =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.loadQuantum")
       .internal()
-      .doc("Set the load quantum for velox file scan, recommend to use the default value (256MB) " +
+      .doc("Set the load quantum for velox file scan, recommend to use the default value (8MB) " +
         "for performance consideration. If Velox cache is enabled, it can be 8MB at most.")
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("256MB")
+      .createWithDefaultString("8MB")
 
   val MAX_COALESCED_DISTANCE_BYTES =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.maxCoalescedDistance")

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -265,7 +265,7 @@ void VeloxBackend::initConnector() {
   connectorConfMap[velox::connector::hive::HiveConfig::kPrefetchRowGroups] =
       backendConf_->get<std::string>(kPrefetchRowGroups, "1");
   connectorConfMap[velox::connector::hive::HiveConfig::kLoadQuantum] =
-      backendConf_->get<std::string>(kLoadQuantum, "268435456"); // 256M
+      backendConf_->get<std::string>(kLoadQuantum, "8388608"); // 8M
   connectorConfMap[velox::connector::hive::HiveConfig::kFooterEstimatedSize] =
       backendConf_->get<std::string>(kDirectorySizeGuess, "32768"); // 32K
   connectorConfMap[velox::connector::hive::HiveConfig::kFilePreloadThreshold] =


### PR DESCRIPTION


## What changes were proposed in this pull request?

Velox is using 23 bits fro cache entry size
https://github.com/facebookincubator/velox/pull/10242

## How was this patch tested?

manually tested with local SSD cache enabled
