### PR TITLE
[GLUTEN-8872][CH][Part-3] Fix reading bug for the update operation with the deletion vectors

### DIFF
--- a/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/gluten/delta/GlutenDeltaParquetDeletionVectorSuite.scala
+++ b/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/gluten/delta/GlutenDeltaParquetDeletionVectorSuite.scala
@@ -233,9 +233,6 @@ class GlutenDeltaParquetDeletionVectorSuite
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_delta_parquet_upsert_dv;
                  |""".stripMargin)
-    spark.sql(s"""
-                 |DROP TABLE IF EXISTS lineitem_delta_parquet_upsert_dv;
-                 |""".stripMargin)
 
     spark.sql(s"""
                  |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_upsert_dv

--- a/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/gluten/delta/GlutenDeltaParquetDeletionVectorSuite.scala
+++ b/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/gluten/delta/GlutenDeltaParquetDeletionVectorSuite.scala
@@ -94,20 +94,20 @@ class GlutenDeltaParquetDeletionVectorSuite
                  | select /*+ REPARTITION(6) */ * from lineitem
                  |""".stripMargin)
 
-    val df1 = spark.sql(s"""
-                           | delete from lineitem_delta_parquet_delete_dv
-                           | where mod(l_orderkey, 3) = 1 and l_orderkey < 100
-                           |""".stripMargin)
+    spark.sql(s"""
+                 | delete from lineitem_delta_parquet_delete_dv
+                 | where l_orderkey = 3
+                 |""".stripMargin)
+
     spark.sql(s"""
                  |set spark.gluten.enabled=true;
                  |""".stripMargin)
-
     val df = spark.sql(s"""
                           | select sum(l_linenumber) from lineitem_delta_parquet_delete_dv
                           |""".stripMargin)
     val result = df.collect()
     assert(
-      result.apply(0).get(0) === 1802335
+      result.apply(0).get(0) === 1802425
     )
     val scanExec = collect(df.queryExecution.executedPlan) {
       case f: FileSourceScanExecTransformer => f
@@ -123,16 +123,61 @@ class GlutenDeltaParquetDeletionVectorSuite
     spark.sql(s"""
                  | delete from lineitem_delta_parquet_delete_dv where mod(l_orderkey, 3) = 2
                  |""".stripMargin)
+
     spark.sql(s"""
                  |set spark.gluten.enabled=true;
                  |""".stripMargin)
-
     val df3 = spark.sql(s"""
                            | select sum(l_linenumber) from lineitem_delta_parquet_delete_dv
                            |""".stripMargin)
     assert(
-      df3.collect().apply(0).get(0) === 1200560
+      df3.collect().apply(0).get(0) === 1200650
     )
+  }
+
+  test("test parquet table delete + update with the delta DV") {
+    spark.sql(s"""
+                 |set spark.gluten.enabled=false;
+                 |""".stripMargin)
+    spark.sql(s"""
+                 |DROP TABLE IF EXISTS lineitem_delta_parquet_update_dv;
+                 |""".stripMargin)
+
+    spark.sql(s"""
+                 |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_update_dv
+                 |($q1SchemaString)
+                 |USING delta
+                 |TBLPROPERTIES (delta.enableDeletionVectors='true')
+                 |LOCATION '$basePath/lineitem_delta_parquet_update_dv'
+                 |""".stripMargin)
+
+    spark.sql(s"""
+                 | insert into table lineitem_delta_parquet_update_dv
+                 | select * from lineitem
+                 |""".stripMargin)
+
+    spark.sql(
+      s"""
+         | update lineitem_delta_parquet_update_dv set l_returnflag = 'AAA' where l_orderkey < 200
+         |""".stripMargin)
+
+    spark.sql(s"""
+                 |set spark.gluten.enabled=true;
+                 |""".stripMargin)
+    val df =
+      spark.sql(s"""
+                   | select sum(l_linenumber)
+                   | from lineitem_delta_parquet_update_dv
+                   | where l_returnflag = 'AAA'
+                   |""".stripMargin)
+    val result = df.collect()
+    assert(
+      result.apply(0).get(0) === 662
+    )
+    val scanExec = collect(df.queryExecution.executedPlan) {
+      case f: FileSourceScanExecTransformer => f
+    }
+    assert(scanExec.nonEmpty)
   }
 
   test("test parquet partition table delete with the delta DV") {
@@ -158,14 +203,14 @@ class GlutenDeltaParquetDeletionVectorSuite
                    | select /*+ REPARTITION(6) */ * from lineitem
                    |""".stripMargin)
 
