### PR TITLE
[GLUTEN-8846][CH] [Part 1] Support Positional Deletes

### DIFF
--- a/cpp-ch/clickhouse.version
+++ b/cpp-ch/clickhouse.version
@@ -1,3 +1,3 @@
 CH_ORG=Kyligence
 CH_BRANCH=rebase_ch/20250308
-CH_COMMIT=66d2ceec2aa
+CH_COMMIT=5cf4c5b0dc5

--- a/cpp-ch/local-engine/Common/BlockTypeUtils.h
+++ b/cpp-ch/local-engine/Common/BlockTypeUtils.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 #include <Core/Block.h>
 #include <DataTypes/DataTypeDate32.h>
@@ -148,6 +149,14 @@ struct CppToDataType<Int64>
 };
 
 template <>
+struct CppToDataType<std::string>
+{
+    using Type = DB::DataTypeString;
+    using ColumnType = Type::ColumnType; //DB::ColumnString;
+    static auto create() { return std::make_shared<Type>(); }
+};
+
+template <>
 struct CppToDataType<UInt64>
 {
     using Type = DB::DataTypeUInt64;
@@ -184,6 +193,15 @@ template <typename T>
 DB::ColumnWithTypeAndName createColumnConst(size_t size, T value, const std::string & col_name)
 {
     return {createColumnConst(size, value), CppToDataType<T>::create(), col_name};
+}
+
+template <typename T>
+DB::ColumnPtr createColumn(size_t size, const std::function<T(size_t)> & valueAt)
+{
+    auto column = CppToDataType<T>::ColumnType::create();
+    for (size_t i = 0; i < size; ++i)
+        column->insert(valueAt(i));
+    return column;
 }
 
 // end of CppToDataType

--- a/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.cpp
+++ b/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.cpp
@@ -17,14 +17,15 @@
 
 #include "ParquetMeta.h"
 
+#include <Formats/FormatFactory.h>
 #include <Formats/FormatSettings.h>
 #include <Processors/Formats/Impl/ArrowBufferedStreams.h>
+#include <Processors/Formats/Impl/ArrowColumnToCHColumn.h>
 #include <Processors/Formats/Impl/ArrowFieldIndexUtil.h>
 #include <Storages/Parquet/ArrowUtils.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/schema.h>
 #include <parquet/metadata.h>
-#include "Processors/Formats/Impl/ArrowColumnToCHColumn.h"
 
 namespace DB
 {
@@ -34,13 +35,14 @@ extern const int BAD_ARGUMENTS;
 }
 }
 
