### PR TITLE
[GLUTEN-9039][CH] Improve array_sort performance when only single argument is input 

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -889,7 +889,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
       argument: ExpressionTransformer,
       function: ExpressionTransformer,
       expr: ArraySort): ExpressionTransformer = {
-    GenericExpressionTransformer(substraitExprName, Seq(argument, function), expr)
+    CHArraySortTransformer(substraitExprName, argument, function, expr)
   }
 
   override def genDateAddTransformer(

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressionTransformer.scala
@@ -270,3 +270,35 @@ case class CHStringSplitTransformer(
   // In Spark: split return Array(String), while Array is nullable
   // In CH: splitByXXX return Array(Nullable(String))
 }
+
+case class CHArraySortTransformer(
+    substraitExprName: String,
+    argument: ExpressionTransformer,
+    function: ExpressionTransformer,
+    original: Expression)
+  extends ExpressionTransformer {
+  override def children: Seq[ExpressionTransformer] = {
+    def comparatorNotNull(left: Expression, right: Expression): Expression = {
+      val lit0 = Literal(0)
+      val lit1 = Literal(1)
+      val litm1 = Literal(-1)
+      If(LessThan(left, right), litm1, If(GreaterThan(left, right), lit1, lit0))
+    }
+
+    // Check if original.function is default comparator
+    // If it is, we only transform the argument and it is good for performance in CH backend.
+    // Otherwise, we transform both argument and function
+    val functionExpr = original.asInstanceOf[ArraySort].function.asInstanceOf[LambdaFunction]
+    val defaultComparatorNotNull =
+      comparatorNotNull(functionExpr.children(1), functionExpr.children(2))
+    val defaultComparor = ArraySort.comparator(functionExpr.children(1), functionExpr.children(2))
+    val isDefaultComparator = functionExpr.function.semanticEquals(defaultComparatorNotNull) ||
+      functionExpr.function.semanticEquals(defaultComparor)
+
+    if (isDefaultComparator) {
+      Seq(argument)
+    } else {
+      Seq(argument, function)
+    }
+  }
+}

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -1045,6 +1045,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
+<<<<<<< HEAD
   test("GLUTEN-8723 fix slice unexpected exception") {
     val create_sql = "create table t_8723 (full_user_agent string) using orc"
     val insert_sql = "insert into t_8723 values(NULL)"
@@ -1232,7 +1233,8 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
   }
 
   test("Test partition values with special characters") {
-    spark.sql("""
+    spark.sql(
+      """
       CREATE TABLE tbl_9050 (
         product_id STRING,
         quantity INT
@@ -1248,5 +1250,15 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark("select *, input_file_name() from tbl_9050", true, { _ => })
 
     sql("DROP TABLE tbl_9050")
+  }
+
+  test("Test array_sort without comparator") {
+    // default comparator with array elements not nullable guaranteed
+    val sql1 = "select array_sort(split(cast(id * 10 as string), '0')) from range(10)"
+    compareResultsAgainstVanillaSpark(sql1, true, { _ => })
+
+    // default comparator without array elements not nullable guaranteed
+    val sql2 = "select array_sort(array(id+1, null, id+2)) from range(10)"
+    compareResultsAgainstVanillaSpark(sql2, true, { _ => })
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -1045,7 +1045,6 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
-<<<<<<< HEAD
   test("GLUTEN-8723 fix slice unexpected exception") {
     val create_sql = "create table t_8723 (full_user_agent string) using orc"
     val insert_sql = "insert into t_8723 values(NULL)"
@@ -1233,8 +1232,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
   }
 
   test("Test partition values with special characters") {
-    spark.sql(
-      """
+    spark.sql("""
       CREATE TABLE tbl_9050 (
         product_id STRING,
         quantity INT

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayHighOrderFunctions.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayHighOrderFunctions.cpp
@@ -186,13 +186,12 @@ public:
         auto ch_func_name = getCHFunctionName(substrait_func);
         auto parsed_args = parseFunctionArguments(substrait_func, actions_dag);
 
-        if (parsed_args.size() != 2)
-            throw DB::Exception(DB::ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH, "array_sort function must have two arguments");
+        if (parsed_args.size() < 1 || parsed_args.size() > 2)
+            throw DB::Exception(DB::ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH, "array_sort function must have one or two arguments");
 
-        if (isDefaultCompare(substrait_func.arguments()[1].value().scalar_function()))
-        {
+        /// When only one argument is provided, we use the default comparator.
+        if (parsed_args.size() == 1)
             return toFunctionNode(actions_dag, ch_func_name, {parsed_args[0]});
-        }
 
         auto lambda_args = collectLambdaArguments(parser_context, substrait_func.arguments()[1].value().scalar_function());
         if (lambda_args.size() != 2 || !lambda_args.front().type->equals(*(lambda_args.back().type)))
@@ -209,121 +208,6 @@ public:
         parsed_args[0] = ActionsDAGUtil::convertNodeTypeIfNeeded(actions_dag, parsed_args[0], dst_array_type);
 
         return toFunctionNode(actions_dag, ch_func_name, {parsed_args[1], parsed_args[0]});
-    }
-private:
-
-    /// The default lambda compare function for array_sort, `array_sort(x)`.
-    bool isDefaultCompare(const substrait::Expression_ScalarFunction & scalar_function) const
-    {
-        String left_variable_name, right_variable_name;
-        auto names_types = collectLambdaArguments(parser_context, scalar_function);
-        {
-            auto it = names_types.begin();
-            left_variable_name = it->name;
-            it++;
-            right_variable_name = it->name;
-        }
-
-        auto is_function = [&](const substrait::Expression & expr, const String & function_name) {
-            return expr.has_scalar_function()
-                && expression_parser->getFunctionNameInSignature(expr.scalar_function().function_reference()) == function_name;
-        };
-
-        auto is_variable = [&](const substrait::Expression & expr, const String & var) {
-            if (!is_function(expr, "namedlambdavariable"))
-            {
-                return false;
-            }
-            const auto var_expr = expr.scalar_function().arguments()[0].value();
-            if (!var_expr.has_literal())
-                return false;
-            auto [_, name] = LiteralParser::parse(var_expr.literal());
-            return var == name.safeGet<String>();
-        };
-
-        auto is_int_value = [&](const substrait::Expression & expr, Int32 val) {
-            if (!expr.has_literal())
-                return false;
-            auto [_, x] = LiteralParser::parse(expr.literal());
-            return val == x.safeGet<Int32>();
-        };
-
-        auto is_variable_null = [&](const substrait::Expression & expr, const String & var) {
-            return is_function(expr, "is_null") && is_variable(expr.scalar_function().arguments(0).value(), var);
-        };
-
-        auto is_both_null = [&](const substrait::Expression & expr) {
-            return is_function(expr, "and")
-                && is_variable_null(expr.scalar_function().arguments(0).value(), left_variable_name)
-                && is_variable_null(expr.scalar_function().arguments(1).value(), right_variable_name);
-        };
-
-        auto is_left_greater_right = [&](const substrait::Expression & expr) {
-            if (!expr.has_if_then())
-                return false;
-
-            const auto & if_ = expr.if_then().ifs(0);
-            if (!is_function(if_.if_(), "gt"))
-                return false;
-
-            const auto & less_args = if_.if_().scalar_function().arguments();
-            return is_variable(less_args[0].value(), left_variable_name)
-                && is_variable(less_args[1].value(), right_variable_name)
-                && is_int_value(if_.then(), 1)
-                && is_int_value(expr.if_then().else_(), 0);
-        };
-
-        auto is_left_less_right = [&](const substrait::Expression & expr) {
-            if (!expr.has_if_then())
-                return false;
-
-            const auto & if_ = expr.if_then().ifs(0);
-            if (!is_function(if_.if_(), "lt"))
-                return false;
-
-            const auto & less_args = if_.if_().scalar_function().arguments();
-            return is_variable(less_args[0].value(), left_variable_name)
-                && is_variable(less_args[1].value(), right_variable_name)
-                && is_int_value(if_.then(), -1)
-                && is_left_greater_right(expr.if_then().else_());
-        };
-
-        auto is_right_null_else = [&](const substrait::Expression & expr) {
-            if (!expr.has_if_then())
-                return false;
-
-            /// if right arg is null, return 1
-            const auto & if_then = expr.if_then();
-            return is_variable_null(if_then.ifs(0).if_(), right_variable_name)
-                && is_int_value(if_then.ifs(0).then(), -1)
-                && is_left_less_right(if_then.else_());
-
-        };
-
-        auto is_left_null_else = [&](const substrait::Expression & expr) {
-            if (!expr.has_if_then())
-                return false;
-
-            /// if left arg is null, return 1
-            const auto & if_then = expr.if_then();
-            return is_variable_null(if_then.ifs(0).if_(), left_variable_name)
-                && is_int_value(if_then.ifs(0).then(), 1)
-                && is_right_null_else(if_then.else_());
-        };
-
-        auto is_if_both_null_else = [&](const substrait::Expression & expr) {
-            if (!expr.has_if_then())
-            {
-                return false;
-            }
-            const auto & if_ = expr.if_then().ifs(0);
-            return is_both_null(if_.if_())
-                && is_int_value(if_.then(), 0)
-                && is_left_null_else(expr.if_then().else_());
-        };
-
-        const auto & lambda_body = scalar_function.arguments()[0].value();
-        return is_if_both_null_else(lambda_body);
     }
 };
 static FunctionParserRegister<FunctionParserArraySort> register_array_sort;


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#9039)

Before opt: spark  array_sort(arr) ->  CH arraySparkSort(func, arr)
After opt:    spark  array_sort(arr) -> CH  arraySparkSort(arr) 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

