### PR TITLE
[GLUTEN-9057][VL] Avoid flatten unnecessary vector in ColumnarBatch.select

### DIFF
--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -147,17 +147,16 @@ std::shared_ptr<VeloxColumnarBatch> VeloxColumnarBatch::select(
   std::vector<VectorPtr> childVectors;
   childNames.reserve(columnIndices.size());
   childVectors.reserve(columnIndices.size());
-  auto vector = getFlattenedRowVector();
-  auto type = facebook::velox::asRowType(vector->type());
+  auto type = facebook::velox::asRowType(rowVector_->type());
 
   for (uint32_t i = 0; i < columnIndices.size(); i++) {
     auto index = columnIndices[i];
-    auto child = vector->childAt(index);
+    auto child = rowVector_->childAt(index);
     childNames.push_back(type->nameOf(index));
     childVectors.push_back(child);
   }
 
-  auto rowVector = makeRowVector(pool, numRows(), std::move(childNames), vector->nulls(), std::move(childVectors));
+  auto rowVector = makeRowVector(pool, numRows(), std::move(childNames), rowVector_->nulls(), std::move(childVectors));
   return std::make_shared<VeloxColumnarBatch>(rowVector);
 }
 

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -45,7 +45,7 @@ RowVectorPtr makeRowVector(
 }
 } // namespace
 
