### PR TITLE
[GLUTEN-8981][VL] Add vcpkg triplet for building Gluten on arm

### DIFF
--- a/dev/package-vcpkg.sh
+++ b/dev/package-vcpkg.sh
@@ -33,6 +33,11 @@ if [ "$LINUX_OS" == "centos" ]; then
   fi
 fi
 
+if [ "$ARCH" = "aarch64" ]; then
+  export VCPKG_FORCE_SYSTEM_BINARIES=1
+  export CPU_TARGET="aarch64"
+fi
+
 
 # build gluten with velox backend, prompt always respond y
 export PROMPT_ALWAYS_RESPOND=y

--- a/dev/vcpkg/env.sh
+++ b/dev/vcpkg/env.sh
@@ -10,7 +10,7 @@ SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 export VCPKG_ROOT="$SCRIPT_ROOT/.vcpkg"
 export VCPKG="$SCRIPT_ROOT/.vcpkg/vcpkg"
-export VCPKG_TRIPLET=$([ "${CPU_TARGET:-}" = "aarch64" ] && echo "arm64-linux-release" || echo "x64-linux-avx")
+export VCPKG_TRIPLET=$([ "${CPU_TARGET:-}" = "aarch64" ] && echo "arm64-linux-neon" || echo "x64-linux-avx")
 export VCPKG_TRIPLET_INSTALL_DIR=${SCRIPT_ROOT}/vcpkg_installed/${VCPKG_TRIPLET}
 
 ${SCRIPT_ROOT}/init.sh "$@"

--- a/dev/vcpkg/triplets/arm64-linux-neon.cmake
+++ b/dev/vcpkg/triplets/arm64-linux-neon.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux) 
+
+set(VCPKG_C_FLAGS "-march=armv8-a+crc ")
+set(VCPKG_CXX_FLAGS "-march=armv8-a+crc -std=c++17 ")
+set(VCPKG_LINKER_FLAGS "-static-libstdc++ -static-libgcc")

--- a/dev/vcpkg/triplets/arm64-linux-neon.cmake
+++ b/dev/vcpkg/triplets/arm64-linux-neon.cmake
@@ -3,8 +3,8 @@ set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 
-set(VCPKG_CMAKE_SYSTEM_NAME Linux) 
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 
-set(VCPKG_C_FLAGS "-march=armv8-a+crc ")
-set(VCPKG_CXX_FLAGS "-march=armv8-a+crc -std=c++17 ")
+set(VCPKG_C_FLAGS "-march=armv8-a+crc")
+set(VCPKG_CXX_FLAGS "-march=armv8-a+crc -std=c++17")
 set(VCPKG_LINKER_FLAGS "-static-libstdc++ -static-libgcc")


### PR DESCRIPTION

## What changes were proposed in this pull request?

fixed #8981

And fixed “Environment variable VCPKG_FORCE_SYSTEM_BINARIES” warning

You only need to execute package-vcpkg.sh to complete the compilation of the corresponding platform


## How was this patch tested?

in arm platform， you can execute the package-vcpkg.sh like this:
./dev/package-vcpkage.sh

 To execute package-vcpkg.sh to compile the dependency libraries in vcpkg.json and vcpkg-tool。
 "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm, s390x, ppc64le and riscv platforms" is not displayed.

i build it on my local pc（cpu：m1pro ； centos7 docker）. i will show the logs :

<img width="982" alt="compare-faile" src="https://github.com/user-attachments/assets/a2d52897-abcb-437a-a883-6625ecb035f7" />
<img width="1078" alt="compare-ok" src="https://github.com/user-attachments/assets/e398f8b1-e226-4db9-9742-1a61a7044a3b" />
