### PR TITLE
[CORE] Remove unused configuration option `spark.gluten.sql.columnar.preferColumnar`

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -204,18 +204,16 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
   }
 
   test("test 'GLUTEN-5016'") {
-    withSQLConf(("spark.gluten.sql.columnar.preferColumnar", "false")) {
-      val sql =
-        """
-          |SELECT
-          |   sum(l_quantity) AS sum_qty
-          |FROM
-          |   lineitem
-          |WHERE
-          |   l_shipdate <= date'1998-09-02'
-          |""".stripMargin
-      runSql(sql, noFallBack = true) { _ => }
-    }
+    val sql =
+      """
+        |SELECT
+        |   sum(l_quantity) AS sum_qty
+        |FROM
+        |   lineitem
+        |WHERE
+        |   l_shipdate <= date'1998-09-02'
+        |""".stripMargin
+    runSql(sql, noFallBack = true) { _ => }
   }
 
   test("test rewrite date conversion") {

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -156,8 +156,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableColumnarShuffle: Boolean = getConf(COLUMNAR_SHUFFLE_ENABLED)
 
-  def enablePreferColumnar: Boolean = getConf(COLUMNAR_PREFER_ENABLED)
-
   def physicalJoinOptimizationThrottle: Integer =
     getConf(COLUMNAR_PHYSICAL_JOIN_OPTIMIZATION_THROTTLE)
 
@@ -962,13 +960,6 @@ object GlutenConfig {
         "shuffle will be used if the number of columns is greater than this threshold.")
       .intConf
       .createWithDefault(100000)
-
-  val COLUMNAR_PREFER_ENABLED =
-    buildConf("spark.gluten.sql.columnar.preferColumnar")
-      .internal()
-      .doc("Prefer to use columnar operators if set to true.")
-      .booleanConf
-      .createWithDefault(true)
 
   val COLUMNAR_TABLE_CACHE_ENABLED =
     buildConf("spark.gluten.sql.columnar.tableCache")


### PR DESCRIPTION
The option is no longer used after https://github.com/apache/incubator-gluten/pull/9145. Remove it from source code.