### PR TITLE
[VL] Use isType func to check type

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -90,7 +90,7 @@ bool SubstraitToVeloxPlanValidator::parseVeloxType(
 }
 
 bool SubstraitToVeloxPlanValidator::flattenSingleLevel(const TypePtr& type, std::vector<TypePtr>& out) {
-  if (type->kind() != TypeKind::ROW) {
+  if (!type->isRow()) {
     LOG_VALIDATION_MSG("Type is not a RowType.");
     return false;
   }
@@ -106,7 +106,7 @@ bool SubstraitToVeloxPlanValidator::flattenSingleLevel(const TypePtr& type, std:
 }
 
 bool SubstraitToVeloxPlanValidator::flattenDualLevel(const TypePtr& type, std::vector<std::vector<TypePtr>>& out) {
-  if (type->kind() != TypeKind::ROW) {
+  if (!type->isRow()) {
     LOG_VALIDATION_MSG("Type is not a RowType.");
     return false;
   }
@@ -242,19 +242,13 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
 
 bool SubstraitToVeloxPlanValidator::isAllowedCast(const TypePtr& fromType, const TypePtr& toType) {
   // Currently cast is not allowed for various categories, code has a bunch of rules
-  // which define the cast categories and if we should offload to velox. Currently
+  // which define the cast categories and if we should offload to velox. Currently,
   // the following categories are denied.
   //
   // 1. from/to isIntervalYearMonth is not allowed.
   // 2. Date to most categories except few supported types is not allowed.
   // 3. Timestamp to most categories except few supported types is not allowed.
   // 4. Certain complex types are not allowed.
-
-  TypeKind fromKind = fromType->kind();
-  TypeKind toKind = toType->kind();
-
-  static const std::unordered_set<TypeKind> complexTypeList = {
-      TypeKind::ARRAY, TypeKind::MAP, TypeKind::ROW, TypeKind::VARBINARY};
 
   // Don't support isIntervalYearMonth.
   if (fromType->isIntervalYearMonth() || toType->isIntervalYearMonth()) {
@@ -263,26 +257,26 @@ bool SubstraitToVeloxPlanValidator::isAllowedCast(const TypePtr& fromType, const
   }
 
   // Limited support for DATE to X.
-  if (fromType->isDate() && toKind != TypeKind::TIMESTAMP && toKind != TypeKind::VARCHAR) {
+  if (fromType->isDate() && !toType->isTimestamp() && !toType->isVarchar()) {
     LOG_VALIDATION_MSG("Casting from DATE to " + toType->toString() + " is not supported.");
     return false;
   }
 
   // Limited support for Timestamp to X.
-  if (fromKind == TypeKind::TIMESTAMP && !(toType->isDate() || toKind == TypeKind::VARCHAR)) {
+  if (fromType->isTimestamp() && !(toType->isDate() || toType->isVarchar())) {
     LOG_VALIDATION_MSG(
         "Casting from TIMESTAMP to " + toType->toString() + " is not supported or has incorrect result.");
     return false;
   }
 
   // Limited support for X to Timestamp.
-  if (toKind == TypeKind::TIMESTAMP && !fromType->isDate()) {
+  if (toType->isTimestamp() && !fromType->isDate()) {
     LOG_VALIDATION_MSG("Casting from " + fromType->toString() + " to TIMESTAMP is not supported.");
     return false;
   }
 
   // Limited support for Complex types.
-  if (complexTypeList.find(fromKind) != complexTypeList.end()) {
+  if (fromType->isArray() || fromType->isMap() || fromType->isRow() || fromType->isVarbinary()) {
     LOG_VALIDATION_MSG("Casting from " + fromType->toString() + " is not currently supported.");
     return false;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox's type has isXXX func to check the type, using this function can make the code more concise.

## How was this patch tested?

N/A

