### PR TITLE
[VL] Delete global reference to a class object in JNI unload

### DIFF
--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -81,6 +81,7 @@ void JNI_OnUnload(JavaVM* vm, void*) {
   vm->GetEnv(reinterpret_cast<void**>(&env), jniVersion);
 
   env->DeleteGlobalRef(blockStripesClass);
+  env->DeleteGlobalRef(infoCls);
 
   finalizeVeloxJniUDF(env);
   finalizeVeloxJniFileSystem(env);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The global reference to class object of `NativePlanValidationInfo` was introduced in #9092. It should be explicitly deleted in JNI unload.


