### PR TITLE
[CORE] Enlarge defaultRecursionLimit by pre-loading the protobuf class

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -130,9 +130,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${custom.protobuf.version}</version>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.gluten</groupId>

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -157,9 +157,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${custom.protobuf.version}</version>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.gluten</groupId>

--- a/gluten-arrow/pom.xml
+++ b/gluten-arrow/pom.xml
@@ -52,9 +52,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${custom.protobuf.version}</version>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.config.GlutenConfig._
 import org.apache.gluten.events.GlutenBuildInfoEvent
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.GlutenSessionExtensions
+import org.apache.gluten.initializer.Initializer
 import org.apache.gluten.task.TaskListener
 
 import org.apache.spark.{SparkConf, SparkContext, TaskFailedReason}
@@ -55,6 +56,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
   private var _sc: Option[SparkContext] = None
 
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
+    Initializer
     _sc = Some(sc)
     val conf = pluginContext.conf()
 
@@ -267,6 +269,7 @@ private[gluten] class GlutenExecutorPlugin extends ExecutorPlugin {
 
   /** Initialize the executor plugin. */
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
+    Initializer
     // Initialize Backend.
     Component.sorted().foreach(_.onExecutorStart(ctx))
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -23,7 +23,7 @@ import org.apache.gluten.config.GlutenConfig._
 import org.apache.gluten.events.GlutenBuildInfoEvent
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.GlutenSessionExtensions
-import org.apache.gluten.initializer.Initializer
+import org.apache.gluten.initializer.CodedInputStreamClassInitializer
 import org.apache.gluten.task.TaskListener
 
 import org.apache.spark.{SparkConf, SparkContext, TaskFailedReason}
@@ -56,7 +56,6 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
   private var _sc: Option[SparkContext] = None
 
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
-    Initializer
     _sc = Some(sc)
     val conf = pluginContext.conf()
 
@@ -269,7 +268,7 @@ private[gluten] class GlutenExecutorPlugin extends ExecutorPlugin {
 
   /** Initialize the executor plugin. */
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
-    Initializer
+    CodedInputStreamClassInitializer
     // Initialize Backend.
     Component.sorted().foreach(_.onExecutorStart(ctx))
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/initializer/CodedInputStreamClassInitializer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/initializer/CodedInputStreamClassInitializer.scala
@@ -18,10 +18,19 @@ package org.apache.gluten.initializer
 
 import java.lang.reflect.Field
 
-object Initializer {
+/**
+ * Pre-load the class instance for CodedInputStream and modify its defaultRecursionLimit to avoid
+ * the limit is hit for deeply nested plans. This is based on the fact that the same class loader is
+ * used to load this class in the program, then this modification will really take effect.
+ */
+object CodedInputStreamClassInitializer {
   {
     try {
-      val clazz: Class[_] = Class.forName("com.google.protobuf.CodedInputStream")
+      // scalastyle:off classforname
+      // Use the shaded class name.
+      val clazz: Class[_] =
+        Class.forName("org.apache.gluten.shaded.com.google.protobuf.CodedInputStream")
+      // scalastyle:on classforname
       val field: Field = clazz.getDeclaredField("defaultRecursionLimit")
       field.setAccessible(true)
       // Enlarge defaultRecursionLimit whose original value is 100.

--- a/gluten-core/src/main/scala/org/apache/gluten/initializer/Initializer.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/initializer/Initializer.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.initializer
+
+import java.lang.reflect.Field
+
+object Initializer {
+  {
+    try {
+      val clazz: Class[_] = Class.forName("com.google.protobuf.CodedInputStream")
+      val field: Field = clazz.getDeclaredField("defaultRecursionLimit")
+      field.setAccessible(true)
+      // Enlarge defaultRecursionLimit whose original value is 100.
+      field.setInt(null, 100000)
+    } catch {
+      case e: Exception => e.printStackTrace()
+    }
+  }
+}

--- a/gluten-delta/pom.xml
+++ b/gluten-delta/pom.xml
@@ -82,7 +82,7 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/gluten-hudi/pom.xml
+++ b/gluten-hudi/pom.xml
@@ -75,12 +75,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/gluten-iceberg/pom.xml
+++ b/gluten-iceberg/pom.xml
@@ -78,12 +78,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>${protobuf.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <scope>test</scope>

--- a/gluten-substrait/pom.xml
+++ b/gluten-substrait/pom.xml
@@ -124,9 +124,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${custom.protobuf.version}</version>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -352,8 +352,6 @@
                     <ignoreClass>org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter$ChainedIterator</ignoreClass>
                     <ignoreClass>org.apache.spark.memory.MemoryConsumer</ignoreClass>
                     <ignoreClass>org.apache.spark.memory.TaskMemoryManager </ignoreClass>
-                    <!-- protobuf -->
-                    <ignoreClass>com.google.protobuf.*</ignoreClass>
                   </ignoreClasses>
                   <scopes>
                     <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,6 @@
 
     <!-- The original protobuf version -->
     <protobuf.version>3.23.4</protobuf.version>
-    <!-- The custom protobuf version (based on 3.23.4) with recursion limit enlarged. -->
-    <custom.protobuf.version>3.23.4-0</custom.protobuf.version>
     <guava.version>32.0.1-jre</guava.version>
     <!--spotless-->
     <spotless.version>2.27.2</spotless.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We previously introduced custom protobuf dependency with only defaultRecursionLimit enlarged to avoid the limit is hit for deeply nested plans (one user reported this issue). It is not easy to upgrade this dependency since it requires local build and then publishing the jar to maven repo.

With this change, we can remove the custom protobuf dependency for easily upgrading protobuf when needed.

## How was this patch tested?

Verified by local remote debug.

