### PR TITLE
[TEST] Remove useless param for runAndCompare

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseExcelFormatSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseExcelFormatSuite.scala
@@ -208,11 +208,11 @@ class GlutenClickHouseExcelFormatSuite
       "select * from filter_timestamp where account_time = timestamp'2020-10-01 10:10:10'"
     val sql5: String =
       "select * from filter_timestamp where account_date in ('2020-10-01', '2020-10-02')"
-    runAndCompare(sql1) {}
-    runAndCompare(sql2) {}
-    runAndCompare(sql3) {}
-    runAndCompare(sql4) {}
-    runAndCompare(sql5) {}
+    runAndCompare(sql1)
+    runAndCompare(sql2)
+    runAndCompare(sql3)
+    runAndCompare(sql4)
+    runAndCompare(sql5)
   }
   // scalastyle:on line.size.limit
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
@@ -32,7 +32,7 @@ class ArrowCsvScanSuiteV1 extends ArrowCsvScanSuiteBase {
   }
 
   test("csv scan v1") {
-    val df = runAndCompare("select * from student")()
+    val df = runAndCompare("select * from student")
     val plan = df.queryExecution.executedPlan
     assert(plan.find(s => s.isInstanceOf[ColumnarToRowExec]).isDefined)
     assert(plan.find(_.isInstanceOf[BaseArrowScanExec]).isDefined)
@@ -46,7 +46,7 @@ class ArrowCsvScanSuiteV1 extends ArrowCsvScanSuiteBase {
   }
 
   test("csv scan with schema v1") {
-    val df = runAndCompare("select * from student_option_schema")()
+    val df = runAndCompare("select * from student_option_schema")
     val plan = df.queryExecution.executedPlan
     assert(plan.find(s => s.isInstanceOf[ColumnarToRowExec]).isDefined)
     val scan = plan.find(_.isInstanceOf[BaseArrowScanExec])
@@ -69,7 +69,7 @@ class ArrowCsvScanSuiteV2 extends ArrowCsvScanSuite {
   }
 
   test("csv scan") {
-    runAndCompare("select * from student")()
+    runAndCompare("select * from student")
   }
 }
 
@@ -97,14 +97,14 @@ class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
 abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
 
   test("csv scan with option string as null") {
-    val df = runAndCompare("select * from student_option_str")()
+    val df = runAndCompare("select * from student_option_str")
     val plan = df.queryExecution.executedPlan
     assert(plan.find(_.isInstanceOf[ColumnarToRowExec]).isDefined)
     assert(plan.find(_.isInstanceOf[BaseArrowScanExec]).isDefined)
   }
 
   test("csv scan with option delimiter") {
-    val df = runAndCompare("select * from student_option")()
+    val df = runAndCompare("select * from student_option")
     val plan = df.queryExecution.executedPlan
     assert(plan.find(s => s.isInstanceOf[ColumnarToRowExec]).isDefined)
     assert(plan.find(_.isInstanceOf[BaseArrowScanExec]).isDefined)
@@ -112,26 +112,26 @@ abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
 
   test("csv scan with missing columns") {
     val df =
-      runAndCompare("select languagemissing, language, id_new_col from student_option_schema_lm")()
+      runAndCompare("select languagemissing, language, id_new_col from student_option_schema_lm")
     val plan = df.queryExecution.executedPlan
     assert(plan.find(s => s.isInstanceOf[VeloxColumnarToRowExec]).isDefined)
     assert(plan.find(_.isInstanceOf[BaseArrowScanExec]).isDefined)
   }
 
   test("csv scan with different name") {
-    val df = runAndCompare("select * from student_option_schema")()
+    val df = runAndCompare("select * from student_option_schema")
     val plan = df.queryExecution.executedPlan
     assert(plan.find(s => s.isInstanceOf[ColumnarToRowExec]).isDefined)
     assert(plan.find(_.isInstanceOf[BaseArrowScanExec]).isDefined)
 
-    val df2 = runAndCompare("select * from student_option_schema")()
+    val df2 = runAndCompare("select * from student_option_schema")
     val plan2 = df2.queryExecution.executedPlan
     assert(plan2.find(s => s.isInstanceOf[ColumnarToRowExec]).isDefined)
     assert(plan2.find(_.isInstanceOf[BaseArrowScanExec]).isDefined)
   }
 
   test("csv scan with filter") {
-    val df = runAndCompare("select * from student where Name = 'Peter'")()
+    val df = runAndCompare("select * from student where Name = 'Peter'")
     assert(df.queryExecution.executedPlan.find(s => s.isInstanceOf[ColumnarToRowExec]).isEmpty)
     assert(
       df.queryExecution.executedPlan

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxWindowExpressionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxWindowExpressionSuite.scala
@@ -83,7 +83,7 @@ class VeloxWindowExpressionSuite extends WholeStageTransformerSuite {
         |)
         |SELECT * FROM t WHERE rn = 1
         |""".stripMargin
-    ) {}
+    )
   }
 
   test("collect_list / collect_set") {

--- a/gluten-substrait/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/execution/WholeStageTransformerSuite.scala
@@ -232,16 +232,13 @@ abstract class WholeStageTransformerSuite
    * spark environment with gluten disabled config.
    *
    * @param sql
-   * @param f
    * @return
    */
-  protected def runAndCompare(sql: String)(f: => Unit): DataFrame = {
+  protected def runAndCompare(sql: String): DataFrame = {
     var expected: Seq[Row] = null
     withSQLConf(vanillaSparkConfs(): _*) {
-      f
       expected = spark.sql(sql).collect()
     }
-    f
     val df = spark.sql(sql)
     checkAnswer(df, expected)
     df


### PR DESCRIPTION
## What changes were proposed in this pull request?
Resolve compile warning, `runAndCompare("**") {}` should be used instead of `runAndCompare("**")()`, but param `f` is not used, so remove it.
```
[WARNING] /opt/gluten/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala:113: warning: [deprecation @ org.apache.gluten.execution.ArrowCsvScanSuite.<local ArrowCsvScanSuite>.df | origin=org.apache.gluten.execution.WholeStageTransformerSuite.runAndCompare | version=2.11.0] Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
[WARNING]         signature: WholeStageTransformerSuite.runAndCompare(sql: String)(f: => Unit): org.apache.spark.sql.DataFrame
[WARNING]   given arguments: <none>
[WARNING]  after adaptation: WholeStageTransformerSuite.runAndCompare((): Unit)
[WARNING]       runAndCompare("select languagemissing, language, id_new_col from student_option_schema_lm")()
```


## How was this patch tested?


