### PR TITLE
[GLUTEN-9087] [Core] Make substrait node not depend on spark

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
@@ -25,7 +25,7 @@ import org.apache.gluten.metrics.IMetrics
 import org.apache.gluten.sql.shims.{DeltaShimLoader, SparkShimLoader}
 import org.apache.gluten.substrait.plan.PlanNode
 import org.apache.gluten.substrait.rel._
-import org.apache.gluten.substrait.rel.LocalFilesNode.{ReadFileFormat, SchemaField}
+import org.apache.gluten.substrait.rel.LocalFilesNode.{FileSchema, ReadFileFormat, SchemaField}
 import org.apache.gluten.vectorized.{BatchIterator, CHNativeExpressionEvaluator, CloseableCHColumnBatchIterator}
 
 import org.apache.spark.{InterruptibleIterator, SparkConf, TaskContext}
@@ -55,7 +55,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
 
-  private def getFileSchema(schema: StructType, names: Seq[String]): java.util.List[SchemaField] = {
+  private def getFileSchema(schema: StructType, names: Seq[String]): FileSchema = {
     val dataSchema = ArrayBuffer[SchemaField]()
     schema.foreach {
       field =>
@@ -72,7 +72,7 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
         }
         dataSchema += newField
     }
-    dataSchema.asJava
+    new FileSchema(dataSchema.asJava)
   }
 
   private def createNativeIterator(

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -25,8 +25,8 @@ import org.apache.gluten.expression.ExpressionNames.MONOTONICALLY_INCREASING_ID
 import org.apache.gluten.extension.ExpressionExtensionTrait
 import org.apache.gluten.extension.columnar.heuristic.HeuristicTransform
 import org.apache.gluten.sql.shims.SparkShimLoader
-import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
-import org.apache.gluten.utils.{CHJoinValidateUtil, UnknownJoinStrategy}
+import org.apache.gluten.substrait.expression.{ExpressionNode, WindowFunctionNode}
+import org.apache.gluten.utils.{CHJoinValidateUtil, UnknownJoinStrategy, WindowFunctionNodeUtil}
 import org.apache.gluten.vectorized.CHColumnarBatchSerializer
 
 import org.apache.spark.ShuffleDependency
@@ -714,7 +714,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
           case wf @ (RowNumber() | Rank(_) | DenseRank(_) | PercentRank(_)) =>
             val aggWindowFunc = wf.asInstanceOf[AggregateWindowFunction]
             val frame = aggWindowFunc.frame.asInstanceOf[SpecifiedWindowFrame]
-            val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            val windowFunctionNode = WindowFunctionNodeUtil.makeWindowFunction(
               WindowFunctionsBuilder.create(args, aggWindowFunc).toInt,
               new JArrayList[ExpressionNode](),
               columnName,
@@ -741,7 +741,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
                     .replaceWithExpressionTransformer(expr, originalInputAttributes)
                     .doTransform(args)))
 
-            val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            val windowFunctionNode = WindowFunctionNodeUtil.makeWindowFunction(
               CHExpressions.createAggregateFunction(args, aggExpression.aggregateFunction).toInt,
               childrenNodeList,
               columnName,
@@ -791,7 +791,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
                   offsetWf.default,
                   attributeSeq = originalInputAttributes)
                 .doTransform(args))
