### PR TITLE
[VL] Acquire off-heap global memory via the new API for off-heap broadcast exchange

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -55,7 +55,7 @@ object GlobalOffHeapMemory {
       MemoryMode.OFF_HEAP)
   }
 
-  def free(numBytes: Long): Unit = {
+  def release(numBytes: Long): Unit = {
     memoryManager().releaseStorageMemory(numBytes, MemoryMode.OFF_HEAP)
   }
 

--- a/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -25,22 +25,25 @@ import java.lang.reflect.Field
 import java.util.UUID
 
 /**
- * API #acuqire is for reserving some global off-heap memory from Spark memory manager. Once reserved, Spark
- * tasks will have less off-heap memory to use because of the reservation.
+ * API #acuqire is for reserving some global off-heap memory from Spark memory manager. Once
+ * reserved, Spark tasks will have less off-heap memory to use because of the reservation.
  *
  * Note the API #acuqire doesn't trigger spills on Spark tasks although OOM may be encountered.
  *
- * The utility internally relies on the Spark storage memory pool. As Spark doesn't expect trait BlockId to be
- * extended by user, TestBlockId is chosen for the storage memory reservations.
+ * The utility internally relies on the Spark storage memory pool. As Spark doesn't expect trait
+ * BlockId to be extended by user, TestBlockId is chosen for the storage memory reservations.
  */
 object GlobalOffHeapMemory {
   private val FIELD_MEMORY_MANAGER: Field = {
-    val f = try {
-      classOf[TaskMemoryManager].getDeclaredField("memoryManager")
-    } catch {
-      case e: Exception =>
-        throw new GlutenException("Unable to find field TaskMemoryManager#memoryManager via reflection", e)
-    }
+    val f =
+      try {
+        classOf[TaskMemoryManager].getDeclaredField("memoryManager")
+      } catch {
+        case e: Exception =>
+          throw new GlutenException(
+            "Unable to find field TaskMemoryManager#memoryManager via reflection",
+            e)
+      }
     f.setAccessible(true)
     f
   }

--- a/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -24,6 +24,15 @@ import org.apache.spark.storage.BlockId
 import java.lang.reflect.Field
 import java.util.UUID
 
+/**
+ * API #acuqire is for reserving some global off-heap memory from Spark memory manager. Once reserved, Spark
+ * tasks will have less off-heap memory to use because of the reservation.
+ *
+ * Note the API #acuqire doesn't trigger spills on Spark tasks although OOM may be encountered.
+ *
+ * The utility internally relies on the Spark storage memory pool. As Spark doesn't expect trait BlockId to be
+ * extended by user, TestBlockId is chosen for the storage memory reservations.
+ */
 object GlobalOffHeapMemory {
   private val FIELD_MEMORY_MANAGER: Field = {
     val f = try {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -48,7 +48,7 @@ case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int]
         "not equal to buffer lengths!")
     assert(totalBytes >= 0, "Unsafe buffer array total bytes can't be negative!")
   }
-  private val allocatedBytes = totalBytes + 7;
+  private val allocatedBytes = (totalBytes + 7) / 8 * 8
 
   /**
    * A single array to store all bytesBufferArray's value, it's inited once when first time get

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.unsafe
 
-import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.exception.GlutenException
 
 import org.apache.spark.SparkEnv
@@ -79,9 +78,12 @@ case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int]
       val numBytes = totalBytes + 7
       if (!GlobalOffHeapMemory.acquire(numBytes)) {
         val memoryManager = SparkEnv.get.memoryManager
-        throw new GlutenException(s"Spark off-heap memory is exhausted." +
-          s" Storage: ${memoryManager.offHeapStorageMemoryUsed} / ${memoryManager.maxOffHeapStorageMemory}," +
-          s" execution: ${memoryManager.offHeapExecutionMemoryUsed} / ${GlutenConfig.get.offHeapMemorySize - memoryManager.maxOffHeapStorageMemory}")
+        val offHeapMemoryTotal =
+          memoryManager.maxOffHeapStorageMemory + memoryManager.offHeapExecutionMemoryUsed
+        throw new GlutenException(
+          s"Spark off-heap memory is exhausted." +
+            s" Storage: ${memoryManager.offHeapStorageMemoryUsed} / $offHeapMemoryTotal," +
+            s" execution: ${memoryManager.offHeapExecutionMemoryUsed} / $offHeapMemoryTotal")
       }
       longArray = new LongArray(MemoryAllocator.UNSAFE.allocate(numBytes))
     }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -41,7 +41,6 @@ import org.apache.spark.unsafe.memory.MemoryAllocator
 @Experimental
 case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int], totalBytes: Long)
   extends Logging {
-  private val allocatedBytes = totalBytes + 7;
   {
     assert(
       arraySize == bytesBufferLengths.length,
@@ -49,6 +48,7 @@ case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int]
         "not equal to buffer lengths!")
     assert(totalBytes >= 0, "Unsafe buffer array total bytes can't be negative!")
   }
+  private val allocatedBytes = totalBytes + 7;
 
   /**
    * A single array to store all bytesBufferArray's value, it's inited once when first time get

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -81,7 +81,7 @@ case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int]
         val memoryManager = SparkEnv.get.memoryManager
         throw new GlutenException(s"Spark off-heap memory is exhausted." +
           s" Storage: ${memoryManager.offHeapStorageMemoryUsed} / ${memoryManager.maxOffHeapStorageMemory}," +
-          s" execution: ${memoryManager.offHeapExecutionMemoryUsed} / ${GlutenConfig.get.offHeapMemorySize}")
+          s" execution: ${memoryManager.offHeapExecutionMemoryUsed} / ${GlutenConfig.get.offHeapMemorySize - memoryManager.maxOffHeapStorageMemory}")
       }
       longArray = new LongArray(MemoryAllocator.UNSAFE.allocate(numBytes))
     }

--- a/backends-velox/src/test/scala/org/apache/spark/memory/GlobalOffHeapMemorySuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/memory/GlobalOffHeapMemorySuite.scala
@@ -95,7 +95,7 @@ class GlobalOffHeapMemorySuite extends AnyFunSuite with BeforeAndAfterAll {
             Collections.emptyMap())
       Assert.assertTrue(GlobalOffHeapMemory.acquire(300))
       Assert.assertEquals(100, consumer.borrow(200))
-      GlobalOffHeapMemory.free(10)
+      GlobalOffHeapMemory.release(10)
       Assert.assertEquals(10, consumer.borrow(50))
     }
   }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelationTest.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelationTest.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.unsafe;
 
 import org.apache.spark.{SparkConf, SparkEnv}
-import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode
@@ -37,9 +36,6 @@ class UnsafeColumnarBuildSideRelationTest extends SharedSparkSession {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val taskMemoryManager = new TaskMemoryManager(
-      new UnifiedMemoryManager(SparkEnv.get.conf, Long.MaxValue, Long.MaxValue / 2, 1),
-      0)
     val a = AttributeReference("a", StringType, nullable = false, null)()
     val output = Seq(a)
     val totalArraySize = 1
@@ -48,8 +44,7 @@ class UnsafeColumnarBuildSideRelationTest extends SharedSparkSession {
     val bytesArray = UnsafeBytesBufferArray(
       1,
       perArraySize,
-      10,
-      taskMemoryManager
+      10
     )
     bytesArray.putBytesBuffer(0, "1234567890".getBytes())
     unsafeRelWithIdentityMode = UnsafeColumnarBuildSideRelation(


### PR DESCRIPTION
A follow-up for #8762 to avoid creating a dummy TaskMemoryManager (which was hack) for reserving off-heap memory for off-heap broadcast exchange. 

The code now calls new API introduced in https://github.com/apache/incubator-gluten/pull/9066 to acquire for off-heap storage memory.