### PR TITLE
[GLUTEN-9055][CH] Fix input_file_name diff from hive text table

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseHiveTableSuite.scala
@@ -1673,7 +1673,7 @@ class GlutenClickHouseHiveTableSuite
              |""".stripMargin
 
         val select1Sql = s"SELECT input_file_name() from $tableName"
-        val select2Sql = s"SELECT input_file_name(), input_file_block_start(), " +
+        val select2Sql = s"SELECT input_file_block_start(), " +
           s"input_file_block_length() FROM $tableName"
         s"input_file_block_length() FROM $tableName"
         val dropSql = s"DROP TABLE IF EXISTS $tableName"

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -76,7 +76,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.distinct
+    requestedAttributes.map(attr => originalAttributes.getOrElse(attr, attr)).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -76,7 +76,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes).distinct
+    requestedAttributes.distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -76,7 +76,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.distinct
+    requestedAttributes.map(attr => originalAttributes.getOrElse(attr, attr)).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -76,7 +76,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes).distinct
+    requestedAttributes.distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -78,7 +78,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes).distinct
+    requestedAttributes.distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -78,7 +78,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.distinct
+    requestedAttributes.map(attr => originalAttributes.getOrElse(attr, attr)).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -78,7 +78,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.map(originalAttributes).distinct
+    requestedAttributes.distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/hive/execution/AbstractHiveTableScanExec.scala
@@ -78,7 +78,7 @@ abstract private[hive] class AbstractHiveTableScanExec(
 
   override val output: Seq[Attribute] = {
     // Retrieve the original attributes based on expression ID so that capitalization matches.
-    requestedAttributes.distinct
+    requestedAttributes.map(attr => originalAttributes.getOrElse(attr, attr)).distinct
   }
 
   // Bind all partition key attribute references in the partition pruning predicate for later


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: \#9055 by making PushDownInputFileExpression effective for hive text table.  

After fixing, there is still tiny diff between vanilla and gluten: when format is textfile, input_file_name() in vanilla returns paths like 'file:/xxx', ut in gluten it returns paths like 'file:///xxx', users who use input_file_name() in gluten should be aware of that.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

