### PR TITLE
[GLUTEN-9076][VL] Prioritize offloading supported hive udf in ColumnarPartialProject

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/GlutenHiveUDFSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/GlutenHiveUDFSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
+import org.apache.gluten.config.GlutenConfig.GLUTEN_SUPPORTED_HIVE_UDFS
 import org.apache.gluten.execution.ColumnarPartialProjectExec
 import org.apache.gluten.udf.CustomerUDF
 
@@ -76,6 +77,8 @@ class GlutenHiveUDFSuite extends GlutenQueryTest with SQLTestUtils {
       // this rule may potentially block testing of other optimization rules such as
       // ConstantPropagation etc.
       .set(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, ConvertToLocalRelation.ruleName)
+      // mapping udf_substr to velox substring function
+      .set(GLUTEN_SUPPORTED_HIVE_UDFS.key, "udf_substr:substring")
 
     conf.set(
       StaticSQLConf.WAREHOUSE_PATH,
@@ -198,6 +201,54 @@ class GlutenHiveUDFSuite extends GlutenQueryTest with SQLTestUtils {
         )
       )
       checkOperatorMatch[ColumnarPartialProjectExec](df)
+    }
+  }
+
+  test("UDFMapping should prioritize over ColumnarPartialProject when both applicable") {
+    withTempFunction("udf_substr") {
+      withTempFunction("udf_substr2") {
+        withTempFunction("udf_sort_array") {
+          sql(s"""
+                 |CREATE TEMPORARY FUNCTION udf_sort_array AS
+                 |'org.apache.hadoop.hive.ql.udf.generic.GenericUDFSortArray';
+                 |""".stripMargin)
+          Seq("udf_substr", "udf_substr2").foreach {
+            testudf =>
+              sql(s"""CREATE TEMPORARY FUNCTION $testudf AS
+                     |'org.apache.hadoop.hive.ql.udf.UDFSubstr';
+                     |""".stripMargin)
+
+              val df = sql(s"""
+                              |select
+                              |  l_partkey,
+                              |  udf_sort_array(array(10, l_orderkey, 1)),
+                              |  $testudf(l_comment, 1, 5)
+                              |FROM lineitem WHERE l_partkey <= 5 and l_orderkey <1000
+                              |""".stripMargin)
+              val executedPlan = getExecutedPlan(df)
+              checkGlutenOperatorMatch[ColumnarPartialProjectExec](df)
+              val partialProject = executedPlan
+                .filter {
+                  _ match {
+                    case _: ColumnarPartialProjectExec => true
+                    case _ => false
+                  }
+                }
+                .head
+                .asInstanceOf[ColumnarPartialProjectExec]
+
+              if (testudf == "udf_substr") {
+                // Since udf_substr is supported to transform,
+                // then we should only partial project udf_sort_array.
+                assert(partialProject.output.count(_.name.startsWith("_SparkPartialProject")) == 1)
+              } else {
+                // Since both udf_sort_array and udf_substr2 is not supported to transform,
+                // then we should partial project udf_sort_array and udf_substr2.
+                assert(partialProject.output.count(_.name.startsWith("_SparkPartialProject")) == 2)
+              }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Where both `spark.gluten.supported.hive.udfs` and `spark.gluten.sql.columnar.partial.project` rules are applicable, we should prioritize `UDFMapping` over `ColumnarPartialProject`.

For example,

```
set spark.gluten.supported.hive.udfs=udfB; # which means udfB is rewrite in velox side
select default.udfA(input1), default.udfB(input2), get_json_object(input3, '$.a') from t
```

Before this patch, the plan is

```
---------------------------------------------------------------------------------------------------------------------------------
| ColumnarPartialProject(default.udfA(input1) as _SparkPartialProject0,  default.udfB(input2) as _SparkPartialProject1, input3) |
---------------------------------------------------------------------------------------------------------------------------------
                                                                                    |
---------------------------------------------------------------------------------------------------------------------------------
|ProjectExecTransformer(_SparkPartialProject0, _SparkPartialProject1, get_json_object(input3, '$.a'))|
---------------------------------------------------------------------------------------------------------------------------------
```
which means, both `udfA` and `udfB` are `partial projected` in java, thought `udfB` can be transformed and offloaded to velox.


after this patch, the plan is
```
---------------------------------------------------------------------------------------------------------------------------------
| ColumnarPartialProject(default.udfA(input1) as _SparkPartialProject0,  input2, input3)                                        |
---------------------------------------------------------------------------------------------------------------------------------
                                                                                    |
---------------------------------------------------------------------------------------------------------------------------------
|ProjectExecTransformer(_SparkPartialProject0, default.udfB(input2), get_json_object(input3, '$.a'))                            |
---------------------------------------------------------------------------------------------------------------------------------
```

so that the `default.udfB` can be transformed and offload to velox to evaluation.



(Fixes: \#9076)

## How was this patch tested?

Manually