### PR TITLE
[GLUTEN-9106][VL] Add support for staticInvoke CharVarcharCodegenUtils. #9107

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -854,6 +854,47 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  // Add test suite for CharVarcharCodegenUtils functions.
+  // A ProjectExecTransformer is expected to be constructed after expr support.
+  // We currently test below functions with Spark v3.4
+  testWithSpecifiedSparkVersion("Test charTypeWriteSideCheck function", Some("3.4")) {
+    withTable("src", "dest") {
+
+      sql("create table src(id string) USING PARQUET")
+      sql("insert into src values('s')")
+      sql("create table dest(id char(3)) USING PARQUET")
+      // check whether the executed plan of a dataframe contains the expected plan.
+      runQueryAndCompare("insert into dest select id from src") {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+    }
+  }
+
+  testWithSpecifiedSparkVersion("Test varcharTypeWriteSideCheck function", Some("3.4")) {
+    withTable("src", "dest") {
+
+      sql("create table src(id string) USING PARQUET")
+      sql("insert into src values('abc')")
+      sql("create table dest(id varchar(10)) USING PARQUET")
+      // check whether the executed plan of a dataframe contains the expected plan.
+      runQueryAndCompare("insert into dest select id from src") {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+    }
+  }
+
+  testWithSpecifiedSparkVersion("Test readSidePadding function", Some("3.4")) {
+    withTable("src", "dest") {
+
+      sql("create table tgt(id char(3)) USING PARQUET")
+      sql("insert into tgt values('p')")
+      // check whether the executed plan of a dataframe contains the expected plan.
+      runQueryAndCompare("select id from tgt") {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+    }
+  }
+
   test("Test hex function") {
     runQueryAndCompare("SELECT hex(l_partkey), hex(l_shipmode) FROM lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -164,6 +164,32 @@ object ExpressionConverter extends SQLConfHelper with Logging {
                 child.map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap)),
                 i)
           }
+        } else if (objectName.endsWith("CharVarcharCodegenUtils")) {
+          val children = i.arguments
+          i.functionName match {
+            case "varcharTypeWriteSideCheck" =>
+              return GenericExpressionTransformer(
+                ExpressionNames.VARCHAR_TYPE_WRITE_SIDE_CHECK,
+                children
+                  .map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap))
+                  .toSeq,
+                i)
+            case "charTypeWriteSideCheck" =>
+              return GenericExpressionTransformer(
+                ExpressionNames.CHAR_TYPE_WRITE_SIDE_CHECK,
+                children
+                  .map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap))
+                  .toSeq,
+                i)
+            case "readSidePadding" =>
+              // println(s"enters readSidePadding")
+              return GenericExpressionTransformer(
+                ExpressionNames.READ_SIDE_PADDING,
+                children
+                  .map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap))
+                  .toSeq,
+                i)
+          }
         }
       case _ =>
     }

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -356,4 +356,9 @@ object ExpressionNames {
   // A placeholder for native UDF functions
   final val UDF_PLACEHOLDER = "udf_placeholder"
   final val UDAF_PLACEHOLDER = "udaf_placeholder"
+
+  // Spark Catalyst util functions
+  final val VARCHAR_TYPE_WRITE_SIDE_CHECK = "varchar_type_write_side_check"
+  final val CHAR_TYPE_WRITE_SIDE_CHECK = "char_type_write_side_check"
+  final val READ_SIDE_PADDING = "read_side_padding"
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To add support for static function callls in Spark's CharVarcharCodegenUtils.java, we add expr matching pattern in Gluten ExpressionConverter.

(Fixes: \#9106)

## How was this patch tested?

Added test cases in Gluten's ScalarFunctionsValidateSuite.
Built Gluten Velox with Spark 3.4 (Spark3.4.4 in pom.xml default) and test sqls.

for test_varcharWriteSideCheck: 
```sql
create table srcvarchar(id string) stored as parquet;
create table tgt_vanilla(id varchar(3)) stored as parquet;
create table tgt(id varchar(3)) stored as parquet;

create table srcchar(id string) stored as parquet;
create table tgt_vanilla(id char(3)) stored as parquet;
create table tgt(id char(3)) stored as parquet;

insert into srcvarchar values ('a');
insert into srcvarchar values ('ab');
insert into srcvarchar values ('t  '); -- trail space but should retain
insert into srcvarchar values ('tra '); -- trail space but should trim
insert into srcvarchar values ('中  '); -- trailing space but should retain
insert into srcvarchar values ('中   '); -- trailing space but should trim to 3
insert into srcvarchar values ('中文中国'); -- will fail

insert into tgt select id from srcvarchar
```

for charWriteSideCheck: 
```sql
insert into srcchar values ('a');
insert into srcchar values ('ab');
insert into srcchar values ('快');
insert into srcchar values ('捷  ');
insert into tgt_vanilla select id from srcchar where id='abcd';
```

check plan to validate such operations offload to native and do not cause operator fallback:
![3668dcde999255823c0bfcfc9f55970](https://github.com/user-attachments/assets/9a5a37ce-8f6a-4dc3-bd63-a6f80845dcf0)