### PR TITLE
[VL] Account some C++ untracked memory allocations into Spark global off-heap memory

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -79,7 +79,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
     // Overhead memory limits.
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.SPARK_OFFHEAP_SIZE_KEY)
-    val desiredOverheadSize = (0.15 * offHeapSize).toLong.max(ByteUnit.MiB.toBytes(192))
+    val desiredOverheadSize = (0.3 * offHeapSize).toLong.max(ByteUnit.MiB.toBytes(384))
     if (!SparkResourceUtil.isMemoryOverheadSet(conf)) {
       // If memory overhead is not set by user, automatically set it according to off-heap settings.
       logInfo(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -123,7 +123,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
   override def onDriverShutdown(): Unit = {
     if (!driverStopped.compareAndSet(false, true)) {
-      // Make sure we call the static initializers only once.
+      // Make sure we call the shutdown hooks only once.
       logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
@@ -156,12 +156,12 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
   override def onExecutorShutdown(): Unit = {
     if (!executorStopped.compareAndSet(false, true)) {
-      // Make sure we call the static initializers only once.
+      // Make sure we call the shutdown hooks only once.
       logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
     if (inLocalMode(SparkEnv.get.conf)) {
-      // Don't do static initializations from executor side in local mode.
+      // Don't call shutdown hooks from executor side in local mode.
       // Driver already did that.
       logInfo("Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
       return

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -28,7 +28,6 @@ import org.apache.gluten.init.NativeBackendInitializer
 import org.apache.gluten.jni.{JniLibLoader, JniWorkspace}
 import org.apache.gluten.udf.UdfJniWrapper
 import org.apache.gluten.utils._
-
 import org.apache.spark.{HdfsConfGenerator, ShuffleDependency, SparkConf, SparkContext, SparkEnv}
 import org.apache.spark.api.plugin.PluginContext
 import org.apache.spark.internal.Logging
@@ -42,7 +41,6 @@ import org.apache.spark.sql.execution.datasources.velox.{VeloxParquetWriterInjec
 import org.apache.spark.sql.expression.UDFResolver
 import org.apache.spark.sql.internal.{GlutenConfigUtil, StaticSQLConf}
 import org.apache.spark.util.{SparkDirectoryUtil, SparkResourceUtil}
-
 import org.apache.commons.lang3.StringUtils
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -124,7 +122,8 @@ class VeloxListenerApi extends ListenerApi with Logging {
   override def onDriverShutdown(): Unit = {
     if (!driverStopped.compareAndSet(false, true)) {
       // Make sure we call the static initializers only once.
-      logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
+      logInfo(
+        "Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
     shutdown()
@@ -155,15 +154,17 @@ class VeloxListenerApi extends ListenerApi with Logging {
   }
 
   override def onExecutorShutdown(): Unit = {
-    if (!executorStopped.compareAndSet(false, true)) {
+    if (!driverStopped.compareAndSet(false, true)) {
       // Make sure we call the static initializers only once.
-      logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
+      logInfo(
+        "Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
     if (inLocalMode(SparkEnv.get.conf)) {
       // Don't do static initializations from executor side in local mode.
       // Driver already did that.
-      logInfo("Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
+      logInfo(
+        "Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
       return
     }
     shutdown()
@@ -237,8 +238,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
   }
 
   private def shutdown(): Unit = {
-    NativeBackendInitializer
-      .forBackend(VeloxBackend.BACKEND_NAME)
+    NativeBackendInitializer.forBackend(VeloxBackend.BACKEND_NAME)
       .stop()
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -28,7 +28,8 @@ import org.apache.gluten.init.NativeBackendInitializer
 import org.apache.gluten.jni.{JniLibLoader, JniWorkspace}
 import org.apache.gluten.udf.UdfJniWrapper
 import org.apache.gluten.utils._
-import org.apache.spark.{HdfsConfGenerator, ShuffleDependency, SparkConf, SparkContext, SparkEnv}
+
+import org.apache.spark.{HdfsConfGenerator, ShuffleDependency, SparkConf, SparkContext}
 import org.apache.spark.api.plugin.PluginContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.GlobalOffHeapMemory
@@ -41,6 +42,7 @@ import org.apache.spark.sql.execution.datasources.velox.{VeloxParquetWriterInjec
 import org.apache.spark.sql.expression.UDFResolver
 import org.apache.spark.sql.internal.{GlutenConfigUtil, StaticSQLConf}
 import org.apache.spark.util.{SparkDirectoryUtil, SparkResourceUtil}
+
 import org.apache.commons.lang3.StringUtils
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -119,15 +121,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
     UdfJniWrapper.registerFunctionSignatures()
   }
 
-  override def onDriverShutdown(): Unit = {
-    if (!driverStopped.compareAndSet(false, true)) {
-      // Make sure we call the static initializers only once.
-      logInfo(
-        "Skip rerunning shutdown hooks since they are only supposed to run once.")
-      return
-    }
-    shutdown()
-  }
+  override def onDriverShutdown(): Unit = shutdown()
 
   override def onExecutorStart(pc: PluginContext): Unit = {
     val conf = pc.conf()
@@ -153,22 +147,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
     initialize(conf, isDriver = false)
   }
 
-  override def onExecutorShutdown(): Unit = {
-    if (!driverStopped.compareAndSet(false, true)) {
-      // Make sure we call the static initializers only once.
-      logInfo(
-        "Skip rerunning shutdown hooks since they are only supposed to run once.")
-      return
-    }
-    if (inLocalMode(SparkEnv.get.conf)) {
-      // Don't do static initializations from executor side in local mode.
-      // Driver already did that.
-      logInfo(
-        "Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
-      return
-    }
-    shutdown()
-  }
+  override def onExecutorShutdown(): Unit = shutdown()
 
   private def initialize(conf: SparkConf, isDriver: Boolean): Unit = {
     // Do row / batch type initializations.
@@ -238,8 +217,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
   }
 
   private def shutdown(): Unit = {
-    NativeBackendInitializer.forBackend(VeloxBackend.BACKEND_NAME)
-      .stop()
+    // TODO shutdown implementation in velox to release resources
   }
 }
 
@@ -247,9 +225,7 @@ object VeloxListenerApi {
   // TODO: Implement graceful shutdown and remove these flags.
   //  As spark conf may change when active Spark session is recreated.
   private val driverInitialized: AtomicBoolean = new AtomicBoolean(false)
-  private val driverStopped: AtomicBoolean = new AtomicBoolean(false)
   private val executorInitialized: AtomicBoolean = new AtomicBoolean(false)
-  private val executorStopped: AtomicBoolean = new AtomicBoolean(false)
   private val platformLibDir: String = {
     val osName = System.getProperty("os.name") match {
       case n if n.contains("Linux") => "linux"

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -28,6 +28,7 @@ import org.apache.gluten.init.NativeBackendInitializer
 import org.apache.gluten.jni.{JniLibLoader, JniWorkspace}
 import org.apache.gluten.udf.UdfJniWrapper
 import org.apache.gluten.utils._
+
 import org.apache.spark.{HdfsConfGenerator, ShuffleDependency, SparkConf, SparkContext, SparkEnv}
 import org.apache.spark.api.plugin.PluginContext
 import org.apache.spark.internal.Logging
@@ -41,6 +42,7 @@ import org.apache.spark.sql.execution.datasources.velox.{VeloxParquetWriterInjec
 import org.apache.spark.sql.expression.UDFResolver
 import org.apache.spark.sql.internal.{GlutenConfigUtil, StaticSQLConf}
 import org.apache.spark.util.{SparkDirectoryUtil, SparkResourceUtil}
+
 import org.apache.commons.lang3.StringUtils
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -122,8 +124,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
   override def onDriverShutdown(): Unit = {
     if (!driverStopped.compareAndSet(false, true)) {
       // Make sure we call the static initializers only once.
-      logInfo(
-        "Skip rerunning shutdown hooks since they are only supposed to run once.")
+      logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
     shutdown()
@@ -154,17 +155,15 @@ class VeloxListenerApi extends ListenerApi with Logging {
   }
 
   override def onExecutorShutdown(): Unit = {
-    if (!driverStopped.compareAndSet(false, true)) {
+    if (!executorStopped.compareAndSet(false, true)) {
       // Make sure we call the static initializers only once.
-      logInfo(
-        "Skip rerunning shutdown hooks since they are only supposed to run once.")
+      logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
     if (inLocalMode(SparkEnv.get.conf)) {
       // Don't do static initializations from executor side in local mode.
       // Driver already did that.
-      logInfo(
-        "Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
+      logInfo("Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
       return
     }
     shutdown()
@@ -238,7 +237,8 @@ class VeloxListenerApi extends ListenerApi with Logging {
   }
 
   private def shutdown(): Unit = {
-    NativeBackendInitializer.forBackend(VeloxBackend.BACKEND_NAME)
+    NativeBackendInitializer
+      .forBackend(VeloxBackend.BACKEND_NAME)
       .stop()
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -123,7 +123,7 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
   override def onDriverShutdown(): Unit = {
     if (!driverStopped.compareAndSet(false, true)) {
-      // Make sure we call the shutdown hooks only once.
+      // Make sure we call the static initializers only once.
       logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
@@ -156,12 +156,12 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
   override def onExecutorShutdown(): Unit = {
     if (!executorStopped.compareAndSet(false, true)) {
-      // Make sure we call the shutdown hooks only once.
+      // Make sure we call the static initializers only once.
       logInfo("Skip rerunning shutdown hooks since they are only supposed to run once.")
       return
     }
     if (inLocalMode(SparkEnv.get.conf)) {
-      // Don't call shutdown hooks from executor side in local mode.
+      // Don't do static initializations from executor side in local mode.
       // Driver already did that.
       logInfo("Gluten is running with Spark local mode. Skip running shutdown hooks for executor.")
       return

--- a/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -19,8 +19,9 @@ package org.apache.spark.memory
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.memory.{MemoryUsageRecorder, SimpleMemoryUsageRecorder}
 import org.apache.gluten.memory.listener.ReservationListener
-import org.apache.spark.internal.Logging
+
 import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.internal.Logging
 import org.apache.spark.storage.BlockId
 
 import java.lang.reflect.Field
@@ -116,7 +117,8 @@ object GlobalOffHeapMemory extends Logging {
       // This may happen in test code that mocks the task context without booting up SparkEnv.
       return Some(FIELD_MEMORY_MANAGER.get(tc.taskMemoryManager()).asInstanceOf[MemoryManager])
     }
-    logWarning("Memory manager not found because the code is unlikely be run in a Spark application")
+    logWarning(
+      "Memory manager not found because the code is unlikely be run in a Spark application")
     None
   }
 }

--- a/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -88,7 +88,9 @@ object GlobalOffHeapMemory {
         size
       }
 
-      override def getUsedBytes: Long = recorder.current()
+      override def getUsedBytes: Long = {
+        recorder.current()
+      }
     }
   }
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -76,15 +76,7 @@ case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int]
     assert(bytesBuffer.length == bytesBufferLengths(index))
     // first to allocate underlying long array
     if (null == longArray && index == 0) {
-      if (!GlobalOffHeapMemory.acquire(allocatedBytes)) {
-        val memoryManager = SparkEnv.get.memoryManager
-        val offHeapMemoryTotal =
-          memoryManager.maxOffHeapStorageMemory + memoryManager.offHeapExecutionMemoryUsed
-        throw new GlutenException(
-          s"Spark off-heap memory is exhausted." +
-            s" Storage: ${memoryManager.offHeapStorageMemoryUsed} / $offHeapMemoryTotal," +
-            s" execution: ${memoryManager.offHeapExecutionMemoryUsed} / $offHeapMemoryTotal")
-      }
+      GlobalOffHeapMemory.acquire(allocatedBytes)
       longArray = new LongArray(MemoryAllocator.UNSAFE.allocate(allocatedBytes))
     }
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -16,9 +16,6 @@
  */
 package org.apache.spark.sql.execution.unsafe
 
-import org.apache.gluten.exception.GlutenException
-
-import org.apache.spark.SparkEnv
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.GlobalOffHeapMemory

--- a/backends-velox/src/test/scala/org/apache/spark/memory/GlobalOffHeapMemorySuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/memory/GlobalOffHeapMemorySuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.memory;
 
 import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.memory.memtarget.{Spillers, TreeMemoryTarget}
 import org.apache.gluten.memory.memtarget.spark.TreeMemoryConsumers
 
@@ -24,7 +25,6 @@ import org.apache.spark.TaskContext
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.task.TaskResources
 
-import org.junit.Assert
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -51,14 +51,14 @@ class GlobalOffHeapMemorySuite extends AnyFunSuite with BeforeAndAfterAll {
             TreeMemoryTarget.CAPACITY_UNLIMITED,
             Spillers.NOOP,
             Collections.emptyMap())
-      Assert.assertEquals(300, consumer.borrow(300))
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(50))
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(40))
-      Assert.assertFalse(GlobalOffHeapMemory.acquire(30))
-      Assert.assertFalse(GlobalOffHeapMemory.acquire(11))
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(10))
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(0))
-      Assert.assertFalse(GlobalOffHeapMemory.acquire(1))
+      assert(consumer.borrow(300) == 300)
+      GlobalOffHeapMemory.acquire(50)
+      GlobalOffHeapMemory.acquire(40)
+      assertThrows[GlutenException](GlobalOffHeapMemory.acquire(30))
+      assertThrows[GlutenException](GlobalOffHeapMemory.acquire(11))
+      GlobalOffHeapMemory.acquire(10)
+      GlobalOffHeapMemory.acquire(0)
+      assertThrows[GlutenException](GlobalOffHeapMemory.acquire(1))
     }
   }
 
@@ -74,10 +74,10 @@ class GlobalOffHeapMemorySuite extends AnyFunSuite with BeforeAndAfterAll {
             TreeMemoryTarget.CAPACITY_UNLIMITED,
             Spillers.NOOP,
             Collections.emptyMap())
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(200))
-      Assert.assertEquals(100, consumer.borrow(100))
-      Assert.assertEquals(100, consumer.borrow(200))
-      Assert.assertEquals(0, consumer.borrow(50))
+      GlobalOffHeapMemory.acquire(200)
+      assert(consumer.borrow(100) == 100)
+      assert(consumer.borrow(200) == 100)
+      assert(consumer.borrow(50) == 0)
     }
   }
 
@@ -93,10 +93,10 @@ class GlobalOffHeapMemorySuite extends AnyFunSuite with BeforeAndAfterAll {
             TreeMemoryTarget.CAPACITY_UNLIMITED,
             Spillers.NOOP,
             Collections.emptyMap())
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(300))
-      Assert.assertEquals(100, consumer.borrow(200))
+      GlobalOffHeapMemory.acquire(300)
+      assert(consumer.borrow(200) == 100)
       GlobalOffHeapMemory.release(10)
-      Assert.assertEquals(10, consumer.borrow(50))
+      assert(consumer.borrow(50) == 10)
     }
   }
 
@@ -112,10 +112,10 @@ class GlobalOffHeapMemorySuite extends AnyFunSuite with BeforeAndAfterAll {
             TreeMemoryTarget.CAPACITY_UNLIMITED,
             Spillers.NOOP,
             Collections.emptyMap())
-      Assert.assertEquals(300, consumer.borrow(300))
-      Assert.assertFalse(GlobalOffHeapMemory.acquire(200))
-      Assert.assertEquals(100, consumer.repay(100))
-      Assert.assertTrue(GlobalOffHeapMemory.acquire(200))
+      assert(consumer.borrow(300) == 300)
+      assertThrows[GlutenException](GlobalOffHeapMemory.acquire(200))
+      assert(consumer.repay(100) == 100)
+      GlobalOffHeapMemory.acquire(200)
     }
   }
 }

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -406,11 +406,12 @@ class SparkAllocationListener final : public gluten::AllocationListener {
     usedBytes_ += size;
     while (true) {
       int64_t savedPeakBytes = peakBytes_;
-      if (usedBytes_ <= savedPeakBytes) {
+      int64_t savedUsedBytes = usedBytes_;
+      if (savedUsedBytes <= savedPeakBytes) {
         break;
       }
       // usedBytes_ > savedPeakBytes, update peak
-      if (peakBytes_.compare_exchange_weak(savedPeakBytes, usedBytes_)) {
+      if (peakBytes_.compare_exchange_weak(savedPeakBytes, savedUsedBytes)) {
         break;
       }
     }

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -369,8 +369,7 @@ NOTE: the class must be thread safe
 
 class SparkAllocationListener final : public gluten::AllocationListener {
  public:
-  SparkAllocationListener(JavaVM* vm, jobject jListenerLocalRef, jmethodID jReserveMethod, jmethodID jUnreserveMethod)
-      : vm_(vm), jReserveMethod_(jReserveMethod), jUnreserveMethod_(jUnreserveMethod) {
+  SparkAllocationListener(JavaVM* vm, jobject jListenerLocalRef) : vm_(vm) {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm_, &env);
     jListenerGlobalRef_ = env->NewGlobalRef(jListenerLocalRef);
@@ -398,10 +397,10 @@ class SparkAllocationListener final : public gluten::AllocationListener {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm_, &env);
     if (size < 0) {
-      env->CallLongMethod(jListenerGlobalRef_, jUnreserveMethod_, -size);
+      env->CallLongMethod(jListenerGlobalRef_, unreserveMemoryMethod(env), -size);
       checkException(env);
     } else {
-      env->CallLongMethod(jListenerGlobalRef_, jReserveMethod_, size);
+      env->CallLongMethod(jListenerGlobalRef_, reserveMemoryMethod(env), size);
       checkException(env);
     }
     usedBytes_ += size;
@@ -426,10 +425,28 @@ class SparkAllocationListener final : public gluten::AllocationListener {
   }
 
  private:
+  jclass javaReservationListenerClass(JNIEnv* env) {
+    static jclass javaReservationListenerClass = createGlobalClassReference(
+        env,
+        "Lorg/apache/gluten/memory/listener/"
+        "ReservationListener;");
+    return javaReservationListenerClass;
+  }
+
+  jmethodID reserveMemoryMethod(JNIEnv* env) {
+    static jmethodID reserveMemoryMethod =
+        getMethodIdOrError(env, javaReservationListenerClass(env), "reserve", "(J)J");
+    return reserveMemoryMethod;
+  }
+
+  jmethodID unreserveMemoryMethod(JNIEnv* env) {
+    static jmethodID unreserveMemoryMethod =
+        getMethodIdOrError(env, javaReservationListenerClass(env), "unreserve", "(J)J");
+    return unreserveMemoryMethod;
+  }
+
   JavaVM* vm_;
   jobject jListenerGlobalRef_;
-  const jmethodID jReserveMethod_;
-  const jmethodID jUnreserveMethod_;
   std::atomic_int64_t usedBytes_{0L};
   std::atomic_int64_t peakBytes_{0L};
 };

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -42,10 +42,6 @@
 using namespace gluten;
 
 namespace {
-jclass javaReservationListenerClass;
-
-jmethodID reserveMemoryMethod;
-jmethodID unreserveMemoryMethod;
 
 jclass byteArrayClass;
 
@@ -238,14 +234,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/NativeColumnarToRowInfo;");
   nativeColumnarToRowInfoConstructor = getMethodIdOrError(env, nativeColumnarToRowInfoClass, "<init>", "([I[IJ)V");
 
-  javaReservationListenerClass = createGlobalClassReference(
-      env,
-      "Lorg/apache/gluten/memory/listener/"
-      "ReservationListener;");
-
-  reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", "(J)J");
-  unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", "(J)J");
-
   shuffleReaderMetricsClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ShuffleReaderMetrics;");
   shuffleReaderMetricsSetDecompressTime =
@@ -316,8 +304,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_memory_NativeMemoryManagerJniWrap
   auto backendType = jStringToCString(env, jBackendType);
   auto safeArray = getByteArrayElementsSafe(env, sessionConf);
   auto sparkConf = parseConfMap(env, safeArray.elems(), safeArray.length());
-  std::unique_ptr<AllocationListener> listener =
-      std::make_unique<SparkAllocationListener>(vm, jListener, reserveMemoryMethod, unreserveMemoryMethod);
+  std::unique_ptr<AllocationListener> listener = std::make_unique<SparkAllocationListener>(vm, jListener);
   bool backtrace = sparkConf.at(kBacktraceAllocation) == "true";
   if (backtrace) {
     listener = std::make_unique<BacktraceAllocationListener>(std::move(listener));

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -110,11 +110,12 @@ void ListenableMemoryAllocator::updateUsage(int64_t size) {
   usedBytes_ += size;
   while (true) {
     int64_t savedPeakBytes = peakBytes_;
-    if (usedBytes_ <= savedPeakBytes) {
+    int64_t savedUsedBytes = usedBytes_;
+    if (savedUsedBytes <= savedPeakBytes) {
       break;
     }
     // usedBytes_ > savedPeakBytes, update peak
-    if (peakBytes_.compare_exchange_weak(savedPeakBytes, usedBytes_)) {
+    if (peakBytes_.compare_exchange_weak(savedPeakBytes, savedUsedBytes)) {
       break;
     }
   }

--- a/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
+++ b/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
@@ -37,7 +37,7 @@
 #include "compute/VeloxRuntime.h"
 #include "memory/ArrowMemoryPool.h"
 #include "memory/ColumnarBatch.h"
-#include "memory/VeloxMemoryManager.h"
+#include "compute/VeloxBackend.h"
 #include "utils/Macros.h"
 #include "utils/TestUtils.h"
 #include "utils/VeloxArrowUtils.h"

--- a/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
+++ b/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
@@ -258,7 +258,7 @@ class GoogleBenchmarkVeloxParquetWriteCacheScanBenchmark : public GoogleBenchmar
     auto fileName = "velox_parquet_write.parquet";
 
     auto memoryManager = getDefaultMemoryManager();
-    auto runtime = Runtime::create(kVeloxBackendKind, memoryManager.get());
+    auto runtime = Runtime::create(kVeloxBackendKind, memoryManager);
     auto veloxPool = memoryManager->getAggregateMemoryPool();
 
     for (auto _ : state) {

--- a/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
+++ b/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
@@ -34,10 +34,10 @@
 #include <chrono>
 
 #include "benchmarks/common/BenchmarkUtils.h"
+#include "compute/VeloxBackend.h"
 #include "compute/VeloxRuntime.h"
 #include "memory/ArrowMemoryPool.h"
 #include "memory/ColumnarBatch.h"
-#include "compute/VeloxBackend.h"
 #include "utils/Macros.h"
 #include "utils/TestUtils.h"
 #include "utils/VeloxArrowUtils.h"

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.cc
@@ -40,7 +40,7 @@ std::unordered_map<std::string, std::string> defaultConf() {
 }
 
 void initVeloxBackend(std::unordered_map<std::string, std::string>& conf) {
-  gluten::VeloxBackend::create(conf);
+  gluten::VeloxBackend::create(AllocationListener::noop(), conf);
 }
 
 void initVeloxBackend() {

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -187,7 +187,7 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
       .arbitratorKind = afr.getKind(),
       .extraArbitratorConfigs = getExtraArbitratorConfigs()};
 
-  facebook::velox::memory::MemoryManager::initialize(mmOptions);
+  facebook::velox::memory::initializeMemoryManager(mmOptions);
 
   LOG(INFO) << "Global Velox memory manager was set.";
 }

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -96,7 +96,7 @@ void VeloxBackend::init(
   MemoryManager::registerFactory(kVeloxBackendKind, veloxMemoryManagerFactory, veloxMemoryManagerReleaser);
   Runtime::registerFactory(kVeloxBackendKind, veloxRuntimeFactory, veloxRuntimeReleaser);
 
-  memoryManager_ = std::make_unique<VeloxMemoryManager>(kVeloxBackendKind, listener);
+  memoryManager_ = std::make_unique<VeloxMemoryManager>(kVeloxBackendKind, std::move(listener));
 
   if (backendConf_->get<bool>(kDebugModeEnabled, false)) {
     LOG(INFO) << "VeloxBackend config:" << printConfig(backendConf_->rawConfigs());

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -86,12 +86,13 @@ void veloxRuntimeReleaser(Runtime* runtime) {
 }
 } // namespace
 
-void VeloxBackend::init(std::unique_ptr<AllocationListener> listener, const std::unordered_map<std::string, std::string>& conf) {
+void VeloxBackend::init(
+    std::unique_ptr<AllocationListener> listener,
+    const std::unordered_map<std::string, std::string>& conf) {
   backendConf_ =
       std::make_shared<facebook::velox::config::ConfigBase>(std::unordered_map<std::string, std::string>(conf));
 
-  globalMemoryManager_ =
-      std::make_unique<VeloxMemoryManager>(kVeloxBackendKind, std::move(listener), *backendConf_);
+  globalMemoryManager_ = std::make_unique<VeloxMemoryManager>(kVeloxBackendKind, std::move(listener), *backendConf_);
 
   // Register factories.
   MemoryManager::registerFactory(kVeloxBackendKind, veloxMemoryManagerFactory, veloxMemoryManagerReleaser);

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -72,6 +72,7 @@ class VeloxBackend {
     // On threads exit, thread local variables can be constructed with referencing global variables.
     // So, we need to destruct IOThreadPoolExecutor and stop the threads before global variables get destructed.
     ioExecutor_.reset();
+    globalMemoryManager_.reset();
   }
 
  private:

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -28,7 +28,7 @@
 #include "velox/common/config/Config.h"
 #include "velox/common/memory/MmapAllocator.h"
 
-#include <memory/VeloxMemoryManager.h>
+#include "memory/VeloxMemoryManager.h"
 
 namespace gluten {
 
@@ -63,7 +63,7 @@ class VeloxBackend {
     return backendConf_;
   }
 
-  gluten::VeloxMemoryManager* getGlobalMemoryManager() const {
+  VeloxMemoryManager* getGlobalMemoryManager() const {
     return memoryManager_.get();
   }
 
@@ -95,7 +95,7 @@ class VeloxBackend {
   static std::unique_ptr<VeloxBackend> instance_;
 
   // A global memory manager for the current process.
-  std::unique_ptr<gluten::VeloxMemoryManager> memoryManager_;
+  std::unique_ptr<VeloxMemoryManager> memoryManager_;
   // Instance of AsyncDataCache used for all large allocations.
   std::shared_ptr<facebook::velox::cache::AsyncDataCache> asyncDataCache_;
 

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -94,7 +94,7 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_init_NativeBackendInitializer_init
     throw GlutenException("Unable to get JavaVM instance");
   }
   auto safeArray = getByteArrayElementsSafe(env, conf);
-  // Create a global allocation listener that reserve global off-heap memory from Java-side GlobalOffHeapMemory utility
+  // Create a global allocation listener that reserves global off-heap memory from Java-side GlobalOffHeapMemory utility
   // class.
   std::unique_ptr<AllocationListener> listener = std::make_unique<SparkAllocationListener>(vm, jListener);
   auto sparkConf = parseConfMap(env, safeArray.elems(), safeArray.length());

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -395,7 +395,9 @@ VeloxMemoryManager::~VeloxMemoryManager() {
 }
 
 VeloxMemoryManager* getDefaultMemoryManager() {
-  return VeloxBackend::get()->getGlobalMemoryManager();
+  static auto memoryManager =
+      std::make_unique<VeloxMemoryManager>(kVeloxBackendKind, VeloxBackend::get()->newGlobalAllocationListener());
+  return memoryManager.get();
 }
 
 std::shared_ptr<velox::memory::MemoryPool> defaultLeafVeloxMemoryPool() {

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -36,13 +36,12 @@ namespace gluten {
 
 using namespace facebook;
 
-std::unordered_map<std::string, std::string> getExtraArbitratorConfigs(const facebook::velox::config::ConfigBase& backendConf) {
-  auto reservationBlockSize = backendConf.get<uint64_t>(
-      kMemoryReservationBlockSize, kMemoryReservationBlockSizeDefault);
-  auto memInitCapacity =
-      backendConf.get<uint64_t>(kVeloxMemInitCapacity, kVeloxMemInitCapacityDefault);
-  auto memReclaimMaxWaitMs =
-      backendConf.get<uint64_t>(kVeloxMemReclaimMaxWaitMs, kVeloxMemReclaimMaxWaitMsDefault);
+std::unordered_map<std::string, std::string> getExtraArbitratorConfigs(
+    const facebook::velox::config::ConfigBase& backendConf) {
+  auto reservationBlockSize =
+      backendConf.get<uint64_t>(kMemoryReservationBlockSize, kMemoryReservationBlockSizeDefault);
+  auto memInitCapacity = backendConf.get<uint64_t>(kVeloxMemInitCapacity, kVeloxMemInitCapacityDefault);
+  auto memReclaimMaxWaitMs = backendConf.get<uint64_t>(kVeloxMemReclaimMaxWaitMs, kVeloxMemReclaimMaxWaitMsDefault);
 
   std::unordered_map<std::string, std::string> extraArbitratorConfigs;
   extraArbitratorConfigs[std::string(kMemoryPoolInitialCapacity)] = folly::to<std::string>(memInitCapacity) + "B";
@@ -212,10 +211,13 @@ ArbitratorFactoryRegister::~ArbitratorFactoryRegister() {
   velox::memory::MemoryArbitrator::unregisterFactory(kind_);
 }
 
-VeloxMemoryManager::VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener, const facebook::velox::config::ConfigBase& backendConf)
+VeloxMemoryManager::VeloxMemoryManager(
+    const std::string& kind,
+    std::unique_ptr<AllocationListener> listener,
+    const facebook::velox::config::ConfigBase& backendConf)
     : MemoryManager(kind), listener_(std::move(listener)) {
-  auto reservationBlockSize = backendConf.get<uint64_t>(
-      kMemoryReservationBlockSize, kMemoryReservationBlockSizeDefault);
+  auto reservationBlockSize =
+      backendConf.get<uint64_t>(kMemoryReservationBlockSize, kMemoryReservationBlockSizeDefault);
   blockListener_ = std::make_unique<BlockAllocationListener>(listener_.get(), reservationBlockSize);
   listenableAlloc_ = std::make_unique<ListenableMemoryAllocator>(defaultMemoryAllocator().get(), blockListener_.get());
   arrowPool_ = std::make_unique<ArrowMemoryPool>(listenableAlloc_.get());

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -394,4 +394,12 @@ VeloxMemoryManager::~VeloxMemoryManager() {
 #endif
 }
 
+VeloxMemoryManager* getDefaultMemoryManager() {
+  return VeloxBackend::get()->getGlobalMemoryManager();
+}
+
+std::shared_ptr<velox::memory::MemoryPool> defaultLeafVeloxMemoryPool() {
+  return getDefaultMemoryManager()->getLeafMemoryPool();
+}
+
 } // namespace gluten

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -36,14 +36,6 @@ namespace gluten {
 using namespace facebook;
 
 namespace {
-
-static constexpr std::string_view kMemoryPoolInitialCapacity{"memory-pool-initial-capacity"};
-static constexpr uint64_t kDefaultMemoryPoolInitialCapacity{256 << 20};
-static constexpr std::string_view kMemoryPoolTransferCapacity{"memory-pool-transfer-capacity"};
-static constexpr uint64_t kDefaultMemoryPoolTransferCapacity{128 << 20};
-static constexpr std::string_view kMemoryReclaimMaxWaitMs{"memory-reclaim-max-wait-time"};
-static constexpr std::string_view kDefaultMemoryReclaimMaxWaitMs{"3600000ms"};
-
 template <typename T>
 T getConfig(
     const std::unordered_map<std::string, std::string>& configs,
@@ -58,7 +50,6 @@ T getConfig(
   }
   return defaultValue;
 }
-} // namespace
 
 /// We assume in a single Spark task. No thread-safety should be guaranteed.
 class ListenableArbitrator : public velox::memory::MemoryArbitrator {
@@ -187,48 +178,30 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
   std::unordered_map<velox::memory::MemoryPool*, std::weak_ptr<velox::memory::MemoryPool>> candidates_;
 };
 
-class ArbitratorFactoryRegister {
- public:
-  explicit ArbitratorFactoryRegister(gluten::AllocationListener* listener) : listener_(listener) {
-    static std::atomic_uint32_t id{0UL};
-    kind_ = "GLUTEN_ARBITRATOR_FACTORY_" + std::to_string(id++);
-    velox::memory::MemoryArbitrator::registerFactory(
-        kind_,
-        [this](
-            const velox::memory::MemoryArbitrator::Config& config) -> std::unique_ptr<velox::memory::MemoryArbitrator> {
-          return std::make_unique<ListenableArbitrator>(config, listener_);
-        });
-  }
+} // namespace
 
-  virtual ~ArbitratorFactoryRegister() {
-    velox::memory::MemoryArbitrator::unregisterFactory(kind_);
-  }
+ArbitratorFactoryRegister::ArbitratorFactoryRegister(gluten::AllocationListener* listener) : listener_(listener) {
+  static std::atomic_uint32_t id{0UL};
+  kind_ = "GLUTEN_ARBITRATOR_FACTORY_" + std::to_string(id++);
+  velox::memory::MemoryArbitrator::registerFactory(
+      kind_,
+      [this](
+          const velox::memory::MemoryArbitrator::Config& config) -> std::unique_ptr<velox::memory::MemoryArbitrator> {
+        return std::make_unique<ListenableArbitrator>(config, listener_);
+      });
+}
 
-  const std::string& getKind() const {
-    return kind_;
-  }
-
- private:
-  std::string kind_;
-  gluten::AllocationListener* listener_;
-};
+ArbitratorFactoryRegister::~ArbitratorFactoryRegister() {
+  velox::memory::MemoryArbitrator::unregisterFactory(kind_);
+}
 
 VeloxMemoryManager::VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener)
     : MemoryManager(kind), listener_(std::move(listener)) {
   auto reservationBlockSize = VeloxBackend::get()->getBackendConf()->get<uint64_t>(
       kMemoryReservationBlockSize, kMemoryReservationBlockSizeDefault);
-  auto memInitCapacity =
-      VeloxBackend::get()->getBackendConf()->get<uint64_t>(kVeloxMemInitCapacity, kVeloxMemInitCapacityDefault);
-  auto memReclaimMaxWaitMs =
-      VeloxBackend::get()->getBackendConf()->get<uint64_t>(kVeloxMemReclaimMaxWaitMs, kVeloxMemReclaimMaxWaitMsDefault);
   blockListener_ = std::make_unique<BlockAllocationListener>(listener_.get(), reservationBlockSize);
   listenableAlloc_ = std::make_unique<ListenableMemoryAllocator>(defaultMemoryAllocator().get(), blockListener_.get());
   arrowPool_ = std::make_unique<ArrowMemoryPool>(listenableAlloc_.get());
-
-  std::unordered_map<std::string, std::string> extraArbitratorConfigs;
-  extraArbitratorConfigs[std::string(kMemoryPoolInitialCapacity)] = folly::to<std::string>(memInitCapacity) + "B";
-  extraArbitratorConfigs[std::string(kMemoryPoolTransferCapacity)] = folly::to<std::string>(reservationBlockSize) + "B";
-  extraArbitratorConfigs[std::string(kMemoryReclaimMaxWaitMs)] = folly::to<std::string>(memReclaimMaxWaitMs) + "ms";
 
   ArbitratorFactoryRegister afr(listener_.get());
   velox::memory::MemoryManagerOptions mmOptions{
@@ -239,7 +212,7 @@ VeloxMemoryManager::VeloxMemoryManager(const std::string& kind, std::unique_ptr<
       .coreOnAllocationFailureEnabled = false,
       .allocatorCapacity = velox::memory::kMaxMemory,
       .arbitratorKind = afr.getKind(),
-      .extraArbitratorConfigs = extraArbitratorConfigs};
+      .extraArbitratorConfigs = VeloxBackend::get()->getExtraArbitratorConfigs()};
   veloxMemoryManager_ = std::make_unique<velox::memory::MemoryManager>(mmOptions);
 
   veloxAggregatePool_ = veloxMemoryManager_->addRootPool(

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -34,7 +34,8 @@ constexpr uint64_t kDefaultMemoryPoolTransferCapacity{128 << 20};
 constexpr std::string_view kMemoryReclaimMaxWaitMs{"memory-reclaim-max-wait-time"};
 constexpr std::string_view kDefaultMemoryReclaimMaxWaitMs{"3600000ms"};
 
-std::unordered_map<std::string, std::string> getExtraArbitratorConfigs(const facebook::velox::config::ConfigBase& backendConf);
+std::unordered_map<std::string, std::string> getExtraArbitratorConfigs(
+    const facebook::velox::config::ConfigBase& backendConf);
 
 class ArbitratorFactoryRegister {
  public:
@@ -54,7 +55,10 @@ class ArbitratorFactoryRegister {
 // Make sure the class is thread safe
 class VeloxMemoryManager final : public MemoryManager {
  public:
-  VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener,  const facebook::velox::config::ConfigBase& backendConf);
+  VeloxMemoryManager(
+      const std::string& kind,
+      std::unique_ptr<AllocationListener> listener,
+      const facebook::velox::config::ConfigBase& backendConf);
 
   ~VeloxMemoryManager() override;
   VeloxMemoryManager(const VeloxMemoryManager&) = delete;

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -26,6 +26,21 @@
 
 namespace gluten {
 
+class ArbitratorFactoryRegister {
+ public:
+  explicit ArbitratorFactoryRegister(gluten::AllocationListener* listener);
+
+  virtual ~ArbitratorFactoryRegister();
+
+  const std::string& getKind() const {
+    return kind_;
+  }
+
+ private:
+  std::string kind_;
+  gluten::AllocationListener* listener_;
+};
+
 // Make sure the class is thread safe
 class VeloxMemoryManager final : public MemoryManager {
  public:
@@ -87,7 +102,7 @@ class VeloxMemoryManager final : public MemoryManager {
   std::vector<std::shared_ptr<facebook::velox::memory::MemoryPool>> heldVeloxPools_;
 };
 
-/// Not tracked by Spark and should only used in test or validation.
+/// Not tracked by Spark and should only be used in test or validation.
 inline std::shared_ptr<gluten::VeloxMemoryManager> getDefaultMemoryManager() {
   static auto memoryManager =
       std::make_shared<gluten::VeloxMemoryManager>(gluten::kVeloxBackendKind, gluten::AllocationListener::noop());

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -116,7 +116,6 @@ class VeloxMemoryManager final : public MemoryManager {
   std::vector<std::shared_ptr<facebook::velox::memory::MemoryPool>> heldVeloxPools_;
 };
 
-/// Not tracked by Spark and should only be used in test or validation.
 VeloxMemoryManager* getDefaultMemoryManager();
 
 std::shared_ptr<facebook::velox::memory::MemoryPool> defaultLeafVeloxMemoryPool();

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "compute/VeloxBackend.h"
 #include "memory/AllocationListener.h"
 #include "memory/MemoryAllocator.h"
 #include "memory/MemoryManager.h"
@@ -112,12 +111,8 @@ class VeloxMemoryManager final : public MemoryManager {
 };
 
 /// Not tracked by Spark and should only be used in test or validation.
-inline gluten::VeloxMemoryManager* getDefaultMemoryManager() {
-  return VeloxBackend::get()->getGlobalMemoryManager();
-}
+VeloxMemoryManager* getDefaultMemoryManager();
 
-inline std::shared_ptr<facebook::velox::memory::MemoryPool> defaultLeafVeloxMemoryPool() {
-  return getDefaultMemoryManager()->getLeafMemoryPool();
-}
+std::shared_ptr<facebook::velox::memory::MemoryPool> defaultLeafVeloxMemoryPool();
 
 } // namespace gluten

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -26,6 +26,15 @@
 
 namespace gluten {
 
+constexpr std::string_view kMemoryPoolInitialCapacity{"memory-pool-initial-capacity"};
+constexpr uint64_t kDefaultMemoryPoolInitialCapacity{256 << 20};
+constexpr std::string_view kMemoryPoolTransferCapacity{"memory-pool-transfer-capacity"};
+constexpr uint64_t kDefaultMemoryPoolTransferCapacity{128 << 20};
+constexpr std::string_view kMemoryReclaimMaxWaitMs{"memory-reclaim-max-wait-time"};
+constexpr std::string_view kDefaultMemoryReclaimMaxWaitMs{"3600000ms"};
+
+std::unordered_map<std::string, std::string> getExtraArbitratorConfigs();
+
 class ArbitratorFactoryRegister {
  public:
   explicit ArbitratorFactoryRegister(gluten::AllocationListener* listener);
@@ -103,10 +112,8 @@ class VeloxMemoryManager final : public MemoryManager {
 };
 
 /// Not tracked by Spark and should only be used in test or validation.
-inline std::shared_ptr<gluten::VeloxMemoryManager> getDefaultMemoryManager() {
-  static auto memoryManager =
-      std::make_shared<gluten::VeloxMemoryManager>(gluten::kVeloxBackendKind, gluten::AllocationListener::noop());
-  return memoryManager;
+inline gluten::VeloxMemoryManager* getDefaultMemoryManager() {
+  return VeloxBackend::get()->getGlobalMemoryManager();
 }
 
 inline std::shared_ptr<facebook::velox::memory::MemoryPool> defaultLeafVeloxMemoryPool() {

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -23,6 +23,8 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryPool.h"
 
+#include <velox/common/config/Config.h>
+
 namespace gluten {
 
 constexpr std::string_view kMemoryPoolInitialCapacity{"memory-pool-initial-capacity"};
@@ -32,7 +34,7 @@ constexpr uint64_t kDefaultMemoryPoolTransferCapacity{128 << 20};
 constexpr std::string_view kMemoryReclaimMaxWaitMs{"memory-reclaim-max-wait-time"};
 constexpr std::string_view kDefaultMemoryReclaimMaxWaitMs{"3600000ms"};
 
-std::unordered_map<std::string, std::string> getExtraArbitratorConfigs();
+std::unordered_map<std::string, std::string> getExtraArbitratorConfigs(const facebook::velox::config::ConfigBase& backendConf);
 
 class ArbitratorFactoryRegister {
  public:
@@ -52,7 +54,7 @@ class ArbitratorFactoryRegister {
 // Make sure the class is thread safe
 class VeloxMemoryManager final : public MemoryManager {
  public:
-  VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener);
+  VeloxMemoryManager(const std::string& kind, std::unique_ptr<AllocationListener> listener,  const facebook::velox::config::ConfigBase& backendConf);
 
   ~VeloxMemoryManager() override;
   VeloxMemoryManager(const VeloxMemoryManager&) = delete;

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -16,6 +16,9 @@
  */
 
 #include "SubstraitToVeloxPlan.h"
+
+#include "utils/StringUtil.h"
+
 #include "TypeUtils.h"
 #include "VariantToVectorConverter.h"
 #include "operators/plannodes/RowVectorStream.h"
@@ -498,7 +501,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 }
 
 std::string makeUuid() {
-  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+  return generateUuid();
 }
 
 std::string compressionFileNameSuffix(common::CompressionKind kind) {

--- a/cpp/velox/tests/BufferOutputStreamTest.cc
+++ b/cpp/velox/tests/BufferOutputStreamTest.cc
@@ -29,7 +29,7 @@ class BufferOutputStreamTest : public ::testing::Test, public test::VectorTestBa
  protected:
   // Velox requires the mem manager to be instanced.
   static void SetUpTestCase() {
-    VeloxBackend::create({});
+    VeloxBackend::create(AllocationListener::noop(), {});
     memory::MemoryManager::testingSetInstance({});
   }
 

--- a/cpp/velox/tests/MemoryManagerTest.cc
+++ b/cpp/velox/tests/MemoryManagerTest.cc
@@ -50,7 +50,7 @@ class MemoryManagerTest : public ::testing::Test {
     std::unordered_map<std::string, std::string> conf = {
         {kMemoryReservationBlockSize, std::to_string(kMemoryReservationBlockSizeDefault)},
         {kVeloxMemInitCapacity, std::to_string(kVeloxMemInitCapacityDefault)}};
-    gluten::VeloxBackend::create(conf);
+    gluten::VeloxBackend::create(AllocationListener::noop(), conf);
   }
 
   void SetUp() override {
@@ -333,7 +333,7 @@ class MultiMemoryManagerTest : public ::testing::Test {
     std::unordered_map<std::string, std::string> conf = {
         {kMemoryReservationBlockSize, std::to_string(kMemoryReservationBlockSizeDefault)},
         {kVeloxMemInitCapacity, std::to_string(kVeloxMemInitCapacityDefault)}};
-    gluten::VeloxBackend::create(conf);
+    gluten::VeloxBackend::create(AllocationListener::noop(), conf);
   }
 
   std::unique_ptr<VeloxMemoryManager> newVeloxMemoryManager(std::unique_ptr<AllocationListener> listener) {

--- a/cpp/velox/tests/MemoryManagerTest.cc
+++ b/cpp/velox/tests/MemoryManagerTest.cc
@@ -54,7 +54,8 @@ class MemoryManagerTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    vmm_ = std::make_unique<VeloxMemoryManager>(gluten::kVeloxBackendKind, std::make_unique<MockAllocationListener>());
+    vmm_ = std::make_unique<VeloxMemoryManager>(
+        gluten::kVeloxBackendKind, std::make_unique<MockAllocationListener>(), *VeloxBackend::get()->getBackendConf());
     listener_ = vmm_->getListener();
     allocator_ = vmm_->allocator();
   }
@@ -337,7 +338,8 @@ class MultiMemoryManagerTest : public ::testing::Test {
   }
 
   std::unique_ptr<VeloxMemoryManager> newVeloxMemoryManager(std::unique_ptr<AllocationListener> listener) {
-    return std::make_unique<VeloxMemoryManager>(gluten::kVeloxBackendKind, std::move(listener));
+    return std::make_unique<VeloxMemoryManager>(
+        gluten::kVeloxBackendKind, std::move(listener), *VeloxBackend::get()->getBackendConf());
   }
 };
 

--- a/cpp/velox/tests/RuntimeTest.cc
+++ b/cpp/velox/tests/RuntimeTest.cc
@@ -144,7 +144,7 @@ TEST(TestRuntime, CreateRuntime) {
 }
 
 TEST(TestRuntime, CreateVeloxRuntime) {
-  VeloxBackend::create({});
+  VeloxBackend::create(AllocationListener::noop(), {});
   auto mm = MemoryManager::create(kVeloxBackendKind, AllocationListener::noop());
   auto runtime = Runtime::create(kVeloxBackendKind, mm);
   ASSERT_EQ(typeid(*runtime), typeid(VeloxRuntime));

--- a/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
@@ -20,12 +20,15 @@ import org.apache.gluten.config.GlutenConfig;
 import org.apache.gluten.memory.listener.ReservationListener;
 import org.apache.gluten.utils.ConfigUtil;
 
+import org.apache.spark.util.SparkShutdownManagerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import scala.runtime.BoxedUnit;
 
 // Initialize native backend before calling any native methods from Java side.
 public final class NativeBackendInitializer {

--- a/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
@@ -36,6 +36,7 @@ public final class NativeBackendInitializer {
   private static final Map<String, NativeBackendInitializer> instances = new ConcurrentHashMap<>();
 
   private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final String backendName;
 
   private NativeBackendInitializer(String backendName) {
@@ -58,11 +59,6 @@ public final class NativeBackendInitializer {
       throw new IllegalStateException("Already initialized");
     }
     initialize0(rl, conf);
-    SparkShutdownManagerUtil.addHook(
-        () -> {
-          shutdown();
-          return BoxedUnit.UNIT;
-        });
   }
 
   private void initialize0(ReservationListener rl, scala.collection.Map<String, String> conf) {
@@ -76,6 +72,13 @@ public final class NativeBackendInitializer {
   }
 
   private native void initialize(ReservationListener rl, byte[] configPlan);
+
+  public void stop() {
+    if (!stopped.compareAndSet(false, true)) {
+      throw new IllegalStateException("Already stopped");
+    }
+    shutdown();
+  }
 
   private native void shutdown();
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
@@ -36,7 +36,6 @@ public final class NativeBackendInitializer {
   private static final Map<String, NativeBackendInitializer> instances = new ConcurrentHashMap<>();
 
   private final AtomicBoolean initialized = new AtomicBoolean(false);
-  private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final String backendName;
 
   private NativeBackendInitializer(String backendName) {
@@ -59,6 +58,11 @@ public final class NativeBackendInitializer {
       throw new IllegalStateException("Already initialized");
     }
     initialize0(rl, conf);
+    SparkShutdownManagerUtil.addHook(
+        () -> {
+          shutdown();
+          return BoxedUnit.UNIT;
+        });
   }
 
   private void initialize0(ReservationListener rl, scala.collection.Map<String, String> conf) {
@@ -72,13 +76,6 @@ public final class NativeBackendInitializer {
   }
 
   private native void initialize(ReservationListener rl, byte[] configPlan);
-
-  public void stop() {
-    if (!stopped.compareAndSet(false, true)) {
-      throw new IllegalStateException("Already stopped");
-    }
-    shutdown();
-  }
 
   private native void shutdown();
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
@@ -20,15 +20,12 @@ import org.apache.gluten.config.GlutenConfig;
 import org.apache.gluten.memory.listener.ReservationListener;
 import org.apache.gluten.utils.ConfigUtil;
 
-import org.apache.spark.util.SparkShutdownManagerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import scala.runtime.BoxedUnit;
 
 // Initialize native backend before calling any native methods from Java side.
 public final class NativeBackendInitializer {


### PR DESCRIPTION
1. Pass an allocation listener that reserves memory from `GlobalOffHeapmemory` from Java to C++ for `VeloxMemoryManager::getDefaultMemoryManager()`
2. Memory allocations during the following operations will be tracked with Spark global off-heap memory now (previously untracked):
   - VeloxRuntime::planString
   - nativeValidateWithFailureReason
   - SubstraitToVeloxPlanConverter::constructValuesNode
   - gluten::recordBatch2VeloxColumnarBatch (for testing)

Future TODOs:

1. leak-detection
2. evict / spill from global off-heap memory
