### PR TITLE
[GLUTEN-8964][VL] Support BNLJ full outer join without condition

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -556,8 +556,6 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
   override def supportCartesianProductExec(): Boolean = true
 
-  override def supportBroadcastNestedLoopJoinExec(): Boolean = true
-
   override def supportSampleExec(): Boolean = true
 
   override def supportColumnarArrowUdf(): Boolean = true
@@ -565,5 +563,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
   override def needPreComputeRangeFrameBoundary(): Boolean = true
 
   override def supportCollectLimitExec(): Boolean = true
+
+  override def broadcastNestedLoopJoinSupportsFullOuterJoin(): Boolean = true
 
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.joins.BroadcastNestedLoopJoinExec
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -1988,6 +1989,25 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
   test("support null type in aggregate") {
     runQueryAndCompare("SELECT max(null), min(null) from range(10)".stripMargin) {
       checkGlutenOperatorMatch[HashAggregateExecTransformer]
+    }
+  }
+
+  test("FullOuter in BroadcastNestLoopJoin") {
+    withTable("t1", "t2") {
+      spark.range(10).write.format("parquet").saveAsTable("t1")
+      spark.range(10).write.format("parquet").saveAsTable("t2")
+
+      // with join condition should fallback.
+      withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "1MB") {
+        runQueryAndCompare("SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.id < t2.id") {
+          checkSparkOperatorMatch[BroadcastNestedLoopJoinExec]
+        }
+
+        // without join condition should offload to gluten operator.
+        runQueryAndCompare("SELECT * FROM t1 FULL OUTER JOIN t2") {
+          checkGlutenOperatorMatch[BroadcastNestedLoopJoinExecTransformer]
+        }
+      }
     }
   }
 }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -343,6 +343,9 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     case ::substrait::CrossRel_JoinType::CrossRel_JoinType_JOIN_TYPE_LEFT:
       joinType = core::JoinType::kLeft;
       break;
+    case ::substrait::CrossRel_JoinType::CrossRel_JoinType_JOIN_TYPE_OUTER:
+      joinType = core::JoinType::kFull;
+      break;
     default:
       VELOX_NYI("Unsupported Join type: {}", std::to_string(crossRel.type()));
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1036,6 +1036,13 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::CrossRel& crossR
     case ::substrait::CrossRel_JoinType_JOIN_TYPE_INNER:
     case ::substrait::CrossRel_JoinType_JOIN_TYPE_LEFT:
       break;
