### PR TITLE
[DNM]Support dictionary shuffle

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,30 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to You under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
       <list>
         <IssueNavigationLink>
           <option name="issueRegexp" value="(?:#|GLUTEN-)(\d+)" />
-          <!--
-            GitHub share the sequence number of issues and pull requests, and it will redirect to
-            the right place when the the sequence number not match kind.
-           -->
           <option name="linkRegexp" value="https://github.com/apache/incubator-gluten/issues/$1" />
         </IssueNavigationLink>
       </list>
@@ -32,5 +12,7 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ep/build-velox/build/velox_ep" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ep/build-velox/build/velox_ep/_build/release/_deps/zlib-src" vcs="Git" />
   </component>
 </project>

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -167,7 +167,8 @@ set(VELOX_SRCS
     utils/Common.cc
     utils/ConfigExtractor.cc
     utils/VeloxArrowUtils.cc
-    utils/VeloxBatchResizer.cc)
+    utils/VeloxBatchResizer.cc
+        shuffle/BaseMap.h)
 
 if(ENABLE_S3)
   find_package(ZLIB)

--- a/cpp/velox/shuffle/BaseMap.h
+++ b/cpp/velox/shuffle/BaseMap.h
@@ -1,0 +1,72 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <velox/common/base/Exceptions.h>
+
+#include <unordered_map>
+#include <vector>
+
+namespace gluten {
+template <typename T>
+class FlatMap;
+
+class BaseMap {
+
+public:
+  template <typename T>
+  const FlatMap<T>* asFlatMap() const {
+    return dynamic_cast<const FlatMap<T>*>(this);
+  }
+  
+};
+
+using BaseMapPtr = std::shared_ptr<BaseMap>;
+
+template <typename T>
+class FlatMap : BaseMap {
+public:
+  std::unordered_map<T, int32_t> getValuesMap() {
+    return values_;
+  }
+  std::unordered_map<T, int32_t> values_;
+};
+
+class RowVectorMap : BaseMap {
+public:
+  RowVectorMap(std::vector<BaseMapPtr> children): BaseMap(), childrenSize_(children.size()),
+        children_(std::move(children)) {}
+
+  /// Get the child vector at a given offset.
+  BaseMapPtr& childAt(uint32_t index) {
+    VELOX_CHECK_LT(
+        index,
+        childrenSize_,
+        "Trying to access non-existing child in RowVectorMap");
+    return children_[index];
+  }
+
+  uint32_t childrenSize() const {
+    return childrenSize_;
+  }
+
+  std::vector<BaseMapPtr> children_;
+  size_t childrenSize_;
+
+};
+}


### PR DESCRIPTION
Add a new flag in header to indicate the column is a dictionary vector.
Like this, first create a dictionary map to save the dictionaryValues, and then if insert, add this value to the distinctValues(BufferPtr), convert the it to FlatVector as dictionaryValues in DictinaryVector.
 
The indices is the map it->second.
Split the nulls as before.
 
Only supports RowVector(DictionaryVector<Simple>)
 
For string type, the key type is StringView, it is also supported as map key
Based on this code, I'm not sure whether the input RowVectors encoding is all dictionary or not.
```
template <typename T>
DictionaryVectorPtr<EvalType<T>> VectorMaker::dictionaryVector(
    const std::vector<std::optional<T>>& data) {
  using TEvalType = EvalType<T>;
  // Encodes the data saving distinct values on `distinctValues` and their
  // respective indices on `indices`.
  std::vector<TEvalType> distinctValues;
  std::unordered_map<TEvalType, int32_t> indexMap;
  BufferPtr indices = AlignedBuffer::allocate<int32_t>(data.size(), pool_);
  auto rawIndices = indices->asMutable<int32_t>();
  BufferPtr nulls =
      AlignedBuffer::allocate<bool>(data.size(), pool_, bits::kNotNull);
  auto rawNulls = nulls->asMutable<uint64_t>();
  vector_size_t nullCount = 0;
  for (auto i = 0; i < data.size(); ++i) {
    auto val = data[i];
    if (val == std::nullopt) {
      ++nullCount;
      bits::setNull(rawNulls, i, true);
    } else {
      const auto& [it, inserted] = indexMap.emplace(*val, indexMap.size());
      if (inserted) {
        distinctValues.push_back(*val);
      }
      *rawIndices = it->second;
    }
    ++rawIndices;
  }
  auto values = flatVector(distinctValues);
  auto stats = genVectorMakerStats(data);
  auto dictionaryVector = std::make_unique<DictionaryVector<TEvalType>>(
      pool_,
      nullCount ? nulls : nullptr,
      data.size(),
      std::move(values),
      std::move(indices),
      stats.asSimpleVectorStats(),
      indexMap.size(),
      nullCount,
      stats.isSorted);
 
  return dictionaryVector;
}
```
