### PR TITLE
[CH] Add a comment to explain why the endpoint uses a single thread

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenDriverEndpoint.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenDriverEndpoint.scala
@@ -40,7 +40,8 @@ class GlutenDriverEndpoint extends IsolatedRpcEndpoint with Logging {
   private val driverEndpoint: RpcEndpointRef =
     rpcEnv.setupEndpoint(GlutenRpcConstants.GLUTEN_DRIVER_ENDPOINT_NAME, this)
 
-  // TODO(yuan): get thread cnt from spark context
+  // With Apache Spark, endpoint uses a dedicated thread pool for delivering messages and
+  // ensured to be thread-safe by default.
   override def threadCount(): Int = 1
   override def receive: PartialFunction[Any, Unit] = {
     case GlutenOnExecutionStart(executionId) =>

--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
@@ -40,7 +40,8 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
   @volatile var driverEndpointRef: RpcEndpointRef = null
 
   rpcEnv.setupEndpoint(GlutenRpcConstants.GLUTEN_EXECUTOR_ENDPOINT_NAME, this)
-  // TODO(yuan): get thread cnt from spark context
+  // With Apache Spark, endpoint uses a dedicated thread pool for delivering messages and
+  // ensured to be thread-safe by default.
   override def threadCount(): Int = 1
   override def onStart(): Unit = {
     rpcEnv


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to add a comment to explain why the endpoint uses a single thread. We don't need to set thread count from SparkContext[1].  

[1] https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/rpc/RpcEndpoint.scala#L166-L177


## How was this patch tested?

No need to add tests.

