### PR TITLE
[GLUTEN-8926][CH] MergeTree Parameter Configuration Optimization to Prevent Multithreading Competition for activeSession Being None

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/ClickhouseSnapshot.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/delta/ClickhouseSnapshot.scala
@@ -84,9 +84,11 @@ case class FilterExprsAsKey(
 }
 
 object ClickhouseSnapshot {
+  protected def sparkSession: SparkSession = SparkSession.active
+
   val deltaScanCache: Cache[FilterExprsAsKey, DeltaScan] = CacheBuilder.newBuilder
     .maximumSize(
-      SparkSession.getActiveSession.get.conf
+      sparkSession.conf
         .get(CHBackendSettings.GLUTEN_CLICKHOUSE_DELTA_SCAN_CACHE_SIZE, "10000")
         .toLong)
     .expireAfterAccess(7200L, TimeUnit.SECONDS)
@@ -95,7 +97,7 @@ object ClickhouseSnapshot {
 
   val addFileToAddMTPCache: LoadingCache[AddFileAsKey, AddMergeTreeParts] = CacheBuilder.newBuilder
     .maximumSize(
-      SparkSession.getActiveSession.get.conf
+      sparkSession.conf
         .get(CHBackendSettings.GLUTEN_CLICKHOUSE_ADDFILES_TO_MTPS_CACHE_SIZE, "1000000")
         .toLong)
     .expireAfterAccess(7200L, TimeUnit.SECONDS)
@@ -109,7 +111,7 @@ object ClickhouseSnapshot {
 
   val pathToAddMTPCache: Cache[String, AddMergeTreeParts] = CacheBuilder.newBuilder
     .maximumSize(
-      SparkSession.getActiveSession.get.conf
+      sparkSession.conf
         .get(CHBackendSettings.GLUTEN_CLICKHOUSE_TABLE_PATH_TO_MTPS_CACHE_SIZE, "1000000")
         .toLong)
     .expireAfterAccess(7200L, TimeUnit.SECONDS)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The method for obtaining parameters needs to be adjusted: when activeSession is None, retrieve defaultSession, or throw a more explicit exception.Spark provides this approach, accessible directly via SparkSession.active.

(Fixes: \#8926)
