### PR TITLE
[GLUTEN-9239][CH] Support JDK17 for the CH backend

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -273,6 +273,10 @@
             <artifactId>protobuf-java</artifactId>
             <groupId>com.google.protobuf</groupId>
           </exclusion>
+          <exclusion>
+            <artifactId>jdk.tools</artifactId>
+            <groupId>jdk.tools</groupId>
+          </exclusion>
         </exclusions>
     </dependency>
     <dependency>

--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/CHNativeExpressionEvaluator.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/CHNativeExpressionEvaluator.java
@@ -48,6 +48,10 @@ public class CHNativeExpressionEvaluator extends ExpressionEvaluatorJniWrapper {
     nativeFinalizeNative();
   }
 
+  public static void destroyNative() {
+    nativeDestroyNative();
+  }
+
   // Used to validate the Substrait plan in native compute engine.
   public static boolean doValidate(byte[] subPlan) {
     throw new UnsupportedOperationException("doValidate is not supported in Clickhouse Backend");

--- a/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/backends-clickhouse/src/main/java/org/apache/gluten/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -28,8 +28,11 @@ public class ExpressionEvaluatorJniWrapper {
   /** Call initNative to initialize native computing. */
   static native void nativeInitNative(byte[] confAsPlan);
 
-  /** Call finalizeNative to finalize native computing. */
+  /** Call finalizeNative to finalize native computing for each SparkSession. */
   static native void nativeFinalizeNative();
+
+  /** Call finalizeNative to finalize native computing when jvm shutdown. */
+  static native void nativeDestroyNative();
 
   /**
    * Create a native compute kernel and return a columnar result iterator.

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHListenerApi.scala
@@ -143,7 +143,10 @@ object CHListenerApi {
       initialized = true
       SparkShutdownManagerUtil.addHookForLibUnloading(
         () => {
-          JniLibLoader.forceUnloadAll
+          // Due to the changes in the JNI OnUnLoad calling mechanism of the JDK17,
+          // it needs to manually call the destroy native function
+          // to release ch resources and avoid core dump
+          CHNativeExpressionEvaluator.destroyNative()
         })
     }
   }

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -166,25 +166,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM * vm, void * /*reserved*/)
 
 JNIEXPORT void JNI_OnUnload(JavaVM * vm, void * /*reserved*/)
 {
-    LOG_INFO(&Poco::Logger::get("jni"), "start jni onUnload");
-    local_engine::BackendFinalizerUtil::finalizeGlobally();
-
-    JNIEnv * env;
-    vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_8);
-
-    local_engine::JniErrorsGlobalState::instance().destroy(env);
-    local_engine::BroadCastJoinBuilder::destroy(env);
-    local_engine::SparkMergeTreeWriterJNI::destroy(env);
-    local_engine::SparkRowInfoJNI::destroy(env);
-
-    env->DeleteGlobalRef(block_stripes_class);
-    env->DeleteGlobalRef(split_result_class);
-    env->DeleteGlobalRef(block_stats_class);
-    env->DeleteGlobalRef(local_engine::ShuffleReader::input_stream_class);
-    env->DeleteGlobalRef(local_engine::NativeSplitter::iterator_class);
-    env->DeleteGlobalRef(local_engine::WriteBufferFromJavaOutputStream::output_stream_class);
-    env->DeleteGlobalRef(local_engine::SourceFromJavaIter::serialized_record_batch_iterator_class);
-    env->DeleteGlobalRef(local_engine::SparkRowToCHColumn::spark_row_interator_class);
+    // manually destroy native in 'nativeDestroyNative' method
 }
 
 JNIEXPORT void Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv * env, jclass, jbyteArray conf_plan)
@@ -205,6 +187,26 @@ JNIEXPORT void Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_n
     LOCAL_ENGINE_JNI_METHOD_START
     local_engine::BackendFinalizerUtil::finalizeSessionally();
     LOCAL_ENGINE_JNI_METHOD_END(env, )
+}
+
+JNIEXPORT void Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_nativeDestroyNative(JNIEnv * env, jclass)
+{
+    LOG_INFO(&Poco::Logger::get("jni"), "start destroy native");
+    local_engine::BackendFinalizerUtil::finalizeGlobally();
+
+    local_engine::JniErrorsGlobalState::instance().destroy(env);
+    local_engine::BroadCastJoinBuilder::destroy(env);
+    local_engine::SparkMergeTreeWriterJNI::destroy(env);
+    local_engine::SparkRowInfoJNI::destroy(env);
+
+    env->DeleteGlobalRef(block_stripes_class);
+    env->DeleteGlobalRef(split_result_class);
+    env->DeleteGlobalRef(block_stats_class);
+    env->DeleteGlobalRef(local_engine::ShuffleReader::input_stream_class);
+    env->DeleteGlobalRef(local_engine::NativeSplitter::iterator_class);
+    env->DeleteGlobalRef(local_engine::WriteBufferFromJavaOutputStream::output_stream_class);
+    env->DeleteGlobalRef(local_engine::SourceFromJavaIter::serialized_record_batch_iterator_class);
+    env->DeleteGlobalRef(local_engine::SparkRowToCHColumn::spark_row_interator_class);
 }
 
 /// Set settings for the current query. It assumes that all parameters are started with `CH_RUNTIME_SETTINGS_PREFIX` prefix,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support JDK17 for the CH backend.

Due to the changes in the JNI OnUnLoad calling mechanism of the JDK17, it needs to manually call the destroy native function
to release ch resources and avoid core dump.

Close #9239.

(Fixes: #9239)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

