### PR TITLE
Remove inlined children plan access during native validation of Exchange / CollectLimit

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarCollectLimitBaseExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ColumnarCollectLimitBaseExec.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.backendsapi.BackendsApiManager
-import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.extension.ValidationResult
 import org.apache.gluten.sql.shims.SparkShimLoader
 
@@ -33,15 +31,11 @@ abstract class ColumnarCollectLimitBaseExec(
   override def outputPartitioning: Partitioning = SinglePartition
 
   override protected def doValidateInternal(): ValidationResult = {
-
-    if (
-      (childPlan.supportsColumnar && GlutenConfig.get.enablePreferColumnar) &&
-      BackendsApiManager.getSettings.supportColumnarShuffleExec() &&
-      SparkShimLoader.getSparkShims.isColumnarLimitExecSupported()
-    ) {
-      return ValidationResult.succeeded
+    if (!SparkShimLoader.getSparkShims.isColumnarLimitExecSupported()) {
+      return ValidationResult.failed(
+        "Columnar collect-limit is unsupported under the current Spark version")
     }
-    ValidationResult.failed("Columnar shuffle not enabled or child does not support columnar.")
+    ValidationResult.succeeded
   }
 
   override protected def doExecute()

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -42,9 +42,7 @@ case class OffloadExchange() extends OffloadSingleNode with LogLevelUtil {
   override def offload(plan: SparkPlan): SparkPlan = plan match {
     case p if FallbackTags.nonEmpty(p) =>
       p
-    case s: ShuffleExchangeExec
-        if (s.child.supportsColumnar || GlutenConfig.get.enablePreferColumnar) &&
-          BackendsApiManager.getSettings.supportColumnarShuffleExec() =>
+    case s: ShuffleExchangeExec =>
       logDebug(s"Columnar Processing for ${s.getClass} is currently supported.")
       BackendsApiManager.getSparkPlanExecApiInstance.genColumnarShuffleExchange(s)
     case b: BroadcastExchangeExec =>


### PR DESCRIPTION
We don't usually access child nodes in `doValidateInternal`s implementation. Such kind of validation operations should be considered cost-based optimisation and be done in whole-stage fallback or in ras or in an individual columnar rule.

The patch removes the relevant code. This could be a fix for https://github.com/apache/incubator-gluten/pull/8914's CI failure.