### PR TITLE
[CORE] Avoid ClassNotFoundException when loading a shaded protobuf class

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -270,7 +270,7 @@ private[gluten] class GlutenExecutorPlugin extends ExecutorPlugin {
 
   /** Initialize the executor plugin. */
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
-    CodedInputStreamClassInitializer
+    CodedInputStreamClassInitializer.modifyDefaultRecursionLimitUnsafe
     // Initialize Backend.
     Component.sorted().foreach(_.onExecutorStart(ctx))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up fix for #8904. This exception can happen in maven test due to the class we are loading is shaded in final package phase.

## How was this patch tested?

No such exception printed in CI test.