-            val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            val windowFunctionNode = WindowFunctionNodeUtil.makeWindowFunction(
               WindowFunctionsBuilder.create(args, offsetWf).toInt,
               childrenNodeList,
               columnName,
@@ -807,7 +807,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
             val childrenNodeList = new JArrayList[ExpressionNode]()
             val literal = buckets.asInstanceOf[Literal]
             childrenNodeList.add(LiteralTransformer(literal).doTransform(args))
-            val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            val windowFunctionNode = WindowFunctionNodeUtil.makeWindowFunction(
               WindowFunctionsBuilder.create(args, wf).toInt,
               childrenNodeList,
               columnName,

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHTransformerApi.scala
@@ -44,6 +44,7 @@ import com.google.common.collect.Lists
 import com.google.protobuf.{Any, Message}
 import org.apache.hadoop.fs.Path
 
+import java.math.{BigDecimal, BigInteger, MathContext}
 import java.util
 
 class CHTransformerApi extends TransformerApi with Logging {
@@ -228,7 +229,8 @@ class CHTransformerApi extends TransformerApi with Logging {
 
     // Just make a fake toType value, because native engine cannot accept datatype itself.
     val toTypeNodes =
-      ExpressionBuilder.makeDecimalLiteral(new Decimal().set(0, dataType.precision, dataType.scale))
+      ExpressionBuilder.makeDecimalLiteral(
+        new BigDecimal(BigInteger.valueOf(0L), dataType.scale, new MathContext(dataType.precision)))
     val expressionNodes =
       Lists.newArrayList(childNode, new BooleanLiteralNode(nullOnOverflow), toTypeNodes)
     val typeNode = ConverterUtils.getTypeNode(dataType, nullable)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
@@ -19,6 +19,8 @@ package org.apache.gluten.expression
 import org.apache.gluten.backendsapi.clickhouse.CHConfig
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.expression.ConverterUtils.FunctionConfig
+import org.apache.gluten.substrait.`type`.I32TypeNode
+import org.apache.gluten.substrait.`type`.StringTypeNode
 import org.apache.gluten.substrait.expression._
 
 import org.apache.spark.sql.catalyst.expressions._
@@ -202,7 +204,8 @@ case class CHRegExpReplaceTransformer(
             substraitExprName,
             Seq(original.subject.dataType, original.regexp.dataType, original.rep.dataType),
             FunctionConfig.OPT)
-          val replacedRepNode = ExpressionBuilder.makeLiteral(replacedValue, StringType, false)
+          val replacedRepNode =
+            ExpressionBuilder.makeStringLiteral(replacedValue, new StringTypeNode(false))
           val exprNodes = Lists.newArrayList(
             childrenWithPos(0).doTransform(args),
             childrenWithPos(1).doTransform(args),
@@ -243,7 +246,7 @@ case class GetArrayItemTransformer(
       Seq(IntegerType, getArrayItem.right.dataType),
       FunctionConfig.OPT)
     val addFunctionId = ExpressionBuilder.newScalarFunction(functionMap, addFunctionName)
-    val literalNode = ExpressionBuilder.makeLiteral(1, IntegerType, false)
+    val literalNode = ExpressionBuilder.makeIntLiteral(1, new I32TypeNode(false))
     rightNode = ExpressionBuilder.makeScalarFunction(
       addFunctionId,
       Lists.newArrayList(literalNode, rightNode),

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -380,7 +380,9 @@ abstract class HashAggregateExecTransformer(
                     val nodeType = ConverterUtils.getTypeNode(lt.dataType, nullable = false)
                     childNodes.add(
                       ExpressionBuilder
-                        .makeLiteral(SparkToJavaConverter.toJava(lt.value, nodeType), nodeType))
+                        .makeLiteral(
+                          SparkToJavaConverter.toJava(lt.value, nodeType, lt.dataType),
+                          nodeType))
                   } else {
                     val sparkType = sparkTypes(adjustedIdx)
                     val attr = rewrittenInputAttributes(adjustedIdx)

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/DecimalLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/DecimalLiteralNode.java
@@ -22,21 +22,19 @@ import org.apache.gluten.substrait.type.TypeNode;
 import com.google.protobuf.ByteString;
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
-import org.apache.spark.sql.types.Decimal;
 
 import java.math.BigDecimal;
 
-public class DecimalLiteralNode extends LiteralNodeWithValue<Decimal> {
+public class DecimalLiteralNode extends LiteralNodeWithValue<BigDecimal> {
   private final ByteString valueBytes;
 
-  public DecimalLiteralNode(Decimal value, TypeNode typeNode) {
+  public DecimalLiteralNode(BigDecimal value, TypeNode typeNode) {
     super(value, typeNode);
     ExpressionBuilder.checkDecimalScale(value.scale());
-    this.valueBytes =
-        ByteString.copyFrom(encodeDecimalIntoBytes(value.toJavaBigDecimal(), value.scale(), 16));
+    this.valueBytes = ByteString.copyFrom(encodeDecimalIntoBytes(value, value.scale(), 16));
   }
 
-  public DecimalLiteralNode(Decimal value) {
+  public DecimalLiteralNode(BigDecimal value) {
     this(value, TypeBuilder.makeDecimal(true, value.precision(), value.scale()));
   }
 
@@ -76,7 +74,7 @@ public class DecimalLiteralNode extends LiteralNodeWithValue<Decimal> {
   }
 
   @Override
-  protected void updateLiteralBuilder(Builder literalBuilder, Decimal value) {
+  protected void updateLiteralBuilder(Builder literalBuilder, BigDecimal value) {
     Expression.Literal.Decimal.Builder decimalBuilder = Expression.Literal.Decimal.newBuilder();
     decimalBuilder.setPrecision(value.precision());
     decimalBuilder.setScale(value.scale());

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/DecimalLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/DecimalLiteralNode.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.substrait.expression;
 
+import org.apache.gluten.substrait.type.DecimalTypeNode;
 import org.apache.gluten.substrait.type.TypeBuilder;
 import org.apache.gluten.substrait.type.TypeNode;
 
@@ -31,7 +32,8 @@ public class DecimalLiteralNode extends LiteralNodeWithValue<BigDecimal> {
   public DecimalLiteralNode(BigDecimal value, TypeNode typeNode) {
     super(value, typeNode);
     ExpressionBuilder.checkDecimalScale(value.scale());
-    this.valueBytes = ByteString.copyFrom(encodeDecimalIntoBytes(value, value.scale(), 16));
+    this.valueBytes =
+        ByteString.copyFrom(encodeDecimalIntoBytes(value, ((DecimalTypeNode) typeNode).scale, 16));
   }
 
   public DecimalLiteralNode(BigDecimal value) {
@@ -75,9 +77,10 @@ public class DecimalLiteralNode extends LiteralNodeWithValue<BigDecimal> {
 
   @Override
   protected void updateLiteralBuilder(Builder literalBuilder, BigDecimal value) {
+    DecimalTypeNode decimalTypeNode = (DecimalTypeNode) getTypeNode();
     Expression.Literal.Decimal.Builder decimalBuilder = Expression.Literal.Decimal.newBuilder();
-    decimalBuilder.setPrecision(value.precision());
-    decimalBuilder.setScale(value.scale());
+    decimalBuilder.setPrecision(decimalTypeNode.precision);
+    decimalBuilder.setScale(decimalTypeNode.scale);
     decimalBuilder.setValue(valueBytes);
 
     literalBuilder.setDecimal(decimalBuilder.build());

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ListLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ListLiteralNode.java
@@ -22,16 +22,17 @@ import org.apache.gluten.substrait.type.TypeNode;
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
 import io.substrait.proto.Type;
-import org.apache.spark.sql.catalyst.util.ArrayData;
 
-public class ListLiteralNode extends LiteralNodeWithValue<ArrayData> {
-  public ListLiteralNode(ArrayData array, TypeNode typeNode) {
-    super(array, typeNode);
+import java.util.List;
+
+public class ListLiteralNode extends LiteralNodeWithValue<List<Object>> {
+  public ListLiteralNode(List<Object> list, TypeNode typeNode) {
+    super(list, typeNode);
   }
 
   @Override
-  protected void updateLiteralBuilder(Builder literalBuilder, ArrayData array) {
-    Object[] elements = array.array();
+  protected void updateLiteralBuilder(Builder literalBuilder, List<Object> list) {
+    Object[] elements = list.toArray();
     TypeNode elementType = ((ListNode) getTypeNode()).getNestedType();
 
     if (elements.length > 0) {

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/MapLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/MapLiteralNode.java
@@ -22,17 +22,18 @@ import org.apache.gluten.substrait.type.TypeNode;
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
 import io.substrait.proto.Type;
-import org.apache.spark.sql.catalyst.util.MapData;
 
-public class MapLiteralNode extends LiteralNodeWithValue<MapData> {
-  public MapLiteralNode(MapData map, TypeNode typeNode) {
+import java.util.Map;
+
+public class MapLiteralNode extends LiteralNodeWithValue<Map<Object, Object>> {
+  public MapLiteralNode(Map<Object, Object> map, TypeNode typeNode) {
     super(map, typeNode);
   }
 
   @Override
-  protected void updateLiteralBuilder(Builder literalBuilder, MapData map) {
-    Object[] keys = map.keyArray().array();
-    Object[] values = map.valueArray().array();
+  protected void updateLiteralBuilder(Builder literalBuilder, Map<Object, Object> map) {
+    Object[] keys = map.keySet().toArray();
+    Object[] values = map.values().toArray();
     TypeNode mapType = ((MapNode) getTypeNode()).getKeyType();
     TypeNode valueType = ((MapNode) getTypeNode()).getValueType();
 

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/StructLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/StructLiteralNode.java
@@ -16,7 +16,9 @@
  */
 package org.apache.gluten.substrait.expression;
 
-import org.apache.gluten.substrait.type.*;
+import org.apache.gluten.substrait.type.NothingNode;
+import org.apache.gluten.substrait.type.StructNode;
+import org.apache.gluten.substrait.type.TypeNode;
 
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
@@ -34,57 +36,11 @@ public class StructLiteralNode extends LiteralNodeWithValue<List<Object>> {
     if (value.get(index) == null) {
       return ExpressionBuilder.makeNullLiteral(type);
     }
-
-    if (type instanceof BooleanTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof I8TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof I16TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof I32TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof I64TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof FP32TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof FP64TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof DateTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof TimestampTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof StringTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof BinaryTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof DecimalTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof ListNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof MapNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
-    if (type instanceof StructNode) {
-      return ExpressionBuilder.makeLiteral(value.get(index), type);
-    }
     if (type instanceof NothingNode) {
       return ExpressionBuilder.makeNullLiteral(type);
     }
-    throw new UnsupportedOperationException(
-        type.toString() + " is not supported in getFieldLiteral.");
+
+    return ExpressionBuilder.makeLiteral(value.get(index), type);
   }
 
   @Override

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/StructLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/StructLiteralNode.java
@@ -20,68 +20,65 @@ import org.apache.gluten.substrait.type.*;
 
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
-import org.apache.spark.sql.catalyst.InternalRow;
 
-public class StructLiteralNode extends LiteralNodeWithValue<InternalRow> {
-  public StructLiteralNode(InternalRow row, TypeNode typeNode) {
-    super(row, typeNode);
+import java.util.List;
+
+public class StructLiteralNode extends LiteralNodeWithValue<List<Object>> {
+  public StructLiteralNode(List<Object> struct, TypeNode typeNode) {
+    super(struct, typeNode);
   }
 
   public LiteralNode getFieldLiteral(int index) {
-    InternalRow value = getValue();
+    List<Object> value = getValue();
     TypeNode type = ((StructNode) getTypeNode()).getFieldTypes().get(index);
-    if (value.isNullAt(index)) {
+    if (value.get(index) == null) {
       return ExpressionBuilder.makeNullLiteral(type);
     }
 
     if (type instanceof BooleanTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getBoolean(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof I8TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getByte(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof I16TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getShort(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof I32TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getInt(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof I64TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getLong(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof FP32TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getFloat(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof FP64TypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getDouble(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof DateTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getInt(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof TimestampTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getLong(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof StringTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getUTF8String(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof BinaryTypeNode) {
-      return ExpressionBuilder.makeLiteral(value.getBinary(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof DecimalTypeNode) {
-      return ExpressionBuilder.makeLiteral(
-          value.getDecimal(
-              index, ((DecimalTypeNode) type).precision, ((DecimalTypeNode) type).scale),
-          type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof ListNode) {
-      return ExpressionBuilder.makeLiteral(value.getArray(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof MapNode) {
-      return ExpressionBuilder.makeLiteral(value.getMap(index), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof StructNode) {
-      return ExpressionBuilder.makeLiteral(
-          value.getStruct(index, ((StructNode) type).getFieldTypes().size()), type);
+      return ExpressionBuilder.makeLiteral(value.get(index), type);
     }
     if (type instanceof NothingNode) {
       return ExpressionBuilder.makeNullLiteral(type);
@@ -91,7 +88,7 @@ public class StructLiteralNode extends LiteralNodeWithValue<InternalRow> {
   }
 
   @Override
-  protected void updateLiteralBuilder(Builder literalBuilder, InternalRow row) {
+  protected void updateLiteralBuilder(Builder literalBuilder, List<Object> struct) {
     Expression.Literal.Struct.Builder structBuilder = Expression.Literal.Struct.newBuilder();
     for (int i = 0; i < ((StructNode) getTypeNode()).getFieldTypes().size(); ++i) {
       structBuilder.addFields(getFieldLiteral(i).getLiteral());

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesBuilder.java
@@ -16,6 +16,12 @@
  */
 package org.apache.gluten.substrait.rel;
 
+import org.apache.gluten.substrait.utils.SubstraitUtil;
+
+import com.google.protobuf.Any;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +41,15 @@ public class LocalFilesBuilder {
       List<String> preferredLocations,
       Map<String, String> properties,
       List<Map<String, Object>> otherMetadataColumns) {
+    List<Map<String, Any>> newOtherMetadataColumns = new ArrayList<>(otherMetadataColumns.size());
+    for (Map<String, Object> otherMetadataColumn : otherMetadataColumns) {
+      Map<String, Any> newOtherMetadataColumn = new HashMap<>();
+      for (Map.Entry<String, Object> entry : otherMetadataColumn.entrySet()) {
+        newOtherMetadataColumn.put(
+            entry.getKey(), SubstraitUtil.convertJavaObjectToAny(entry.getValue()));
+      }
+      newOtherMetadataColumns.add(newOtherMetadataColumn);
+    }
     return new LocalFilesNode(
         index,
         paths,
@@ -47,7 +62,7 @@ public class LocalFilesBuilder {
         fileFormat,
         preferredLocations,
         properties,
-        otherMetadataColumns);
+        newOtherMetadataColumns);
   }
 
   public static LocalFilesNode makeLocalFiles(String iterPath) {

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
@@ -63,9 +63,21 @@ public class LocalFilesNode implements SplitInfo {
     }
   }
 
+  public static class FileSchema {
+    private final List<SchemaField> fields;
+
+    public FileSchema(List<SchemaField> fields) {
+      this.fields = fields;
+    }
+
+    public List<SchemaField> getFields() {
+      return fields;
+    }
+  }
+
   protected ReadFileFormat fileFormat = ReadFileFormat.UnknownFormat;
   private Boolean iterAsInput = false;
-  private List<SchemaField> fileSchema;
+  private FileSchema fileSchema;
   private Map<String, String> fileReadProperties;
 
   LocalFilesNode(
@@ -110,7 +122,7 @@ public class LocalFilesNode implements SplitInfo {
     paths.addAll(newPaths);
   }
 
-  public void setFileSchema(List<SchemaField> schema) {
+  public void setFileSchema(FileSchema schema) {
     this.fileSchema = schema;
   }
 
@@ -119,7 +131,7 @@ public class LocalFilesNode implements SplitInfo {
 
     if (fileSchema != null) {
       Type.Struct.Builder structBuilder = Type.Struct.newBuilder();
-      for (SchemaField field : fileSchema) {
+      for (SchemaField field : fileSchema.fields) {
         structBuilder.addTypes(field.type.toProtobuf());
         namedStructBuilder.addNames(field.name);
       }

--- a/gluten-substrait/src/main/java/org/apache/gluten/utils/SparkToJavaConverter.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/utils/SparkToJavaConverter.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils;
+
+import org.apache.gluten.substrait.type.BinaryTypeNode;
+import org.apache.gluten.substrait.type.BooleanTypeNode;
+import org.apache.gluten.substrait.type.DateTypeNode;
+import org.apache.gluten.substrait.type.DecimalTypeNode;
+import org.apache.gluten.substrait.type.FP32TypeNode;
+import org.apache.gluten.substrait.type.FP64TypeNode;
+import org.apache.gluten.substrait.type.I16TypeNode;
+import org.apache.gluten.substrait.type.I32TypeNode;
+import org.apache.gluten.substrait.type.I64TypeNode;
+import org.apache.gluten.substrait.type.I8TypeNode;
+import org.apache.gluten.substrait.type.ListNode;
+import org.apache.gluten.substrait.type.MapNode;
+import org.apache.gluten.substrait.type.StringTypeNode;
+import org.apache.gluten.substrait.type.StructNode;
+import org.apache.gluten.substrait.type.TimestampTypeNode;
+import org.apache.gluten.substrait.type.TypeNode;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.types.Decimal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SparkToJavaConverter {
+
+  public static Object toJava(Object obj, TypeNode nodeType) {
+    if ((nodeType instanceof BooleanTypeNode)
+        || (nodeType instanceof I8TypeNode)
+        || (nodeType instanceof I32TypeNode)
+        || (nodeType instanceof I64TypeNode)
+        || (nodeType instanceof FP32TypeNode)
+        || (nodeType instanceof FP64TypeNode)
+        || (nodeType instanceof DateTypeNode)
+        || (nodeType instanceof TimestampTypeNode)
+        || (nodeType instanceof StringTypeNode)
+        || (nodeType instanceof BinaryTypeNode)) {
+      return obj;
+    } else if (nodeType instanceof DecimalTypeNode) {
+      return ((Decimal) obj).toJavaBigDecimal();
+    } else if (nodeType instanceof ListNode) {
+      ListNode listType = (ListNode) nodeType;
+      /**
+       * if (obj instanceof UnsafeArrayData) { UnsafeArrayData unsafeArray = (UnsafeArrayData) obj;
+       * List<Object> javaList = new ArrayList<>(unsafeArray.numElements()); for (Object elem :
+       * unsafeArray.array()) { javaList.add(toJava(elem, listType.getNestedType())); } return
+       * javaList; } else if (obj instanceof ArrayData) {
+       */
+      ArrayData array = (ArrayData) obj;
+      List<Object> javaList = new ArrayList<>(array.numElements());
+      for (Object elem : array.array()) {
+        javaList.add(toJava(elem, listType.getNestedType()));
+      }
+      return javaList;
+    } else if (nodeType instanceof MapNode) {
+      MapNode mapType = (MapNode) nodeType;
+      MapData map = (MapData) obj;
+      Map<Object, Object> javaMap = new HashMap<>(map.numElements());
+      for (int i = 0; i < map.numElements(); i++) {
+        javaMap.put(
+            toJava(map.keyArray().array()[i], mapType.getKeyType()),
+            toJava(map.valueArray().array()[i], mapType.getValueType()));
+      }
+      return javaMap;
+    } else if (nodeType instanceof StructNode) {
+      StructNode structType = (StructNode) nodeType;
+      InternalRow struct = (InternalRow) obj;
+      List<Object> javaList = new ArrayList<>(struct.numFields());
+      for (int i = 0; i < struct.numFields(); i++) {
+        if (struct.isNullAt(i)) {
+          javaList.add(i, null);
+        } else {
+          TypeNode fieldType = structType.getFieldTypes().get(i);
+          if (fieldType instanceof BooleanTypeNode) {
+            javaList.add(i, toJava(struct.getBoolean(i), fieldType));
+          } else if (fieldType instanceof I8TypeNode) {
+            javaList.add(i, toJava(struct.getByte(i), fieldType));
+          } else if (fieldType instanceof I16TypeNode) {
+            javaList.add(i, toJava(struct.getShort(i), fieldType));
+          } else if (fieldType instanceof I32TypeNode) {
+            javaList.add(i, toJava(struct.getInt(i), fieldType));
+          } else if (fieldType instanceof I64TypeNode) {
+            javaList.add(i, toJava(struct.getLong(i), fieldType));
+          } else if (fieldType instanceof FP32TypeNode) {
+            javaList.add(i, toJava(struct.getFloat(i), fieldType));
+          } else if (fieldType instanceof FP64TypeNode) {
+            javaList.add(i, toJava(struct.getDouble(i), fieldType));
+          } else if (fieldType instanceof DateTypeNode) {
+            javaList.add(i, toJava(struct.getInt(i), fieldType));
+          } else if (fieldType instanceof TimestampTypeNode) {
+            javaList.add(i, toJava(struct.getLong(i), fieldType));
+          } else if (fieldType instanceof StringTypeNode) {
+            javaList.add(i, toJava(struct.getString(i), fieldType));
+          } else if (fieldType instanceof BinaryTypeNode) {
+            javaList.add(i, toJava(struct.getBinary(i), fieldType));
+          } else if (fieldType instanceof DecimalTypeNode) {
+            DecimalTypeNode decimalType = (DecimalTypeNode) fieldType;
+            javaList.add(
+                i,
+                toJava(struct.getDecimal(i, decimalType.precision, decimalType.scale), fieldType));
+          } else if (fieldType instanceof ListNode) {
+            javaList.add(i, toJava(struct.getArray(i), fieldType));
+          } else if (fieldType instanceof MapNode) {
+            javaList.add(i, toJava(struct.getMap(i), fieldType));
+          } else if (fieldType instanceof StructNode) {
+            StructNode structFieldType = (StructNode) fieldType;
+            javaList.add(
+                i, toJava(struct.getStruct(i, structFieldType.getFieldTypes().size()), fieldType));
+          } else {
+            throw new UnsupportedOperationException(
+                fieldType + " is not supported in StructNodeType.");
+          }
+        }
+      }
+      return javaList;
+    } else {
+      throw new UnsupportedOperationException(nodeType + " is not supported to convert.");
+    }
+  }
+}

--- a/gluten-substrait/src/main/java/org/apache/gluten/utils/SparkToJavaConverter.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/utils/SparkToJavaConverter.java
@@ -46,6 +46,9 @@ import java.util.Map;
 public class SparkToJavaConverter {
 
   public static Object toJava(Object obj, TypeNode nodeType) {
+    if (obj == null) {
+      return null;
+    }
     if ((nodeType instanceof BooleanTypeNode)
         || (nodeType instanceof I8TypeNode)
         || (nodeType instanceof I32TypeNode)

--- a/gluten-substrait/src/main/java/org/apache/gluten/utils/SparkToJavaConverter.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/utils/SparkToJavaConverter.java
@@ -51,6 +51,7 @@ public class SparkToJavaConverter {
     }
     if ((nodeType instanceof BooleanTypeNode)
         || (nodeType instanceof I8TypeNode)
+        || (nodeType instanceof I16TypeNode)
         || (nodeType instanceof I32TypeNode)
         || (nodeType instanceof I64TypeNode)
         || (nodeType instanceof FP32TypeNode)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConditionalTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConditionalTransformer.scala
@@ -45,7 +45,8 @@ case class CaseWhenTransformer(
     // generate else value node, maybe null
     val elseValueNode = elseValue
       .map(_.doTransform(args))
-      .getOrElse(ExpressionBuilder.makeLiteral(null, branchDataType, true))
+      .getOrElse(ExpressionBuilder.makeNullLiteral(
+        ConverterUtils.getTypeNode(branchDataType, nullable = true)))
     new IfThenNode(ifNodes, thenNodes, elseValueNode)
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.expression
 
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode}
+import org.apache.gluten.utils.SparkToJavaConverter
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.types.DataType
@@ -79,7 +80,8 @@ object GenericExpressionTransformer {
 case class LiteralTransformer(original: Literal) extends LeafExpressionTransformer {
   override def substraitExprName: String = "literal"
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    ExpressionBuilder.makeLiteral(original.value, original.dataType, original.nullable)
+    val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)
+    ExpressionBuilder.makeLiteral(SparkToJavaConverter.toJava(original.value, typeNode), typeNode)
   }
 }
 object LiteralTransformer {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionTransformer.scala
@@ -81,7 +81,9 @@ case class LiteralTransformer(original: Literal) extends LeafExpressionTransform
   override def substraitExprName: String = "literal"
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)
-    ExpressionBuilder.makeLiteral(SparkToJavaConverter.toJava(original.value, typeNode), typeNode)
+    ExpressionBuilder.makeLiteral(
+      SparkToJavaConverter.toJava(original.value, typeNode, original.dataType),
+      typeNode)
   }
 }
 object LiteralTransformer {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.expression
 
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode}
+import org.apache.gluten.utils.SparkToJavaConverter
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
@@ -57,9 +58,11 @@ object InExpressionTransformer {
         // Sort elements for deterministic behaviours
         .sortBy(Literal(_, valueType).toString())
         .map(
-          value =>
+          value => {
+            val nodeType = ConverterUtils.getTypeNode(valueType, value == null)
             ExpressionBuilder
-              .makeLiteral(value, ConverterUtils.getTypeNode(valueType, value == null)))
+              .makeLiteral(SparkToJavaConverter.toJava(value, nodeType), nodeType)
+          })
         .asJava)
 
     ExpressionBuilder.makeSingularOrListNode(leftNode, expressionNodes)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
@@ -56,7 +56,10 @@ object InExpressionTransformer {
       values.toSeq
         // Sort elements for deterministic behaviours
         .sortBy(Literal(_, valueType).toString())
-        .map(value => ExpressionBuilder.makeLiteral(value, valueType, value == null))
+        .map(
+          value =>
+            ExpressionBuilder
+              .makeLiteral(value, ConverterUtils.getTypeNode(valueType, value == null)))
         .asJava)
 
     ExpressionBuilder.makeSingularOrListNode(leftNode, expressionNodes)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
@@ -61,7 +61,7 @@ object InExpressionTransformer {
           value => {
             val nodeType = ConverterUtils.getTypeNode(valueType, value == null)
             ExpressionBuilder
-              .makeLiteral(SparkToJavaConverter.toJava(value, nodeType), nodeType)
+              .makeLiteral(SparkToJavaConverter.toJava(value, nodeType, valueType), nodeType)
           })
         .asJava)
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ScalarSubqueryTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ScalarSubqueryTransformer.scala
@@ -39,6 +39,8 @@ case class ScalarSubqueryTransformer(substraitExprName: String, query: ScalarSub
     // before doing transform.
     val result = query.eval(InternalRow.empty)
     val typeNode = ConverterUtils.getTypeNode(query.dataType, result == null)
-    ExpressionBuilder.makeLiteral(SparkToJavaConverter.toJava(result, typeNode), typeNode)
+    ExpressionBuilder.makeLiteral(
+      SparkToJavaConverter.toJava(result, typeNode, query.dataType),
+      typeNode)
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/WindowFunctionNodeUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/WindowFunctionNodeUtil.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils
+
+import org.apache.gluten.expression.ExpressionConverter
+import org.apache.gluten.substrait.`type`.TypeNode
+import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.PreComputeRangeFrameBound
+
+import java.util
+
+import scala.collection.JavaConverters
+
+object WindowFunctionNodeUtil {
+
+  def makeWindowFunction(
+      functionId: Integer,
+      expressionNodes: util.List[ExpressionNode],
+      columnName: String,
+      outputTypeNode: TypeNode,
+      upperBound: Expression,
+      lowerBound: Expression,
+      frameType: String,
+      originalInputAttributes: util.List[Attribute]): WindowFunctionNode = {
+    makeWindowFunction(
+      functionId,
+      expressionNodes,
+      columnName,
+      outputTypeNode,
+      upperBound,
+      lowerBound,
+      frameType,
+      false,
+      originalInputAttributes)
+  }
+
+  def makeWindowFunction(
+      functionId: Integer,
+      expressionNodes: util.List[ExpressionNode],
+      columnName: String,
+      outputTypeNode: TypeNode,
+      upperBound: Expression,
+      lowerBound: Expression,
+      frameType: String,
+      ignoreNulls: Boolean,
+      originalInputAttributes: util.List[Attribute]): WindowFunctionNode = {
+    val upperBoundType = upperBound.sql
+    val lowerBoundType = lowerBound.sql
+    val upperBoundFoldable = upperBound.foldable
+    val lowerBoundFoldable = lowerBound.foldable
+    var upperBoundOffset = 0L
+    var lowerBoundOffset = 0L
+    var upperBoundRefNode: ExpressionNode = null
+    var lowerBoundRefNode: ExpressionNode = null
+    val isPreComputeRangeFrameUpperBound = upperBound.isInstanceOf[PreComputeRangeFrameBound]
+    val isPreComputeRangeFrameLowerBound = lowerBound.isInstanceOf[PreComputeRangeFrameBound]
+    if (isPreComputeRangeFrameUpperBound) {
+      upperBoundOffset = upperBound.eval(null).toString.toLong
+      upperBoundRefNode = ExpressionConverter
+        .replaceWithExpressionTransformer(
+          upperBound.asInstanceOf[PreComputeRangeFrameBound].child.toAttribute,
+          JavaConverters.asScalaIteratorConverter(originalInputAttributes.iterator).asScala.toSeq
+        )
+        .doTransform(new util.HashMap[String, Long])
+    }
+    if (isPreComputeRangeFrameLowerBound) {
+      lowerBoundOffset = lowerBound.eval(null).toString.toLong
+      lowerBoundRefNode = ExpressionConverter
+        .replaceWithExpressionTransformer(
+          lowerBound.asInstanceOf[PreComputeRangeFrameBound].child.toAttribute,
+          JavaConverters.asScalaIteratorConverter(originalInputAttributes.iterator).asScala.toSeq
+        )
+        .doTransform(new util.HashMap[String, Long])
+    }
+    ExpressionBuilder.makeWindowFunction(
+      functionId,
+      expressionNodes,
+      columnName,
+      outputTypeNode,
+      upperBoundType,
+      lowerBoundType,
+      frameType,
+      ignoreNulls,
+      upperBoundFoldable,
+      lowerBoundFoldable,
+      upperBoundOffset,
+      lowerBoundOffset,
+      upperBoundRefNode,
+      lowerBoundRefNode,
+      isPreComputeRangeFrameUpperBound,
+      isPreComputeRangeFrameLowerBound
+    )
+  }
+
+}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/WindowFunctionNodeUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/WindowFunctionNodeUtil.scala
@@ -64,14 +64,13 @@ object WindowFunctionNodeUtil {
     val lowerBoundType = lowerBound.sql
     val upperBoundFoldable = upperBound.foldable
     val lowerBoundFoldable = lowerBound.foldable
-    var upperBoundOffset = 0L
-    var lowerBoundOffset = 0L
+    var upperBoundOffset = upperBound.eval(null).toString.toLong
+    var lowerBoundOffset = lowerBound.eval(null).toString.toLong
     var upperBoundRefNode: ExpressionNode = null
     var lowerBoundRefNode: ExpressionNode = null
     val isPreComputeRangeFrameUpperBound = upperBound.isInstanceOf[PreComputeRangeFrameBound]
     val isPreComputeRangeFrameLowerBound = lowerBound.isInstanceOf[PreComputeRangeFrameBound]
     if (isPreComputeRangeFrameUpperBound) {
-      upperBoundOffset = upperBound.eval(null).toString.toLong
       upperBoundRefNode = ExpressionConverter
         .replaceWithExpressionTransformer(
           upperBound.asInstanceOf[PreComputeRangeFrameBound].child.toAttribute,
@@ -80,7 +79,6 @@ object WindowFunctionNodeUtil {
         .doTransform(new util.HashMap[String, Long])
     }
     if (isPreComputeRangeFrameLowerBound) {
-      lowerBoundOffset = lowerBound.eval(null).toString.toLong
       lowerBoundRefNode = ExpressionConverter
         .replaceWithExpressionTransformer(
           lowerBound.asInstanceOf[PreComputeRangeFrameBound].child.toAttribute,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/WindowFunctionNodeUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/WindowFunctionNodeUtil.scala
@@ -64,13 +64,14 @@ object WindowFunctionNodeUtil {
     val lowerBoundType = lowerBound.sql
     val upperBoundFoldable = upperBound.foldable
     val lowerBoundFoldable = lowerBound.foldable
-    var upperBoundOffset = upperBound.eval(null).toString.toLong
-    var lowerBoundOffset = lowerBound.eval(null).toString.toLong
+    var upperBoundOffset = 0L
+    var lowerBoundOffset = 0L
     var upperBoundRefNode: ExpressionNode = null
     var lowerBoundRefNode: ExpressionNode = null
     val isPreComputeRangeFrameUpperBound = upperBound.isInstanceOf[PreComputeRangeFrameBound]
     val isPreComputeRangeFrameLowerBound = lowerBound.isInstanceOf[PreComputeRangeFrameBound]
     if (isPreComputeRangeFrameUpperBound) {
+      upperBoundOffset = upperBound.eval(null).toString.toLong
       upperBoundRefNode = ExpressionConverter
         .replaceWithExpressionTransformer(
           upperBound.asInstanceOf[PreComputeRangeFrameBound].child.toAttribute,
@@ -79,12 +80,19 @@ object WindowFunctionNodeUtil {
         .doTransform(new util.HashMap[String, Long])
     }
     if (isPreComputeRangeFrameLowerBound) {
+      lowerBoundOffset = lowerBound.eval(null).toString.toLong
       lowerBoundRefNode = ExpressionConverter
         .replaceWithExpressionTransformer(
           lowerBound.asInstanceOf[PreComputeRangeFrameBound].child.toAttribute,
           JavaConverters.asScalaIteratorConverter(originalInputAttributes.iterator).asScala.toSeq
         )
         .doTransform(new util.HashMap[String, Long])
+    }
+    if (upperBoundFoldable) {
+      upperBoundOffset = upperBound.eval(null).toString.toLong
+    }
+    if (lowerBoundFoldable) {
+      lowerBoundOffset = lowerBound.eval(null).toString.toLong
     }
     ExpressionBuilder.makeWindowFunction(
       functionId,

--- a/gluten-substrait/src/test/scala/org/apache/gluten/utils/SparkToJavaConverterSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/utils/SparkToJavaConverterSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils
+
+import org.apache.gluten.substrait.`type`._
+
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
+import org.apache.spark.sql.types.Decimal
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.math.{BigDecimal, BigInteger, MathContext}
+import java.util
+
+class SparkToJavaConverterSuite extends AnyFunSuite {
+  test("Convert decimal") {
+    val decimal =
+      SparkToJavaConverter.toJava(new Decimal().set(11, 5, 3), new DecimalTypeNode(false, 5, 3))
+    val result = new BigDecimal(BigInteger.valueOf(11), 3, new MathContext(5))
+    assert(result.equals(decimal))
+  }
+
+  test("Convert binary") {
+    val binary =
+      SparkToJavaConverter
+        .toJava(Array[Byte](5, 6, 7), new BinaryTypeNode(false))
+        .asInstanceOf[Array[Byte]]
+    val result = Array[Byte](5, 6, 7)
+    assert(result.sameElements(binary))
+  }
+
+  test("Convert row") {
+    val doubleArray = Array[Any](6.66, 2.22)
+    val strArray = Array[Any]("str1", "str2")
+    val list = new GenericArrayData(doubleArray)
+    val strList = new GenericArrayData(strArray)
+    val array = new Array[Any](5)
+    array(0) = true
+    array(1) = 777777
+    array(2) = list
+    array(3) = new ArrayBasedMapData(strList, list)
+    array(4) = 12356L
+    val row = new GenericInternalRow(array)
+    val fieldTypes = new util.ArrayList[TypeNode]()
+    fieldTypes.add(new BooleanTypeNode(false))
+    fieldTypes.add(new DateTypeNode(false))
+    fieldTypes.add(new ListNode(false, new FP64TypeNode(false)))
+    fieldTypes.add(new MapNode(false, new StringTypeNode(false), new FP64TypeNode(false)))
+    fieldTypes.add(new TimestampTypeNode(false))
+    val javaRow =
+      SparkToJavaConverter.toJava(row, new StructNode(false, fieldTypes))
+    val result = new util.ArrayList[Object]()
+    result.add(java.lang.Boolean.TRUE)
+    result.add(java.lang.Integer.valueOf(777777))
+    val javaDoubleList = new util.ArrayList[Double]()
+    javaDoubleList.add(6.66)
+    javaDoubleList.add(2.22)
+    result.add(javaDoubleList)
+    val javaMap = new util.HashMap[String, Double]()
+    javaMap.put("str1", 6.66)
+    javaMap.put("str2", 2.22)
+    result.add(javaMap)
+    result.add(java.lang.Long.valueOf(12356))
+    assert(javaRow == result)
+  }
+}

--- a/gluten-substrait/src/test/scala/org/apache/gluten/utils/SparkToJavaConverterSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/utils/SparkToJavaConverterSuite.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.substrait.`type`._
 
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
-import org.apache.spark.sql.types.Decimal
+import org.apache.spark.sql.types.{DataTypes, Decimal, StructField, StructType}
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -65,8 +65,18 @@ class SparkToJavaConverterSuite extends AnyFunSuite {
     fieldTypes.add(new ListNode(false, new FP64TypeNode(false)))
     fieldTypes.add(new MapNode(false, new StringTypeNode(false), new FP64TypeNode(false)))
     fieldTypes.add(new TimestampTypeNode(false))
+    val structFields = new Array[StructField](5)
+    structFields(0) = StructField("bool", DataTypes.BooleanType)
+    structFields(1) = StructField("date", DataTypes.DateType)
+    structFields(2) = StructField("array", DataTypes.createArrayType(DataTypes.DoubleType))
+    structFields(3) =
+      StructField("map", DataTypes.createMapType(DataTypes.StringType, DataTypes.DoubleType))
+    structFields(4) = StructField("time", DataTypes.TimestampType)
     val javaRow =
-      SparkToJavaConverter.toJava(row, new StructNode(false, fieldTypes), null)
+      SparkToJavaConverter.toJava(
+        row,
+        new StructNode(false, fieldTypes),
+        new StructType(structFields))
     val result = new util.ArrayList[Object]()
     result.add(java.lang.Boolean.TRUE)
     result.add(java.lang.Integer.valueOf(777777))

--- a/gluten-substrait/src/test/scala/org/apache/gluten/utils/SparkToJavaConverterSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/utils/SparkToJavaConverterSuite.scala
@@ -30,7 +30,10 @@ import java.util
 class SparkToJavaConverterSuite extends AnyFunSuite {
   test("Convert decimal") {
     val decimal =
-      SparkToJavaConverter.toJava(new Decimal().set(11, 5, 3), new DecimalTypeNode(false, 5, 3))
+      SparkToJavaConverter.toJava(
+        new Decimal().set(11, 5, 3),
+        new DecimalTypeNode(false, 5, 3),
+        null)
     val result = new BigDecimal(BigInteger.valueOf(11), 3, new MathContext(5))
     assert(result.equals(decimal))
   }
@@ -38,7 +41,7 @@ class SparkToJavaConverterSuite extends AnyFunSuite {
   test("Convert binary") {
     val binary =
       SparkToJavaConverter
-        .toJava(Array[Byte](5, 6, 7), new BinaryTypeNode(false))
+        .toJava(Array[Byte](5, 6, 7), new BinaryTypeNode(false), null)
         .asInstanceOf[Array[Byte]]
     val result = Array[Byte](5, 6, 7)
     assert(result.sameElements(binary))
@@ -63,7 +66,7 @@ class SparkToJavaConverterSuite extends AnyFunSuite {
     fieldTypes.add(new MapNode(false, new StringTypeNode(false), new FP64TypeNode(false)))
     fieldTypes.add(new TimestampTypeNode(false))
     val javaRow =
-      SparkToJavaConverter.toJava(row, new StructNode(false, fieldTypes))
+      SparkToJavaConverter.toJava(row, new StructNode(false, fieldTypes), null)
     val result = new util.ArrayList[Object]()
     result.add(java.lang.Boolean.TRUE)
     result.add(java.lang.Integer.valueOf(777777))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr make the substrait related class not depend on spark. So it can be reused by flink.

(Fixes: \#9087)

## How was this patch tested?

This patch was tested by unit tests and existing integration tests


