### PR TITLE
[GLUTEN-9019][VL] Add a check to fall back "cast decimal to timestamp"

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -263,6 +263,11 @@ bool SubstraitToVeloxPlanValidator::isAllowedCast(const TypePtr& fromType, const
 
   // Limited support for X to Timestamp.
   if (toType->isTimestamp()) {
+    if (fromType->isDecimal()) {
+      // Decimal to Timestamp is not supported.
+      LOG_VALIDATION_MSG("Casting from " + fromType->toString() + " to TIMESTAMP is not supported.");
+      return false;
+    }
     if (fromType->isDate()) {
       return true;
     }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -266,4 +266,14 @@ class GlutenCastSuite extends CastSuiteBase with GlutenTestsTrait {
         }
     }
   }
+
+  testGluten("cast decimal to timestamp") {
+    val tz = TimeZone.getTimeZone(TimeZone.getDefault.getID)
+    val c = Calendar.getInstance(tz)
+    c.set(2015, 0, 1, 0, 0, 0)
+    c.set(Calendar.MILLISECOND, 123)
+    val d = Decimal(c.getTimeInMillis.toDouble / 1000)
+    checkEvaluation(cast(d, TimestampType), new Timestamp(c.getTimeInMillis))
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

velox does not support cast decimal to timestamp.

The `isInteger()` check in velox returns true for decimal type.

Fixes: #9019

## How was this patch tested?

added unit test

