### PR TITLE
[GLUTEN-9093][CH] Add TryCastSuite for CH backend Spark 3.4

### DIFF
--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -1714,6 +1714,37 @@ class ClickHouseTestSettings extends BackendTestSettings {
   enableSuite[GlutenSparkSessionExtensionSuite]
   enableSuite[GlutenHiveSQLQueryCHSuite]
   enableSuite[GlutenPercentileSuite]
+  enableSuite[GlutenTryCastSuite]
+    .exclude(
+      "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
+    )
+    .exclude("ANSI mode: Throw exception on casting out-of-range value to byte type")
+    .exclude("ANSI mode: Throw exception on casting out-of-range value to short type")
+    .exclude("ANSI mode: Throw exception on casting out-of-range value to int type")
+    .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
+    .exclude("cast from invalid string to numeric should throw NumberFormatException")
+    .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
+    // Set timezone through config.
+    .exclude("data type casting")
+    .excludeCH("null cast")
+    .excludeCH("cast string to date")
+    .excludeCH("cast string to timestamp")
+    .excludeGlutenTest("cast string to timestamp")
+    .excludeCH("SPARK-22825 Cast array to string")
+    .excludeCH("SPARK-33291: Cast array with null elements to string")
+    .excludeCH("SPARK-22973 Cast map to string")
+    .excludeCH("SPARK-22981 Cast struct to string")
+    .excludeCH("SPARK-33291: Cast struct with null elements to string")
+    .excludeCH("SPARK-35111: Cast string to year-month interval")
+    .excludeCH("cast from timestamp II")
+    .excludeCH("cast a timestamp before the epoch 1970-01-01 00:00:00Z II")
+    .excludeCH("cast a timestamp before the epoch 1970-01-01 00:00:00Z")
+    .excludeCH("cast from array II")
+    .excludeCH("cast from array III")
+    .excludeCH("cast from struct III")
+    .excludeCH("ANSI mode: cast string to timestamp with parse error")
+    .excludeCH("ANSI mode: cast string to date with parse error")
+    .excludeCH("Gluten - data type casting")
 
   override def getSQLQueryTestSettings: SQLQueryTestSettings = ClickHouseSQLQueryTestSettings
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - We don't run TryCastSuite for CH 3.4 currently
 - Enabling the same and bringing parity with other backends.

## How was this patch tested?
 - Unit Test