### PR TITLE
[DOC] add doc about experimental feature using off-heap to store broadcast build relation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -98,6 +98,7 @@ The following configurations are related to Velox settings.
 | spark.gluten.velox.fs.s3a.connect.timeout                            | Timeout for AWS s3 connection.                                                                                                                     | 1s                |
 | spark.gluten.sql.columnar.backend.velox.orc.scan.enabled             | Enable velox orc scan. If disabled, vanilla spark orc scan will be used.                                                                           | true              |
 | spark.gluten.sql.complexType.scan.fallback.enabled                   | Force fallback for complex type scan, including struct, map, array.                                                                                | true              |
+| spark.gluten.velox.offHeapBroadcastBuildRelation.enabled             | Experimental: If enabled, broadcast build relation will use offheap memory. Otherwise, broadcast build relation will use onheap memory, default value is false |                   |
 
 Additionally, you can control the configurations of gluten at thread level by local property.
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -564,6 +564,8 @@ To enable this feature, you can set the following Spark configuration:
 |-------------------------------------------------------------|---------|-------------------------------------------------------------------|
 | `spark.gluten.velox.offHeapBroadcastBuildRelation.enabled`  | `false` | Enable/disable off-heap storage for broadcast build relations.    |
 
+This feature has been tested through a series of tests, and we are collecting more feedback from users. If you have memory problem on broadcast build relations, please try this feature and give more feedbacks.
+
 **Note**: This feature will become the default behavior once stabilized. Stay tuned for updates!
 
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -564,24 +564,6 @@ Set the following configuration in your Spark session to enable the feature:
 |-------------------------------------------------------------|---------|-------------------------------------------------------------------|
 | `spark.gluten.velox.offHeapBroadcastBuildRelation.enabled`  | `false` | Enable/disable off-heap storage for broadcast build relations.    |
 
-**Example** (In `spark-defaults.conf`):
-```properties
-spark.gluten.velox.offHeapBroadcastBuildRelation.enabled=true
-```
-
-#### 1. Enable via Spark Session
-```scala
-val spark = SparkSession.builder()
-  .appName("GlutenOffHeapBroadcastDemo")
-  .config("spark.gluten.velox.offHeapBroadcastBuildRelation.enabled", "true")
-  .getOrCreate()
-```
-
-#### 2. Enable via Spark SQL
-```sql
-SET spark.gluten.velox.offHeapBroadcastBuildRelation.enabled=true;
-```
-
 **Note**: This feature will become the default behavior once stabilized. Stay tuned for updates!
 
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -558,7 +558,7 @@ can be found [here](https://docs.google.com/document/d/1eZNWPUEdiz2JPJfhyVn9hrk6
 ### Configuration
 
 ### Enable Off-Heap Broadcast
-Set the following configuration in your Spark session to enable the feature:
+To enable this feature, you can set the following Spark configuration:
 
 | Property                                                    | Default | Description                                                       |
 |-------------------------------------------------------------|---------|-------------------------------------------------------------------|

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -545,6 +545,46 @@ I20231121 10:19:42.348845 90094332 WholeStageResultIterator.cc:220] Native Plan 
       queuedWallNanos              sum: 2.00us, count: 1, min: 2.00us, max: 2.00us
 ```
 
+
+## Broadcast Build Relations to Off-Heap(Experimental)
+
+The experimental feature **Off-Heap Broadcast Build Relations** aims to mitigate out-of-memory (OOM) issues caused by heap memory consumption during broadcast operations. Detailed design
+can be found [here](https://docs.google.com/document/d/1eZNWPUEdiz2JPJfhyVn9hrk6SqJFRNzOMZm6u5Yredk/edit?tab=t.0)
+
+### Purpose & how it works
+- **Avoid OOM**: Prevent OOM errors when broadcasting large datasets.
+- **Reduce Heap Memory Usage**: Store broadcast build relations in Spark off-heap memory instead of on-heap memory
+
+### Configuration
+
+### Enable Off-Heap Broadcast
+Set the following configuration in your Spark session to enable the feature:
+
+| Property                                                    | Default | Description                                                       |
+|-------------------------------------------------------------|---------|-------------------------------------------------------------------|
+| `spark.gluten.velox.offHeapBroadcastBuildRelation.enabled`  | `false` | Enable/disable off-heap storage for broadcast build relations.    |
+
+**Example** (In `spark-defaults.conf`):
+```properties
+spark.gluten.velox.offHeapBroadcastBuildRelation.enabled=true
+```
+
+#### 1. Enable via Spark Session
+```scala
+val spark = SparkSession.builder()
+  .appName("GlutenOffHeapBroadcastDemo")
+  .config("spark.gluten.velox.offHeapBroadcastBuildRelation.enabled", "true")
+  .getOrCreate()
+```
+
+#### 2. Enable via Spark SQL
+```sql
+SET spark.gluten.velox.offHeapBroadcastBuildRelation.enabled=true;
+```
+
+**Note**: This feature will become the default behavior once stabilized. Stay tuned for updates!
+
+
 # Accelerators
 
 Please refer [HBM](VeloxHBM.md) [QAT](VeloxQAT.md) [IAA](VeloxIAA.md) for details


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/incubator-gluten/pull/8127 has introduced feature on moving memory use of broadcast  use from on heap to off-heap. This PR aims to add document on how to use it.

