### PR TITLE
[GLUTEN-8437][VL] Fix the exception when verifying the PrestoPage header during the Presto deserialization process

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -501,6 +501,8 @@ class VeloxRssSortShuffleReaderDeserializer::VeloxInputStream : public facebook:
 
   void next(bool throwIfPastEnd) override;
 
+  size_t remainingSize() const override;
+
   std::shared_ptr<arrow::io::InputStream> in_;
   const facebook::velox::BufferPtr buffer_;
   uint64_t offset_ = -1;
@@ -574,6 +576,10 @@ std::shared_ptr<ColumnarBatch> VeloxRssSortShuffleReaderDeserializer::next() {
   }
 
   return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
+}
+
+size_t VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::remainingSize() const {
+  return std::numeric_limits<unsigned long>::max();
 }
 
 VeloxShuffleReaderDeserializerFactory::VeloxShuffleReaderDeserializerFactory(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since the total size of the stream cannot be directly obtained while reading the RSS stream, the current remainingSize represents the remaining size of the current buffer, not the actual remaining size of the entire stream. However, in Velox, there is a validation process for remainingSize. Therefore, this PR is necessary to address the issue.

## How was this patch tested?

CI

