### PR TITLE
[HOTFIX] Fix binary release name for Spark 3.5.2 with Scala 2.13 

### DIFF
--- a/.github/workflows/util/install_spark_resources.sh
+++ b/.github/workflows/util/install_spark_resources.sh
@@ -29,11 +29,12 @@ function install_spark() {
   local scala_version="$3"
   local spark_version_short=$(echo "${spark_version}" | cut -d '.' -f 1,2 | tr -d '.')
   local scala_suffix=$([ "${scala_version}" == '2.13' ] && echo '-scala-2.13' || echo '')
+  local scala_suffix_short=$([ "${scala_version}" == '2.13' ] && echo '-scala2.13' || echo '')
   local mirror_host='https://www.apache.org/dyn/closer.lua/'
   local url_query='?action=download'
   local checksum_suffix='sha512'
   local url_path="spark/spark-${spark_version}/"
-  local local_binary="spark-${spark_version}-bin-hadoop${hadoop_version}${scala_suffix}.tgz"
+  local local_binary="spark-${spark_version}-bin-hadoop${hadoop_version}${scala_suffix_short}.tgz"
   local local_binary_checksum="${local_binary}.${checksum_suffix}"
   local local_source="spark-${spark_version}.tgz"
   local local_source_checksum="${local_source}.${checksum_suffix}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes binary release names with Scala 2.13, e.g. from
spark-3.5.2-bin-hadoop3-scala-2.13.tgz
to
spark-3.5.2-bin-hadoop3-scala2.13.tgz


## How was this patch tested?

1. invalid URL: https://www.apache.org/dyn/closer.lua/spark/spark-3.5.2/spark-3.5.2-bin-hadoop3-scala-2.13.tgz?action=download
2. valid URL: https://www.apache.org/dyn/closer.lua/spark/spark-3.5.2/spark-3.5.2-bin-hadoop3-scala2.13.tgz?action=download
