### PR TITLE
[GLUTEN-9176][CH] Rewrite aggregate if to aggregate with filter clause

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -421,6 +421,13 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
     )
   }
 
+  def enableAggregateIfToFilter(): Boolean = {
+    SparkEnv.get.conf.getBoolean(
+      CHConfig.runtimeConfig("enable_aggregate_if_to_filter"),
+      defaultValue = true
+    )
+  }
+
   override def enableNativeWriteFiles(): Boolean = {
     GlutenConfig.get.enableNativeWriter.getOrElse(false)
   }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -67,6 +67,7 @@ object CHRuleApi {
     injector.injectResolutionRule(spark => new CollapseGetJsonObjectExpressionRule(spark))
     injector.injectResolutionRule(spark => new RepalceFromJsonWithGetJsonObject(spark))
     injector.injectOptimizerRule(spark => new CommonSubexpressionEliminateRule(spark))
+    injector.injectOptimizerRule(spark => new AggregateIfToFilterRule(spark))
     injector.injectOptimizerRule(spark => new SimplifySumRule(spark))
     injector.injectOptimizerRule(spark => new ExtendedColumnPruning(spark))
     injector.injectOptimizerRule(spark => CHAggregateFunctionRewriteRule(spark))

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/AggregateIfToFilterRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/AggregateIfToFilterRule.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+
+// Rule1: sum(if(cond, expr, 0)) -> sum(expr) FILTER (WHERE cond)
+// Rule2: func(if(cond, expr, null)) -> func(expr) FILTER (WHERE cond)
+case class AggregateIfToFilterRule(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transform {
+    case agg @ Aggregate(groupingExpressions, aggregateExpressions, child) =>
+      val newAggregateExpressions = aggregateExpressions.map(transformExpression)
+      agg.copy(aggregateExpressions = newAggregateExpressions.map(_.asInstanceOf[NamedExpression]))
+  }
+
+  private def transformExpression(expr: Expression): Expression = expr match {
+    case aggrExpr @ AggregateExpression(aggrFunc, _, isDistinct, filter, _)
+        if !isDistinct && filter.isEmpty =>
+      aggrFunc match {
+        // sum(if(cond, expr, 0)) -> sum(expr) FILTER (WHERE cond)
+        case Sum(If(cond, expr, Literal(0, _)), _) =>
+          aggrExpr.copy(
+            aggregateFunction = Sum(expr),
+            filter = Some(cond)
+          )
+        // func(if(cond, expr, null)) -> func(expr) FILTER (WHERE cond)
+        case _ if aggrFunc.children.size == 1 =>
+          val expr = aggrFunc.children.head
+          expr match {
+            case ifExpr @ If(cond, childExpr, Literal(null, _)) =>
+              aggrExpr.copy(
+                aggregateFunction =
+                  aggrFunc.withNewChildren(Seq(childExpr)).asInstanceOf[AggregateFunction],
+                filter = Some(cond)
+              )
+            case _ => aggrExpr
+          }
+        case _ => aggrExpr
+      }
+    case aggrExpr @ AggregateExpression(_, _, _, _, _) => aggrExpr
+    case e: Expression => e.mapChildren(transformExpression)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rewrite aggregate if to aggregate with filter clause to use CH aggregate combinator -If . 
- Rule1: sum(if(cond, expr, 0)) -> sum(expr) FILTER (WHERE cond)
- Rule2: func(if(cond, expr, null)) -> func(expr) FILTER (WHERE cond)

(Fixes: \#9176)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

