### PR TITLE
[VL][MIRROR] Migrate Velox runtime config flags to dynamic VeloxRuntime settings

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -112,6 +112,13 @@ object VeloxConfig {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(TimeUnit.MINUTES.toMillis(60))
 
+  val COLUMNAR_VELOX_MEMORY_POOL_CAPACITY_TRANSFER_ACROSS_TASKS =
+    buildConf("spark.gluten.sql.columnar.backend.velox.memoryPoolCapacityTransferAcrossTasks")
+      .internal()
+      .doc("Whether to allow memory capacity transfer between memory pools from different tasks.")
+      .booleanConf
+      .createWithDefault(true)
+
   val COLUMNAR_VELOX_SSD_CACHE_PATH =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdCachePath")
       .internal()

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -49,16 +49,6 @@
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/serializers/PrestoSerializer.h"
 
-DECLARE_bool(velox_exception_user_stacktrace_enabled);
-DECLARE_int32(velox_memory_num_shared_leaf_pools);
-DECLARE_bool(velox_memory_use_hugepages);
-DECLARE_bool(velox_ssd_odirect);
-DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
-DECLARE_int32(cache_prefetch_min_pct);
-
-DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
-DEFINE_int32(gluten_velox_aysnc_timeout_on_task_stopping, 30000, "Aysnc timout when task is being stopped");
-
 using namespace facebook;
 
 namespace gluten {

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -49,6 +49,16 @@
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/serializers/PrestoSerializer.h"
 
+DECLARE_bool(velox_exception_user_stacktrace_enabled);
+DECLARE_int32(velox_memory_num_shared_leaf_pools);
+DECLARE_bool(velox_memory_use_hugepages);
+DECLARE_bool(velox_ssd_odirect);
+DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
+DECLARE_int32(cache_prefetch_min_pct);
+
+DECLARE_int32(gluten_velox_async_timeout_on_task_stopping);
+DEFINE_int32(gluten_velox_async_timeout_on_task_stopping, 30000, "Async timout when task is being stopped");
+
 using namespace facebook;
 
 namespace gluten {
@@ -103,7 +113,8 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
   google::InitGoogleLogging("gluten");
 
   // Allow growing buffer in another task through its memory pool.
-  FLAGS_velox_memory_pool_capacity_transfer_across_tasks = true;
+  FLAGS_velox_memory_pool_capacity_transfer_across_tasks =
+      backendConf_->get<int32_t>(kMemoryPoolCapacityTransferAcrossTasks, true);
 
   // Avoid creating too many shared leaf pools.
   FLAGS_velox_memory_num_shared_leaf_pools = 0;
@@ -120,7 +131,7 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
   FLAGS_velox_memory_use_hugepages = backendConf_->get<bool>(kMemoryUseHugePages, kMemoryUseHugePagesDefault);
 
   // Async timeout.
-  FLAGS_gluten_velox_aysnc_timeout_on_task_stopping =
+  FLAGS_gluten_velox_async_timeout_on_task_stopping =
       backendConf_->get<int32_t>(kVeloxAsyncTimeoutOnTaskStopping, kVeloxAsyncTimeoutOnTaskStoppingDefault);
 
   // Setup and register.

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -114,7 +114,7 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
 
   // Allow growing buffer in another task through its memory pool.
   FLAGS_velox_memory_pool_capacity_transfer_across_tasks =
-      backendConf_->get<int32_t>(kMemoryPoolCapacityTransferAcrossTasks, true);
+      backendConf_->get<bool>(kMemoryPoolCapacityTransferAcrossTasks, true);
 
   // Avoid creating too many shared leaf pools.
   FLAGS_velox_memory_num_shared_leaf_pools = 0;

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -29,16 +29,6 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/memory/MmapAllocator.h"
 
-DECLARE_bool(velox_exception_user_stacktrace_enabled);
-DECLARE_int32(velox_memory_num_shared_leaf_pools);
-DECLARE_bool(velox_memory_use_hugepages);
-DECLARE_bool(velox_ssd_odirect);
-DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
-DECLARE_int32(cache_prefetch_min_pct);
-
-DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
-DEFINE_int32(gluten_velox_aysnc_timeout_on_task_stopping, 30000, "Aysnc timout when task is being stopped");
-
 namespace gluten {
 // This kind string must be same with VeloxBackend#name in java side.
 inline static const std::string kVeloxBackendKind{"velox"};

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -29,6 +29,16 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/memory/MmapAllocator.h"
 
+DECLARE_bool(velox_exception_user_stacktrace_enabled);
+DECLARE_int32(velox_memory_num_shared_leaf_pools);
+DECLARE_bool(velox_memory_use_hugepages);
+DECLARE_bool(velox_ssd_odirect);
+DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
+DECLARE_int32(cache_prefetch_min_pct);
+
+DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
+DEFINE_int32(gluten_velox_aysnc_timeout_on_task_stopping, 30000, "Aysnc timout when task is being stopped");
+
 namespace gluten {
 // This kind string must be same with VeloxBackend#name in java side.
 inline static const std::string kVeloxBackendKind{"velox"};

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -65,6 +65,11 @@ VeloxRuntime::VeloxRuntime(
   debugModeEnabled_ = veloxCfg_->get<bool>(kDebugModeEnabled, false);
   FLAGS_minloglevel = veloxCfg_->get<uint32_t>(kGlogSeverityLevel, FLAGS_minloglevel);
   FLAGS_v = veloxCfg_->get<uint32_t>(kGlogVerboseLevel, FLAGS_v);
+  FLAGS_velox_exception_user_stacktrace_enabled =
+      veloxCfg_->get<bool>(kEnableUserExceptionStacktrace, FLAGS_velox_exception_user_stacktrace_enabled);
+  FLAGS_velox_exception_system_stacktrace_enabled =
+      veloxCfg_->get<bool>(kEnableSystemExceptionStacktrace, FLAGS_velox_exception_system_stacktrace_enabled);
+  FLAGS_velox_memory_use_hugepages = veloxCfg_->get<bool>(kMemoryUseHugePages, FLAGS_velox_memory_use_hugepages);
 }
 
 void VeloxRuntime::parsePlan(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) {

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -34,6 +34,11 @@
 #include "utils/ConfigExtractor.h"
 #include "utils/VeloxArrowUtils.h"
 
+DECLARE_bool(velox_exception_user_stacktrace_enabled);
+DECLARE_bool(velox_memory_use_hugepages);
+DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
+DECLARE_int32(cache_prefetch_min_pct);
+
 #ifdef ENABLE_HDFS
 #include "operators/writer/VeloxParquetDataSourceHDFS.h"
 #endif
@@ -70,6 +75,9 @@ VeloxRuntime::VeloxRuntime(
   FLAGS_velox_exception_system_stacktrace_enabled =
       veloxCfg_->get<bool>(kEnableSystemExceptionStacktrace, FLAGS_velox_exception_system_stacktrace_enabled);
   FLAGS_velox_memory_use_hugepages = veloxCfg_->get<bool>(kMemoryUseHugePages, FLAGS_velox_memory_use_hugepages);
+  FLAGS_cache_prefetch_min_pct = veloxCfg_->get<bool>(kCachePrefetchMinPct, FLAGS_cache_prefetch_min_pct);
+  FLAGS_velox_memory_pool_capacity_transfer_across_tasks = veloxCfg_->get<bool>(
+      kMemoryPoolCapacityTransferAcrossTasks, FLAGS_velox_memory_pool_capacity_transfer_across_tasks);
 }
 
 void VeloxRuntime::parsePlan(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) {

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -127,6 +127,8 @@ const std::string kLoadQuantum = "spark.gluten.sql.columnar.backend.velox.loadQu
 const std::string kMaxCoalescedDistance = "spark.gluten.sql.columnar.backend.velox.maxCoalescedDistance";
 const std::string kMaxCoalescedBytes = "spark.gluten.sql.columnar.backend.velox.maxCoalescedBytes";
 const std::string kCachePrefetchMinPct = "spark.gluten.sql.columnar.backend.velox.cachePrefetchMinPct";
+const std::string kMemoryPoolCapacityTransferAcrossTasks =
+    "spark.gluten.sql.columnar.backend.velox.memoryPoolCapacityTransferAcrossTasks";
 
 // write fies
 const std::string kMaxPartitions = "spark.gluten.sql.columnar.backend.velox.maxPartitionsPerWritersSession";

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -29,8 +29,6 @@
 #include "memory/ArrowMemoryPool.h"
 #include "utils/Exception.h"
 
-DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
-
 namespace gluten {
 
 using namespace facebook;

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -29,6 +29,8 @@
 #include "memory/ArrowMemoryPool.h"
 #include "utils/Exception.h"
 
+DECLARE_int32(gluten_velox_async_timeout_on_task_stopping);
+
 namespace gluten {
 
 using namespace facebook;
@@ -377,7 +379,7 @@ bool VeloxMemoryManager::tryDestructSafe() {
 }
 
 VeloxMemoryManager::~VeloxMemoryManager() {
-  static const uint32_t kWaitTimeoutMs = FLAGS_gluten_velox_aysnc_timeout_on_task_stopping; // 30s by default
+  static const uint32_t kWaitTimeoutMs = FLAGS_gluten_velox_async_timeout_on_task_stopping; // 30s by default
   uint32_t accumulatedWaitMs = 0UL;
   bool destructed = false;
   for (int32_t tryCount = 0; accumulatedWaitMs < kWaitTimeoutMs; tryCount++) {

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -494,7 +494,10 @@ object GlutenConfig {
       "spark.gluten.sql.columnar.backend.velox.queryTraceNodeIds",
       "spark.gluten.sql.columnar.backend.velox.queryTraceMaxBytes",
       "spark.gluten.sql.columnar.backend.velox.queryTraceTaskRegExp",
-      "spark.gluten.sql.columnar.backend.velox.opTraceDirectoryCreateConfig"
+      "spark.gluten.sql.columnar.backend.velox.opTraceDirectoryCreateConfig",
+      "spark.gluten.sql.columnar.backend.velox.enableUserExceptionStacktrace",
+      "spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace",
+      "spark.gluten.sql.columnar.backend.velox.memoryUseHugePages"
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -497,7 +497,9 @@ object GlutenConfig {
       "spark.gluten.sql.columnar.backend.velox.opTraceDirectoryCreateConfig",
       "spark.gluten.sql.columnar.backend.velox.enableUserExceptionStacktrace",
       "spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace",
-      "spark.gluten.sql.columnar.backend.velox.memoryUseHugePages"
+      "spark.gluten.sql.columnar.backend.velox.memoryUseHugePages",
+      "spark.gluten.sql.columnar.backend.velox.cachePrefetchMinPct",
+      "spark.gluten.sql.columnar.backend.velox.memoryPoolCapacityTransferAcrossTasks"
     )
     nativeConfMap.putAll(conf.filter(e => keys.contains(e._1)).asJava)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the flags `FLAGS_velox_exception_user_stacktrace_enabled`, `FLAGS_velox_exception_system_stacktrace_enabled`, `FLAGS_velox_memory_use_hugepages`, `FLAGS_cache_prefetch_min_pct` and `FLAGS_velox_memory_pool_capacity_transfer_across_tasks` are utilized in the Velox runtime, but their configuration is currently limited to VeloxBackend. This PR migrates their configuration to VeloxRuntime, enabling dynamic modification through session configurations and runtime adjustments.
## How was this patch tested?
GA

