### PR TITLE
[GLUTEN-9245][VL] Fix partial project expression contains subquery

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -47,15 +47,17 @@ import scala.collection.mutable.ListBuffer
  * @param original
  *   extract the ScalaUDF from original project list as Alias in UnsafeProjection and
  *   AttributeReference in ColumnarPartialProjectExec output
- * @param projectList The project output, with this argument in case class, function
- *                    QueryPlan.expressions can return the Expression list correctly,
- *                    then the function executeQuery can find the SubQuery from Expression
+ * @param projectList
+ *   The project output, with this argument in case class, function QueryPlan.expressions can return
+ *   the Expression list correctly, then the function executeQuery can find the SubQuery from
+ *   Expression
  * @param child
  *   child plan
  */
-case class ColumnarPartialProjectExec(original: ProjectExec, projectList: Seq[NamedExpression],
-                                      child: SparkPlan)(
-    replacedAliasUdf: Seq[Alias])
+case class ColumnarPartialProjectExec(
+    original: ProjectExec,
+    projectList: Seq[NamedExpression],
+    child: SparkPlan)(replacedAliasUdf: Seq[Alias])
   extends UnaryExecNode
   with ValidatablePlan {
 
@@ -347,7 +349,8 @@ object ColumnarPartialProjectExec {
       p => replaceExpressionUDF(p, replacedAliasUdf).asInstanceOf[NamedExpression]
     }
     val partialProject =
-      ColumnarPartialProjectExec(original, original.projectList, original.child)(replacedAliasUdf.toSeq)
+      ColumnarPartialProjectExec(original, original.projectList, original.child)
+    (replacedAliasUdf.toSeq)
     ProjectExecTransformer(newProjectList, partialProject)
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -349,8 +349,8 @@ object ColumnarPartialProjectExec {
       p => replaceExpressionUDF(p, replacedAliasUdf).asInstanceOf[NamedExpression]
     }
     val partialProject =
-      ColumnarPartialProjectExec(original, original.projectList, original.child)
-    (replacedAliasUdf.toSeq)
+      ColumnarPartialProjectExec(original, original.projectList, original.child)(
+        replacedAliasUdf.toSeq)
     ProjectExecTransformer(newProjectList, partialProject)
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -47,10 +47,14 @@ import scala.collection.mutable.ListBuffer
  * @param original
  *   extract the ScalaUDF from original project list as Alias in UnsafeProjection and
  *   AttributeReference in ColumnarPartialProjectExec output
+ * @param projectList The project output, with this argument in case class, function
+ *                    QueryPlan.expressions can return the Expression list correctly,
+ *                    then the function executeQuery can find the SubQuery from Expression
  * @param child
  *   child plan
  */
-case class ColumnarPartialProjectExec(original: ProjectExec, child: SparkPlan)(
+case class ColumnarPartialProjectExec(original: ProjectExec, projectList: Seq[NamedExpression],
+                                      child: SparkPlan)(
     replacedAliasUdf: Seq[Alias])
   extends UnaryExecNode
   with ValidatablePlan {
@@ -343,7 +347,7 @@ object ColumnarPartialProjectExec {
       p => replaceExpressionUDF(p, replacedAliasUdf).asInstanceOf[NamedExpression]
     }
     val partialProject =
-      ColumnarPartialProjectExec(original, original.child)(replacedAliasUdf.toSeq)
+      ColumnarPartialProjectExec(original, original.projectList, original.child)(replacedAliasUdf.toSeq)
     ProjectExecTransformer(newProjectList, partialProject)
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -85,7 +85,7 @@ abstract class UDFPartialProjectSuite extends WholeStageTransformerSuite {
 
   test("test subquery") {
     runQueryAndCompare(
-      "select plus_two(" +
+      "select plus_one(" +
         "(select plus_one(count(*)) from (values (1)) t0(inner_c))) as col " +
         "from (values (2),(3)) t1(outer_c)") {
       checkGlutenOperatorMatch[ColumnarPartialProjectExec]

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -84,10 +84,10 @@ abstract class UDFPartialProjectSuite extends WholeStageTransformerSuite {
   }
 
   test("test subquery") {
-    runQueryAndCompare("select plus_two(" +
-      "(select plus_one(count(*)) from (values (1)) t0(inner_c))) as col " +
-      "from (values (2),(3)) t1(outer_c)")
-    {
+    runQueryAndCompare(
+      "select plus_two(" +
+        "(select plus_one(count(*)) from (values (1)) t0(inner_c))) as col " +
+        "from (values (2),(3)) t1(outer_c)") {
       checkGlutenOperatorMatch[ColumnarPartialProjectExec]
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -83,6 +83,15 @@ abstract class UDFPartialProjectSuite extends WholeStageTransformerSuite {
     }
   }
 
+  test("test subquery") {
+    runQueryAndCompare("select plus_two(" +
+      "(select plus_one(count(*)) from (values (1)) t0(inner_c))) as col " +
+      "from (values (2),(3)) t1(outer_c)")
+    {
+      checkGlutenOperatorMatch[ColumnarPartialProjectExec]
+    }
+  }
+
   ignore("test plus_one with column used twice") {
     runQueryAndCompare(
       "SELECT sum(plus_one(cast(l_orderkey as long)) + hash(l_orderkey)) from lineitem") {


### PR DESCRIPTION
With argument projectList in class `ColumnarPartialProjectExec`, function QueryPlan.expressions can return the Expression list correctly, then the function executeQuery can find the SubQuery from Expression.