+using namespace DB;
 
 namespace local_engine
 {
 
-std::unique_ptr<parquet::ParquetFileReader> ParquetMetaBuilder::openInputParquetFile(DB::ReadBuffer & read_buffer)
+std::unique_ptr<parquet::ParquetFileReader> ParquetMetaBuilder::openInputParquetFile(ReadBuffer & read_buffer)
 {
-    const DB::FormatSettings format_settings{
+    const FormatSettings format_settings{
         .seekable_read = true,
     };
     std::atomic<int> is_stopped{0};
@@ -49,13 +51,28 @@ std::unique_ptr<parquet::ParquetFileReader> ParquetMetaBuilder::openInputParquet
     return parquet::ParquetFileReader::Open(arrow_file, parquet::default_reader_properties(), nullptr);
 }
 
+Block ParquetMetaBuilder::collectFileSchema(const ContextPtr & context, ReadBuffer & read_buffer)
+{
+    assert(dynamic_cast<SeekableReadBuffer *>(&read_buffer) != nullptr);
+
+    FormatSettings format_settings = getFormatSettings(context);
+    ParquetMetaBuilder metaBuilder{
+        .case_insensitive = format_settings.parquet.case_insensitive_column_matching,
+        .allow_missing_columns = false,
+        .collectPageIndex = false,
+        .collectSchema = true};
+    metaBuilder.build(read_buffer);
+
+    return metaBuilder.fileHeader;
+}
+
 std::vector<Int32> ParquetMetaBuilder::pruneColumn(
-    const DB::Block & header, const parquet::FileMetaData & metadata, bool case_insensitive, bool allow_missing_columns)
+    const Block & header, const parquet::FileMetaData & metadata, bool case_insensitive, bool allow_missing_columns)
 {
     std::shared_ptr<arrow::Schema> schema;
     THROW_ARROW_NOT_OK(parquet::arrow::FromParquetSchema(metadata.schema(), &schema));
 
-    DB::ArrowFieldIndexUtil field_util(case_insensitive, allow_missing_columns);
+    ArrowFieldIndexUtil field_util(case_insensitive, allow_missing_columns);
     auto index_mapping = field_util.findRequiredIndices(header, *schema, metadata);
 
     std::vector<Int32> column_indices;
@@ -93,7 +110,7 @@ ParquetMetaBuilder & ParquetMetaBuilder::buildSchema(const parquet::FileMetaData
         std::shared_ptr<arrow::Schema> schema;
         THROW_ARROW_NOT_OK(parquet::arrow::FromParquetSchema(file_meta.schema(), &schema));
 
-        fileHeader = DB::ArrowColumnToCHColumn::arrowSchemaToCHHeader(*schema, "Parquet", false, true);
+        fileHeader = ArrowColumnToCHColumn::arrowSchemaToCHHeader(*schema, "Parquet", false, true);
     }
     return *this;
 }
@@ -175,7 +192,7 @@ ParquetMetaBuilder & ParquetMetaBuilder::buildAllRowRange(const parquet::FileMet
 ParquetMetaBuilder & ParquetMetaBuilder::buildRowRange(
     parquet::ParquetFileReader & reader,
     const parquet::FileMetaData & file_meta,
-    const DB::Block & readBlock,
+    const Block & readBlock,
     const ColumnIndexFilter * column_index_filter)
 {
     if (collectPageIndex)
@@ -200,8 +217,8 @@ ParquetMetaBuilder & ParquetMetaBuilder::buildRowRange(
 }
 
 ParquetMetaBuilder & ParquetMetaBuilder::build(
-    DB::ReadBuffer & read_buffer,
-    const DB::Block & readBlock,
+    ReadBuffer & read_buffer,
+    const Block & readBlock,
     const ColumnIndexFilter * column_index_filter,
     const std::function<bool(UInt64)> & should_include_row_group)
 {
@@ -213,7 +230,7 @@ ParquetMetaBuilder & ParquetMetaBuilder::build(
         .buildRowRange(*reader, *fileMetaData, readBlock, column_index_filter);
 }
 
-ParquetMetaBuilder & ParquetMetaBuilder::build(DB::ReadBuffer & read_buffer, const std::function<bool(UInt64)> & should_include_row_group)
+ParquetMetaBuilder & ParquetMetaBuilder::build(ReadBuffer & read_buffer, const std::function<bool(UInt64)> & should_include_row_group)
 {
     auto reader = openInputParquetFile(read_buffer);
     fileMetaData = reader->metadata();

--- a/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.cpp
+++ b/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.cpp
@@ -206,21 +206,21 @@ ParquetMetaBuilder & ParquetMetaBuilder::build(
     const std::function<bool(UInt64)> & should_include_row_group)
 {
     auto reader = openInputParquetFile(read_buffer);
-    const auto file_meta = reader->metadata();
-    return buildRequiredRowGroups(*file_meta, should_include_row_group)
-        .buildSkipRowGroup(*file_meta)
-        .buildSchema(*file_meta)
-        .buildRowRange(*reader, *file_meta, readBlock, column_index_filter);
+    fileMetaData = reader->metadata();
+    return buildRequiredRowGroups(*fileMetaData, should_include_row_group)
+        .buildSkipRowGroup(*fileMetaData)
+        .buildSchema(*fileMetaData)
+        .buildRowRange(*reader, *fileMetaData, readBlock, column_index_filter);
 }
 
 ParquetMetaBuilder & ParquetMetaBuilder::build(DB::ReadBuffer & read_buffer, const std::function<bool(UInt64)> & should_include_row_group)
 {
     auto reader = openInputParquetFile(read_buffer);
-    const auto file_meta = reader->metadata();
-    return buildRequiredRowGroups(*file_meta, should_include_row_group)
-        .buildSkipRowGroup(*file_meta)
-        .buildSchema(*file_meta)
-        .buildAllRowRange(*file_meta);
+    fileMetaData = reader->metadata();
+    return buildRequiredRowGroups(*fileMetaData, should_include_row_group)
+        .buildSkipRowGroup(*fileMetaData)
+        .buildSchema(*fileMetaData)
+        .buildAllRowRange(*fileMetaData);
 }
 
 

--- a/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.h
+++ b/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.h
@@ -72,6 +72,8 @@ struct ParquetMetaBuilder
 
     static std::unique_ptr<parquet::ParquetFileReader> openInputParquetFile(DB::ReadBuffer & read_buffer);
 
+    static DB::Block collectFileSchema(const DB::ContextPtr & context, DB::ReadBuffer & read_buffer);
+
 private:
     ParquetMetaBuilder &
     buildRequiredRowGroups(const parquet::FileMetaData & file_meta, const std::function<bool(UInt64)> & should_include_row_group);

--- a/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.h
+++ b/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.h
@@ -47,6 +47,8 @@ struct ParquetMetaBuilder
     bool collectPageIndex = false;
     bool collectSchema = false;
 
+    std::shared_ptr<parquet::FileMetaData> fileMetaData;
+
     //
     std::vector<RowGroupInformation> readRowGroups;
 

--- a/cpp-ch/local-engine/Storages/Parquet/VectorizedParquetRecordReader.h
+++ b/cpp-ch/local-engine/Storages/Parquet/VectorizedParquetRecordReader.h
@@ -214,6 +214,9 @@ class VectorizedParquetBlockInputFormat final : public DB::IInputFormat
 protected:
     void onCancel() noexcept override { is_stopped = 1; }
 
+    // TODO: create ColumnIndexFilter here, currently disable it now.
+    void setKeyCondition(const std::shared_ptr<const DB::KeyCondition> & key_condition_) override { }
+
 public:
     VectorizedParquetBlockInputFormat(
         DB::ReadBuffer & in_,

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FileReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FileReader.cpp
@@ -273,15 +273,11 @@ std::unique_ptr<NormalFileReader> createNormalFileReader(
     const std::shared_ptr<const DB::KeyCondition> & key_condition = nullptr,
     const ColumnIndexFilterPtr & column_index_filter = nullptr)
 {
+    file->initialize(column_index_filter);
     auto createInputFormat = [&](const DB::Block & new_read_header_) -> FormatFile::InputFormatPtr
     {
-        // Apply key condition to the reader.
-        // If use_local_format is true, column_index_filter will be used otherwise it will be ignored
-        if (auto * parquetFile = dynamic_cast<ParquetFormatFile *>(file.get()))
-            return parquetFile->createInputFormat(new_read_header_, key_condition, column_index_filter);
-
         auto input_format = file->createInputFormat(new_read_header_);
-        if (key_condition)
+        if (key_condition && input_format)
             input_format->inputFormat().setKeyCondition(key_condition);
         return input_format;
     };

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FileReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FileReader.cpp
@@ -273,26 +273,24 @@ std::unique_ptr<NormalFileReader> createNormalFileReader(
     const std::shared_ptr<const DB::KeyCondition> & key_condition = nullptr,
     const ColumnIndexFilterPtr & column_index_filter = nullptr)
 {
-    FormatFile::InputFormatPtr input_format;
-    if (auto * parquetFile = dynamic_cast<ParquetFormatFile *>(file.get()))
+    auto createInputFormat = [&](const DB::Block & new_read_header_) -> FormatFile::InputFormatPtr
     {
-        /// Apply key condition to the reader.
-        /// If use_local_format is true, column_index_filter will be used  otherwise it will be ignored
-        input_format = parquetFile->createInputFormat(to_read_header_, key_condition, column_index_filter);
-    }
-    else
-    {
-        input_format = file->createInputFormat(to_read_header_);
+        // Apply key condition to the reader.
+        // If use_local_format is true, column_index_filter will be used otherwise it will be ignored
+        if (auto * parquetFile = dynamic_cast<ParquetFormatFile *>(file.get()))
+            return parquetFile->createInputFormat(new_read_header_, key_condition, column_index_filter);
+
+        auto input_format = file->createInputFormat(new_read_header_);
         if (key_condition)
             input_format->inputFormat().setKeyCondition(key_condition);
-    }
-    if (!input_format)
-        return nullptr;
+        return input_format;
+    };
 
     if (file->getFileInfo().has_iceberg())
-        return iceberg::IcebergReader::create(file, to_read_header_, output_header_, input_format);
+        return iceberg::IcebergReader::create(file, to_read_header_, output_header_, createInputFormat);
 
-    return std::make_unique<NormalFileReader>(file, to_read_header_, output_header_, input_format);
+    auto input_format = createInputFormat(to_read_header_);
+    return input_format == nullptr ? nullptr : std::make_unique<NormalFileReader>(file, to_read_header_, output_header_, input_format);
 }
 }
 std::unique_ptr<BaseReader> BaseReader::create(

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
@@ -25,6 +25,7 @@
 #include <Parser/TypeParser.h>
 #include <Processors/Formats/IInputFormat.h>
 #include <Storages/SubstraitSource/ReadBufferBuilder.h>
+#include <Storages/SubstraitSource/substrait_fwd.h>
 #include <substrait/plan.pb.h>
 
 namespace DB
@@ -39,7 +40,6 @@ namespace local_engine
 {
 
 class FormatFile;
-using substraitInputFile = substrait::ReadRel::LocalFiles::FileOrFiles;
 
 class FileMetaColumns
 {

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ParquetFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ParquetFormatFile.cpp
@@ -47,10 +47,10 @@ extern const int UNKNOWN_TYPE;
 }
 }
 
+using namespace DB;
 
 namespace local_engine
 {
-
 struct ShouldIncludeRowGroup
 {
     const substraitInputFile & file_info;
@@ -65,7 +65,7 @@ struct ShouldIncludeRowGroup
 
 namespace
 {
-ParquetMetaBuilder collectRequiredRowGroups(DB::ReadBuffer & read_buffer, const substraitInputFile & file_info)
+ParquetMetaBuilder collectRequiredRowGroups(ReadBuffer & read_buffer, const substraitInputFile & file_info)
 {
     ParquetMetaBuilder result;
     ShouldIncludeRowGroup should_include_row_group{file_info};
@@ -77,18 +77,18 @@ ParquetMetaBuilder collectRequiredRowGroups(DB::ReadBuffer & read_buffer, const 
 using namespace ParquetVirtualMeta;
 class ParquetInputFormat : public FormatFile::InputFormat
 {
-    const DB::Block readHeader;
-    const DB::Block outputHeader;
+    const Block readHeader;
+    const Block outputHeader;
     std::unique_ptr<ColumnIndexRowRangesProvider> rowRangesProvider;
     std::optional<VirtualColumnRowIndexReader> row_index_reader;
 
 public:
     ParquetInputFormat(
-        std::unique_ptr<DB::ReadBuffer> read_buffer_,
-        const DB::InputFormatPtr & input_,
+        std::unique_ptr<ReadBuffer> read_buffer_,
+        const InputFormatPtr & input_,
         std::unique_ptr<ColumnIndexRowRangesProvider> provider,
-        DB::Block readHeader_,
-        DB::Block outputHeader_)
+        Block readHeader_,
+        Block outputHeader_)
         : InputFormat(std::move(read_buffer_), input_)
         , readHeader(std::move(readHeader_))
         , outputHeader(std::move(outputHeader_))
@@ -100,16 +100,16 @@ public:
     {
     }
 
-    DB::Chunk generate() override
+    Chunk generate() override
     {
         if (readHeader.columns() == 0)
         {
             assert(outputHeader.columns());
             assert(row_index_reader);
             // TODO: format_settings_.parquet.max_block_size
-            DB::Columns cols{row_index_reader->readBatch(8192)};
+            Columns cols{row_index_reader->readBatch(8192)};
             size_t rows = cols[0]->size();
-            return DB::Chunk(std::move(cols), rows);
+            return Chunk(std::move(cols), rows);
         }
         auto chunk = input->generate();
         size_t num_rows = chunk.getNumRows();
@@ -128,26 +128,31 @@ public:
 };
 
 ParquetFormatFile::ParquetFormatFile(
-    const DB::ContextPtr & context_,
+    const ContextPtr & context_,
     const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_,
     const ReadBufferBuilderPtr & read_buffer_builder_,
     bool use_local_format_)
-    : FormatFile(context_, file_info_, read_buffer_builder_), use_pageindex_reader(use_local_format_)
+    : FormatFile(context_, file_info_, read_buffer_builder_), use_pageindex_reader{use_local_format_}
 {
 }
 
-FormatFile::InputFormatPtr ParquetFormatFile::createInputFormat(
-    const DB::Block & header,
-    const std::shared_ptr<const DB::KeyCondition> & key_condition,
-    const ColumnIndexFilterPtr & column_index_filter) const
+void ParquetFormatFile::initialize(const ColumnIndexFilterPtr & filter)
 {
+    column_index_filter_ = filter;
+    read_buffer_ = read_buffer_builder->build(file_info);
+    if (file_info.has_iceberg())
+        file_schema = ParquetMetaBuilder::collectFileSchema(context, *read_buffer_);
+}
+
+FormatFile::InputFormatPtr ParquetFormatFile::createInputFormat(const Block & header)
+{
+    assert(read_buffer_);
+
     bool readRowIndex = hasMetaColumns(header);
     bool usePageIndexReader = (use_pageindex_reader || readRowIndex) && onlyHasFlatType(header);
-    auto read_buffer = read_buffer_builder->build(file_info);
-    auto format_settings = DB::getFormatSettings(context);
-
-    DB::Block output_header = header;
-    DB::Block read_header = removeMetaColumns(header);
+    auto format_settings = getFormatSettings(context);
+    Block output_header = header;
+    Block read_header = removeMetaColumns(header);
 
     ParquetMetaBuilder metaBuilder{
         .collectPageIndex = usePageIndexReader || readRowIndex,
@@ -156,54 +161,63 @@ FormatFile::InputFormatPtr ParquetFormatFile::createInputFormat(
         .allow_missing_columns = format_settings.parquet.allow_missing_columns};
 
     ShouldIncludeRowGroup should_include_row_group{file_info};
-    if (auto * seekable_in = dynamic_cast<DB::SeekableReadBuffer *>(read_buffer.get()))
+    if (auto * seekable_in = dynamic_cast<SeekableReadBuffer *>(read_buffer_.get()))
     {
         // reuse the read_buffer to avoid opening the file twice.
         // especially，the cost of opening a hdfs file is large.
-        metaBuilder.build(*seekable_in, read_header, column_index_filter.get(), should_include_row_group);
+        metaBuilder.build(*seekable_in, read_header, column_index_filter_.get(), should_include_row_group);
         seekable_in->seek(0, SEEK_SET);
     }
     else
     {
         const auto in = read_buffer_builder->build(file_info);
-        metaBuilder.build(*in, read_header, column_index_filter.get(), should_include_row_group);
+        metaBuilder.build(*in, read_header, column_index_filter_.get(), should_include_row_group);
     }
+
+    column_index_filter_.reset();
 
     if (metaBuilder.readRowGroups.empty())
         return nullptr;
 
     auto provider = usePageIndexReader || readRowIndex ? std::make_unique<ColumnIndexRowRangesProvider>(metaBuilder) : nullptr;
 
-    if (usePageIndexReader)
+    auto createVectorizedFormat = [&]() -> InputFormatPtr
     {
-        auto input = std::make_shared<VectorizedParquetBlockInputFormat>(*read_buffer, read_header, *provider, format_settings);
+        auto input = std::make_shared<VectorizedParquetBlockInputFormat>(*read_buffer_, read_header, *provider, format_settings);
         return std::make_shared<ParquetInputFormat>(
-            std::move(read_buffer), input, std::move(provider), std::move(read_header), std::move(output_header));
-    }
+            std::move(read_buffer_), input, std::move(provider), std::move(read_header), std::move(output_header));
+    };
 
-    const DB::Settings & settings = context->getSettingsRef();
-    format_settings.parquet.skip_row_groups = std::unordered_set<int>(metaBuilder.skipRowGroups.begin(), metaBuilder.skipRowGroups.end());
-
-    if (readRowIndex)
+    auto createParquetBlockInputFormat = [&]() -> InputFormatPtr
     {
-        assert(provider);
-        /// In case of readRowIndex, we need to preserve the order of the rows
-        format_settings.parquet.preserve_order = true;
+        const Settings & settings = context->getSettingsRef();
+        format_settings.parquet.skip_row_groups
+            = std::unordered_set<int>(metaBuilder.skipRowGroups.begin(), metaBuilder.skipRowGroups.end());
 
-        /// TODO: enable filter push down again
-        format_settings.parquet.filter_push_down = false;
-    }
+        if (readRowIndex)
+        {
+            assert(provider);
 
-    auto input = std::make_shared<DB::ParquetBlockInputFormat>(
-        *read_buffer,
-        read_header,
-        format_settings,
-        settings[DB::Setting::max_parsing_threads],
-        settings[DB::Setting::max_download_threads],
-        8192);
-    input->setKeyCondition(key_condition);
-    return std::make_shared<ParquetInputFormat>(
-        std::move(read_buffer), input, std::move(provider), std::move(read_header), std::move(output_header));
+            // In the case of readRowIndex, we need to preserve the order of the rows
+            format_settings.parquet.preserve_order = true;
+
+            // TODO: enable filter push down again
+            // We need to disable fiter push down and read all row groups, so that we can get correct row index.
+            format_settings.parquet.filter_push_down = false;
+        }
+
+        auto input = std::make_shared<ParquetBlockInputFormat>(
+            *read_buffer_,
+            read_header,
+            format_settings,
+            settings[Setting::max_parsing_threads],
+            settings[Setting::max_download_threads],
+            8192);
+        return std::make_shared<ParquetInputFormat>(
+            std::move(read_buffer_), input, std::move(provider), std::move(read_header), std::move(output_header));
+    };
+
+    return usePageIndexReader ? createVectorizedFormat() : createParquetBlockInputFormat();
 }
 
 std::optional<size_t> ParquetFormatFile::getTotalRows()
@@ -228,18 +242,17 @@ std::optional<size_t> ParquetFormatFile::getTotalRows()
     }
 }
 
-bool ParquetFormatFile::onlyHasFlatType(const DB::Block & header)
+bool ParquetFormatFile::onlyHasFlatType(const Block & header)
 {
     return std::ranges::all_of(
         header,
-        [](DB::ColumnWithTypeAndName const & col)
+        [](ColumnWithTypeAndName const & col)
         {
-            const DB::DataTypePtr type_not_nullable = DB::removeNullable(col.type);
-            const DB::WhichDataType which(type_not_nullable);
-            return !DB::isArray(which) && !DB::isMap(which) && !DB::isTuple(which);
+            const DataTypePtr type_not_nullable = removeNullable(col.type);
+            const WhichDataType which(type_not_nullable);
+            return !isArray(which) && !isMap(which) && !isTuple(which);
         });
 }
-
 
 }
 #endif

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/EqualityDeleteFileReader.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/EqualityDeleteFileReader.h
@@ -58,15 +58,16 @@ public:
 class EqualityDeleteFileReader
 {
     const DB::ContextPtr & context_;
-    const DB::Block & read_header_;
     const substraitIcebergDeleteFile & deleteFile_;
+    DB::Block data_file_schema_for_delete_;
 
 public:
     static DB::ExpressionActionsPtr createDeleteExpr(
         const DB::ContextPtr & context,
-        const DB::Block & to_read_header,
+        const DB::Block & data_file_header,
         const google::protobuf::RepeatedPtrField<substraitIcebergDeleteFile> & delete_files,
-        const std::vector<int> & equality_delete_files);
+        const std::vector<int> & equality_delete_files,
+        DB::Block & reader_header);
 
     explicit EqualityDeleteFileReader(
         const DB::ContextPtr & context, const DB::Block & read_header, const substraitIcebergDeleteFile & deleteFile);

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergMetadataColumn.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergMetadataColumn.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <string>
+#include <Common/BlockTypeUtils.h>
+
+namespace local_engine::iceberg
+{
+struct IcebergMetadataColumn
+{
+    int id;
+    std::string name;
+    DB::DataTypePtr type;
+    std::string doc;
+
+    IcebergMetadataColumn(int _id, const std::string & _name, const DB::DataTypePtr & _type, const std::string & _doc)
+        : id(_id), name(_name), type(_type), doc(_doc)
+    {
+    }
+
+    static std::shared_ptr<IcebergMetadataColumn> icebergDeleteFilePathColumn()
+    {
+        static auto file_path
+            = std::make_shared<IcebergMetadataColumn>(2147483546, "file_path", STRING(), "Path of a file in which a deleted row is stored");
+        return file_path;
+    }
+
+    static std::shared_ptr<IcebergMetadataColumn> icebergDeletePosColumn()
+    {
+        static auto pos
+            = std::make_shared<IcebergMetadataColumn>(2147483545, "pos", BIGINT(), "Ordinal position of a deleted row in the data file");
+        return pos;
+    }
+
+    static DB::NamesAndTypesList & getNamesAndTypesList()
+    {
+        static DB::NamesAndTypesList names_and_types_list{
+            {icebergDeleteFilePathColumn()->name, icebergDeleteFilePathColumn()->type},
+            {icebergDeletePosColumn()->name, icebergDeletePosColumn()->type}};
+        return names_and_types_list;
+    }
+};
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergReader.cpp
@@ -16,49 +16,55 @@
  */
 #include "IcebergReader.h"
 
+#include <Columns/FilterDescription.h>
 #include <DataTypes/DataTypeNullable.h>
-#include <Interpreters/ExpressionActions.h>
-#include <Interpreters/ExpressionAnalyzer.h>
+#include <Storages/Parquet/ParquetMeta.h>
+#include <Storages/SubstraitSource/Delta/Bitmap/DeltaDVRoaringBitmapArray.h>
 #include <Storages/SubstraitSource/iceberg/EqualityDeleteFileReader.h>
+#include <Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.h>
+#include <Common/BlockTypeUtils.h>
 
 using namespace DB;
 
 namespace local_engine::iceberg
 {
 
+
 std::unique_ptr<IcebergReader> IcebergReader::create(
     const FormatFilePtr & file_,
     const Block & to_read_header_,
     const Block & output_header_,
-    const FormatFile::InputFormatPtr & input_format_)
+    const std::function<FormatFile::InputFormatPtr(const DB::Block &)> & input_format_callback)
 {
     const auto & delete_files = file_->getFileInfo().iceberg().delete_files();
     std::map<IcebergReadOptions::FileContent, std::vector<int>> partitions;
     for (size_t i = 0; i < delete_files.size(); ++i)
         partitions[delete_files[i].filecontent()].push_back(i);
 
-    // TODO: constexpr auto position_delete = IcebergReadOptions::POSITION_DELETES;
     assert(!partitions.contains(IcebergReadOptions::DATA));
-    const auto it = partitions.find(IcebergReadOptions::EQUALITY_DELETES);
-
     const auto & context = file_->getContext();
 
-    ExpressionActionsPtr delete_expr;
-    if (it != partitions.end())
-    {
-        const auto & equality_delete_files = it->second;
-        assert(!equality_delete_files.empty());
+    DB::Block new_header = to_read_header_.cloneEmpty();
 
-        EqualityDeleteActionBuilder expressionInputs{context, to_read_header_.getNamesAndTypesList()};
-        for (auto deleteIndex : equality_delete_files)
-        {
-            const auto & delete_file = delete_files[deleteIndex];
-            if (delete_file.recordcount() > 0)
-                EqualityDeleteFileReader{context, to_read_header_, delete_file}.readDeleteValues(expressionInputs);
-        }
-        delete_expr = expressionInputs.finish();
+    /// Load POSITION_DELETES
+    const auto it_pos = partitions.find(IcebergReadOptions::POSITION_DELETES);
+    std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array;
+    if (it_pos != partitions.end())
+    {
+        assert(!ParquetVirtualMeta::hasMetaColumns(to_read_header_));
+        new_header.insert({BIGINT(), ParquetVirtualMeta::TMP_ROWINDEX});
+        delete_bitmap_array = createBitmapExpr(context, new_header, file_->getFileInfo(), delete_files, it_pos->second);
     }
-    return std::make_unique<IcebergReader>(file_, to_read_header_, output_header_, input_format_, delete_expr);
+
+    /// Load EQUALITY_DELETES
+    const auto it_equal = partitions.find(IcebergReadOptions::EQUALITY_DELETES);
+    ExpressionActionsPtr delete_expr = it_equal == partitions.end()
+        ? nullptr
+        : EqualityDeleteFileReader::createDeleteExpr(context, new_header, delete_files, it_equal->second);
+
+    assert(!ParquetVirtualMeta::hasMetaColumns(output_header_));
+    return std::make_unique<IcebergReader>(
+        file_, new_header, output_header_, input_format_callback(new_header), delete_expr, std::move(delete_bitmap_array));
 }
 
 IcebergReader::IcebergReader(
@@ -66,16 +72,21 @@ IcebergReader::IcebergReader(
     const Block & to_read_header_,
     const Block & output_header_,
     const FormatFile::InputFormatPtr & input_format_,
-    const ExpressionActionsPtr & delete_expr_)
+    const ExpressionActionsPtr & delete_expr_,
+    std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array_)
     : NormalFileReader(file_, to_read_header_, output_header_, input_format_)
     , delete_expr(delete_expr_)
     , delete_expr_column_name(EqualityDeleteActionBuilder::COLUMN_NAME)
+    , delete_bitmap_array(std::move(delete_bitmap_array_))
 {
 }
 
+IcebergReader::~IcebergReader() = default;
+
+
 Chunk IcebergReader::doPull()
 {
-    if (!delete_expr)
+    if (!delete_expr && !delete_bitmap_array)
         return NormalFileReader::doPull();
 
     while (true)
@@ -84,12 +95,68 @@ Chunk IcebergReader::doPull()
         if (chunk.getNumRows() == 0)
             return chunk;
 
-        deleteRows(chunk);
+        Block deleted_block;
+        if (delete_expr)
+            deleted_block = applyEqualityDelete(chunk);
+
+        if (delete_bitmap_array)
+        {
+            if (!delete_expr)
+            {
+                auto delete_mask = ColumnUInt8::create(chunk.getNumRows(), 1);
+                deleted_block = readHeader.cloneWithColumns(chunk.detachColumns());
+                deleted_block.insert({delete_mask->getPtr(), UINT8(), delete_expr_column_name});
+            }
+            deleted_block = applyPositionDelete(std::move(deleted_block));
+        }
+
+        chunk = filterRows(std::move(deleted_block));
 
         if (chunk.getNumRows() != 0)
+        {
+            if (ParquetVirtualMeta::hasMetaColumns(readHeader))
+            {
+                auto rows = chunk.getNumRows();
+                auto columns = chunk.detachColumns();
+                columns.pop_back();
+                chunk.setColumns(std::move(columns), rows);
+            }
             return chunk;
+        }
     }
 }
+
+Block IcebergReader::applyEqualityDelete(Chunk & chunk) const
+{
+    assert(delete_expr);
+    assert(!delete_expr_column_name.empty());
+    size_t num_rows_before_filtration = chunk.getNumRows();
+    auto columns = chunk.detachColumns();
+    Block block = readHeader.cloneWithColumns(columns);
+    delete_expr->execute(block, num_rows_before_filtration);
+    return block;
+}
+
+DB::Block IcebergReader::applyPositionDelete(DB::Block block) const
+{
+    assert(delete_bitmap_array);
+    size_t num_of_rows = block.rows();
+    size_t filter_column_position = block.getPositionByName(delete_expr_column_name);
+    size_t pos_column_position = block.getPositionByName(ParquetVirtualMeta::TMP_ROWINDEX);
+    MutableColumns mutation = block.mutateColumns();
+    auto & filter_column = assert_cast<ColumnUInt8 &>(*mutation[filter_column_position]);
+    auto & pos_column = assert_cast<ColumnInt64 &>(*mutation[pos_column_position]);
+
+    DB::ColumnInt64::Container & pos = pos_column.getData();
+    DB::ColumnUInt8::Container & filter = filter_column.getData();
+
+    for (int i = 0; i < num_of_rows; i++)
+        if (delete_bitmap_array->rb_contains(pos[i]))
+            filter[i] = 0;
+    block.setColumns(std::move(mutation));
+    return block;
+}
+
 
 namespace
 {
@@ -99,25 +166,15 @@ void removeFilterIfNeed(Columns & columns, size_t filter_column_position)
 }
 }
 
-void IcebergReader::deleteRows(Chunk & chunk) const
+DB::Chunk IcebergReader::filterRows(Block block) const
 {
+    size_t num_rows_before_filtration = block.rows();
+    auto columns = block.getColumns();
+    DataTypes types = block.getDataTypes();
+    size_t filter_column_position = block.getPositionByName(delete_expr_column_name);
+    block.clear();
+
     // filter out rows that are deleted
-    assert(delete_expr);
-    assert(!delete_expr_column_name.empty());
-
-    size_t num_rows_before_filtration = chunk.getNumRows();
-    auto columns = chunk.detachColumns();
-    DataTypes types;
-    size_t filter_column_position;
-    {
-        Block block = readHeader.cloneWithColumns(columns);
-        columns.clear();
-        delete_expr->execute(block, num_rows_before_filtration);
-        filter_column_position = block.getPositionByName(delete_expr_column_name);
-        columns = block.getColumns();
-        types = block.getDataTypes();
-    }
-
     size_t num_columns = columns.size();
     ColumnPtr filter_column = columns[filter_column_position];
 
@@ -155,15 +212,16 @@ void IcebergReader::deleteRows(Chunk & chunk) const
 
     /// If the current block is completely filtered out, let's move on to the next one.
     if (num_filtered_rows == 0)
-        return;
+        return {};
 
+    Chunk chunk;
     /// If all the rows pass through the filter.
     if (num_filtered_rows == num_rows_before_filtration)
     {
         /// No need to touch the rest of the columns.
         removeFilterIfNeed(columns, filter_column_position);
         chunk.setColumns(std::move(columns), num_rows_before_filtration);
-        return;
+        return chunk;
     }
 
     /// Filter the rest of the columns.
@@ -185,6 +243,7 @@ void IcebergReader::deleteRows(Chunk & chunk) const
 
     removeFilterIfNeed(columns, filter_column_position);
     chunk.setColumns(std::move(columns), num_filtered_rows);
+    return chunk;
 }
 
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergReader.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergReader.h
@@ -30,6 +30,7 @@ class IcebergReader final : public NormalFileReader
     DB::ExpressionActionsPtr delete_expr;
     const std::string delete_expr_column_name;
     std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array;
+    size_t start_remove_index;
 
 public:
     static std::unique_ptr<IcebergReader> create(
@@ -44,7 +45,8 @@ public:
         const DB::Block & output_header_,
         const FormatFile::InputFormatPtr & input_format_,
         const DB::ExpressionActionsPtr & delete_expr_,
-        std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array_);
+        std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array_,
+        size_t start_remove_index_);
 
     ~IcebergReader() override;
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergReader.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/IcebergReader.h
@@ -18,31 +18,42 @@
 
 #include <Storages/SubstraitSource/FileReader.h>
 
+namespace local_engine
+{
+class DeltaDVRoaringBitmapArray;
+}
+
 namespace local_engine::iceberg
 {
 class IcebergReader final : public NormalFileReader
 {
     DB::ExpressionActionsPtr delete_expr;
     const std::string delete_expr_column_name;
+    std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array;
 
 public:
     static std::unique_ptr<IcebergReader> create(
         const FormatFilePtr & file_,
         const DB::Block & to_read_header_,
         const DB::Block & output_header_,
-        const FormatFile::InputFormatPtr & input_format_);
+        const std::function<FormatFile::InputFormatPtr(const DB::Block &)> & input_format_callback);
 
     IcebergReader(
         const FormatFilePtr & file_,
         const DB::Block & to_read_header_,
         const DB::Block & output_header_,
         const FormatFile::InputFormatPtr & input_format_,
-        const DB::ExpressionActionsPtr & delete_expr_ = nullptr);
+        const DB::ExpressionActionsPtr & delete_expr_,
+        std::unique_ptr<DeltaDVRoaringBitmapArray> delete_bitmap_array_);
+
+    ~IcebergReader() override;
 
 protected:
     DB::Chunk doPull() override;
 
-    void deleteRows(DB::Chunk & chunk) const;
+    DB::Block applyEqualityDelete(DB::Chunk & chunk) const;
+    DB::Block applyPositionDelete(DB::Block block) const;
+    DB::Chunk filterRows(DB::Block block) const;
 };
 
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.cpp
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PositionalDeleteFileReader.h"
+
+#include <Functions/FunctionFactory.h>
+#include <Storages/SubstraitSource/Delta/Bitmap/DeltaDVRoaringBitmapArray.h>
+#include <Storages/SubstraitSource/iceberg/IcebergMetadataColumn.h>
+#include <Storages/SubstraitSource/iceberg/SimpleParquetReader.h>
+#include <Common/BlockTypeUtils.h>
+
+
+using namespace DB;
+
+namespace local_engine::iceberg
+{
+
+using namespace google::protobuf;
+
+
+std::unique_ptr<DeltaDVRoaringBitmapArray> createBitmapExpr(
+    const ContextPtr & context,
+    const Block & /*to_read_header*/,
+    const substraitInputFile & file_,
+    const RepeatedPtrField<substraitIcebergDeleteFile> & delete_files,
+    const std::vector<int> & position_delete_files)
+{
+    assert(!position_delete_files.empty());
+
+    std::unique_ptr<DeltaDVRoaringBitmapArray> result = std::make_unique<DeltaDVRoaringBitmapArray>(context);
+
+    for (auto deleteIndex : position_delete_files)
+    {
+        const auto & delete_file = delete_files[deleteIndex];
+        assert(delete_file.filecontent() == IcebergReadOptions::POSITION_DELETES);
+        if (delete_file.recordcount() == 0)
+            continue;
+
+        ActionsDAG actions_dag{IcebergMetadataColumn::getNamesAndTypesList()};
+        ActionsDAG::NodeRawConstPtrs filter_node;
+        {
+            ActionsDAG & actions = actions_dag;
+            const std::string Equal{"equals"};
+            auto equalBuilder = FunctionFactory::instance().get(Equal, context);
+
+            ActionsDAG::NodeRawConstPtrs args;
+            args.push_back(&actions.findInOutputs(IcebergMetadataColumn::icebergDeleteFilePathColumn()->name));
+            args.push_back(&actions.addColumn(createColumnConst<std::string>(1, file_.uri_file(), "_")));
+            filter_node.push_back(&actions.addFunction(equalBuilder, std::move(args), "__"));
+        }
+
+        auto filter = ActionsDAG::buildFilterActionsDAG(filter_node);
+
+        // Block header{{{IcebergMetadataColumn::icebergDeletePosColumn()->type, IcebergMetadataColumn::icebergDeletePosColumn()->name}}};
+        Block header{
+            {
+                {IcebergMetadataColumn::icebergDeleteFilePathColumn()->type, IcebergMetadataColumn::icebergDeleteFilePathColumn()->name},
+                {IcebergMetadataColumn::icebergDeletePosColumn()->type, IcebergMetadataColumn::icebergDeletePosColumn()->name}
+            }
+        };
+
+        SimpleParquetReader reader{context, delete_file, std::move(header), filter};
+        Block deleteBlock = reader.next();
+
+        while (deleteBlock.rows() > 0)
+        {
+            assert(deleteBlock.columns() == 2);
+            const auto * pos_column = typeid_cast<const ColumnInt64 *>(deleteBlock.getByPosition(1).column.get());
+            if (pos_column == nullptr)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected ColumnInt64 for position deletes");
+
+            const ColumnInt64::Container & vec = pos_column->getData();
+            const Int64 * pos = vec.data();
+            for (int i = 0; i < deleteBlock.rows(); i++)
+                result->rb_add(pos[i]);
+
+            deleteBlock = reader.next();
+        }
+    }
+    return result->rb_is_empty() ? nullptr : std::move(result);
+}
+
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <Interpreters/Context_fwd.h>
+#include <Storages/SubstraitSource/substrait_fwd.h>
+
+namespace local_engine
+{
+class DeltaDVRoaringBitmapArray;
+}
+namespace local_engine::iceberg
+{
+
+std::unique_ptr<DeltaDVRoaringBitmapArray> createBitmapExpr(
+    const DB::ContextPtr & context,
+    const DB::Block & /*to_read_header*/,
+    const substraitInputFile & file_,
+    const google::protobuf::RepeatedPtrField<substraitIcebergDeleteFile> & delete_files,
+    const std::vector<int> & position_delete_files);
+
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/PositionalDeleteFileReader.h
@@ -25,11 +25,29 @@ class DeltaDVRoaringBitmapArray;
 namespace local_engine::iceberg
 {
 
+
+/**
+ * @brief Creates a bitmap expression for positional delete files.
+ *
+ * This function processes the provided positional delete files and constructs a bitmap
+ * to represent the deleted positions. It reads the delete files, applies a filter, and
+ * adds the positions to a DeltaDVRoaringBitmapArray.
+ *
+ * @param context The execution context.
+ * @param data_file_header The header of the data file (unused).
+ * @param file_ The input file.
+ * @param delete_files A list of delete files.
+ * @param position_delete_files Indices of the delete files that are positional deletes.
+ * @param reader_header The block header for the reader, which may be modified if it doesn't contain row index.
+ * @return A unique pointer to a DeltaDVRoaringBitmapArray containing the deleted positions,
+ *         or nullptr if no positions are deleted.
+ */
 std::unique_ptr<DeltaDVRoaringBitmapArray> createBitmapExpr(
     const DB::ContextPtr & context,
-    const DB::Block & /*to_read_header*/,
+    const DB::Block & data_file_header,
     const substraitInputFile & file_,
     const google::protobuf::RepeatedPtrField<substraitIcebergDeleteFile> & delete_files,
-    const std::vector<int> & position_delete_files);
+    const std::vector<int> & position_delete_files,
+    DB::Block & reader_header);
 
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/SimpleParquetReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/SimpleParquetReader.cpp
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "SimpleParquetReader.h"
+#include <Formats/FormatFactory.h>
+#include <Processors/Formats/Impl/ArrowBufferedStreams.h>
+#include <Processors/Formats/Impl/Parquet/ColumnFilterHelper.h>
+#include <Processors/Formats/Impl/Parquet/ParquetReader.h>
+#include <Storages/Parquet/ParquetMeta.h>
+#include <Storages/SubstraitSource/ReadBufferBuilder.h>
+#include <Poco/URI.h>
+
+using namespace DB;
+namespace local_engine
+{
+
+namespace iceberg
+{
+substraitInputFile fromDeleteFile(const substraitIcebergDeleteFile & deleteFile)
+{
+    assert(
+        deleteFile.filecontent() == IcebergReadOptions::EQUALITY_DELETES
+        || deleteFile.filecontent() == IcebergReadOptions::POSITION_DELETES);
+    assert(deleteFile.has_parquet());
+    substraitInputFile file;
+    file.set_uri_file(deleteFile.filepath());
+    file.set_start(0);
+    file.set_length(deleteFile.filesize());
+    return file;
+}
+}
+
+SimpleParquetReader::SimpleParquetReader(
+    const ContextPtr & context, const substraitInputFile & file_info, Block header, const std::optional<ActionsDAG> & filter)
+{
+    const Poco::URI file_uri{file_info.uri_file()};
+    ReadBufferBuilderPtr read_buffer_builder = ReadBufferBuilderFactory::instance().createBuilder(file_uri.getScheme(), context);
+
+    read_buffer_arrow_ = read_buffer_builder->build(file_info);
+    FormatSettings format_settings = getFormatSettings(context);
+
+    if (!header.columns())
+    {
+        ParquetMetaBuilder metaBuilder{
+            .case_insensitive = format_settings.parquet.case_insensitive_column_matching,
+            .allow_missing_columns = false,
+            .collectPageIndex = false,
+            .collectSchema = true};
+        metaBuilder.build(*read_buffer_arrow_);
+        auto * seekable = dynamic_cast<SeekableReadBuffer *>(read_buffer_arrow_.get());
+        assert(seekable != nullptr);
+        header = std::move(metaBuilder.fileHeader);
+    }
+
+    std::shared_ptr<arrow::io::RandomAccessFile> arrow_file;
+    {
+        std::atomic<int> is_stopped{0};
+        arrow_file = asArrowFile(*read_buffer_arrow_, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES);
+    }
+
+    // TODO: set min_bytes_for_seek
+    ParquetReader::Settings settings{
+        .arrow_properties = parquet::ArrowReaderProperties(),
+        .reader_properties = parquet::ReaderProperties(ArrowMemoryPool::instance()),
+        .format_settings = format_settings};
+
+    read_buffer_reader_ = read_buffer_builder->build(file_info);
+
+    auto * seekable = dynamic_cast<SeekableReadBuffer *>(read_buffer_reader_.get());
+    assert(seekable != nullptr);
+    assert(header.columns());
+
+    reader_ = std::make_shared<ParquetReader>(std::move(header), *seekable, arrow_file, settings);
+    reader_->setSourceArrowFile(arrow_file);
+    if (filter.has_value())
+        pushFilterToParquetReader(*filter, *reader_);
+}
+
+SimpleParquetReader::SimpleParquetReader(
+    const ContextPtr & context, const substraitIcebergDeleteFile & file_info, Block header, const std::optional<ActionsDAG> & filter)
+    : SimpleParquetReader(context, iceberg::fromDeleteFile(file_info), std::move(header), filter)
+{
+}
+
+SimpleParquetReader::~SimpleParquetReader() = default;
+
+Block SimpleParquetReader::next() const
+{
+    return reader_->read();
+}
+
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/SimpleParquetReader.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/iceberg/SimpleParquetReader.h
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <Core/Block.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/Context_fwd.h>
+#include <Storages/SubstraitSource/substrait_fwd.h>
+
+namespace DB
+{
+class ReadBuffer;
+class ParquetReader;
+}
+namespace local_engine
+{
+
+namespace iceberg
+{
+substraitInputFile fromDeleteFile(const substraitIcebergDeleteFile & deleteFile);
+}
+
+class ColumnIndexRowRangesProvider;
+class VectorizedParquetRecordReader;
+
+/// we currently use VectorizedParquetRecordReader to read parquet files.
+class SimpleParquetReader
+{
+    std::unique_ptr<DB::ReadBuffer> read_buffer_arrow_;
+    std::unique_ptr<DB::ReadBuffer> read_buffer_reader_;
+    std::shared_ptr<DB::ParquetReader> reader_;
+
+public:
+    SimpleParquetReader(
+        const DB::ContextPtr & context,
+        const substraitInputFile & file_info,
+        DB::Block header = {},
+        const std::optional<DB::ActionsDAG> & filter = std::nullopt);
+    SimpleParquetReader(
+        const DB::ContextPtr & context,
+        const substraitIcebergDeleteFile & file_info,
+        DB::Block header = {},
+        const std::optional<DB::ActionsDAG> & filter = std::nullopt);
+    ~SimpleParquetReader();
+
+    DB::Block next() const;
+};
+
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/substrait_fwd.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/substrait_fwd.h
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <substrait/algebra.pb.h>
+
+namespace local_engine
+{
+using substraitInputFile = substrait::ReadRel::LocalFiles::FileOrFiles;
+using substraitIcebergDeleteFile = substrait::ReadRel::LocalFiles::FileOrFiles::IcebergReadOptions::DeleteFile;
+using IcebergReadOptions = substrait::ReadRel::LocalFiles::FileOrFiles::IcebergReadOptions;
+using FileContent = IcebergReadOptions::FileContent;
+
+}

--- a/cpp-ch/local-engine/tests/gtest_iceberge_test.cpp
+++ b/cpp-ch/local-engine/tests/gtest_iceberge_test.cpp
@@ -25,10 +25,10 @@
 #include <Storages/Output/NormalFileWriter.h>
 #include <Storages/SubstraitSource/FileReader.h>
 #include <Storages/SubstraitSource/FormatFile.h>
-#include <Storages/SubstraitSource/ParquetFormatFile.h>
 #include <Storages/SubstraitSource/ReadBufferBuilder.h>
 #include <Storages/SubstraitSource/SubstraitFileSource.h>
 #include <Storages/SubstraitSource/iceberg/EqualityDeleteFileReader.h>
+#include <Storages/SubstraitSource/iceberg/IcebergMetadataColumn.h>
 #include <gtest/gtest.h>
 #include <tests/utils/ReaderTestBase.h>
 #include <tests/utils/TempFilePath.h>
@@ -53,10 +53,176 @@ namespace local_engine::test
 class IcebergTest : public ReaderTestBase
 {
 public:
-    using substraitIcebergDeleteFile = substrait::ReadRel::LocalFiles::FileOrFiles::IcebergReadOptions::DeleteFile;
-
     static constexpr int rowCount = 20000;
-private:
+
+    std::shared_ptr<iceberg::IcebergMetadataColumn> pathColumn_ =
+    iceberg::IcebergMetadataColumn::icebergDeleteFilePathColumn();
+    std::shared_ptr<iceberg::IcebergMetadataColumn> posColumn_ =
+        iceberg::IcebergMetadataColumn::icebergDeletePosColumn();
+
+protected:
+    /// Input is like <"deleteFile1", <"dataFile1", {pos_RG1, pos_RG2,..}>,
+    /// <"dataFile2", {pos_RG1, pos_RG2,..}>
+    std::unordered_map<std::string, std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+    writePositionDeleteFiles(
+      const std::unordered_map<
+          std::string, // delete file name
+          std::multimap<
+              std::string,
+              std::vector<int64_t>>>&
+          deleteFilesForBaseDatafiles, // <base file name, delete position
+                                       // vector for all RowGroups>
+      std::map<std::string, std::shared_ptr<TempFilePath>> baseFilePaths)
+    {
+        std::unordered_map<std::string, std::pair<int64_t, std::shared_ptr<TempFilePath>>> deleteFilePaths;
+        deleteFilePaths.reserve(deleteFilesForBaseDatafiles.size());
+
+        for (const auto& deleteFile : deleteFilesForBaseDatafiles)
+        {
+            auto deleteFileName = deleteFile.first;
+            auto deleteFileContent = deleteFile.second;
+            auto deleteFilePath = TempFilePath::tmp("parquet");
+
+            std::vector<DB::Block> deleteFileVectors;
+            int64_t totalPositionsInDeleteFile = 0;
+            for (auto& deleteFileRowGroup : deleteFileContent)
+            {
+                auto baseFileName = deleteFileRowGroup.first;
+                // TODO: check baseFilePath using URI format
+                auto baseFilePath = "file://" + baseFilePaths[baseFileName]->string();
+                auto positionsInRowGroup = deleteFileRowGroup.second;
+
+                auto filePathVector = createColumn<std::string>(positionsInRowGroup.size(),
+                    [&](size_t /*row*/) { return baseFilePath; });
+                auto deletePosVector = createColumn<int64_t>(positionsInRowGroup);
+
+                DB::Block deleteFileVector {
+                    {filePathVector, pathColumn_->type, pathColumn_->name},
+                    {deletePosVector, posColumn_->type, posColumn_->name}
+                };
+
+                deleteFileVectors.push_back(deleteFileVector);
+                totalPositionsInDeleteFile += positionsInRowGroup.size();
+            }
+
+            writeToFile(deleteFilePath->string(),deleteFileVectors);
+
+            deleteFilePaths[deleteFileName] = std::make_pair(totalPositionsInDeleteFile, deleteFilePath);
+        }
+        return deleteFilePaths;
+    }
+
+    std::string getDuckDBQuery(
+      const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
+      const std::unordered_map<
+          std::string,
+          std::multimap<std::string, std::vector<int64_t>>>&
+          deleteFilesForBaseDatafiles)
+    {
+        int64_t totalNumRowsInAllBaseFiles = 0;
+        std::map<std::string, int64_t> baseFileSizes;
+        for (auto rowGroupSizesInFile : rowGroupSizesForFiles)
+        {
+            // Sum up the row counts in all RowGroups in each base file
+            baseFileSizes[rowGroupSizesInFile.first] += std::accumulate(
+                rowGroupSizesInFile.second.begin(),
+                rowGroupSizesInFile.second.end(),
+                0LL);
+            totalNumRowsInAllBaseFiles += baseFileSizes[rowGroupSizesInFile.first];
+        }
+
+        // Group the delete vectors by baseFileName
+        std::map<std::string, std::vector<std::vector<int64_t>>> deletePosVectorsForAllBaseFiles;
+
+        for (auto deleteFile : deleteFilesForBaseDatafiles)
+        {
+            auto deleteFileContent = deleteFile.second;
+            for (auto rowGroup : deleteFileContent)
+            {
+                auto baseFileName = rowGroup.first;
+                deletePosVectorsForAllBaseFiles[baseFileName].push_back(rowGroup.second);
+            }
+        }
+
+        // Flatten and deduplicate the delete position vectors in
+        // deletePosVectorsForAllBaseFiles from previous step, and count the total
+        // number of distinct delete positions for all base files
+        std::map<std::string, std::vector<int64_t>>
+            flattenedDeletePosVectorsForAllBaseFiles;
+        int64_t totalNumDeletePositions = 0;
+        for (auto deleteVectorsForBaseFile : deletePosVectorsForAllBaseFiles)
+        {
+            auto baseFileName = deleteVectorsForBaseFile.first;
+            auto deletePositionVectors = deleteVectorsForBaseFile.second;
+            std::vector<int64_t> deletePositionVector =
+                flattenAndDedup(deletePositionVectors, baseFileSizes[baseFileName]);
+            flattenedDeletePosVectorsForAllBaseFiles[baseFileName] =
+                deletePositionVector;
+            totalNumDeletePositions += deletePositionVector.size();
+        }
+
+        // Now build the DuckDB queries
+        if (totalNumDeletePositions == 0)
+        {
+            return "SELECT * FROM IcebergTest.tmp";
+        }
+        else if (totalNumDeletePositions >= totalNumRowsInAllBaseFiles)
+        {
+            return "SELECT * FROM IcebergTest.tmp WHERE 1 = 0";
+        }
+        else
+        {
+            // Convert the delete positions in all base files into column values
+            std::vector<int64_t> allDeleteValues;
+
+            int64_t numRowsInPreviousBaseFiles = 0;
+            for (auto baseFileSize : baseFileSizes)
+            {
+                auto deletePositions =
+                    flattenedDeletePosVectorsForAllBaseFiles[baseFileSize.first];
+
+                if (numRowsInPreviousBaseFiles > 0)
+                {
+                    for (int64_t& deleteValue : deletePositions)
+                    {
+                        deleteValue += numRowsInPreviousBaseFiles;
+                    }
+                }
+
+                allDeleteValues.insert(
+                    allDeleteValues.end(),
+                    deletePositions.begin(),
+                    deletePositions.end());
+
+                numRowsInPreviousBaseFiles += baseFileSize.second;
+            }
+
+            return fmt::format(
+                "SELECT * FROM IcebergTest.tmp WHERE c0 NOT IN ({})",
+                makeNotInList(allDeleteValues));
+        }
+    }
+
+
+    std::vector<int64_t> flattenAndDedup(
+        const std::vector<std::vector<int64_t>>& deletePositionVectors,
+        int64_t baseFileSize) {
+        std::vector<int64_t> deletePositionVector;
+        for (auto vec : deletePositionVectors) {
+            for (auto pos : vec) {
+                if (pos >= 0 && pos < baseFileSize) {
+                    deletePositionVector.push_back(pos);
+                }
+            }
+        }
+
+        std::sort(deletePositionVector.begin(), deletePositionVector.end());
+        auto last =
+            std::unique(deletePositionVector.begin(), deletePositionVector.end());
+        deletePositionVector.erase(last, deletePositionVector.end());
+
+        return deletePositionVector;
+    }
 
     std::string makeNotInList(const std::vector<int64_t>& deletePositionVector) {
         if (deletePositionVector.empty()) {
@@ -136,6 +302,21 @@ private:
         EXPECT_TRUE(assertEqualResults(collectResult( reader), runClickhouseSQL(duckDbSql), msg));
     }
 
+    void assertQuery(std::vector<std::unique_ptr<BaseReader>> readers, const std::string& duckDbSql) const
+    {
+        BaseReaders base_readers {
+            .readers = readers,
+        };
+
+        auto msg = fmt::format("\nExpected result from running Clickhouse sql: {}", duckDbSql);
+        auto  actual = collectResult( base_readers);
+        auto  expected = runClickhouseSQL(duckDbSql);
+        // headBlock(actual);
+        // headBlock(expected);
+        EXPECT_TRUE(assertEqualResults(actual, expected, msg));
+    }
+
+
 protected:
     std::unique_ptr<BaseReader> makeIcebergSplit(
         const std::string& dataFilePath,
@@ -159,6 +340,7 @@ protected:
     }
 
     substraitIcebergDeleteFile makeDeleteFile(
+        FileContent file_content,
         const std::string & _path,
         uint64_t _recordCount,
         uint64_t _fileSizeInBytes,
@@ -167,7 +349,7 @@ protected:
         std::unordered_map<int32_t, std::string> _upperBounds = {} )
     {
         substraitIcebergDeleteFile deleteFile;
-        deleteFile.set_filecontent(substrait::ReadRel_LocalFiles_FileOrFiles_IcebergReadOptions_FileContent_EQUALITY_DELETES);
+        deleteFile.set_filecontent(file_content);
         deleteFile.set_filepath("file://" + _path);
         deleteFile.set_recordcount(_recordCount);
         deleteFile.set_filesize(_fileSizeInBytes);
@@ -233,6 +415,164 @@ public:
         return dataFilePaths;
     }
 
+    //TODO: write multiple groups
+    std::map<std::string, std::shared_ptr<TempFilePath>>
+    writeDataFiles(const std::map<std::string, std::vector<int64_t>> & rowGroupSizesForFiles)
+    {
+        std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths;
+
+        std::vector<DB::Block> dataVectorsJoined;
+        dataVectorsJoined.reserve(rowGroupSizesForFiles.size());
+
+        int64_t startingValue = 0;
+        for (auto& dataFile : rowGroupSizesForFiles) {
+            dataFilePaths[dataFile.first] = TempFilePath::tmp("parquet");
+
+            // We make the values are continuously increasing even across base data
+            // files. This is to make constructing DuckDB queries easier
+            std::vector<DB::Block> dataVectors =
+                makeVectors(dataFile.second, startingValue);
+            writeToFile(
+                dataFilePaths[dataFile.first]->string(),
+                dataVectors,
+                true);
+
+            for (int i = 0; i < dataVectors.size(); i++) {
+                dataVectorsJoined.push_back(dataVectors[i]);
+            }
+        }
+        createDuckDbTable(dataVectorsJoined);
+        return dataFilePaths;
+    }
+
+    /// @rowGroupSizesForFiles The key is the file name, and the value is a vector
+    /// of RowGroup sizes
+    /// @deleteFilesForBaseDatafiles The key is the delete file name, and the
+    /// value contains the information about the content of this delete file.
+    /// e.g. {
+    ///         "delete_file_1",
+    ///         {
+    ///             {"data_file_1", {1, 2, 3}},
+    ///             {"data_file_1", {4, 5, 6}},
+    ///             {"data_file_2", {0, 2, 4}}
+    ///         }
+    ///     }
+    /// represents one delete file called delete_file_1, which contains delete
+    /// positions for data_file_1 and data_file_2. THere are 3 RowGroups in this
+    /// delete file, the first two contain positions for data_file_1, and the last
+    /// contain positions for data_file_2
+    void assertPositionalDeletes(
+        const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
+        const std::unordered_map<
+            std::string,
+            std::multimap<std::string, std::vector<int64_t>>>&
+            deleteFilesForBaseDatafiles,
+        int32_t numPrefetchSplits = 0)
+    {
+        // Keep the reference to the deleteFilePath, otherwise the corresponding
+        // file will be deleted.
+        std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths =
+            writeDataFiles(rowGroupSizesForFiles);
+        std::unordered_map<std::string, std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+        deleteFilePaths = writePositionDeleteFiles(
+            deleteFilesForBaseDatafiles, dataFilePaths);
+
+        std::vector<std::unique_ptr<BaseReader>> splits;
+
+        for (const auto& dataFile : dataFilePaths) {
+            std::string baseFileName = dataFile.first;
+            std::string baseFilePath = dataFile.second->string();
+
+            std::vector<substraitIcebergDeleteFile> deleteFiles;
+
+            for (auto const& deleteFile : deleteFilesForBaseDatafiles) {
+                std::string deleteFileName = deleteFile.first;
+                std::multimap<std::string, std::vector<int64_t>> deleteFileContent =
+                    deleteFile.second;
+
+                if (deleteFileContent.count(baseFileName) != 0) {
+                    // If this delete file contains rows for the target base file, then
+                    // add it to the split
+                    auto deleteFilePath =
+                        deleteFilePaths[deleteFileName].second->string();
+
+                    substraitIcebergDeleteFile icebergDeleteFile = makeDeleteFile(
+                        IcebergReadOptions::POSITION_DELETES,
+                        deleteFilePath,
+                        deleteFilePaths[deleteFileName].first,
+                        testing::internal::GetFileSize(
+                            std::fopen(deleteFilePath.c_str(), "r")));
+                    deleteFiles.push_back(icebergDeleteFile);
+                }
+            }
+
+            splits.emplace_back(makeIcebergSplit(baseFilePath, deleteFiles));
+        }
+
+        std::string duckdbSql =
+            getDuckDBQuery(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+        assertQuery(std::move(splits), duckdbSql);
+    }
+
+    /// Create 1 base data file data_file_1 with 2 RowGroups of 10000 rows each.
+    /// Also create 1 delete file delete_file_1 which contains delete positions
+    /// for data_file_1.
+    void assertSingleBaseFileSingleDeleteFile(
+        const std::vector<int64_t>& deletePositionsVec) {
+        std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
+            {"data_file_1", {10000, 10000}}};
+        std::unordered_map<
+            std::string,
+            std::multimap<std::string, std::vector<int64_t>>>
+            deleteFilesForBaseDatafiles = {
+            {"delete_file_1", {{"data_file_1", deletePositionsVec}}}};
+
+        assertPositionalDeletes(
+            rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0);
+    }
+
+    /// Create 3 base data files, where the first file data_file_0 has 500 rows,
+    /// the second file data_file_1 contains 2 RowGroups of 10000 rows each, and
+    /// the third file data_file_2 contains 500 rows. It creates 1 positional
+    /// delete file delete_file_1, which contains delete positions for
+    /// data_file_1.
+    void assertMultipleBaseFileSingleDeleteFile(
+        const std::vector<int64_t>& deletePositionsVec) {
+        int64_t previousFileRowCount = 500;
+        int64_t afterFileRowCount = 500;
+
+        assertPositionalDeletes(
+            {
+                {"data_file_0", {previousFileRowCount}},
+                {"data_file_1", {10000, 10000}},
+                {"data_file_2", {afterFileRowCount}},
+            },
+            {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
+            0);
+    }
+
+    /// Create 1 base data file data_file_1 with 2 RowGroups of 10000 rows each.
+    /// Create multiple delete files with name data_file_1, data_file_2, and so on
+    void assertSingleBaseFileMultipleDeleteFiles(
+        const std::vector<std::vector<int64_t>>& deletePositionsVecs) {
+        std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
+            {"data_file_1", {10000, 10000}}};
+
+        std::unordered_map<
+            std::string,
+            std::multimap<std::string, std::vector<int64_t>>>
+            deleteFilesForBaseDatafiles;
+        for (int i = 0; i < deletePositionsVecs.size(); i++) {
+            std::string deleteFileName = fmt::format("delete_file_{}", i);
+            deleteFilesForBaseDatafiles[deleteFileName] = {
+                {"data_file_1", deletePositionsVecs[i]}};
+        }
+        assertPositionalDeletes(
+            rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0);
+    }
+
+
     // TODO: rename duckDbSql => chDbSql
     void assertEqualityDeletes(
       const std::unordered_map<int8_t, std::vector<std::vector<int64_t>>>&
@@ -279,7 +619,8 @@ public:
 
             deleteFilePaths.push_back(writeEqualityDeleteFile(equalityDeleteVector));
             deleteFiles.push_back(
-                makeDeleteFile(deleteFilePaths.back()->string(),
+                makeDeleteFile(IcebergReadOptions::EQUALITY_DELETES,
+                    deleteFilePaths.back()->string(),
                     equalityDeleteVector[0].size(),
                     testing::internal::GetFileSize(std::fopen(deleteFilePaths.back()->string().c_str(), "r")),
                     equalityFieldIds));
@@ -319,6 +660,31 @@ public:
         // }
     }
 
+    void assertMultipleSplits(
+        const std::vector<int64_t>& deletePositions,
+        int32_t splitCount,
+        int32_t numPrefetchSplits) {
+
+        std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles;
+        for (int32_t i = 0; i < splitCount; i++) {
+            std::string dataFileName = fmt::format("data_file_{}", i);
+            rowGroupSizesForFiles[dataFileName] = {rowCount};
+        }
+
+        std::unordered_map<
+            std::string,
+            std::multimap<std::string, std::vector<int64_t>>>
+            deleteFilesForBaseDatafiles;
+        for (int i = 0; i < splitCount; i++) {
+            std::string deleteFileName = fmt::format("delete_file_{}", i);
+            deleteFilesForBaseDatafiles[deleteFileName] = {
+                {fmt::format("data_file_{}", i), deletePositions}};
+        }
+
+        assertPositionalDeletes(
+            rowGroupSizesForFiles, deleteFilesForBaseDatafiles, numPrefetchSplits);
+    }
+
     std::shared_ptr<TempFilePath> writeEqualityDeleteFile(
       const std::vector<std::vector<int64_t>>& equalityDeleteVector)
     {
@@ -331,6 +697,30 @@ public:
         auto deleteFilePath = TempFilePath::tmp("parquet");
         writeToFile(deleteFilePath->string(), DB::Block(columns));
         return deleteFilePath;
+    }
+
+    std::vector<int64_t> makeRandomIncreasingValues(int64_t begin, int64_t end) {
+        EXPECT_TRUE(begin < end);
+
+        std::mt19937 gen{0};
+        std::vector<int64_t> values;
+        values.reserve(end - begin);
+        for (int i = begin; i < end; i++) {
+            if (std::uniform_int_distribution<uint32_t>(0, 9)(gen) > 8){
+                values.push_back(i);
+            }
+        }
+        return values;
+    }
+
+    std::vector<int64_t> makeContinuousIncreasingValues(
+        int64_t begin,
+        int64_t end)
+    {
+        std::vector<int64_t> values;
+        values.resize(end - begin);
+        std::iota(values.begin(), values.end(), begin);
+        return values;
     }
 
     std::vector<int64_t> makeSequenceValues(int32_t numRows, int8_t repeat = 1)
@@ -391,22 +781,235 @@ public:
         }
         return rowVectors;
     }
+
+    std::vector<DB::Block> makeVectors(const std::vector<int64_t> & vectorSizes, int64_t& startingValue)
+    {
+        std::vector<DB::Block> vectors;
+        vectors.reserve(vectorSizes.size());
+
+        for (int j = 0; j < vectorSizes.size(); j++) {
+            auto data = makeContinuousIncreasingValues(
+                startingValue, startingValue + vectorSizes[j]);
+            vectors.emplace_back(DB::Block{createColumn(data, "c0")});
+            startingValue += vectorSizes[j];
+        }
+
+        return vectors;
+    }
 };
 
+/// This test creates one single data file and one delete file. The parameter
+/// passed to assertSingleBaseFileSingleDeleteFile is the delete positions.
+TEST_F(IcebergTest, singleBaseFileSinglePositionalDeleteFile)
+{
+    assertSingleBaseFileSingleDeleteFile({{0, 1, 2, 3}});
+    // Delete the first and last row in each batch (10000 rows per batch)
+    assertSingleBaseFileSingleDeleteFile({{0, 9999, 10000, 19999}});
+    // Delete several rows in the second batch (10000 rows per batch)
+    assertSingleBaseFileSingleDeleteFile({{10000, 10002, 19999}});
+    // Delete random rows
+    assertSingleBaseFileSingleDeleteFile({makeRandomIncreasingValues(0, 20000)});
+    // Delete 0 rows
+    assertSingleBaseFileSingleDeleteFile({});
+    // Delete all rows
+    assertSingleBaseFileSingleDeleteFile(
+        {makeContinuousIncreasingValues(0, 20000)});
+    // Delete rows that don't exist
+    assertSingleBaseFileSingleDeleteFile({{20000, 29999}});
+}
+
+/// This test creates 3 base data files, only the middle one has corresponding
+/// delete positions. The parameter passed to
+/// assertSingleBaseFileSingleDeleteFile is the delete positions.for the middle
+/// base file.
+TEST_F(IcebergTest, MultipleBaseFilesSinglePositionalDeleteFile) {
+
+    assertMultipleBaseFileSingleDeleteFile({0, 1, 2, 3});
+    assertMultipleBaseFileSingleDeleteFile({0, 9999, 10000, 19999});
+    assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
+    assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
+    assertMultipleBaseFileSingleDeleteFile(
+        makeRandomIncreasingValues(0, rowCount));
+    assertMultipleBaseFileSingleDeleteFile({});
+    assertMultipleBaseFileSingleDeleteFile(
+        makeContinuousIncreasingValues(0, rowCount));
+}
+
+/// This test creates one base data file/split with multiple delete files. The
+/// parameter passed to assertSingleBaseFileMultipleDeleteFiles is the vector of
+/// delete files. Each leaf vector represents the delete positions in that
+/// delete file.
+TEST_F(IcebergTest, singleBaseFileMultiplePositionalDeleteFiles) {
+
+    // Delete row 0, 1, 2, 3 from the first batch out of two.
+    assertSingleBaseFileMultipleDeleteFiles({{1}, {2}, {3}, {4}});
+    // Delete the first and last row in each batch (10000 rows per batch).
+    assertSingleBaseFileMultipleDeleteFiles({{0}, {9999}, {10000}, {19999}});
+
+    assertSingleBaseFileMultipleDeleteFiles({{500, 21000}});
+
+    assertSingleBaseFileMultipleDeleteFiles(
+        {makeRandomIncreasingValues(0, 10000),
+         makeRandomIncreasingValues(10000, 20000),
+         makeRandomIncreasingValues(5000, 15000)});
+
+    assertSingleBaseFileMultipleDeleteFiles(
+        {makeContinuousIncreasingValues(0, 10000),
+         makeContinuousIncreasingValues(10000, 20000)});
+
+    assertSingleBaseFileMultipleDeleteFiles(
+        {makeContinuousIncreasingValues(0, 10000),
+         makeContinuousIncreasingValues(10000, 20000),
+         makeRandomIncreasingValues(5000, 15000)});
+
+    assertSingleBaseFileMultipleDeleteFiles(
+        {makeContinuousIncreasingValues(0, 20000),
+         makeContinuousIncreasingValues(0, 20000)});
+
+    assertSingleBaseFileMultipleDeleteFiles(
+        {makeRandomIncreasingValues(0, 20000),
+         {},
+         makeRandomIncreasingValues(5000, 15000)});
+
+    assertSingleBaseFileMultipleDeleteFiles({{}, {}});
+}
+
+/// This test creates 2 base data files, and 1 or 2 delete files, with unaligned
+/// RowGroup boundaries
+TEST_F(IcebergTest, multipleBaseFileMultiplePositionalDeleteFiles) {
+
+  std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles;
+  std::unordered_map<
+      std::string,
+      std::multimap<std::string, std::vector<int64_t>>>
+      deleteFilesForBaseDatafiles;
+
+  // Create two data files, each with two RowGroups
+  rowGroupSizesForFiles["data_file_1"] = {100, 85};
+  rowGroupSizesForFiles["data_file_2"] = {99, 1};
+
+  // Delete 3 rows from the first RowGroup in data_file_1
+  deleteFilesForBaseDatafiles["delete_file_1"] = {{"data_file_1", {0, 1, 99}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete 3 rows from the second RowGroup in data_file_1
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {100, 101, 184}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete random rows from the both RowGroups in data_file_1
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeRandomIncreasingValues(0, 185)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete all rows in data_file_1
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeContinuousIncreasingValues(0, 185)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+  //
+  // Delete non-existent rows from data_file_1
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeRandomIncreasingValues(186, 300)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete several rows from both RowGroups in both data files
+  deleteFilesForBaseDatafiles.clear();
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // The delete file delete_file_1 contains 3 RowGroups itself, with the first 3
+  // deleting some repeating rows in data_file_1, and the last 2 RowGroups
+  // deleting some  repeating rows in data_file_2
+  deleteFilesForBaseDatafiles.clear();
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 1, 2, 3}},
+      {"data_file_1", {1, 2, 3, 4}},
+      {"data_file_1", makeRandomIncreasingValues(0, 185)},
+      {"data_file_2", {1, 3, 5, 7}},
+      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // delete_file_2 contains non-overlapping delete rows for each data files in
+  // each RowGroup
+  deleteFilesForBaseDatafiles.clear();
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 1, 2, 3}}, {"data_file_2", {1, 3, 5, 7}}};
+  deleteFilesForBaseDatafiles["delete_file_2"] = {
+      {"data_file_1", {1, 2, 3, 4}},
+      {"data_file_1", {98, 99, 100, 101, 184}},
+      {"data_file_2", {3, 5, 7, 9}},
+      {"data_file_2", {98, 99, 100}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Two delete files each containing overlapping delete rows for both data
+  // files
+  deleteFilesForBaseDatafiles.clear();
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeRandomIncreasingValues(0, 185)},
+      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
+  deleteFilesForBaseDatafiles["delete_file_2"] = {
+      {"data_file_1", makeRandomIncreasingValues(10, 120)},
+      {"data_file_2", makeRandomIncreasingValues(50, 100)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+}
+
+TEST_F(IcebergTest, positionalDeletesMultipleSplits)
+{
+
+    assertMultipleSplits({1, 2, 3, 4}, 10, 5);
+    assertMultipleSplits({1, 2, 3, 4}, 10, 0);
+    assertMultipleSplits({1, 2, 3, 4}, 10, 10);
+    assertMultipleSplits({0, 9999, 10000, 19999}, 10, 3);
+    assertMultipleSplits(makeRandomIncreasingValues(0, 20000), 10, 3);
+    assertMultipleSplits(makeContinuousIncreasingValues(0, 20000), 10, 3);
+    assertMultipleSplits({}, 10, 3);
+}
 
 TEST_F(IcebergTest, tmp2)
 {
-    std::shared_ptr<TempFilePath> dataFilePath =
-        writeDataFiles(rowCount, 4)[0];
 
-    runClickhouseSQL(fmt::format("select count(*) from file('{}')", dataFilePath->string()));
-    DB::Block block = runClickhouseSQL("select count(*) from IcebergTest.tmp");
-    EXPECT_TRUE(assertEqualResults(block, DB::Block{createColumn<UInt64>({rowCount}, "count()")}));
+    {
+        context_->setSetting("input_format_parquet_use_native_reader_with_filter_push_down", true);
+        std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles;
+        // Create two data files, each with two RowGroups
+        rowGroupSizesForFiles["data_file_1"] = {100, 85};
+        rowGroupSizesForFiles["data_file_2"] = {99, 1};
+
+        std::unordered_map<std::string, std::multimap<std::string, std::vector<int64_t>>> deleteFilesForBaseDatafiles;
+
+        deleteFilesForBaseDatafiles["delete_file_1"] = {
+            {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
+
+        std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths =
+            writeDataFiles(rowGroupSizesForFiles);
+
+        std::unordered_map<std::string, std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+        deleteFilePaths = writePositionDeleteFiles( deleteFilesForBaseDatafiles, dataFilePaths);
+        assert(deleteFilePaths.size() == 1);
+
+        auto x = runClickhouseSQL(fmt::format("select pos from file('{}') where file_path = 'file://{}'",
+            deleteFilePaths["delete_file_1"].second->string(), dataFilePaths["data_file_2"]->string()));
+        // auto y = runClickhouseSQL(fmt::format("select * from file('{}')",
+        //     deleteFilePaths["delete_file_1"].second->string()));
+        headBlock(x, 100 , 100);
+
+        context_->setSetting("input_format_parquet_use_native_reader_with_filter_push_down", DB::Field(false));
+    }
 
 
-    auto read = makeIcebergSplit(dataFilePath->string());
-    DB::Block actual = collectResult( *read);
-    EXPECT_TRUE(assertEqualResults( actual, runClickhouseSQL("select * from IcebergTest.tmp")));
+    {
+        std::shared_ptr<TempFilePath> dataFilePath = writeDataFiles(rowCount, 4)[0];
+
+        runClickhouseSQL(fmt::format("select count(*) from file('{}')", dataFilePath->string()));
+        DB::Block block = runClickhouseSQL("select count(*) from IcebergTest.tmp");
+        EXPECT_TRUE(assertEqualResults(block, DB::Block{createColumn<UInt64>({rowCount}, "count()")}));
+
+
+        auto read = makeIcebergSplit(dataFilePath->string());
+        DB::Block actual = collectResult( *read);
+        EXPECT_TRUE(assertEqualResults( actual, runClickhouseSQL("select * from IcebergTest.tmp")));
+    }
 }
 
 TEST_F(IcebergTest, EqualityDeleteActionBuilder)


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#8846)

Enhance Parquet and Iceberg readers to handle delete columns not in select list and support positional delete operations in Iceberg tables.

### Positional Delete Support

- **Bitmap**  
  Introduced `DeltaDVRoaringBitmapArray` for efficient position tracking:

  ```cpp
  void rb_add(Int64 x);  // Add deleted positions
  bool rb_contains(Int64 x) const;  // Check position existence
  ```

- **Reader Integration**  
  - `PositionalDeleteFileReader` processes position delete files
  - Iceberg metadata column handling:

    ```cpp
    static std::shared_ptr<IcebergMetadataColumn> icebergDeletePosColumn();
    ```

- **Filter**  
  Modified Iceberg reader to apply bitmap filters during chunk generation:
  ```cpp
  delete_bitmap_array->rb_contains(pos[i]);
  ```

###  Delete columns not in select list

Fix an issue when excuting sql like `select c0 from t ` and **Equality Delete File** contains `c1`

  - Added `collectFileSchema` in `ParquetMetaBuilder` to extract file schema
  - Append read header isf delete columns are not in select list
  - Modified `IcebergReader` to remove temporary columns after applying deletes:
  
  ```cpp
  columns.erase(columns.begin() + start_remove_index, columns.end());
  ```

## How was this patch tested?

using gtest

