### PR TITLE
Add scala suffix to tar command

### DIFF
--- a/.github/workflows/util/install_spark_resources.sh
+++ b/.github/workflows/util/install_spark_resources.sh
@@ -68,7 +68,7 @@ function install_spark() {
     echo "Skipping checksum because shasum is not installed." 1>&2
   fi
 
-  tar --strip-components=1 -xf "${local_binary}" spark-"${spark_version}"-bin-hadoop"${hadoop_version}"/jars/
+  tar --strip-components=1 -xf "${local_binary}" spark-"${spark_version}"-bin-hadoop"${hadoop_version}""${scala_suffix_short}"/jars/
   mkdir -p ${INSTALL_DIR}/shims/spark"${spark_version_short}"/spark_home/assembly/target/scala-"${scala_version}"
   mv jars ${INSTALL_DIR}/shims/spark"${spark_version_short}"/spark_home/assembly/target/scala-"${scala_version}"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For spark distributions with scala 2.13, the folder has a scala2.13 prefix
tar --strip-components=1 -xf spark-3.5.2-bin-hadoop3-scala2.13.tgz spark-3.5.2-bin-hadoop3-scala2.13/jars/



## How was this patch tested?

Run `tar --strip-components=1 -xf spark-3.5.2-bin-hadoop3-scala2.13.tgz spark-3.5.2-bin-hadoop3-scala2.13/jars/` locally
