### PR TITLE
[GLUTEN-7690][CORE] GlutenConfig should using SQLConf provided by SparkSession first

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHConfig.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHConfig.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.config.GlutenConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.network.util.ByteUnit
-import org.apache.spark.sql.internal.SQLConf
 
 object CHConfig {
   private[clickhouse] val BACKEND_NAME: String = "ch"
@@ -57,7 +56,7 @@ object CHConfig {
   def startWithSettingsPrefix(key: String): Boolean = key.startsWith(RUNTIME_SETTINGS)
   def removeSettingsPrefix(key: String): String = key.substring(RUNTIME_SETTINGS.length + 1)
 
-  def get: CHConfig = new CHConfig(SQLConf.get)
+  def get: CHConfig = new CHConfig()
 
   import GlutenConfig._
 
@@ -106,7 +105,7 @@ object CHConfig {
       .createWithDefault(false)
 }
 
-class CHConfig(conf: SQLConf) extends GlutenConfig(conf) {
+class CHConfig extends GlutenConfig {
   import CHConfig._
 
   def enableOnePipelineMergeTreeWrite: Boolean =

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -19,12 +19,11 @@ package org.apache.gluten.config
 import org.apache.gluten.config.GlutenConfig.{buildConf, buildStaticConf, COLUMNAR_MAX_BATCH_SIZE}
 
 import org.apache.spark.network.util.ByteUnit
-import org.apache.spark.sql.internal.SQLConf
 
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-class VeloxConfig(conf: SQLConf) extends GlutenConfig(conf) {
+class VeloxConfig extends GlutenConfig {
   import VeloxConfig._
 
   def veloxColumnarWindowType: String = getConf(COLUMNAR_VELOX_WINDOW_TYPE)
@@ -64,9 +63,7 @@ class VeloxConfig(conf: SQLConf) extends GlutenConfig(conf) {
 
 object VeloxConfig {
 
-  def get: VeloxConfig = {
-    new VeloxConfig(SQLConf.get)
-  }
+  def get: VeloxConfig = new VeloxConfig()
 
   val COLUMNAR_VELOX_WINDOW_TYPE =
     buildConf("spark.gluten.sql.columnar.backend.velox.window.type")

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/ColumnarRuleApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/ColumnarRuleApplier.scala
@@ -31,8 +31,6 @@ object ColumnarRuleApplier {
       val session: SparkSession,
       val caller: CallerInfo,
       val outputsColumnar: Boolean) {
-    val glutenConf: GlutenConfig = {
-      new GlutenConfig(session.sessionState.conf)
-    }
+    val glutenConf: GlutenConfig = new GlutenConfig(session)
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/injector/GlutenInjector.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/injector/GlutenInjector.scala
@@ -44,8 +44,8 @@ class GlutenInjector private[injector] (control: InjectorControl) {
   }
 
   private def applier(session: SparkSession): ColumnarRuleApplier = {
-    val conf = new GlutenConfig(session.sessionState.conf)
-    if (conf.enableRas) {
+    val glutenConf = new GlutenConfig(session)
+    if (glutenConf.enableRas) {
       return ras.createApplier(session)
     }
     legacy.createApplier(session)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -696,7 +696,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         )
       case t: TransformKeys =>
         // default is `EXCEPTION`
-        val mapKeyDedupPolicy = SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
+        val mapKeyDedupPolicy = conf.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
         if (mapKeyDedupPolicy == SQLConf.MapKeyDedupPolicy.LAST_WIN.toString) {
           // TODO: Remove after fix ready for
           //  https://github.com/facebookincubator/velox/issues/10219

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.config
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.{GlutenConfigUtil, SQLConf, SQLConfProvider}
 
 import com.google.common.collect.ImmutableList
@@ -33,8 +34,12 @@ case class GlutenNumaBindingInfo(
     totalCoreRange: Array[String] = null,
     numCoresPerExecutor: Int = -1) {}
 
-class GlutenConfig(conf: SQLConf) extends Logging {
+class GlutenConfig(sessionOpt: Option[SparkSession] = None) extends Logging {
   import GlutenConfig._
+
+  def this(spark: SparkSession) = this(Some(spark))
+
+  def conf: SQLConf = sessionOpt.map(_.sessionState.conf).getOrElse(SQLConf.get)
 
   private lazy val configProvider = new SQLConfProvider(conf)
 
@@ -436,9 +441,7 @@ object GlutenConfig {
   val SPARK_SHUFFLE_SPILL_COMPRESS = "spark.shuffle.spill.compress"
   val SPARK_SHUFFLE_SPILL_COMPRESS_DEFAULT: Boolean = true
 
-  def get: GlutenConfig = {
-    new GlutenConfig(SQLConf.get)
-  }
+  def get: GlutenConfig = new GlutenConfig()
 
   def prefixOf(backendName: String): String = {
     GLUTEN_CONFIG_PREFIX + backendName


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to improve `GlutenConfig` that using `SQLConf` provided by `SparkSession` first.
Please refer https://github.com/apache/spark/pull/48693

(Fixes: \#7690)

## How was this patch tested?

integration tests