+    case ::substrait::CrossRel_JoinType_JOIN_TYPE_OUTER:
+      if (crossRel.has_expression()) {
+        LOG_VALIDATION_MSG("Full outer join type with condition is not supported in CrossRel");
+        return false;
+      } else {
+        break;
+      }
     default:
       LOG_VALIDATION_MSG("Unsupported Join type in CrossRel");
       return false;

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -145,8 +145,6 @@ trait BackendSettingsApi {
 
   def supportCartesianProductExecWithCondition(): Boolean = true
 
-  def supportBroadcastNestedLoopJoinExec(): Boolean = true
-
   def supportSampleExec(): Boolean = false
 
   def supportColumnarArrowUdf(): Boolean = false
@@ -154,5 +152,7 @@ trait BackendSettingsApi {
   def needPreComputeRangeFrameBoundary(): Boolean = false
 
   def supportCollectLimitExec(): Boolean = false
+
+  def broadcastNestedLoopJoinSupportsFullOuterJoin(): Boolean = false
 
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BroadcastNestedLoopJoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BroadcastNestedLoopJoinExecTransformer.scala
@@ -169,6 +169,13 @@ abstract class BroadcastNestedLoopJoinExecTransformer(
   def validateJoinTypeAndBuildSide(): ValidationResult = {
     val result = joinType match {
       case _: InnerLike | LeftOuter | RightOuter => ValidationResult.succeeded
+      case FullOuter =>
+        if (condition.isEmpty) {
+          ValidationResult.succeeded
+        } else {
+          ValidationResult.failed(
+            s"FullOuter join with join condition is not supported with BroadcastNestedLoopJoin")
+        }
       case _ =>
         ValidationResult.failed(s"$joinType join is not supported with BroadcastNestedLoopJoin")
     }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BroadcastNestedLoopJoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BroadcastNestedLoopJoinExecTransformer.scala
@@ -169,7 +169,8 @@ abstract class BroadcastNestedLoopJoinExecTransformer(
   def validateJoinTypeAndBuildSide(): ValidationResult = {
     val result = joinType match {
       case _: InnerLike | LeftOuter | RightOuter => ValidationResult.succeeded
-      case FullOuter =>
+      case FullOuter
+          if BackendsApiManager.getSettings.broadcastNestedLoopJoinSupportsFullOuterJoin() =>
         if (condition.isEmpty) {
           ValidationResult.succeeded
         } else {

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
@@ -144,7 +144,7 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
         // FULL JOIN && t1Size < t2Size => BuildLeft
         assertJoinBuildSide("SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 FULL JOIN t2", bl, BuildLeft)
         // FULL OUTER && t1Size < t2Size => BuildLeft
-        assertJoinBuildSide("SELECT * FROM t1 FULL OUTER JOIN t2", bl, BuildLeft)
+        assertJoinBuildSide("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.key < t2.key", bl, BuildLeft)
         // LEFT JOIN => BuildRight
         assertJoinBuildSide("SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 LEFT JOIN t2", blt, BuildRight)
         // RIGHT JOIN => BuildLeft
@@ -156,10 +156,13 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
         // INNER JOIN && broadcast(t2) => BuildRight
         assertJoinBuildSide("SELECT /*+ MAPJOIN(t2) */ * FROM t1 JOIN t2", blt, BuildRight)
         // FULL OUTER && broadcast(t1) => BuildLeft
-        assertJoinBuildSide("SELECT /*+ MAPJOIN(t1) */ * FROM t1 FULL OUTER JOIN t2", bl, BuildLeft)
+        assertJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t1) */ * FROM t1 FULL OUTER JOIN t2 on t1.key < t2.key",
+          bl,
+          BuildLeft)
         // FULL OUTER && broadcast(t2) => BuildRight
         assertJoinBuildSide(
-          "SELECT /*+ MAPJOIN(t2) */ * FROM t1 FULL OUTER JOIN t2",
+          "SELECT /*+ MAPJOIN(t2) */ * FROM t1 FULL OUTER JOIN t2 on t1.key < t2.key",
           bl,
           BuildRight)
         // LEFT JOIN && broadcast(t1) => BuildLeft
@@ -193,8 +196,11 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
       /* ######## test cases for non-equal join ######### */
       withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "true") {
         // For full outer join, prefer to broadcast the smaller side.
-        assertJoinBuildSide("SELECT * FROM t1 FULL OUTER JOIN t2", bl, BuildLeft)
-        assertJoinBuildSide("SELECT * FROM t2 FULL OUTER JOIN t1", bl, BuildRight)
+        assertJoinBuildSide("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.key < t2.key", bl, BuildLeft)
+        assertJoinBuildSide(
+          "SELECT * FROM t2 FULL OUTER JOIN t1 on t1.key < t2.key",
+          bl,
+          BuildRight)
 
         // For inner join, prefer to broadcast the smaller side, if broadcast-able.
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> (t2Size + 1).toString()) {

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
@@ -142,9 +142,12 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
         // INNER JOIN && t1Size < t2Size => BuildLeft
         assertJoinBuildSide("SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 JOIN t2", blt, BuildLeft)
         // FULL JOIN && t1Size < t2Size => BuildLeft
-        assertJoinBuildSide("SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 FULL JOIN t2", bl, BuildLeft)
+        assertJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 FULL JOIN t2 ON t1.key < t2.key",
+          bl,
+          BuildLeft)
         // FULL OUTER && t1Size < t2Size => BuildLeft
-        assertJoinBuildSide("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.key < t2.key", bl, BuildLeft)
+        assertJoinBuildSide("SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.key < t2.key", bl, BuildLeft)
         // LEFT JOIN => BuildRight
         assertJoinBuildSide("SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 LEFT JOIN t2", blt, BuildRight)
         // RIGHT JOIN => BuildLeft

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -114,13 +114,14 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       spark.range(10).write.format("parquet").saveAsTable("t1")
       spark.range(10).write.format("parquet").saveAsTable("t2")
 
-      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2")
+      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.id < t2.id")
       val execution = glutenStore.execution(id)
       if (BackendTestUtils.isVeloxBackendLoaded()) {
         assert(execution.get.numFallbackNodes == 1)
         assert(
           execution.get.fallbackNodeToReason.head._2
-            .contains("FullOuter join is not supported with BroadcastNestedLoopJoin"))
+            .contains(
+              "FullOuter join with join condition is not supported with BroadcastNestedLoopJoin"))
       } else {
         assert(execution.get.numFallbackNodes == 0)
       }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.GlutenBuildInfo
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.events.GlutenPlanFallbackEvent
 import org.apache.gluten.execution.FileSourceScanExecTransformer
-import org.apache.gluten.utils.BackendTestUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -114,17 +114,9 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       spark.range(10).write.format("parquet").saveAsTable("t1")
       spark.range(10).write.format("parquet").saveAsTable("t2")
 
-      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.id < t2.id")
+      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2")
       val execution = glutenStore.execution(id)
-      if (BackendTestUtils.isVeloxBackendLoaded()) {
-        assert(execution.get.numFallbackNodes == 1)
-        assert(
-          execution.get.fallbackNodeToReason.head._2
-            .contains(
-              "FullOuter join with join condition is not supported with BroadcastNestedLoopJoin"))
-      } else {
-        assert(execution.get.numFallbackNodes == 0)
-      }
+      execution.get.numFallbackNodes == 0
     }
 
     // [GLUTEN-4119] Skip add ReusedExchange to fallback node

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -115,14 +115,10 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       spark.range(10).write.format("parquet").saveAsTable("t1")
       spark.range(10).write.format("parquet").saveAsTable("t2")
 
-      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.id < t2.id")
+      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2")
       val execution = glutenStore.execution(id)
       if (BackendTestUtils.isVeloxBackendLoaded()) {
-        assert(execution.get.numFallbackNodes == 1)
-        assert(
-          execution.get.fallbackNodeToReason.head._2
-            .contains(
-              "FullOuter join with join condition is not supported with BroadcastNestedLoopJoin"))
+        assert(execution.get.numFallbackNodes == 0)
       } else {
         assert(execution.get.numFallbackNodes == 2)
       }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -115,13 +115,14 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       spark.range(10).write.format("parquet").saveAsTable("t1")
       spark.range(10).write.format("parquet").saveAsTable("t2")
 
-      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2")
+      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.id < t2.id")
       val execution = glutenStore.execution(id)
       if (BackendTestUtils.isVeloxBackendLoaded()) {
         assert(execution.get.numFallbackNodes == 1)
         assert(
           execution.get.fallbackNodeToReason.head._2
-            .contains("FullOuter join is not supported with BroadcastNestedLoopJoin"))
+            .contains(
+              "FullOuter join with join condition is not supported with BroadcastNestedLoopJoin"))
       } else {
         assert(execution.get.numFallbackNodes == 2)
       }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -115,14 +115,10 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       spark.range(10).write.format("parquet").saveAsTable("t1")
       spark.range(10).write.format("parquet").saveAsTable("t2")
 
-      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.id < t2.id")
+      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2")
       val execution = glutenStore.execution(id)
       if (BackendTestUtils.isVeloxBackendLoaded()) {
-        assert(execution.get.numFallbackNodes == 1)
-        assert(
-          execution.get.fallbackNodeToReason.head._2
-            .contains(
-              "FullOuter join with join condition is not supported with BroadcastNestedLoopJoin"))
+        assert(execution.get.numFallbackNodes == 0)
       } else {
         assert(execution.get.numFallbackNodes == 2)
       }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -115,13 +115,14 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait with AdaptiveSparkPlanHelp
       spark.range(10).write.format("parquet").saveAsTable("t1")
       spark.range(10).write.format("parquet").saveAsTable("t2")
 
-      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2")
+      val id = runExecution("SELECT * FROM t1 FULL OUTER JOIN t2 on t1.id < t2.id")
       val execution = glutenStore.execution(id)
       if (BackendTestUtils.isVeloxBackendLoaded()) {
         assert(execution.get.numFallbackNodes == 1)
         assert(
           execution.get.fallbackNodeToReason.head._2
-            .contains("FullOuter join is not supported with BroadcastNestedLoopJoin"))
+            .contains(
+              "FullOuter join with join condition is not supported with BroadcastNestedLoopJoin"))
       } else {
         assert(execution.get.numFallbackNodes == 2)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, BroadcastNestedLoopJoin doesn't support full outer join. That's because in velox/presto, it supposed that the probe side and build side(broadcast side) are all in one worker, so that it can output mismatch records from build side.

But for spark, the probe side are distributed across different executors, so that velox cann't recognize the mismatch records from build side.
But if the join condition is empty (which is usually the case where BroadcastedNestedLoopJoin take effect), there is no need to output mismatch records. 



(Fixes: \#8964)

## How was this patch tested?

UT and manually
