### PR TITLE
[CORE] LocalPartitionWriter should discard the evict since it use hash/sort evict

### DIFF
--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -614,32 +614,6 @@ arrow::Status LocalPartitionWriter::sortEvict(
   return arrow::Status::OK();
 }
 
-// FIXME: Remove this code path for local partition writer.
-arrow::Status LocalPartitionWriter::evict(uint32_t partitionId, std::unique_ptr<BlockPayload> blockPayload, bool stop) {
-  rawPartitionLengths_[partitionId] += blockPayload->rawSize();
-
-  if (lastEvictPid_ != -1 && partitionId < lastEvictPid_) {
-    RETURN_NOT_OK(finishSpill(true));
-    lastEvictPid_ = -1;
-  }
-  RETURN_NOT_OK(requestSpill(stop));
-
-  if (!stop) {
-    RETURN_NOT_OK(spiller_->spill(partitionId, std::move(blockPayload)));
-  } else {
-    if (spills_.size() > 0) {
-      for (auto pid = lastEvictPid_ + 1; pid <= partitionId; ++pid) {
-        auto bytesEvicted = totalBytesEvicted_;
-        RETURN_NOT_OK(mergeSpills(pid));
-        partitionLengths_[pid] = totalBytesEvicted_ - bytesEvicted;
-      }
-    }
-    RETURN_NOT_OK(spiller_->spill(partitionId, std::move(blockPayload)));
-  }
-  lastEvictPid_ = partitionId;
-  return arrow::Status::OK();
-}
-
 arrow::Status LocalPartitionWriter::reclaimFixedSize(int64_t size, int64_t* actual) {
   // Finish last spiller.
   RETURN_NOT_OK(finishSpill(true));

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -47,7 +47,10 @@ class LocalPartitionWriter : public PartitionWriter {
       std::shared_ptr<arrow::Buffer> compressed,
       bool isFinal) override;
 
-  arrow::Status evict(uint32_t partitionId, std::unique_ptr<BlockPayload> blockPayload, bool stop) override;
+  // This code path is not used by LocalPartitionWriter, Not implement it by default.
+  arrow::Status evict(uint32_t partitionId, std::unique_ptr<BlockPayload> blockPayload, bool stop) override {
+    return arrow::Status::NotImplemented("Invalid code path for local shuffle writer.");
+  }
 
   /// The stop function performs several tasks:
   /// 1. Opens the final data file.


### PR DESCRIPTION
## What changes were proposed in this pull request?
LocalPartitionWriter should discard the evict since it use hash/sort evict

## How was this patch tested?
GA

