### PR TITLE
[GLUTEN-9113][VL]  Remove Unused not_equal Function Mapping

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -393,7 +393,6 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"lte", "lessthanorequal"},
     {"gt", "greaterthan"},
     {"gte", "greaterthanorequal"},
-    {"not_equal", "notequalto"},
     {"char_length", "length"},
     {"strpos", "instr"},
     {"ends_with", "endswith"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark internally rewrites (a != b) as NOT (a = b), this meas spark never use the mapping(not_equal -> notequalto). velox does not implement a native notequalto function. so this maping should be removed.

(Fixes: \#9113)


