### PR TITLE
[VL] Move hudi test package to org.apache.gluten.execution

### DIFF
--- a/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxHudiSuite.scala
+++ b/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxHudiSuite.scala
@@ -16,6 +16,4 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.execution.HudiSuite
-
 class VeloxHudiSuite extends HudiSuite {}

--- a/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxHudiSuite.scala
+++ b/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxHudiSuite.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.execution
+package org.apache.gluten.execution
 
 import org.apache.gluten.execution.HudiSuite
 

--- a/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxTPCHHudiSuite.scala
+++ b/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxTPCHHudiSuite.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.execution.VeloxTPCHSuite
 import org.apache.spark.SparkConf
 
 import java.io.File

--- a/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxTPCHHudiSuite.scala
+++ b/backends-velox/src-hudi/test/scala/org/apache/gluten/execution/VeloxTPCHHudiSuite.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.execution
+package org.apache.gluten.execution
 
 import org.apache.gluten.execution.VeloxTPCHSuite
 import org.apache.spark.SparkConf


### PR DESCRIPTION
## What changes were proposed in this pull request?
The package name for the `src-hudi/test` in velox-backend is missing "gluten."

## How was this patch tested?
N/A

