### PR TITLE
[GLUTEN-9111][VL] Add support for casting Y/M Interval to varchar

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -243,8 +243,8 @@ bool SubstraitToVeloxPlanValidator::isAllowedCast(const TypePtr& fromType, const
   // 4. Certain complex types are not allowed.
 
   // Don't support isIntervalYearMonth.
-  if (fromType->isIntervalYearMonth() || toType->isIntervalYearMonth()) {
-    return false;
+  if ((fromType->isIntervalYearMonth() && toType->kind() != TypeKind::VARCHAR) || toType->isIntervalYearMonth()) {
+      return false;
   }
 
   // Limited support for DATE to X.

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2025_03_24
+VELOX_REPO=https://github.com/ArnavBalyan/velox.git
+VELOX_BRANCH=arnavb/cast-yrm-string
 VELOX_HOME=""
 
 OS=`uname -s`


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - Year month interval to string falls back, add support for the same.
 - Offloads varchar type to Velox interval casting.
## How was this patch tested?
 - UTs
