### PR TITLE
[GLUTEN-8891][VL] Allow to reuse local SSD cache on Spark context restart

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -147,13 +147,12 @@ object VeloxConfig {
       .booleanConf
       .createWithDefault(false)
 
-  val COLUMNAR_VELOX_SSD_CACHE_CLEANUP =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdResue")
+  val COLUMNAR_VELOX_SSD_REUSE =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdReuse")
       .internal()
       .doc("The flag for cache resue")
       .booleanConf
       .createWithDefault(false)
-
 
   val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.IOThreads")

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -155,13 +155,6 @@ object VeloxConfig {
       .intConf
       .createWithDefault(0)
 
-  val COLUMNAR_VELOX_SSD_REUSE =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdReuse")
-      .internal()
-      .doc("The flag for cache resue")
-      .booleanConf
-      .createWithDefault(false)
-
   val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.IOThreads")
       .internal()

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -148,11 +148,11 @@ object VeloxConfig {
       .createWithDefault(false)
 
   val COLUMNAR_VELOX_SSD_CACHE_CLEANUP =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCleanup")
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdResue")
       .internal()
-      .doc("The flag for cache cleanup")
+      .doc("The flag for cache resue")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
 
   val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -147,6 +147,14 @@ object VeloxConfig {
       .booleanConf
       .createWithDefault(false)
 
+  val COLUMNAR_VELOX_SSD_CHCEKPOINT_INTERVAL_SIZE =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCheckpointIntervalBytes")
+      .internal()
+      .doc("Checkpoint after every 'checkpointIntervalBytes' for SSD cache. " +
+        "0 means no checkpointing. If checkpoint is enabled, SSD cache will be resued")
+      .intConf
+      .createWithDefault(0)
+
   val COLUMNAR_VELOX_SSD_REUSE =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdReuse")
       .internal()

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -147,6 +147,14 @@ object VeloxConfig {
       .booleanConf
       .createWithDefault(false)
 
+  val COLUMNAR_VELOX_SSD_CACHE_CLEANUP =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCleanup")
+      .internal()
+      .doc("The flag for cache cleanup")
+      .booleanConf
+      .createWithDefault(true)
+
+
   val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.IOThreads")
       .internal()

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -212,7 +212,7 @@ void VeloxBackend::initCache() {
     int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);
     std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
 
-    ssdCleanup = backendConf_->get<bool>(kVeloxSsdCleanup, true);
+    ssdResue_ = backendConf_->get<bool>(kVeloxSsdResue, false);
     cachePathPrefix_ = ssdCachePathPrefix;
     cacheFilePrefix_ = getCacheFilePrefix();
     std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -211,13 +211,15 @@ void VeloxBackend::initCache() {
     int32_t ssdCacheShards = backendConf_->get<int32_t>(kVeloxSsdCacheShards, kVeloxSsdCacheShardsDefault);
     int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);
     std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
+    int32_t ssdCheckpointIntervalSize = backendConf_->get<int32_t>(kVeloxSsdCheckpointIntervalBytes, 0);
 
     ssdReuse_ = backendConf_->get<bool>(kVeloxSsdResue, false);
     cachePathPrefix_ = ssdCachePathPrefix;
     cacheFilePrefix_ = getCacheFilePrefix();
     std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;
     ssdCacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ssdCacheIOThreads);
-    const cache::SsdCache::Config config(ssdCachePath, ssdCacheSize, ssdCacheShards, ssdCacheExecutor_.get());
+    const cache::SsdCache::Config config(
+        ssdCachePath, ssdCacheSize, ssdCacheShards, ssdCacheExecutor_.get(), ssdCheckpointIntervalSize);
     auto ssd = std::make_unique<velox::cache::SsdCache>(config);
 
     std::error_code ec;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -204,6 +204,7 @@ void VeloxBackend::initJolFilesystem() {
 }
 
 std::unique_ptr<facebook::velox::cache::SsdCache> VeloxBackend::initSsdCache() {
+  uint64_t memCacheSize = backendConf_->get<uint64_t>(kVeloxMemCacheSize, kVeloxMemCacheSizeDefault);
   uint64_t ssdCacheSize = backendConf_->get<uint64_t>(kVeloxSsdCacheSize, kVeloxSsdCacheSizeDefault);
   int32_t ssdCacheShards = backendConf_->get<int32_t>(kVeloxSsdCacheShards, kVeloxSsdCacheShardsDefault);
   int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -212,6 +212,7 @@ void VeloxBackend::initCache() {
     int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);
     std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
 
+    ssdCleanup = backendConf_->get<bool>(kVeloxSsdCleanup, true);
     cachePathPrefix_ = ssdCachePathPrefix;
     cacheFilePrefix_ = getCacheFilePrefix();
     std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -213,7 +213,7 @@ void VeloxBackend::initCache() {
     std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
     int32_t ssdCheckpointIntervalSize = backendConf_->get<int32_t>(kVeloxSsdCheckpointIntervalBytes, 0);
 
-    ssdReuse_ = backendConf_->get<bool>(kVeloxSsdResue, false);
+    ssdReuse_ = ssdCheckpointIntervalSize > 0 ? : true : false;
     cachePathPrefix_ = ssdCachePathPrefix;
     cacheFilePrefix_ = getCacheFilePrefix();
     std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -225,6 +225,10 @@ std::unique_ptr<facebook::velox::cache::SsdCache> VeloxBackend::initSsdCache() {
           "not enough space for ssd cache in " + ssdCachePath + " cache size: " + std::to_string(ssdCacheSize) +
           "free space: " + std::to_string(si.available));
     }
+    LOG(INFO) << "STARTUP: Using AsyncDataCache with SSD memory cache size: " << memCacheSize
+              << ", ssdCache prefix: " << ssdCachePath << ", ssdCache size: " << ssdCacheSize
+              << ", ssdCache shards: " << ssdCacheShards << ", ssdCache IO threads: " << ssdCacheIOThreads
+              << ", checkpoints interval size: " << ssdCheckpointIntervalSize;
     return ssd;
 }
 
@@ -241,12 +245,10 @@ void VeloxBackend::initCache() {
         VELOX_FAIL("not enough memory space for caching");
     }
     if (ssdCacheSize == 0) {
-      LOG(INFO) << "AsyncDataCache will do memory caching only as ssd cache size is 0";
-      // TODO: this is not tracked by Spark.
+      LOG(INFO) << "STARTUP: Using AsyncDataCache memory cache size: " << memCacheSize;
       asyncDataCache_ = velox::cache::AsyncDataCache::create(allocator_);
     } else {
        auto ssd = initSsdCache();
-      // TODO: this is not tracked by Spark.
       asyncDataCache_ = velox::cache::AsyncDataCache::create(allocator_, std::move(ssd));
     }
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -212,7 +212,7 @@ void VeloxBackend::initCache() {
     int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);
     std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
 
-    ssdResue_ = backendConf_->get<bool>(kVeloxSsdResue, false);
+    ssdReuse_ = backendConf_->get<bool>(kVeloxSsdResue, false);
     cachePathPrefix_ = ssdCachePathPrefix;
     cacheFilePrefix_ = getCacheFilePrefix();
     std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -232,8 +232,9 @@ void VeloxBackend::initCache() {
     }
 
     // assert memCacheSize > memoryManager.capacity
-    // auto manager_ = facebook::velox::memory::MemoryManager::getInstance();
-    // auto allocator_ = static_cast<memory::MmapAllocator*>(manager_->allocator());
+    if (memCacheSize > allocator_.capacity()) {
+        VELOX_FAIL("not enough memory space for caching");
+    }
     auto allocator_ = facebook::velox::memory::memoryManager()->allocator();
     if (ssdCacheSize == 0) {
       LOG(INFO) << "AsyncDataCache will do memory caching only as ssd cache size is 0";

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -204,32 +204,32 @@ void VeloxBackend::initJolFilesystem() {
 }
 
 std::unique_ptr<facebook::velox::cache::SsdCache> VeloxBackend::initSsdCache() {
-    uint64_t ssdCacheSize = backendConf_->get<uint64_t>(kVeloxSsdCacheSize, kVeloxSsdCacheSizeDefault);
-    int32_t ssdCacheShards = backendConf_->get<int32_t>(kVeloxSsdCacheShards, kVeloxSsdCacheShardsDefault);
-    int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);
-    std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
-    int32_t ssdCheckpointIntervalSize = backendConf_->get<int32_t>(kVeloxSsdCheckpointIntervalBytes, 0);
+  uint64_t ssdCacheSize = backendConf_->get<uint64_t>(kVeloxSsdCacheSize, kVeloxSsdCacheSizeDefault);
+  int32_t ssdCacheShards = backendConf_->get<int32_t>(kVeloxSsdCacheShards, kVeloxSsdCacheShardsDefault);
+  int32_t ssdCacheIOThreads = backendConf_->get<int32_t>(kVeloxSsdCacheIOThreads, kVeloxSsdCacheIOThreadsDefault);
+  std::string ssdCachePathPrefix = backendConf_->get<std::string>(kVeloxSsdCachePath, kVeloxSsdCachePathDefault);
+  int32_t ssdCheckpointIntervalSize = backendConf_->get<int32_t>(kVeloxSsdCheckpointIntervalBytes, 0);
 
-    ssdReuse_ = ssdCheckpointIntervalSize > 0 ? true : false;
-    cachePathPrefix_ = ssdCachePathPrefix;
-    cacheFilePrefix_ = getCacheFilePrefix();
-    std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;
-    ssdCacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ssdCacheIOThreads);
-    const cache::SsdCache::Config config(
-        ssdCachePath, ssdCacheSize, ssdCacheShards, ssdCacheExecutor_.get(), ssdCheckpointIntervalSize);
-    auto ssd = std::make_unique<velox::cache::SsdCache>(config);
-    std::error_code ec;
-    const std::filesystem::space_info si = std::filesystem::space(ssdCachePathPrefix, ec);
-    if (si.available < ssdCacheSize) {
-      VELOX_FAIL(
-          "not enough space for ssd cache in " + ssdCachePath + " cache size: " + std::to_string(ssdCacheSize) +
-          "free space: " + std::to_string(si.available));
-    }
-    LOG(INFO) << "STARTUP: Using AsyncDataCache with SSD memory cache size: " << memCacheSize
-              << ", ssdCache prefix: " << ssdCachePath << ", ssdCache size: " << ssdCacheSize
-              << ", ssdCache shards: " << ssdCacheShards << ", ssdCache IO threads: " << ssdCacheIOThreads
-              << ", checkpoints interval size: " << ssdCheckpointIntervalSize;
-    return ssd;
+  ssdReuse_ = ssdCheckpointIntervalSize > 0 ? true : false;
+  cachePathPrefix_ = ssdCachePathPrefix;
+  cacheFilePrefix_ = getCacheFilePrefix();
+  std::string ssdCachePath = ssdCachePathPrefix + "/" + cacheFilePrefix_;
+  ssdCacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ssdCacheIOThreads);
+  const cache::SsdCache::Config config(
+      ssdCachePath, ssdCacheSize, ssdCacheShards, ssdCacheExecutor_.get(), ssdCheckpointIntervalSize);
+  auto ssd = std::make_unique<velox::cache::SsdCache>(config);
+  std::error_code ec;
+  const std::filesystem::space_info si = std::filesystem::space(ssdCachePathPrefix, ec);
+  if (si.available < ssdCacheSize) {
+    VELOX_FAIL(
+        "not enough space for ssd cache in " + ssdCachePath + " cache size: " + std::to_string(ssdCacheSize) +
+        "free space: " + std::to_string(si.available));
+  }
+  LOG(INFO) << "STARTUP: Using AsyncDataCache with SSD memory cache size: " << memCacheSize
+            << ", ssdCache prefix: " << ssdCachePath << ", ssdCache size: " << ssdCacheSize
+            << ", ssdCache shards: " << ssdCacheShards << ", ssdCache IO threads: " << ssdCacheIOThreads
+            << ", checkpoints interval size: " << ssdCheckpointIntervalSize;
+  return ssd;
 }
 
 void VeloxBackend::initCache() {
@@ -242,13 +242,13 @@ void VeloxBackend::initCache() {
     auto allocator_ = facebook::velox::memory::memoryManager()->allocator();
     // assert memCacheSize > memoryManager.capacity
     if (memCacheSize > allocator_->capacity()) {
-        VELOX_FAIL("not enough memory space for caching");
+      VELOX_FAIL("not enough memory space for caching");
     }
     if (ssdCacheSize == 0) {
       LOG(INFO) << "STARTUP: Using AsyncDataCache memory cache size: " << memCacheSize;
       asyncDataCache_ = velox::cache::AsyncDataCache::create(allocator_);
     } else {
-       auto ssd = initSsdCache();
+      auto ssd = initSsdCache();
       asyncDataCache_ = velox::cache::AsyncDataCache::create(allocator_, std::move(ssd));
     }
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -37,8 +37,7 @@ inline static const std::string kVeloxBackendKind{"velox"};
 class VeloxBackend {
  public:
   ~VeloxBackend() {
-    if (!ssdResue_ &&
-        dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
+    if (!ssdResue_ && dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
       LOG(INFO) << asyncDataCache_->toString();
       for (const auto& entry : std::filesystem::directory_iterator(cachePathPrefix_)) {
         if (entry.path().filename().string().find(cacheFilePrefix_) != std::string::npos) {
@@ -81,7 +80,7 @@ class VeloxBackend {
 
   std::string getCacheFilePrefix() {
     if (ssdResue_) {
-        return "cache.";
+      return "cache.";
     }
     return "cache." + boost::lexical_cast<std::string>(boost::uuids::random_generator()()) + ".";
   }

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -37,7 +37,7 @@ inline static const std::string kVeloxBackendKind{"velox"};
 class VeloxBackend {
  public:
   ~VeloxBackend() {
-    if (ssdCleanup &&
+    if (!ssdResue_ &&
         dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
       LOG(INFO) << asyncDataCache_->toString();
       for (const auto& entry : std::filesystem::directory_iterator(cachePathPrefix_)) {
@@ -80,7 +80,7 @@ class VeloxBackend {
   void initJolFilesystem();
 
   std::string getCacheFilePrefix() {
-    if (!ssdCleanup) {
+    if (ssdResue_) {
         return "cache.";
     }
     return "cache." + boost::lexical_cast<std::string>(boost::uuids::random_generator()()) + ".";
@@ -95,7 +95,7 @@ class VeloxBackend {
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
   std::shared_ptr<facebook::velox::memory::MmapAllocator> cacheAllocator_;
 
-  bool ssdCleanup;
+  bool ssdResue_;
   std::string cachePathPrefix_;
   std::string cacheFilePrefix_;
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -96,6 +96,7 @@ class VeloxBackend {
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
   std::shared_ptr<facebook::velox::memory::MmapAllocator> cacheAllocator_;
 
+
   bool ssdReuse_;
   std::string cachePathPrefix_;
   std::string cacheFilePrefix_;

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -26,6 +26,7 @@
 
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/config/Config.h"
+#include "velox/common/caching/SsdCache.h"
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/memory/MmapAllocator.h"
 
@@ -77,6 +78,7 @@ class VeloxBackend {
   void initCache();
   void initConnector();
   void initUdf();
+  std::unique_ptr<facebook::velox::cache::SsdCache> initSsdCache();
 
   void initJolFilesystem();
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -37,7 +37,8 @@ inline static const std::string kVeloxBackendKind{"velox"};
 class VeloxBackend {
  public:
   ~VeloxBackend() {
-    if (dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
+    if (backendConf_->get<bool>(kVeloxSsdCleanup, false) &&
+        dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
       LOG(INFO) << asyncDataCache_->toString();
       for (const auto& entry : std::filesystem::directory_iterator(cachePathPrefix_)) {
         if (entry.path().filename().string().find(cacheFilePrefix_) != std::string::npos) {
@@ -79,6 +80,9 @@ class VeloxBackend {
   void initJolFilesystem();
 
   std::string getCacheFilePrefix() {
+    if (!backendConf_->get<bool>(kVeloxSsdCleanup, false)) {
+        return "cache.";
+    }
     return "cache." + boost::lexical_cast<std::string>(boost::uuids::random_generator()()) + ".";
   }
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -25,8 +25,8 @@
 #include <filesystem>
 
 #include "velox/common/caching/AsyncDataCache.h"
-#include "velox/common/config/Config.h"
 #include "velox/common/caching/SsdCache.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/memory/MmapAllocator.h"
 
@@ -37,8 +37,7 @@ inline static const std::string kVeloxBackendKind{"velox"};
 /// Should not put heavily work here.
 class VeloxBackend {
  public:
-  ~VeloxBackend() {
-  }
+  ~VeloxBackend() {}
 
   static void create(const std::unordered_map<std::string, std::string>& conf);
 
@@ -97,7 +96,6 @@ class VeloxBackend {
 
   std::unique_ptr<folly::IOThreadPoolExecutor> ssdCacheExecutor_;
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
-
 
   bool ssdReuse_;
   std::string cachePathPrefix_;

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -37,7 +37,7 @@ inline static const std::string kVeloxBackendKind{"velox"};
 class VeloxBackend {
  public:
   ~VeloxBackend() {
-    if (backendConf_->get<bool>(kVeloxSsdCleanup, false) &&
+    if (ssdCleanup &&
         dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
       LOG(INFO) << asyncDataCache_->toString();
       for (const auto& entry : std::filesystem::directory_iterator(cachePathPrefix_)) {
@@ -80,7 +80,7 @@ class VeloxBackend {
   void initJolFilesystem();
 
   std::string getCacheFilePrefix() {
-    if (!backendConf_->get<bool>(kVeloxSsdCleanup, false)) {
+    if (!ssdCleanup) {
         return "cache.";
     }
     return "cache." + boost::lexical_cast<std::string>(boost::uuids::random_generator()()) + ".";
@@ -95,6 +95,7 @@ class VeloxBackend {
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
   std::shared_ptr<facebook::velox::memory::MmapAllocator> cacheAllocator_;
 
+  bool ssdCleanup;
   std::string cachePathPrefix_;
   std::string cacheFilePrefix_;
 

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -102,7 +102,6 @@ const uint32_t kVeloxSsdCacheShardsDefault = 1;
 const std::string kVeloxSsdCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.ssdCacheIOThreads";
 const uint32_t kVeloxSsdCacheIOThreadsDefault = 1;
 const std::string kVeloxSsdODirectEnabled = "spark.gluten.sql.columnar.backend.velox.ssdODirect";
-const std::string kVeloxSsdResue = "spark.gluten.sql.columnar.backend.velox.ssdReuse";
 const std::string kVeloxSsdCheckpointIntervalBytes =
     "spark.gluten.sql.columnar.backend.velox.ssdCheckpointIntervalBytes";
 

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -102,7 +102,7 @@ const uint32_t kVeloxSsdCacheShardsDefault = 1;
 const std::string kVeloxSsdCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.ssdCacheIOThreads";
 const uint32_t kVeloxSsdCacheIOThreadsDefault = 1;
 const std::string kVeloxSsdODirectEnabled = "spark.gluten.sql.columnar.backend.velox.ssdODirect";
-const std::string kVeloxSsdCleanup = "spark.gluten.sql.columnar.backend.velox.ssdCleanup";
+const std::string kVeloxSsdResue = "spark.gluten.sql.columnar.backend.velox.ssdResue";
 
 // async
 const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.IOThreads";

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -102,6 +102,7 @@ const uint32_t kVeloxSsdCacheShardsDefault = 1;
 const std::string kVeloxSsdCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.ssdCacheIOThreads";
 const uint32_t kVeloxSsdCacheIOThreadsDefault = 1;
 const std::string kVeloxSsdODirectEnabled = "spark.gluten.sql.columnar.backend.velox.ssdODirect";
+const std::string kVeloxSsdCleanup = "spark.gluten.sql.columnar.backend.velox.ssdCleanup";
 
 // async
 const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.IOThreads";

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -103,6 +103,8 @@ const std::string kVeloxSsdCacheIOThreads = "spark.gluten.sql.columnar.backend.v
 const uint32_t kVeloxSsdCacheIOThreadsDefault = 1;
 const std::string kVeloxSsdODirectEnabled = "spark.gluten.sql.columnar.backend.velox.ssdODirect";
 const std::string kVeloxSsdResue = "spark.gluten.sql.columnar.backend.velox.ssdReuse";
+const std::string kVeloxSsdCheckpointIntervalBytes =
+    "spark.gluten.sql.columnar.backend.velox.ssdCheckpointIntervalBytes";
 
 // async
 const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.IOThreads";

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -102,7 +102,7 @@ const uint32_t kVeloxSsdCacheShardsDefault = 1;
 const std::string kVeloxSsdCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.ssdCacheIOThreads";
 const uint32_t kVeloxSsdCacheIOThreadsDefault = 1;
 const std::string kVeloxSsdODirectEnabled = "spark.gluten.sql.columnar.backend.velox.ssdODirect";
-const std::string kVeloxSsdResue = "spark.gluten.sql.columnar.backend.velox.ssdResue";
+const std::string kVeloxSsdResue = "spark.gluten.sql.columnar.backend.velox.ssdReuse";
 
 // async
 const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.IOThreads";


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds one config to allow reuse of local SSD cache
Before this patch, the ssd cache will be discarded on spark context shutdown. After this with the new config(ssdReuse) the cache will be kept there, and the users need to manually delete it

Fixes: #8891 

## How was this patch tested?

manual tests
