### PR TITLE
[GLUTEN-9239][CH] [PART-1] Support Java-17 Rmove `JNI_OnUnload`

### DIFF
--- a/cpp-ch/local-engine/libch-hide-jemalloc.map
+++ b/cpp-ch/local-engine/libch-hide-jemalloc.map
@@ -3,6 +3,5 @@
       Java_org_apache_gluten*;
       Java_org_apache_spark*;
       JNI_OnLoad;
-      JNI_OnUnload;
     local: *;
 };

--- a/cpp-ch/local-engine/libch.map
+++ b/cpp-ch/local-engine/libch.map
@@ -3,7 +3,6 @@
       Java_org_apache_gluten*;
       Java_org_apache_spark*;
       JNI_OnLoad;
-      JNI_OnUnload;
       aligned_alloc;
       calloc;
       dallocx;

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -171,11 +171,6 @@ JNIEXPORT jint JNI_OnLoad(JavaVM * vm, void * /*reserved*/)
     return JNI_VERSION_1_8;
 }
 
-JNIEXPORT void JNI_OnUnload(JavaVM * vm, void * /*reserved*/)
-{
-    // manually destroy native in 'nativeDestroyNative' method
-}
-
 JNIEXPORT void Java_org_apache_gluten_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv * env, jclass, jbyteArray conf_plan)
 {
     LOCAL_ENGINE_JNI_METHOD_START


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `JNI_OnUnload`, since it is no longer needed.  using this PR to run gluten-dev ci for testing java-17

(Fixes: \#9239)

## How was this patch tested?

Using existed UTs