-      val df1 = spark.sql(s"""
-                             | delete from lineitem_delta_partition_parquet_delete_dv
-                             | where mod(l_orderkey, 3) = 1
-                             |""".stripMargin)
+      spark.sql(s"""
+                   | delete from lineitem_delta_partition_parquet_delete_dv
+                   | where mod(l_orderkey, 3) = 1
+                   |""".stripMargin)
+
       spark.sql(s"""
                    |set spark.gluten.enabled=true;
                    |""".stripMargin)
-
       val df =
         spark.sql(s"""
                      | select sum(l_linenumber) from lineitem_delta_partition_parquet_delete_dv
@@ -179,6 +224,99 @@ class GlutenDeltaParquetDeletionVectorSuite
       }
       assert(scanExec.nonEmpty)
     }
+  }
+
+  test("test parquet table upsert with the delta DV") {
+    spark.sql(s"""
+                 |set spark.gluten.enabled=false;
+                 |""".stripMargin)
+    spark.sql(s"""
+                 |DROP TABLE IF EXISTS lineitem_delta_parquet_upsert_dv;
+                 |""".stripMargin)
+    spark.sql(s"""
+                 |DROP TABLE IF EXISTS lineitem_delta_parquet_upsert_dv;
+                 |""".stripMargin)
+
+    spark.sql(s"""
+                 |CREATE TABLE IF NOT EXISTS lineitem_delta_parquet_upsert_dv
+                 |($q1SchemaString)
+                 |USING delta
+                 |TBLPROPERTIES (delta.enableDeletionVectors='true')
+                 |LOCATION '$basePath/lineitem_delta_parquet_upsert_dv'
+                 |""".stripMargin)
+
+    spark.sql(s"""
+                 | insert into table lineitem_delta_parquet_upsert_dv
+                 | select * from lineitem
+                 |""".stripMargin)
+
+    spark.sql(s"""
+                 |set spark.gluten.enabled=true;
+                 |""".stripMargin)
+    val df0 = spark.sql(s"""
+                           | select sum(l_linenumber) from lineitem_delta_parquet_upsert_dv
+                           |""".stripMargin)
+    assert(
+      df0.collect().apply(0).get(0) === 1802446
+    )
+    upsertSourceTableAndCheck("lineitem_delta_parquet_upsert_dv")
+  }
+
+  private def upsertSourceTableAndCheck(tableName: String) = {
+    spark.sql(s"""
+                 |set spark.gluten.enabled=false;
+                 |""".stripMargin)
+    // Why selecting l_orderkey having count(*) =1 ?
+    // Answer: to avoid "org.apache.spark.sql.delta.DeltaUnsupportedOperationException:
+    // Cannot perform Merge as multiple source rows matched and attempted to modify the same
+    // target row in the Delta table in possibly conflicting ways."
+    spark.sql(s"""
+          merge into $tableName
+          using (
+
+            select l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax,
+           'Z' as `l_returnflag`,
+            l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+            from lineitem where l_orderkey in (select l_orderkey from lineitem group by l_orderkey having count(*) =1 ) and l_orderkey < 100000
+
+            union
+
+            select l_orderkey + 10000000,
+            l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag,
+            l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment
+            from lineitem where l_orderkey in (select l_orderkey from lineitem group by l_orderkey having count(*) =1 ) and l_orderkey < 100000
+
+          ) as updates
+          on updates.l_orderkey = $tableName.l_orderkey
+          when matched then update set *
+          when not matched then insert *
+          """.stripMargin)
+
+    spark.sql(s"""
+                 |set spark.gluten.enabled=true;
+                 |""".stripMargin)
+    val df1 = spark.sql(s"""
+                           | select sum(l_linenumber) from $tableName
+                           |""".stripMargin)
+    assert(
+      df1.collect().apply(0).get(0) === 1805952
+    )
+
+    val df2 =
+      spark.sql(s"""
+                   | select count(*) from $tableName where l_returnflag = 'Z'
+                   |""".stripMargin)
+    assert(
+      df2.collect().apply(0).get(0) === 3506
+    )
+
+    val df3 =
+      spark.sql(s"""
+                   | select count(*) from $tableName where l_orderkey > 10000000
+                   |""".stripMargin)
+    assert(
+      df3.collect().apply(0).get(0) === 3506
+    )
   }
 }
 // scalastyle:off line.size.limit

--- a/cpp-ch/local-engine/Storages/SubstraitSource/Delta/DeltaReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/Delta/DeltaReader.cpp
@@ -22,6 +22,14 @@
 #include <Storages/Parquet/ParquetMeta.h>
 #include <Storages/SubstraitSource/Delta/DeltaParquetMeta.h>
 
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+}
+
 using namespace DB;
 
 namespace local_engine::delta
@@ -35,25 +43,29 @@ std::unique_ptr<DeltaReader> DeltaReader::create(
     const String & row_index_ids_encoded,
     const String & row_index_filter_type)
 {
-    assert(row_index_filter_type == DeltaDVBitmapConfig::DELTA_ROW_INDEX_FILTER_TYPE_IF_CONTAINED);
+    std::shared_ptr<DeltaDVBitmapConfig> bitmap_config_;
+    if (!row_index_ids_encoded.empty() && !row_index_filter_type.empty())
+    {
+        if (row_index_filter_type != DeltaDVBitmapConfig::DELTA_ROW_INDEX_FILTER_TYPE_IF_CONTAINED)
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Row index filter type does not support : {}", row_index_filter_type);
 
-    auto bitmap_config_ = std::make_shared<DeltaDVBitmapConfig>();
-    rapidjson::Document doc;
-    doc.Parse(row_index_ids_encoded.c_str());
-    assert(!doc.HasParseError());
-    if (doc.HasMember("storageType") && doc["storageType"].IsString())
-        bitmap_config_->storage_type = doc["storageType"].GetString();
-    if (doc.HasMember("pathOrInlineDv") && doc["pathOrInlineDv"].IsString())
-        bitmap_config_->path_or_inline_dv = doc["pathOrInlineDv"].GetString();
-    if (doc.HasMember("offset") && doc["offset"].IsInt())
-        bitmap_config_->offset = doc["offset"].GetInt();
-    if (doc.HasMember("sizeInBytes") && doc["sizeInBytes"].IsInt())
-        bitmap_config_->size_in_bytes = doc["sizeInBytes"].GetInt();
-    if (doc.HasMember("cardinality") && doc["cardinality"].IsInt64())
-        bitmap_config_->cardinality = doc["cardinality"].GetInt64();
-    if (doc.HasMember("maxRowIndex") && doc["maxRowIndex"].IsInt64())
-        bitmap_config_->max_row_index = doc["maxRowIndex"].GetInt64();
-
+        bitmap_config_ = std::make_shared<DeltaDVBitmapConfig>();
+        rapidjson::Document doc;
+        doc.Parse(row_index_ids_encoded.c_str());
+        assert(!doc.HasParseError());
+        if (doc.HasMember("storageType") && doc["storageType"].IsString())
+            bitmap_config_->storage_type = doc["storageType"].GetString();
+        if (doc.HasMember("pathOrInlineDv") && doc["pathOrInlineDv"].IsString())
+            bitmap_config_->path_or_inline_dv = doc["pathOrInlineDv"].GetString();
+        if (doc.HasMember("offset") && doc["offset"].IsInt())
+            bitmap_config_->offset = doc["offset"].GetInt();
+        if (doc.HasMember("sizeInBytes") && doc["sizeInBytes"].IsInt())
+            bitmap_config_->size_in_bytes = doc["sizeInBytes"].GetInt();
+        if (doc.HasMember("cardinality") && doc["cardinality"].IsInt64())
+            bitmap_config_->cardinality = doc["cardinality"].GetInt64();
+        if (doc.HasMember("maxRowIndex") && doc["maxRowIndex"].IsInt64())
+            bitmap_config_->max_row_index = doc["maxRowIndex"].GetInt64();
+    }
     return std::make_unique<DeltaReader>(file_, to_read_header_, output_header_, input_format_, bitmap_config_);
 }
 
@@ -66,15 +78,15 @@ DeltaReader::DeltaReader(
     : NormalFileReader(file_, to_read_header_, output_header_, input_format_)
     , bitmap_config(bitmap_config_)
 {
-    bitmap_array = std::make_unique<DeltaDVRoaringBitmapArray>(file->getContext());
-    bitmap_array->rb_read(bitmap_config->path_or_inline_dv, bitmap_config->offset, bitmap_config->size_in_bytes);
+    if (bitmap_config)
+    {
+        bitmap_array = std::make_unique<DeltaDVRoaringBitmapArray>(file->getContext());
+        bitmap_array->rb_read(bitmap_config->path_or_inline_dv, bitmap_config->offset, bitmap_config->size_in_bytes);
+    }
 }
 
 Chunk DeltaReader::doPull()
 {
-    if (!bitmap_array)
-        return NormalFileReader::doPull();
-
     while (true)
     {
         Chunk chunk = NormalFileReader::doPull();
@@ -90,20 +102,27 @@ Chunk DeltaReader::doPull()
 
 void DeltaReader::deleteRowsByDV(Chunk & chunk) const
 {
-    assert(bitmap_array);
     size_t num_rows = chunk.getNumRows();
     size_t deleted_row_pos = readHeader.getPositionByName(DeltaParquetVirtualMeta::DELTA_INTERNAL_IS_ROW_DELETED);
-    size_t tmp_row_id_pos_output = readHeader.getPositionByName(ParquetVirtualMeta::TMP_ROWINDEX);
     DB::DataTypePtr deleted_row_type = DeltaParquetVirtualMeta::getMetaColumnType(readHeader);
-    size_t tmp_row_id_pos = chunk.getNumColumns() - 1;
-    if (tmp_row_id_pos_output < tmp_row_id_pos)
-        tmp_row_id_pos = tmp_row_id_pos_output;
-
     auto deleted_row_column_nest = DB::ColumnInt8::create(num_rows);
     auto & vec = deleted_row_column_nest->getData();
 
-    for (int i = 0; i < num_rows; i++)
-        vec[i] = bitmap_array->rb_contains(chunk.getColumns()[tmp_row_id_pos]->get64(i));
+    if (bitmap_array)
+    {
+        size_t tmp_row_id_pos_output = readHeader.getPositionByName(ParquetVirtualMeta::TMP_ROWINDEX);
+        size_t tmp_row_id_pos = chunk.getNumColumns() - 1;
+        if (tmp_row_id_pos_output < tmp_row_id_pos)
+            tmp_row_id_pos = tmp_row_id_pos_output;
+        for (int i = 0; i < num_rows; i++)
+            vec[i] = bitmap_array->rb_contains(chunk.getColumns()[tmp_row_id_pos]->get64(i));
+    }
+    else
+    {
+        // the bitmap array is null, set the values of the '__delta_internal_is_row_deleted' column to the false
+        for (int i = 0; i < num_rows; i++)
+            vec[i] = false;
+    }
 
     DB::ColumnPtr deleted_row_column;
     if (deleted_row_type->isNullable())

--- a/cpp-ch/local-engine/Storages/SubstraitSource/Delta/DeltaReader.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/Delta/DeltaReader.cpp
@@ -52,7 +52,8 @@ std::unique_ptr<DeltaReader> DeltaReader::create(
         bitmap_config_ = std::make_shared<DeltaDVBitmapConfig>();
         rapidjson::Document doc;
         doc.Parse(row_index_ids_encoded.c_str());
-        assert(!doc.HasParseError());
+        if (doc.HasParseError())
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid JSON in row_index_ids_encoded: {}", doc.GetParseError());
         if (doc.HasMember("storageType") && doc["storageType"].IsString())
             bitmap_config_->storage_type = doc["storageType"].GetString();
         if (doc.HasMember("pathOrInlineDv") && doc["pathOrInlineDv"].IsString())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix reading bug for the update operation with the deletion vectors: 
Add the '__delta_internal_is_row_deleted' column even if there is no DV for the parquet files

(Fixes: #8872)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

