### PR TITLE
[GLUTEN-9197][CH] Simplify sum aggregate expression

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -414,6 +414,13 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
     )
   }
 
+  def enableSimplifySum(): Boolean = {
+    SparkEnv.get.conf.getBoolean(
+      CHConfig.runtimeConfig("enable_simplify_sum"),
+      defaultValue = true
+    )
+  }
+
   override def enableNativeWriteFiles(): Boolean = {
     GlutenConfig.get.enableNativeWriter.getOrElse(false)
   }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -67,6 +67,7 @@ object CHRuleApi {
     injector.injectResolutionRule(spark => new CollapseGetJsonObjectExpressionRule(spark))
     injector.injectResolutionRule(spark => new RepalceFromJsonWithGetJsonObject(spark))
     injector.injectOptimizerRule(spark => new CommonSubexpressionEliminateRule(spark))
+    injector.injectOptimizerRule(spark => new SimplifySumRule(spark))
     injector.injectOptimizerRule(spark => new ExtendedColumnPruning(spark))
     injector.injectOptimizerRule(spark => CHAggregateFunctionRewriteRule(spark))
     injector.injectOptimizerRule(_ => CountDistinctWithoutExpand)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHHashAggregateExecTransformer.scala
@@ -127,7 +127,7 @@ case class CHHashAggregateExecTransformer(
   lazy val aggregateResultAttributes =
     getAggregateResultAttributes(groupingExpressions, aggregateExpressions)
 
-  protected val modes: Seq[AggregateMode] = aggregateExpressions.map(_.mode).distinct
+  val modes: Seq[AggregateMode] = aggregateExpressions.map(_.mode).distinct
 
   override protected def checkType(dataType: DataType): Boolean = {
     dataType match {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/SimplifySumRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/SimplifySumRule.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.gluten.backendsapi.clickhouse.CHBackendSettings
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+
+// Rule 1: sum(expr / literal) -> sum(expr) / literal
+// Rule 2: sum(expr * literal) -> literal * sum(expr)
+// Rule 3: sum(literal * expr) -> literal * sum(expr)
+case class SimplifySumRule(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!plan.resolved || !CHBackendSettings.enableSimplifySum) {
+      plan
+    } else {
+      plan.transform {
+        case agg @ Aggregate(_, aggregateExpressions, _) =>
+          val newAggregateExpressions = aggregateExpressions.map(transformExpression)
+          agg.copy(aggregateExpressions =
+            newAggregateExpressions.map(_.asInstanceOf[NamedExpression]))
+      }
+    }
+  }
+
+  private def transformExpression(expr: Expression): Expression = expr match {
+    case aggrExpr @ AggregateExpression(Sum(child, _), mode, isDistinct, filter, resultId)
+        if !isDistinct =>
+      child match {
+        // Rule 1: sum(expr / literal) -> sum(expr) / literal
+        case Divide(numerator, denominator @ Literal(_, _), _) =>
+          val newSum = aggrExpr.copy(aggregateFunction = Sum(numerator))
+          Divide(newSum, denominator)
+
+        // Rule 2: sum(expr * literal) -> literal * sum(expr)
+        case Multiply(expr, literal @ Literal(_, _), _) =>
+          val newSum = aggrExpr.copy(aggregateFunction = Sum(expr))
+          Multiply(literal, newSum)
+
+        // Rule 3: sum(literal * expr) -> literal * sum(expr)
+        case Multiply(literal @ Literal(_, _), expr, _) =>
+          val newSum = aggrExpr.copy(aggregateFunction = Sum(expr))
+          Multiply(literal, newSum)
+
+        case _ => aggrExpr
+      }
+    case aggrExpr @ AggregateExpression(_, _, _, _, _) => aggrExpr
+    case e: Expression => e.mapChildren(transformExpression)
+  }
+}

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.backendsapi.clickhouse.CHConfig
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, GlutenTestUtils, Row}
 import org.apache.spark.sql.catalyst.expressions._
@@ -1045,7 +1047,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
-  test("GLUTEN-8723 fix slice unexpected exception") {
+  <<<<<<<.HEAD(test("GLUTEN-8723 fix slice unexpected exception") {
     val create_sql = "create table t_8723 (full_user_agent string) using orc"
     val insert_sql = "insert into t_8723 values(NULL)"
     val select1_sql = "select " +
@@ -1058,7 +1060,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark(select1_sql, true, { _ => })
     compareResultsAgainstVanillaSpark(select2_sql, true, { _ => })
     spark.sql(drop_sql)
-  }
+  })
 
   test("GLUTEN-8715 nan semantics") {
     withTable("test_8715") {
@@ -1258,5 +1260,27 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     // default comparator without array elements not nullable guaranteed
     val sql2 = "select array_sort(array(id+1, null, id+2)) from range(10)"
     compareResultsAgainstVanillaSpark(sql2, true, { _ => })
+  }
+
+  test("Test SimplifySumRule for sum simplification") {
+    val sql = "select sum(id / 3), sum(id * 7), sum(7 * id) from range(10)"
+
+    def checkSimplifiedSum(df: DataFrame): Unit = {
+      val projects = collectWithSubqueries(df.queryExecution.executedPlan) {
+        case project: ProjectExecTransformer
+            if project.child.isInstanceOf[CHHashAggregateExecTransformer] =>
+          project
+      }
+
+      assert(projects.size == 1)
+      assert(projects.head.projectList.size == 3)
+      assert(projects.head.projectList(0).asInstanceOf[Alias].child.isInstanceOf[Divide])
+      assert(projects.head.projectList(1).asInstanceOf[Alias].child.isInstanceOf[Multiply])
+      assert(projects.head.projectList(2).asInstanceOf[Alias].child.isInstanceOf[Multiply])
+    }
+
+    withSQLConf((CHConfig.runtimeConfig("enable_simplify_sum"), "true")) {
+      compareResultsAgainstVanillaSpark(sql, compareResult = true, checkSimplifiedSum)
+    }
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -1047,7 +1047,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
-  <<<<<<<.HEAD(test("GLUTEN-8723 fix slice unexpected exception") {
+  test("GLUTEN-8723 fix slice unexpected exception") {
     val create_sql = "create table t_8723 (full_user_agent string) using orc"
     val insert_sql = "insert into t_8723 values(NULL)"
     val select1_sql = "select " +
@@ -1060,7 +1060,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     compareResultsAgainstVanillaSpark(select1_sql, true, { _ => })
     compareResultsAgainstVanillaSpark(select2_sql, true, { _ => })
     spark.sql(drop_sql)
-  })
+  }
 
   test("GLUTEN-8715 nan semantics") {
     withTable("test_8715") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Simplify sum with the following rules: 
- Rule 1: sum(expr / literal) -> sum(expr) / literal
- Rule 2: sum(expr * literal) -> literal * sum(expr)
- Rule 3: sum(literal * expr) -> literal * sum(expr) 

If current rule is combined with https://github.com/apache/incubator-gluten/pull/9185, we can easily transform
- sum(if(cond, expr/literal, 0)) -> (sum(expr) filter (where cond)) / literal
- sum(if(cond, expr * literal, 0)) -> (sum(expr) filter (where cond)) * literal
- sum(if(cond, literal * expr, 0)) -> (sum(expr) filter (where cond)) * literal


(Fixes: \#9197)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

