### PR TITLE
[GLUTEN-9123][VL][CI] pin setuptools version in CI

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -629,7 +629,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.2.2 cython && \
           pip3 install pandas pyarrow
       - name: Build and run unit test for Spark 3.2.2 (other tests)
@@ -700,7 +700,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.3.1 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.3.1 (other tests)
@@ -774,7 +774,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.4.4 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.4.4 (other tests)
@@ -823,7 +823,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.4.4 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.4.4 (other tests)
@@ -936,7 +936,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.5.2 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.5.2 (other tests)
@@ -979,7 +979,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.5.2 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.5.2 (other tests)
@@ -1026,7 +1026,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.5.2 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.5.2 with scala-2.13 (other tests)
@@ -1092,7 +1092,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.5.2 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.5.2 (other tests)
@@ -1156,7 +1156,7 @@ jobs:
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
-          pip3 install setuptools && \
+          pip3 install setuptools==77.0.3 && \
           pip3 install pyspark==3.5.2 cython && \
           pip3 install pandas pyarrow
       - name: Build and Run unit test for Spark 3.5.2 (other tests)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch pined `setuptools` version to `77.0.3`. 
The new release `78.0.1` is requiring some changes not available in old pyspark

(Fixes: #9123 )

## How was this patch tested?

pass GHA

