### PR TITLE
[GLUTEN-9199][VL] Fix error when creating shuffle file: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments 

### DIFF
--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -387,7 +387,7 @@ std::string LocalPartitionWriter::nextSpilledFileDir() {
 
 arrow::Result<std::shared_ptr<arrow::io::OutputStream>> LocalPartitionWriter::openFile(const std::string& file) {
   std::shared_ptr<arrow::io::FileOutputStream> fout;
-  auto fd = open(file.c_str(), O_WRONLY | O_CREAT | O_TRUNC);
+  auto fd = open(file.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0000);
   // Set the shuffle file permissions to 0644 to keep it consistent with the permissions of
   // the built-in shuffler manager in Spark.
   fchmod(fd, 0644);


### PR DESCRIPTION
Fixes #9199 by setting a default mode to the `open` call.