### PR TITLE
[GLUTEN-9078][CORE] Simplify code of SoftAffinity

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/softaffinity/SoftAffinity.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/softaffinity/SoftAffinity.scala
@@ -22,6 +22,7 @@ import org.apache.gluten.softaffinity.{AffinityManager, SoftAffinityManager}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
+import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.FilePartition
 
 abstract class Affinity(val manager: AffinityManager) extends LogLevelUtil with Logging {
@@ -79,9 +80,15 @@ abstract class Affinity(val manager: AffinityManager) extends LogLevelUtil with 
   }
 
   /** Update the RDD id to SoftAffinityManager */
-  def updateFilePartitionLocations(filePartition: FilePartition, rddId: Int): Unit = {
+  def updateFilePartitionLocations(
+      inputPartitions: Seq[Seq[Seq[InputPartition]]],
+      rddId: Int): Unit = {
     if (SoftAffinityManager.usingSoftAffinity && SoftAffinityManager.detectDuplicateReading) {
-      SoftAffinityManager.updatePartitionMap(filePartition, rddId)
+      inputPartitions.foreach(_.foreach(_.foreach {
+        case f: FilePartition =>
+          SoftAffinityManager.updatePartitionMap(f, rddId)
+        case _ =>
+      }))
     }
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -382,7 +382,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
      * care of [[LeafTransformSupport]] there won't be any other RDD for leaf operator. As a result,
      * genFirstStageIterator rather than genFinalStageIterator will be invoked
      */
-    val allInputPartitions = leafTransformers.map(_.getPartitions.toIndexedSeq)
+    val allInputPartitions = leafTransformers.map(_.getPartitions)
     val allSplitInfos = getSplitInfosFromPartitions(leafTransformers)
 
     if (GlutenConfig.get.enableHdfsViewfs) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two minor changes.
1. Simple the code when iterate over `allInputPartitions`, which is a bit confusion.

```
    allInputPartitions.head.indices.foreach(
      i => {
        val currentPartitions = allInputPartitions.map(_(i))
        currentPartitions.indices.foreach(
          i =>
            currentPartitions(i) match {
              case f: FilePartition =>
                SoftAffinity.updateFilePartitionLocations(f, rdd.id)
              case _ =>
            })
      })
```

2.  Don't need to iterate and check whether `SoftAffinityManager.usingSoftAffinity` are enabled every time inside loop

(Fixes: \#9078)

## How was this patch tested?

Existing UT
