### PR TITLE
[GLUTEN-9095][UT] Remove Vanilla Spark InternalRow based checkEvaluation

### DIFF
--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.GlutenQueryTestUtil.isNaNOrInf
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.ResolveTimeZone
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, ConvertToLocalRelation, NullPropagation}
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.internal.SQLConf
@@ -130,21 +129,17 @@ trait GlutenTestsTrait extends GlutenTestsCommonTrait {
       expression: => Expression,
       expected: Any,
       inputRow: InternalRow = EmptyRow): Unit = {
-    val resolver = ResolveTimeZone
-    val expr = resolver.resolveTimeZones(expression)
-    assert(expr.resolved)
 
     if (canConvertToDataFrame(inputRow)) {
+      val resolver = ResolveTimeZone
+      val expr = resolver.resolveTimeZones(expression)
+      assert(expr.resolved)
+
       glutenCheckExpression(expr, expected, inputRow)
     } else {
-      logWarning(s"The status of this unit test is not guaranteed.")
-      val catalystValue = CatalystTypeConverters.convertToCatalyst(expected)
-      checkEvaluationWithoutCodegen(expr, catalystValue, inputRow)
-      checkEvaluationWithMutableProjection(expr, catalystValue, inputRow)
-      if (GenerateUnsafeProjection.canSupport(expr.dataType)) {
-        checkEvaluationWithUnsafeProjection(expr, catalystValue, inputRow)
-      }
-      checkEvaluationWithOptimization(expr, catalystValue, inputRow)
+      logWarning(
+        "Skipping evaluation - Nonempty inputRow cannot be converted to DataFrame " +
+          "due to complex/unsupported types.\n")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - GlutenCheckExpression currently falls back to internal row for certain complex/unsupported types.
 - As discussed in the PR, this is running Vanilla Spark and does not mean anything for Gluten.
 - Removing the same
## How was this patch tested?
 - Unit Tests