-void VeloxColumnarBatch::doFlatten(std::shared_ptr<BaseVector>& child) {
+void VeloxColumnarBatch::doFlatten(VectorPtr& child) {
   facebook::velox::BaseVector::flattenVector(child);
   if (child->isLazy()) {
     child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
@@ -75,7 +75,7 @@ void VeloxColumnarBatch::ensurePartialFlattened(const std::vector<int32_t>& colu
   }
   ScopedTimer timer(&exportNanos_);
   for (auto indice : columnIndices) {
-    auto& child = rowVector_->children()[indice];
+    auto& child = rowVector_->childAt(indice);
     doFlatten(child);
   }
 }

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -45,7 +45,7 @@ RowVectorPtr makeRowVector(
 }
 } // namespace
 
-void VeloxColumnarBatch::doFlatten(VectorPtr& child) {
+void VeloxColumnarBatch::doFlatten(std::shared_ptr<BaseVector>& child) {
   facebook::velox::BaseVector::flattenVector(child);
   if (child->isLazy()) {
     child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
@@ -75,7 +75,7 @@ void VeloxColumnarBatch::ensurePartialFlattened(const std::vector<int32_t>& colu
   }
   ScopedTimer timer(&exportNanos_);
   for (auto indice : columnIndices) {
-    auto& child = rowVector_->childAt(indice);
+    auto& child = rowVector_->children()[indice];
     doFlatten(child);
   }
 }

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -45,23 +45,39 @@ RowVectorPtr makeRowVector(
 }
 } // namespace
 
+void VeloxColumnarBatch::doFlatten(std::shared_ptr<BaseVector>& child) {
+  facebook::velox::BaseVector::flattenVector(child);
+  if (child->isLazy()) {
+    child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
+    VELOX_DCHECK_NOT_NULL(child);
+  }
+  // In case of output from Limit, RowVector size can be smaller than its children size.
+  if (child->size() > rowVector_->size()) {
+    child = child->slice(0, rowVector_->size());
+  }
+}
+
 void VeloxColumnarBatch::ensureFlattened() {
   if (flattened_) {
     return;
   }
   ScopedTimer timer(&exportNanos_);
   for (auto& child : rowVector_->children()) {
-    facebook::velox::BaseVector::flattenVector(child);
-    if (child->isLazy()) {
-      child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
-      VELOX_DCHECK_NOT_NULL(child);
-    }
-    // In case of output from Limit, RowVector size can be smaller than its children size.
-    if (child->size() > rowVector_->size()) {
-      child = child->slice(0, rowVector_->size());
-    }
+    doFlatten(child);
   }
   flattened_ = true;
+}
+
+// Only flatten the columns specificed by columnIndices
+void VeloxColumnarBatch::ensurePartialFlattened(const std::vector<int32_t>& columnIndices) {
+  if (flattened_) {
+    return;
+  }
+  ScopedTimer timer(&exportNanos_);
+  for (auto indice : columnIndices) {
+    auto& child = rowVector_->children()[indice];
+    doFlatten(child);
+  }
 }
 
 std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
@@ -89,6 +105,11 @@ velox::RowVectorPtr VeloxColumnarBatch::getRowVector() const {
 
 velox::RowVectorPtr VeloxColumnarBatch::getFlattenedRowVector() {
   ensureFlattened();
+  return rowVector_;
+}
+
+velox::RowVectorPtr VeloxColumnarBatch::getPartialFlattenedRowVector(const std::vector<int32_t>& columnIndices) {
+  ensurePartialFlattened(columnIndices);
   return rowVector_;
 }
 
@@ -147,7 +168,7 @@ std::shared_ptr<VeloxColumnarBatch> VeloxColumnarBatch::select(
   std::vector<VectorPtr> childVectors;
   childNames.reserve(columnIndices.size());
   childVectors.reserve(columnIndices.size());
-  auto vector = getFlattenedRowVector();
+  auto vector = getPartialFlattenedRowVector(columnIndices);
   auto type = facebook::velox::asRowType(vector->type());
 
   for (uint32_t i = 0; i < columnIndices.size(); i++) {

--- a/cpp/velox/memory/VeloxColumnarBatch.h
+++ b/cpp/velox/memory/VeloxColumnarBatch.h
@@ -51,9 +51,12 @@ class VeloxColumnarBatch final : public ColumnarBatch {
       const std::vector<int32_t>& columnIndices);
   facebook::velox::RowVectorPtr getRowVector() const;
   facebook::velox::RowVectorPtr getFlattenedRowVector();
+  facebook::velox::RowVectorPtr getPartialFlattenedRowVector(const std::vector<int32_t>& columnIndices);
 
  private:
   void ensureFlattened();
+  void ensurePartialFlattened(const std::vector<int32_t>& columnIndices);
+  void doFlatten(std::shared_ptr<facebook::velox::BaseVector>&);
 
   facebook::velox::RowVectorPtr rowVector_ = nullptr;
   bool flattened_ = false;

--- a/cpp/velox/memory/VeloxColumnarBatch.h
+++ b/cpp/velox/memory/VeloxColumnarBatch.h
@@ -51,12 +51,9 @@ class VeloxColumnarBatch final : public ColumnarBatch {
       const std::vector<int32_t>& columnIndices);
   facebook::velox::RowVectorPtr getRowVector() const;
   facebook::velox::RowVectorPtr getFlattenedRowVector();
-  facebook::velox::RowVectorPtr getPartialFlattenedRowVector(const std::vector<int32_t>& columnIndices);
 
  private:
   void ensureFlattened();
-  void ensurePartialFlattened(const std::vector<int32_t>& columnIndices);
-  void doFlatten(std::shared_ptr<facebook::velox::BaseVector>&);
 
   facebook::velox::RowVectorPtr rowVector_ = nullptr;
   bool flattened_ = false;

--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -70,7 +70,7 @@ void VeloxColumnarToRowConverter::refreshStates(facebook::velox::RowVectorPtr ro
 
 void VeloxColumnarToRowConverter::convert(std::shared_ptr<ColumnarBatch> cb, int64_t startRow) {
   auto veloxBatch = VeloxColumnarBatch::from(veloxPool_.get(), cb);
-  refreshStates(veloxBatch->getRowVector(), startRow);
+  refreshStates(veloxBatch->getFlattenedRowVector(), startRow);
 
   // Initialize the offsets_ , lengths_
   lengths_.clear();


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some cases, `ensureFlattened` is a bit heavy. 

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/553a8ee0-4a03-400e-aacc-0f6b4a45450a" />

While in `ColumnarBatch.select`, not all children of input row vector are needed. 
In some of our test case, this can reduce ~5% vcore times.

(Fixes: \#9057)

## How was this patch tested?

manually

