### PR TITLE
[GLUTEN-9163][VL] Use stream de/compressor in sort-based shuffle

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -825,10 +825,10 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_ShuffleWriterJniWrappe
     jstring codecJstr,
     jstring codecBackendJstr,
     jint compressionLevel,
-    jint sortEvictBufferSize,
+    jint diskWriteBufferSize,
     jint compressionThreshold,
     jstring compressionModeJstr,
-    jint sortBufferInitialSize,
+    jint initialSortBufferSize,
     jboolean useRadixSort,
     jstring dataFileJstr,
     jint numSubDirs,
@@ -856,8 +856,8 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_ShuffleWriterJniWrappe
       .taskAttemptId = static_cast<int64_t>(taskAttemptId),
       .startPartitionId = startPartitionId,
       .shuffleWriterType = ShuffleWriter::stringToType(jStringToCString(env, shuffleWriterTypeJstr)),
-      .sortBufferInitialSize = sortBufferInitialSize,
-      .sortEvictBufferSize = sortEvictBufferSize,
+      .initialSortBufferSize = initialSortBufferSize,
+      .diskWriteBufferSize = diskWriteBufferSize,
       .useRadixSort = static_cast<bool>(useRadixSort)};
 
   // Build PartitionWriterOptions.

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -163,7 +163,7 @@ bool StdMemoryAllocator::reallocate(void* p, int64_t size, int64_t newSize, void
 
 bool StdMemoryAllocator::reallocateAligned(void* p, uint64_t alignment, int64_t size, int64_t newSize, void** out) {
   GLUTEN_CHECK(p != nullptr, "reallocate with nullptr");
-  if (newSize <= 0) {
+  if (newSize < 0) {
     return false;
   }
   if (newSize <= size) {

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -163,7 +163,7 @@ bool StdMemoryAllocator::reallocate(void* p, int64_t size, int64_t newSize, void
 
 bool StdMemoryAllocator::reallocateAligned(void* p, uint64_t alignment, int64_t size, int64_t newSize, void** out) {
   GLUTEN_CHECK(p != nullptr, "reallocate with nullptr");
-  if (newSize < 0) {
+  if (newSize <= 0) {
     return false;
   }
   if (newSize <= size) {

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -655,7 +655,7 @@ LocalPartitionWriter::sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPa
     // For final data file, merge all spills for partitions in [lastEvictPid_ + 1, partitionId]. Note in this function,
     // only the spilled partitions before partitionId are merged. Therefore, the remaining partitions after partitionId
     // are not merged here and will be merged in `stop()`.
-    if (isFinal && spills_.size() > 0) {
+    if (isFinal && !spills_.empty()) {
       for (auto pid = lastEvictPid_ + 1; pid <= partitionId; ++pid) {
         auto bytesEvicted = totalBytesEvicted_;
         RETURN_NOT_OK(mergeSpills(pid));

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -15,25 +15,19 @@
  * limitations under the License.
  */
 
+#include "shuffle/LocalPartitionWriter.h"
+
+#include <glog/logging.h>
 #include <filesystem>
 #include <random>
 #include <thread>
 
-#include <boost/stacktrace.hpp>
-#include <glog/logging.h>
-#include "shuffle/LocalPartitionWriter.h"
-
-#include <folly/compression/Compression.h>
-#include <parquet/platform.h>
-#include <utils/Timer.h>
-
 #include "shuffle/Payload.h"
 #include "shuffle/Spill.h"
 #include "shuffle/Utils.h"
+#include "utils/Timer.h"
 
 namespace gluten {
-namespace {} // namespace
-
 class LocalPartitionWriter::LocalSpiller {
  public:
   LocalSpiller(

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -49,7 +49,8 @@ class LocalPartitionWriter::LocalSpiller {
         codec_(codec),
         diskSpill_(std::make_unique<Spill>()) {
     if (codec_ != nullptr) {
-      GLUTEN_ASSIGN_OR_THROW(compressedOs_, ShuffleCompressedOutputStream::Make(codec_, os, arrow::default_memory_pool()));
+      GLUTEN_ASSIGN_OR_THROW(
+          compressedOs_, ShuffleCompressedOutputStream::Make(codec_, os, arrow::default_memory_pool()));
     }
   }
 

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -21,6 +21,9 @@
 #include <filesystem>
 #include <random>
 #include <thread>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 #include "shuffle/Payload.h"
 #include "shuffle/Spill.h"

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -69,7 +69,7 @@ class LocalPartitionWriter::LocalSpiller {
 
       ARROW_ASSIGN_OR_RAISE(auto end, os_->Tell());
       diskSpill_->insertPayload(partitionId, Payload::kRaw, 0, nullptr, end - start, pool_, nullptr);
-      DLOG(INFO) << "LocalSpiller(final): Spilled partition " << lastPid_ << " file start: " << start
+      DLOG(INFO) << "LocalSpiller(final): Spilled partition " << partitionId << " file start: " << start
                  << ", file end: " << end << ", file: " << spillFile_;
       return arrow::Status::OK();
     }

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -69,8 +69,8 @@ class LocalPartitionWriter::LocalSpiller {
 
       ARROW_ASSIGN_OR_RAISE(auto end, os_->Tell());
       diskSpill_->insertPayload(partitionId, Payload::kRaw, 0, nullptr, end - start, pool_, nullptr);
-      DLOG(INFO) << "LocalSpiller: Spilled partition " << lastPid_ << " file start: " << start << ", file end: " << end
-                 << ", file: " << spillFile_;
+      DLOG(INFO) << "LocalSpiller(final): Spilled partition " << lastPid_ << " file start: " << start
+                 << ", file end: " << end << ", file: " << spillFile_;
       return arrow::Status::OK();
     }
 

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -17,13 +17,13 @@
 
 #include "shuffle/LocalPartitionWriter.h"
 
+#include <fcntl.h>
 #include <glog/logging.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <filesystem>
 #include <random>
 #include <thread>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/stat.h>
 
 #include "shuffle/Payload.h"
 #include "shuffle/Spill.h"

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -40,10 +40,8 @@ class LocalPartitionWriter : public PartitionWriter {
       Evict::type evictType,
       bool reuseBuffers) override;
 
-  arrow::Status sortEvict(
-      uint32_t partitionId,
-      std::unique_ptr<InMemoryPayload> inMemoryPayload,
-      bool isFinal) override;
+  arrow::Status sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload, bool isFinal)
+      override;
 
   // This code path is not used by LocalPartitionWriter, Not implement it by default.
   arrow::Status evict(uint32_t partitionId, std::unique_ptr<BlockPayload> blockPayload, bool stop) override {

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -86,7 +86,7 @@ class LocalPartitionWriter : public PartitionWriter {
 
   arrow::Status requestSpill(bool isFinal);
 
-  arrow::Status finishSpill(bool closeFile);
+  arrow::Status finishSpill();
 
   std::string nextSpilledFileDir();
 

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -38,13 +38,11 @@ class LocalPartitionWriter : public PartitionWriter {
       uint32_t partitionId,
       std::unique_ptr<InMemoryPayload> inMemoryPayload,
       Evict::type evictType,
-      bool reuseBuffers,
-      bool hasComplexType) override;
+      bool reuseBuffers) override;
 
   arrow::Status sortEvict(
       uint32_t partitionId,
       std::unique_ptr<InMemoryPayload> inMemoryPayload,
-      std::shared_ptr<arrow::Buffer> compressed,
       bool isFinal) override;
 
   // This code path is not used by LocalPartitionWriter, Not implement it by default.
@@ -90,7 +88,7 @@ class LocalPartitionWriter : public PartitionWriter {
 
   arrow::Status requestSpill(bool isFinal);
 
-  arrow::Status finishSpill(bool close);
+  arrow::Status finishSpill(bool closeFile);
 
   std::string nextSpilledFileDir();
 

--- a/cpp/core/shuffle/Options.h
+++ b/cpp/core/shuffle/Options.h
@@ -30,7 +30,7 @@ static constexpr int64_t kDefaultSortBufferThreshold = 64 << 20;
 static constexpr int64_t kDefaultPushMemoryThreshold = 4096;
 static constexpr int32_t kDefaultNumSubDirs = 64;
 static constexpr int32_t kDefaultCompressionThreshold = 100;
-static constexpr int32_t kDefaultSortEvictBufferSize = 32 * 1024;
+static constexpr int32_t kDefaultDiskWriteBufferSize = 32 * 1024; // TODO: compare performance with 1M (spark default)
 static const std::string kDefaultCompressionTypeStr = "lz4";
 static constexpr int32_t kDefaultBufferAlignment = 64;
 static constexpr double kDefaultBufferReallocThreshold = 0.25;
@@ -65,9 +65,9 @@ struct ShuffleWriterOptions {
   ShuffleWriterType shuffleWriterType = kHashShuffle;
 
   // Sort shuffle writer.
-  int32_t sortBufferInitialSize = kDefaultSortBufferSize;
-  int32_t sortEvictBufferSize = kDefaultSortEvictBufferSize;
-  bool useRadixSort = kDefaultUseRadixSort;
+  int32_t initialSortBufferSize = kDefaultSortBufferSize; // spark.shuffle.sort.initialBufferSize
+  int32_t diskWriteBufferSize = kDefaultDiskWriteBufferSize; // spark.shuffle.spill.diskWriteBufferSize
+  bool useRadixSort = kDefaultUseRadixSort; // spark.shuffle.sort.useRadixSort
 };
 
 struct PartitionWriterOptions {

--- a/cpp/core/shuffle/PartitionWriter.h
+++ b/cpp/core/shuffle/PartitionWriter.h
@@ -46,14 +46,9 @@ class PartitionWriter : public Reclaimable {
       uint32_t partitionId,
       std::unique_ptr<InMemoryPayload> inMemoryPayload,
       Evict::type evictType,
-      bool reuseBuffers,
-      bool hasComplexType) = 0;
+      bool reuseBuffers) = 0;
 
-  virtual arrow::Status sortEvict(
-      uint32_t partitionId,
-      std::unique_ptr<InMemoryPayload> inMemoryPayload,
-      std::shared_ptr<arrow::Buffer> compressed,
-      bool isFinal) = 0;
+  virtual arrow::Status sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload, bool isFinal) = 0;
 
   std::optional<int64_t> getCompressedBufferLength(const std::vector<std::shared_ptr<arrow::Buffer>>& buffers) {
     if (!codec_) {

--- a/cpp/core/shuffle/PartitionWriter.h
+++ b/cpp/core/shuffle/PartitionWriter.h
@@ -48,7 +48,8 @@ class PartitionWriter : public Reclaimable {
       Evict::type evictType,
       bool reuseBuffers) = 0;
 
-  virtual arrow::Status sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload, bool isFinal) = 0;
+  virtual arrow::Status
+  sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload, bool isFinal) = 0;
 
   std::optional<int64_t> getCompressedBufferLength(const std::vector<std::shared_ptr<arrow::Buffer>>& buffers) {
     if (!codec_) {

--- a/cpp/core/shuffle/Payload.cc
+++ b/cpp/core/shuffle/Payload.cc
@@ -354,6 +354,7 @@ arrow::Result<std::unique_ptr<InMemoryPayload>> InMemoryPayload::merge(
     std::unique_ptr<InMemoryPayload> source,
     std::unique_ptr<InMemoryPayload> append,
     arrow::MemoryPool* pool) {
+  GLUTEN_DCHECK(source->mergable() && append->mergable(), "Cannot merge payloads.");
   auto mergedRows = source->numRows() + append->numRows();
   auto isValidityBuffer = source->isValidityBuffer();
 
@@ -435,10 +436,19 @@ arrow::Result<std::unique_ptr<BlockPayload>> InMemoryPayload::toBlockPayload(
 }
 
 arrow::Status InMemoryPayload::serialize(arrow::io::OutputStream* outputStream) {
-  return arrow::Status::Invalid("Cannot serialize InMemoryPayload.");
+  for (auto& buffer : buffers_) {
+    RETURN_NOT_OK(outputStream->Write(buffer->data(), buffer->size()));
+    buffer = nullptr;
+  }
+  buffers_.clear();
+  return arrow::Status::OK();
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> InMemoryPayload::readBufferAt(uint32_t index) {
+  GLUTEN_CHECK(
+      index < buffers_.size(),
+      "buffer index out of range: index = " + std::to_string(index) +
+          " vs buffer size = " + std::to_string(buffers_.size()));
   return std::move(buffers_[index]);
 }
 
@@ -462,6 +472,10 @@ int64_t InMemoryPayload::rawSize() {
   return getBufferSize(buffers_);
 }
 
+bool InMemoryPayload::mergable() const {
+  return !hasComplexType_;
+}
+
 UncompressedDiskBlockPayload::UncompressedDiskBlockPayload(
     Type type,
     uint32_t numRows,
@@ -475,10 +489,6 @@ UncompressedDiskBlockPayload::UncompressedDiskBlockPayload(
       rawSize_(rawSize),
       pool_(pool),
       codec_(codec) {}
-
-arrow::Result<std::shared_ptr<arrow::Buffer>> UncompressedDiskBlockPayload::readBufferAt(uint32_t index) {
-  return arrow::Status::Invalid("Cannot read buffer from UncompressedDiskBlockPayload.");
-}
 
 arrow::Status UncompressedDiskBlockPayload::serialize(arrow::io::OutputStream* outputStream) {
   ARROW_RETURN_IF(
@@ -554,10 +564,6 @@ arrow::Status CompressedDiskBlockPayload::serialize(arrow::io::OutputStream* out
   ARROW_ASSIGN_OR_RAISE(auto block, inputStream_->Read(rawSize_));
   RETURN_NOT_OK(outputStream->Write(block));
   return arrow::Status::OK();
-}
-
-arrow::Result<std::shared_ptr<arrow::Buffer>> CompressedDiskBlockPayload::readBufferAt(uint32_t index) {
-  return arrow::Status::Invalid("Cannot read buffer from CompressedDiskBlockPayload.");
 }
 
 int64_t CompressedDiskBlockPayload::rawSize() {

--- a/cpp/core/shuffle/Payload.cc
+++ b/cpp/core/shuffle/Payload.cc
@@ -354,7 +354,7 @@ arrow::Result<std::unique_ptr<InMemoryPayload>> InMemoryPayload::merge(
     std::unique_ptr<InMemoryPayload> source,
     std::unique_ptr<InMemoryPayload> append,
     arrow::MemoryPool* pool) {
-  GLUTEN_DCHECK(source->mergable() && append->mergable(), "Cannot merge payloads.");
+  GLUTEN_DCHECK(source->mergeable() && append->mergeable(), "Cannot merge payloads.");
   auto mergedRows = source->numRows() + append->numRows();
   auto isValidityBuffer = source->isValidityBuffer();
 
@@ -472,7 +472,7 @@ int64_t InMemoryPayload::rawSize() {
   return getBufferSize(buffers_);
 }
 
-bool InMemoryPayload::mergable() const {
+bool InMemoryPayload::mergeable() const {
   return !hasComplexType_;
 }
 

--- a/cpp/core/shuffle/Payload.h
+++ b/cpp/core/shuffle/Payload.h
@@ -148,7 +148,7 @@ class InMemoryPayload final : public Payload {
 
   int64_t rawSize() override;
 
-  bool mergable() const;
+  bool mergeable() const;
 
  private:
   std::vector<std::shared_ptr<arrow::Buffer>> buffers_;

--- a/cpp/core/shuffle/Payload.h
+++ b/cpp/core/shuffle/Payload.h
@@ -36,8 +36,6 @@ class Payload {
 
   virtual arrow::Status serialize(arrow::io::OutputStream* outputStream) = 0;
 
-  virtual arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t index) = 0;
-
   virtual int64_t rawSize() = 0;
 
   int64_t getCompressTime() const {
@@ -101,7 +99,7 @@ class BlockPayload final : public Payload {
 
   arrow::Status serialize(arrow::io::OutputStream* outputStream) override;
 
-  arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t pos) override;
+  arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t pos);
 
   int64_t rawSize() override;
 
@@ -127,15 +125,18 @@ class InMemoryPayload final : public Payload {
   InMemoryPayload(
       uint32_t numRows,
       const std::vector<bool>* isValidityBuffer,
-      std::vector<std::shared_ptr<arrow::Buffer>> buffers)
-      : Payload(Type::kUncompressed, numRows, isValidityBuffer), buffers_(std::move(buffers)) {}
+      std::vector<std::shared_ptr<arrow::Buffer>> buffers,
+      bool hasComplexType = false)
+      : Payload(Type::kUncompressed, numRows, isValidityBuffer),
+        buffers_(std::move(buffers)),
+        hasComplexType_(hasComplexType) {}
 
   static arrow::Result<std::unique_ptr<InMemoryPayload>>
   merge(std::unique_ptr<InMemoryPayload> source, std::unique_ptr<InMemoryPayload> append, arrow::MemoryPool* pool);
 
   arrow::Status serialize(arrow::io::OutputStream* outputStream) override;
 
-  arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t index) override;
+  arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t index);
 
   arrow::Result<std::unique_ptr<BlockPayload>> toBlockPayload(
       Payload::Type payloadType,
@@ -147,8 +148,11 @@ class InMemoryPayload final : public Payload {
 
   int64_t rawSize() override;
 
+  bool mergable() const;
+
  private:
   std::vector<std::shared_ptr<arrow::Buffer>> buffers_;
+  bool hasComplexType_;
 };
 
 class UncompressedDiskBlockPayload final : public Payload {
@@ -161,8 +165,6 @@ class UncompressedDiskBlockPayload final : public Payload {
       uint64_t rawSize,
       arrow::MemoryPool* pool,
       arrow::util::Codec* codec);
-
-  arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t index) override;
 
   arrow::Status serialize(arrow::io::OutputStream* outputStream) override;
 
@@ -188,8 +190,6 @@ class CompressedDiskBlockPayload final : public Payload {
       arrow::MemoryPool* pool);
 
   arrow::Status serialize(arrow::io::OutputStream* outputStream) override;
-
-  arrow::Result<std::shared_ptr<arrow::Buffer>> readBufferAt(uint32_t index) override;
 
   int64_t rawSize() override;
 

--- a/cpp/core/shuffle/Spill.cc
+++ b/cpp/core/shuffle/Spill.cc
@@ -21,8 +21,6 @@
 
 namespace gluten {
 
-Spill::Spill(Spill::SpillType type) : type_(type) {}
-
 Spill::~Spill() {
   if (is_) {
     static_cast<void>(is_->Close());
@@ -75,10 +73,6 @@ void Spill::openForRead(uint64_t shuffleFileBufferSize) {
     GLUTEN_ASSIGN_OR_THROW(is_, MmapFileStream::open(spillFile_, shuffleFileBufferSize));
     rawIs_ = is_.get();
   }
-}
-
-Spill::SpillType Spill::type() const {
-  return type_;
 }
 
 void Spill::setSpillFile(const std::string& spillFile) {

--- a/cpp/core/shuffle/Spill.h
+++ b/cpp/core/shuffle/Spill.h
@@ -29,13 +29,7 @@ namespace gluten {
 
 class Spill final {
  public:
-  enum SpillType { kSequentialSpill, kBatchedSpill };
-
-  Spill(SpillType type);
-
   ~Spill();
-
-  SpillType type() const;
 
   void openForRead(uint64_t shuffleFileBufferSize);
 
@@ -70,7 +64,6 @@ class Spill final {
     std::unique_ptr<Payload> payload{};
   };
 
-  SpillType type_;
   std::shared_ptr<gluten::MmapFileStream> is_;
   std::list<PartitionPayload> partitionPayloads_{};
   std::string spillFile_;

--- a/cpp/core/shuffle/Utils.h
+++ b/cpp/core/shuffle/Utils.h
@@ -27,6 +27,9 @@
 
 #include "utils/Compression.h"
 
+#include <utils/Exception.h>
+#include <utils/Timer.h>
+
 namespace gluten {
 
 using BinaryArrayLengthBufferType = uint32_t;
@@ -103,6 +106,365 @@ class MmapFileStream : public arrow::io::InputStream {
   int64_t pos_ = 0;
   int64_t posFetch_ = 0;
   int64_t posRetain_ = 0;
+};
+
+// Adopted from arrow::io::CompressedOutputStream. Rebuild compressor after each `Flush()`.
+class ShuffleCompressedOutputStream : public arrow::io::OutputStream {
+ public:
+  /// \brief Create a compressed output stream wrapping the given output stream.
+  static arrow::Result<std::shared_ptr<ShuffleCompressedOutputStream>>
+  Make(arrow::util::Codec* codec, const std::shared_ptr<OutputStream>& raw, arrow::MemoryPool* pool) {
+    auto res = std::shared_ptr<ShuffleCompressedOutputStream>(new ShuffleCompressedOutputStream(codec, raw, pool));
+    RETURN_NOT_OK(res->Init(codec));
+    return res;
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    return totalPos_;
+  }
+
+  arrow::Status Write(const void* data, int64_t nbytes) override {
+    int64_t flushTime = 0;
+    {
+      ScopedTimer timer(&compressTime_);
+      auto input = static_cast<const uint8_t*>(data);
+      while (nbytes > 0) {
+        int64_t input_len = nbytes;
+        int64_t output_len = compressed_->size() - compressedPos_;
+        uint8_t* output = compressed_->mutable_data() + compressedPos_;
+        ARROW_ASSIGN_OR_RAISE(auto result, compressor_->Compress(input_len, input, output_len, output));
+        compressedPos_ += result.bytes_written;
+
+        if (result.bytes_read == 0) {
+          // Not enough output, try to flush it and retry
+          if (compressedPos_ > 0) {
+            RETURN_NOT_OK(FlushCompressed(flushTime));
+            output_len = compressed_->size() - compressedPos_;
+            output = compressed_->mutable_data() + compressedPos_;
+            ARROW_ASSIGN_OR_RAISE(result, compressor_->Compress(input_len, input, output_len, output));
+            compressedPos_ += result.bytes_written;
+          }
+        }
+        input += result.bytes_read;
+        nbytes -= result.bytes_read;
+        totalPos_ += result.bytes_read;
+        if (compressedPos_ == compressed_->size()) {
+          // Output buffer full, flush it
+          RETURN_NOT_OK(FlushCompressed(flushTime));
+        }
+        if (result.bytes_read == 0) {
+          // Need to enlarge output buffer
+          RETURN_NOT_OK(compressed_->Resize(compressed_->size() * 2));
+        }
+      }
+    }
+    compressTime_ -= flushTime;
+    flushTime_ += flushTime;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override {
+    RETURN_NOT_OK(FinalizeCompression());
+    ARROW_ASSIGN_OR_RAISE(compressor_, codec_->MakeCompressor());
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Close() override {
+    if (isOpen_) {
+      isOpen_ = false;
+      RETURN_NOT_OK(FinalizeCompression());
+      // Do not close the underlying stream, it is the caller's responsibility.
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Abort() override {
+    if (isOpen_) {
+      isOpen_ = false;
+      return raw_->Abort();
+    }
+    return arrow::Status::OK();
+  }
+
+  bool closed() const override {
+    return !isOpen_;
+  }
+
+  int64_t compressTime() const {
+    return compressTime_;
+  }
+
+  int64_t flushTime() const {
+    return flushTime_;
+  }
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(ShuffleCompressedOutputStream);
+
+  ShuffleCompressedOutputStream(
+      arrow::util::Codec* codec,
+      const std::shared_ptr<OutputStream>& raw,
+      arrow::MemoryPool* pool)
+      : codec_(codec), raw_(raw), pool_(pool) {}
+
+  arrow::Status Init(arrow::util::Codec* codec) {
+    ARROW_ASSIGN_OR_RAISE(compressor_, codec->MakeCompressor());
+    ARROW_ASSIGN_OR_RAISE(compressed_, AllocateResizableBuffer(kChunkSize, pool_));
+    compressedPos_ = 0;
+    isOpen_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status FlushCompressed(int64_t& flushTime) {
+    if (compressedPos_ > 0) {
+      ScopedTimer timer(&flushTime);
+      RETURN_NOT_OK(raw_->Write(compressed_->data(), compressedPos_));
+      compressedPos_ = 0;
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status FinalizeCompression() {
+    int64_t flushTime = 0;
+    {
+      ScopedTimer timer(&compressTime_);
+      while (true) {
+        // Try to end compressor
+        int64_t output_len = compressed_->size() - compressedPos_;
+        uint8_t* output = compressed_->mutable_data() + compressedPos_;
+        ARROW_ASSIGN_OR_RAISE(auto result, compressor_->End(output_len, output));
+        compressedPos_ += result.bytes_written;
+
+        // Flush compressed output
+        RETURN_NOT_OK(FlushCompressed(flushTime));
+
+        if (result.should_retry) {
+          // Need to enlarge output buffer
+          RETURN_NOT_OK(compressed_->Resize(compressed_->size() * 2));
+        } else {
+          // Done
+          break;
+        }
+      }
+    }
+    compressTime_ -= flushTime;
+    flushTime_ += flushTime;
+    return arrow::Status::OK();
+  }
+
+  // TODO: Support setting chunk size
+  // Write 64 KB compressed data at a time
+  static const int64_t kChunkSize = 64 * 1024;
+
+  arrow::util::Codec* codec_;
+  std::shared_ptr<OutputStream> raw_;
+  arrow::MemoryPool* pool_;
+
+  std::shared_ptr<arrow::util::Compressor> compressor_;
+  std::shared_ptr<arrow::ResizableBuffer> compressed_;
+
+  bool isOpen_{false};
+  int64_t compressedPos_{0};
+  // Total number of bytes compressed
+  int64_t totalPos_{0};
+
+  // Time spent on compressing data. Flushing the compressed data into raw_ stream is not included.
+  int64_t compressTime_{0};
+  int64_t flushTime_{0};
+};
+
+class CompressedInputStream : public arrow::io::InputStream {
+ public:
+  static arrow::Result<std::shared_ptr<CompressedInputStream>>
+  Make(arrow::util::Codec* codec, const std::shared_ptr<InputStream>& raw, arrow::MemoryPool* pool) {
+    std::shared_ptr<CompressedInputStream> res(new CompressedInputStream(raw, pool));
+    RETURN_NOT_OK(res->Init(codec));
+    return res;
+  }
+
+  arrow::Status Init(arrow::util::Codec* codec) {
+    ARROW_ASSIGN_OR_RAISE(decompressor_, codec->MakeDecompressor());
+    fresh_decompressor_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Close() override {
+    if (is_open_) {
+      is_open_ = false;
+      return raw_->Close();
+    } else {
+      return arrow::Status::OK();
+    }
+  }
+
+  arrow::Status Abort() override {
+    if (is_open_) {
+      is_open_ = false;
+      return raw_->Abort();
+    } else {
+      return arrow::Status::OK();
+    }
+  }
+
+  bool closed() const override {
+    return !is_open_;
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    return total_pos_;
+  }
+
+  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
+    auto out_data = reinterpret_cast<uint8_t*>(out);
+
+    int64_t total_read = 0;
+    bool decompressor_has_data = true;
+
+    while (nbytes - total_read > 0 && decompressor_has_data) {
+      total_read += ReadFromDecompressed(nbytes - total_read, out_data + total_read);
+
+      if (nbytes == total_read) {
+        break;
+      }
+
+      // At this point, no more decompressed data remains, so we need to
+      // decompress more
+      RETURN_NOT_OK(RefillDecompressed(&decompressor_has_data));
+    }
+
+    total_pos_ += total_read;
+    return total_read;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
+    ARROW_ASSIGN_OR_RAISE(auto buf, arrow::AllocateResizableBuffer(nbytes, pool_));
+    ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, Read(nbytes, buf->mutable_data()));
+    RETURN_NOT_OK(buf->Resize(bytes_read));
+    return std::move(buf);
+  }
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(CompressedInputStream);
+
+  CompressedInputStream() = default;
+
+  CompressedInputStream(const std::shared_ptr<InputStream>& raw, arrow::MemoryPool* pool)
+      : raw_(raw), pool_(pool), is_open_(true), compressed_pos_(0), decompressed_pos_(0), total_pos_(0) {}
+
+  // Read compressed data if necessary
+  arrow::Status EnsureCompressedData() {
+    int64_t compressed_avail = compressed_ ? compressed_->size() - compressed_pos_ : 0;
+    if (compressed_avail == 0) {
+      // No compressed data available, read a full chunk
+      ARROW_ASSIGN_OR_RAISE(compressed_, raw_->Read(kChunkSize));
+      compressed_pos_ = 0;
+    }
+    return arrow::Status::OK();
+  }
+
+  // Decompress some data from the compressed_ buffer.
+  // Call this function only if the decompressed_ buffer is empty.
+  arrow::Status DecompressData() {
+    GLUTEN_CHECK(compressed_->data() != nullptr, "Compressed data is null");
+
+    int64_t decompress_size = kDecompressSize;
+
+    while (true) {
+      ARROW_ASSIGN_OR_RAISE(decompressed_, AllocateResizableBuffer(decompress_size, pool_));
+      decompressed_pos_ = 0;
+
+      int64_t input_len = compressed_->size() - compressed_pos_;
+      const uint8_t* input = compressed_->data() + compressed_pos_;
+      int64_t output_len = decompressed_->size();
+      uint8_t* output = decompressed_->mutable_data();
+
+      ARROW_ASSIGN_OR_RAISE(auto result, decompressor_->Decompress(input_len, input, output_len, output));
+      compressed_pos_ += result.bytes_read;
+      if (result.bytes_read > 0) {
+        fresh_decompressor_ = false;
+      }
+      if (result.bytes_written > 0 || !result.need_more_output || input_len == 0) {
+        RETURN_NOT_OK(decompressed_->Resize(result.bytes_written));
+        break;
+      }
+      GLUTEN_CHECK(result.bytes_written == 0, "Decompressor should return 0 bytes written");
+      // Need to enlarge output buffer
+      decompress_size *= 2;
+    }
+    return arrow::Status::OK();
+  }
+
+  // Read a given number of bytes from the decompressed_ buffer.
+  int64_t ReadFromDecompressed(int64_t nbytes, uint8_t* out) {
+    int64_t readable = decompressed_ ? (decompressed_->size() - decompressed_pos_) : 0;
+    int64_t read_bytes = std::min(readable, nbytes);
+
+    if (read_bytes > 0) {
+      memcpy(out, decompressed_->data() + decompressed_pos_, read_bytes);
+      decompressed_pos_ += read_bytes;
+
+      if (decompressed_pos_ == decompressed_->size()) {
+        // Decompressed data is exhausted, release buffer
+        decompressed_.reset();
+      }
+    }
+
+    return read_bytes;
+  }
+
+  // Try to feed more data into the decompressed_ buffer.
+  arrow::Status RefillDecompressed(bool* has_data) {
+    // First try to read data from the decompressor
+    if (compressed_ && compressed_->size() != 0) {
+      if (decompressor_->IsFinished()) {
+        // We just went over the end of a previous compressed stream.
+        RETURN_NOT_OK(decompressor_->Reset());
+        fresh_decompressor_ = true;
+      }
+      RETURN_NOT_OK(DecompressData());
+    }
+    if (!decompressed_ || decompressed_->size() == 0) {
+      // Got nothing, need to read more compressed data
+      RETURN_NOT_OK(EnsureCompressedData());
+      if (compressed_pos_ == compressed_->size()) {
+        // No more data to decompress
+        if (!fresh_decompressor_ && !decompressor_->IsFinished()) {
+          return arrow::Status::IOError("Truncated compressed stream");
+        }
+        *has_data = false;
+        return arrow::Status::OK();
+      }
+      RETURN_NOT_OK(DecompressData());
+    }
+    *has_data = true;
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<InputStream> raw() const {
+    return raw_;
+  }
+
+  // Read 64 KB compressed data at a time
+  static const int64_t kChunkSize = 64 * 1024;
+  // Decompress 1 MB at a time
+  static const int64_t kDecompressSize = 1024 * 1024;
+
+  std::shared_ptr<InputStream> raw_;
+  arrow::MemoryPool* pool_;
+
+  std::shared_ptr<arrow::util::Decompressor> decompressor_;
+  std::shared_ptr<arrow::Buffer> compressed_;
+
+  bool is_open_;
+  // Position in compressed buffer
+  int64_t compressed_pos_;
+  std::shared_ptr<arrow::ResizableBuffer> decompressed_;
+  // Position in decompressed buffer
+  int64_t decompressed_pos_;
+  // True if the decompressor hasn't read any data yet.
+  bool fresh_decompressor_;
+  // Total number of bytes decompressed
+  int64_t total_pos_;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/rss/RssPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/RssPartitionWriter.cc
@@ -30,13 +30,23 @@ void RssPartitionWriter::init() {
 }
 
 arrow::Status RssPartitionWriter::stop(ShuffleWriterMetrics* metrics) {
-  // Push data and collect metrics.
-  auto totalBytesEvicted = std::accumulate(bytesEvicted_.begin(), bytesEvicted_.end(), 0LL);
+  if (rssOs_ != nullptr && !rssOs_->closed()) {
+    if (compressedOs_ != nullptr) {
+      RETURN_NOT_OK(compressedOs_->Close());
+      compressTime_ = compressedOs_->compressTime();
+      spillTime_ -= compressTime_;
+    }
+    RETURN_NOT_OK(rssOs_->Flush());
+    ARROW_ASSIGN_OR_RAISE(bytesEvicted_[lastEvictedPartitionId_], rssOs_->Tell());
+    RETURN_NOT_OK(rssOs_->Close());
+  }
+
   rssClient_->stop();
+
+  auto totalBytesEvicted = std::accumulate(bytesEvicted_.begin(), bytesEvicted_.end(), 0LL);
   // Populate metrics.
   metrics->totalCompressTime += compressTime_;
   metrics->totalEvictTime += spillTime_;
-  metrics->totalWriteTime += writeTime_;
   metrics->totalBytesEvicted += totalBytesEvicted;
   metrics->totalBytesWritten += totalBytesEvicted;
   metrics->partitionLengths = std::move(bytesEvicted_);
@@ -53,17 +63,42 @@ arrow::Status RssPartitionWriter::hashEvict(
     uint32_t partitionId,
     std::unique_ptr<InMemoryPayload> inMemoryPayload,
     Evict::type evictType,
-    bool reuseBuffers,
-    bool hasComplexType) {
-  return doEvict(partitionId, std::move(inMemoryPayload), nullptr);
+    bool reuseBuffers) {
+  return doEvict(partitionId, std::move(inMemoryPayload));
 }
 
-arrow::Status RssPartitionWriter::sortEvict(
-    uint32_t partitionId,
-    std::unique_ptr<InMemoryPayload> inMemoryPayload,
-    std::shared_ptr<arrow::Buffer> compressed,
-    bool isFinal) {
-  return doEvict(partitionId, std::move(inMemoryPayload), std::move(compressed));
+arrow::Status
+RssPartitionWriter::sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload, bool isFinal) {
+  ScopedTimer timer(&spillTime_);
+  if (lastEvictedPartitionId_ != partitionId) {
+    if (lastEvictedPartitionId_ != -1) {
+      GLUTEN_DCHECK(rssOs_ != nullptr && !rssOs_->closed(), "RssPartitionWriterOutputStream should not be null");
+      if (compressedOs_ != nullptr) {
+        RETURN_NOT_OK(compressedOs_->Flush());
+      }
+      RETURN_NOT_OK(rssOs_->Flush());
+      ARROW_ASSIGN_OR_RAISE(bytesEvicted_[lastEvictedPartitionId_], rssOs_->Tell());
+      RETURN_NOT_OK(rssOs_->Close());
+    }
+
+    rssOs_ =
+        std::make_shared<RssPartitionWriterOutputStream>(partitionId, rssClient_.get(), options_.pushBufferMaxSize);
+    RETURN_NOT_OK(rssOs_->init());
+    if (codec_ != nullptr) {
+      ARROW_ASSIGN_OR_RAISE(
+          compressedOs_, ShuffleCompressedOutputStream::Make(codec_.get(), rssOs_, arrow::default_memory_pool()));
+    }
+
+    lastEvictedPartitionId_ = partitionId;
+  }
+
+  rawPartitionLengths_[partitionId] = inMemoryPayload->rawSize();
+  if (compressedOs_ != nullptr) {
+    RETURN_NOT_OK(inMemoryPayload->serialize(compressedOs_.get()));
+  } else {
+    RETURN_NOT_OK(inMemoryPayload->serialize(rssOs_.get()));
+  }
+  return arrow::Status::OK();
 }
 
 arrow::Status RssPartitionWriter::evict(uint32_t partitionId, std::unique_ptr<BlockPayload> blockPayload, bool) {
@@ -74,16 +109,12 @@ arrow::Status RssPartitionWriter::evict(uint32_t partitionId, std::unique_ptr<Bl
   return arrow::Status::OK();
 }
 
-arrow::Status RssPartitionWriter::doEvict(
-    uint32_t partitionId,
-    std::unique_ptr<InMemoryPayload> inMemoryPayload,
-    std::shared_ptr<arrow::Buffer> compressed) {
+arrow::Status RssPartitionWriter::doEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload) {
   rawPartitionLengths_[partitionId] += inMemoryPayload->rawSize();
   auto payloadType = codec_ ? Payload::Type::kCompressed : Payload::Type::kUncompressed;
   ARROW_ASSIGN_OR_RAISE(
       auto payload,
-      inMemoryPayload->toBlockPayload(
-          payloadType, payloadPool_.get(), codec_ ? codec_.get() : nullptr, std::move(compressed)));
+      inMemoryPayload->toBlockPayload(payloadType, payloadPool_.get(), codec_ ? codec_.get() : nullptr, nullptr));
   // Copy payload to arrow buffered os.
   ARROW_ASSIGN_OR_RAISE(auto rssBufferOs, arrow::io::BufferOutputStream::Create(options_.pushBufferMaxSize));
   RETURN_NOT_OK(payload->serialize(rssBufferOs.get()));

--- a/cpp/core/shuffle/rss/RssPartitionWriter.h
+++ b/cpp/core/shuffle/rss/RssPartitionWriter.h
@@ -26,6 +26,8 @@
 
 namespace gluten {
 
+class RssPartitionWriterOutputStream;
+
 class RssPartitionWriter final : public PartitionWriter {
  public:
   RssPartitionWriter(
@@ -41,14 +43,10 @@ class RssPartitionWriter final : public PartitionWriter {
       uint32_t partitionId,
       std::unique_ptr<InMemoryPayload> inMemoryPayload,
       Evict::type evictType,
-      bool reuseBuffers,
-      bool hasComplexType) override;
+      bool reuseBuffers) override;
 
-  arrow::Status sortEvict(
-      uint32_t partitionId,
-      std::unique_ptr<InMemoryPayload> inMemoryPayload,
-      std::shared_ptr<arrow::Buffer> compressed,
-      bool isFinal) override;
+  arrow::Status sortEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload, bool isFinal)
+      override;
 
   arrow::Status evict(uint32_t partitionId, std::unique_ptr<BlockPayload> blockPayload, bool stop) override;
 
@@ -59,14 +57,91 @@ class RssPartitionWriter final : public PartitionWriter {
  private:
   void init();
 
-  arrow::Status doEvict(
-      uint32_t partitionId,
-      std::unique_ptr<InMemoryPayload> inMemoryPayload,
-      std::shared_ptr<arrow::Buffer> compressed);
+  arrow::Status doEvict(uint32_t partitionId, std::unique_ptr<InMemoryPayload> inMemoryPayload);
 
   std::shared_ptr<RssClient> rssClient_;
 
   std::vector<int64_t> bytesEvicted_;
   std::vector<int64_t> rawPartitionLengths_;
+
+  int32_t lastEvictedPartitionId_{-1};
+  std::shared_ptr<RssPartitionWriterOutputStream> rssOs_;
+  std::shared_ptr<ShuffleCompressedOutputStream> compressedOs_;
+};
+
+class RssPartitionWriterOutputStream final : public arrow::io::OutputStream {
+ public:
+  RssPartitionWriterOutputStream(int32_t partitionId, RssClient* rssClient, int64_t pushBufferSize)
+      : partitionId_(partitionId), rssClient_(rssClient), bufferSize_(pushBufferSize) {}
+
+  arrow::Status init() {
+    ARROW_ASSIGN_OR_RAISE(pushBuffer_, arrow::AllocateBuffer(bufferSize_, arrow::default_memory_pool()));
+    pushBufferPtr_ = pushBuffer_->mutable_data();
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Close() override {
+    RETURN_NOT_OK(Flush());
+    pushBuffer_.reset();
+    return arrow::Status::OK();
+  }
+
+  bool closed() const override {
+    return pushBuffer_ == nullptr;
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    return bytesEvicted_ + bufferPos_;
+  }
+
+  arrow::Status Write(const void* data, int64_t nbytes) override {
+    auto dataPtr = static_cast<const char*>(data);
+    if (nbytes < 0) {
+      return arrow::Status::Invalid("write count should be >= 0");
+    }
+    if (nbytes == 0) {
+      return arrow::Status::OK();
+    }
+
+    if (nbytes + bufferPos_ <= bufferSize_) {
+      std::memcpy(pushBufferPtr_ + bufferPos_, dataPtr, nbytes);
+      bufferPos_ += nbytes;
+      return arrow::Status::OK();
+    }
+
+    int64_t bytesWritten = 0;
+    while (bytesWritten < nbytes) {
+      auto remaining = nbytes - bytesWritten;
+      if (remaining <= bufferSize_ - bufferPos_) {
+        std::memcpy(pushBufferPtr_ + bufferPos_, dataPtr + bytesWritten, remaining);
+        bufferPos_ += remaining;
+        return arrow::Status::OK();
+      }
+      auto toWrite = bufferSize_ - bufferPos_;
+      std::memcpy(pushBufferPtr_ + bufferPos_, dataPtr + bytesWritten, toWrite);
+      bytesWritten += toWrite;
+      bufferPos_ += toWrite;
+      RETURN_NOT_OK(Flush());
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override {
+    if (bufferPos_ > 0) {
+      bytesEvicted_ += rssClient_->pushPartitionData(partitionId_, reinterpret_cast<char*>(pushBufferPtr_), bufferPos_);
+      bufferPos_ = 0;
+    }
+    return arrow::Status::OK();
+  }
+
+ private:
+  int32_t partitionId_;
+  RssClient* rssClient_;
+  int64_t bufferSize_{kDefaultPushMemoryThreshold};
+
+  std::shared_ptr<arrow::Buffer> pushBuffer_;
+  uint8_t* pushBufferPtr_{nullptr};
+  int64_t bufferPos_{0};
+  int64_t bytesEvicted_{0};
 };
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -963,8 +963,7 @@ arrow::Status VeloxHashShuffleWriter::evictBuffers(
     bool reuseBuffers) {
   if (!buffers.empty()) {
     auto payload = std::make_unique<InMemoryPayload>(numRows, &isValidityBuffer_, std::move(buffers), hasComplexType_);
-    RETURN_NOT_OK(
-        partitionWriter_->hashEvict(partitionId, std::move(payload), Evict::kCache, reuseBuffers));
+    RETURN_NOT_OK(partitionWriter_->hashEvict(partitionId, std::move(payload), Evict::kCache, reuseBuffers));
   }
   return arrow::Status::OK();
 }

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -962,9 +962,9 @@ arrow::Status VeloxHashShuffleWriter::evictBuffers(
     std::vector<std::shared_ptr<arrow::Buffer>> buffers,
     bool reuseBuffers) {
   if (!buffers.empty()) {
-    auto payload = std::make_unique<InMemoryPayload>(numRows, &isValidityBuffer_, std::move(buffers));
+    auto payload = std::make_unique<InMemoryPayload>(numRows, &isValidityBuffer_, std::move(buffers), hasComplexType_);
     RETURN_NOT_OK(
-        partitionWriter_->hashEvict(partitionId, std::move(payload), Evict::kCache, reuseBuffers, hasComplexType_));
+        partitionWriter_->hashEvict(partitionId, std::move(payload), Evict::kCache, reuseBuffers));
   }
   return arrow::Status::OK();
 }
@@ -1373,9 +1373,10 @@ arrow::Result<int64_t> VeloxHashShuffleWriter::evictPartitionBuffersMinSize(int6
     for (auto& item : pidToSize) {
       auto pid = item.first;
       ARROW_ASSIGN_OR_RAISE(auto buffers, assembleBuffers(pid, false));
-      auto payload = std::make_unique<InMemoryPayload>(item.second, &isValidityBuffer_, std::move(buffers));
+      auto payload =
+          std::make_unique<InMemoryPayload>(item.second, &isValidityBuffer_, std::move(buffers), hasComplexType_);
       metrics_.totalBytesToEvict += payload->rawSize();
-      RETURN_NOT_OK(partitionWriter_->hashEvict(pid, std::move(payload), Evict::kSpill, false, hasComplexType_));
+      RETURN_NOT_OK(partitionWriter_->hashEvict(pid, std::move(payload), Evict::kSpill, false));
       evicted = beforeEvict - partitionBufferPool_->bytes_allocated();
       if (evicted >= size) {
         break;

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -19,6 +19,8 @@
 
 #include <arrow/array/array_binary.h>
 #include <arrow/io/buffered.h>
+#include <arrow/io/compressed.h>
+#include <velox/common/caching/AsyncDataCache.h>
 
 #include "memory/VeloxColumnarBatch.h"
 #include "shuffle/GlutenByteStream.h"
@@ -41,14 +43,16 @@
 using namespace facebook::velox;
 
 namespace gluten {
-
 namespace {
+constexpr uint64_t kMaxReadBufferSize = (1 << 20) - AlignedBuffer::kPaddedSize;
 
 struct BufferViewReleaser {
   BufferViewReleaser() : BufferViewReleaser(nullptr) {}
+
   BufferViewReleaser(std::shared_ptr<arrow::Buffer> arrowBuffer) : bufferReleaser_(std::move(arrowBuffer)) {}
 
   void addRef() const {}
+
   void release() const {}
 
  private:
@@ -281,7 +285,6 @@ std::shared_ptr<VeloxColumnarBatch> makeColumnarBatch(
   auto rowVector = deserialize(type, payload->numRows(), veloxBuffers, pool);
   return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
 }
-
 } // namespace
 
 VeloxHashShuffleReaderDeserializer::VeloxHashShuffleReaderDeserializer(
@@ -388,28 +391,37 @@ VeloxSortShuffleReaderDeserializer::VeloxSortShuffleReaderDeserializer(
       veloxPool_(veloxPool),
       deserializeTime_(deserializeTime),
       decompressTime_(decompressTime) {
-  GLUTEN_ASSIGN_OR_THROW(in_, arrow::io::BufferedInputStream::Create(bufferSize, memoryPool, std::move(in)));
+  GLUTEN_ASSIGN_OR_THROW(
+      auto bufferedIn, arrow::io::BufferedInputStream::Create(bufferSize, memoryPool, std::move(in)));
+  if (codec_ != nullptr) {
+    GLUTEN_ASSIGN_OR_THROW(in_, arrow::io::CompressedInputStream::Make(codec_.get(), bufferedIn, arrowPool_));
+  } else {
+    in_ = bufferedIn;
+  }
 }
 
 std::shared_ptr<ColumnarBatch> VeloxSortShuffleReaderDeserializer::next() {
   if (reachedEos_) {
-    if (cachedRows_ > 0) {
-      return deserializeToBatch();
-    }
     return nullptr;
   }
 
-  if (cachedRows_ >= batchSize_) {
-    return deserializeToBatch();
+  if (rowBuffer_ == nullptr) {
+    rowBuffer_ = AlignedBuffer::allocate<char>(kMaxReadBufferSize, veloxPool_);
+    rowBufferPtr_ = rowBuffer_->asMutable<char>();
+    data_.reserve(batchSize_);
+  }
+
+  if (lastRowSize_ != 0) {
+    readNextRow();
   }
 
   while (cachedRows_ < batchSize_) {
-    uint32_t numRows = 0;
-    GLUTEN_ASSIGN_OR_THROW(
-        auto arrowBuffers,
-        BlockPayload::deserialize(in_.get(), codec_, arrowPool_, numRows, deserializeTime_, decompressTime_));
+    GLUTEN_ASSIGN_OR_THROW(auto bytes, in_->Read(sizeof(RowSizeType), &lastRowSize_));
+    bytesRead_ += sizeof(RowSizeType);
 
-    if (arrowBuffers.empty()) {
+    GLUTEN_CHECK(lastRowSize_ <= kMaxReadBufferSize, "Row size exceeds max read buffer size");
+
+    if (bytes == 0) {
       reachedEos_ = true;
       if (cachedRows_ > 0) {
         return deserializeToBatch();
@@ -417,80 +429,31 @@ std::shared_ptr<ColumnarBatch> VeloxSortShuffleReaderDeserializer::next() {
       return nullptr;
     }
 
-    if (numRows > 0) {
-      auto buffer = std::move(arrowBuffers[0]);
-      cachedInputs_.emplace_back(numRows, wrapInBufferViewAsOwner(buffer->data(), buffer->size(), buffer));
-      cachedRows_ += numRows;
-    } else {
-      // numRows = 0 indicates that we read a segment of a large row.
-      readLargeRow(arrowBuffers);
+    if (lastRowSize_ + bytesRead_ > kMaxReadBufferSize) {
+      return deserializeToBatch();
     }
+    readNextRow();
   }
+
   return deserializeToBatch();
 }
 
 std::shared_ptr<ColumnarBatch> VeloxSortShuffleReaderDeserializer::deserializeToBatch() {
   ScopedTimer timer(&deserializeTime_);
-  std::vector<std::string_view> data;
-  data.reserve(std::min(cachedRows_, batchSize_));
 
-  uint32_t readRows = 0;
-  auto cur = cachedInputs_.begin();
-  while (readRows < batchSize_ && cur != cachedInputs_.end()) {
-    auto buffer = cur->second;
-    const auto* rawBuffer = buffer->as<char>();
-    while (rowOffset_ < cur->first && readRows < batchSize_) {
-      auto rowSize = *(reinterpret_cast<const RowSizeType*>(rawBuffer + byteOffset_)) - sizeof(RowSizeType);
-      byteOffset_ += sizeof(RowSizeType);
-      data.push_back(std::string_view(rawBuffer + byteOffset_, rowSize));
-      byteOffset_ += rowSize;
-      ++rowOffset_;
-      ++readRows;
-    }
-    if (rowOffset_ == cur->first) {
-      rowOffset_ = 0;
-      byteOffset_ = 0;
-      ++cur;
-    }
-  }
-  cachedRows_ -= readRows;
-  auto rowVector = facebook::velox::row::CompactRow::deserialize(data, rowType_, veloxPool_);
-  // Free memory.
-  auto iter = cachedInputs_.begin();
-  while (iter++ != cur) {
-    cachedInputs_.pop_front();
-  }
+  auto rowVector = facebook::velox::row::CompactRow::deserialize(data_, rowType_, veloxPool_);
+
+  cachedRows_ = 0;
+  bytesRead_ = 0;
+  data_.resize(0);
   return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
 }
 
-void VeloxSortShuffleReaderDeserializer::readLargeRow(std::vector<std::shared_ptr<arrow::Buffer>>& arrowBuffers) {
-  // Cache the read segment.
-  std::vector<std::shared_ptr<arrow::Buffer>> buffers;
-  auto rowSize = *reinterpret_cast<RowSizeType*>(const_cast<uint8_t*>(arrowBuffers[0]->data()));
-  RowSizeType bufferSize = arrowBuffers[0]->size();
-  buffers.emplace_back(std::move(arrowBuffers[0]));
-  // Read and cache the remaining segments.
-  uint32_t numRows;
-  while (bufferSize < rowSize) {
-    GLUTEN_ASSIGN_OR_THROW(
-        arrowBuffers,
-        BlockPayload::deserialize(in_.get(), codec_, arrowPool_, numRows, deserializeTime_, decompressTime_));
-    VELOX_DCHECK_EQ(numRows, 0);
-    bufferSize += arrowBuffers[0]->size();
-    buffers.emplace_back(std::move(arrowBuffers[0]));
-  }
-  VELOX_CHECK_EQ(bufferSize, rowSize);
-  // Merge all segments.
-  GLUTEN_ASSIGN_OR_THROW(std::shared_ptr<arrow::Buffer> rowBuffer, arrow::AllocateBuffer(rowSize, arrowPool_));
-  RowSizeType bytes = 0;
-  auto* dst = rowBuffer->mutable_data();
-  for (const auto& buffer : buffers) {
-    VELOX_DCHECK_NOT_NULL(buffer);
-    gluten::fastCopy(dst + bytes, buffer->data(), buffer->size());
-    bytes += buffer->size();
-  }
-  cachedInputs_.emplace_back(1, wrapInBufferViewAsOwner(rowBuffer->data(), rowSize, rowBuffer));
-  cachedRows_++;
+void VeloxSortShuffleReaderDeserializer::readNextRow() {
+  GLUTEN_THROW_NOT_OK(in_->Read(lastRowSize_, rowBufferPtr_ + bytesRead_));
+  data_.push_back(std::string_view(rowBufferPtr_ + bytesRead_, lastRowSize_));
+  bytesRead_ += lastRowSize_;
+  ++cachedRows_;
 }
 
 class VeloxRssSortShuffleReaderDeserializer::VeloxInputStream : public facebook::velox::GlutenByteInputStream {
@@ -705,5 +668,4 @@ int64_t VeloxShuffleReader::getDecompressTime() const {
 int64_t VeloxShuffleReader::getDeserializeTime() const {
   return factory_->getDeserializeTime();
 }
-
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -387,14 +387,14 @@ VeloxSortShuffleReaderDeserializer::VeloxSortShuffleReaderDeserializer(
       codec_(codec),
       rowType_(rowType),
       batchSize_(batchSize),
-      arrowPool_(memoryPool),
       veloxPool_(veloxPool),
       deserializeTime_(deserializeTime),
       decompressTime_(decompressTime) {
   GLUTEN_ASSIGN_OR_THROW(
       auto bufferedIn, arrow::io::BufferedInputStream::Create(bufferSize, memoryPool, std::move(in)));
   if (codec_ != nullptr) {
-    GLUTEN_ASSIGN_OR_THROW(in_, arrow::io::CompressedInputStream::Make(codec_.get(), bufferedIn, memoryPool));
+    GLUTEN_ASSIGN_OR_THROW(
+        in_, arrow::io::CompressedInputStream::Make(codec_.get(), bufferedIn, arrow::default_memory_pool()));
   } else {
     in_ = bufferedIn;
   }

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -394,7 +394,7 @@ VeloxSortShuffleReaderDeserializer::VeloxSortShuffleReaderDeserializer(
   GLUTEN_ASSIGN_OR_THROW(
       auto bufferedIn, arrow::io::BufferedInputStream::Create(bufferSize, memoryPool, std::move(in)));
   if (codec_ != nullptr) {
-    GLUTEN_ASSIGN_OR_THROW(in_, arrow::io::CompressedInputStream::Make(codec_.get(), bufferedIn, arrowPool_));
+    GLUTEN_ASSIGN_OR_THROW(in_, arrow::io::CompressedInputStream::Make(codec_.get(), bufferedIn, memoryPool));
   } else {
     in_ = bufferedIn;
   }

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -417,10 +417,6 @@ std::shared_ptr<ColumnarBatch> VeloxSortShuffleReaderDeserializer::next() {
 
   while (cachedRows_ < batchSize_) {
     GLUTEN_ASSIGN_OR_THROW(auto bytes, in_->Read(sizeof(RowSizeType), &lastRowSize_));
-    bytesRead_ += sizeof(RowSizeType);
-
-    GLUTEN_CHECK(lastRowSize_ <= kMaxReadBufferSize, "Row size exceeds max read buffer size");
-
     if (bytes == 0) {
       reachedEos_ = true;
       if (cachedRows_ > 0) {
@@ -428,6 +424,9 @@ std::shared_ptr<ColumnarBatch> VeloxSortShuffleReaderDeserializer::next() {
       }
       return nullptr;
     }
+
+    GLUTEN_CHECK(
+        lastRowSize_ <= kMaxReadBufferSize, "Row size exceeds max read buffer size: " + std::to_string(lastRowSize_));
 
     if (lastRowSize_ + bytesRead_ > kMaxReadBufferSize) {
       return deserializeToBatch();

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -91,7 +91,6 @@ class VeloxSortShuffleReaderDeserializer final : public ColumnarBatchIterator {
   facebook::velox::RowTypePtr rowType_;
   uint32_t batchSize_;
 
-  arrow::MemoryPool* arrowPool_;
   facebook::velox::memory::MemoryPool* veloxPool_;
   int64_t& deserializeTime_;
   int64_t& decompressTime_;

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -84,24 +84,28 @@ class VeloxSortShuffleReaderDeserializer final : public ColumnarBatchIterator {
  private:
   std::shared_ptr<ColumnarBatch> deserializeToBatch();
 
-  void readLargeRow(std::vector<std::shared_ptr<arrow::Buffer>>& arrowBuffers);
+  void readNextRow();
 
-  std::shared_ptr<arrow::io::InputStream> in_;
   std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<arrow::util::Codec> codec_;
   facebook::velox::RowTypePtr rowType_;
   uint32_t batchSize_;
+
   arrow::MemoryPool* arrowPool_;
   facebook::velox::memory::MemoryPool* veloxPool_;
   int64_t& deserializeTime_;
   int64_t& decompressTime_;
 
-  std::list<std::pair<uint32_t, facebook::velox::BufferPtr>> cachedInputs_;
+  facebook::velox::BufferPtr rowBuffer_;
+  char* rowBufferPtr_;
+  uint32_t bytesRead_{0};
+  uint32_t lastRowSize_{0};
+  std::vector<std::string_view> data_;
+
+  std::shared_ptr<arrow::io::InputStream> in_;
+
   uint32_t cachedRows_{0};
   bool reachedEos_{false};
-
-  uint32_t rowOffset_{0};
-  size_t byteOffset_{0};
 };
 
 class VeloxRssSortShuffleReaderDeserializer : public ColumnarBatchIterator {

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -79,6 +79,8 @@ class VeloxSortShuffleReaderDeserializer final : public ColumnarBatchIterator {
       int64_t& deserializeTime,
       int64_t& decompressTime);
 
+  ~VeloxSortShuffleReaderDeserializer() override;
+
   std::shared_ptr<ColumnarBatch> next() override;
 
  private:
@@ -90,13 +92,12 @@ class VeloxSortShuffleReaderDeserializer final : public ColumnarBatchIterator {
   std::shared_ptr<arrow::util::Codec> codec_;
   facebook::velox::RowTypePtr rowType_;
   uint32_t batchSize_;
-
   facebook::velox::memory::MemoryPool* veloxPool_;
   int64_t& deserializeTime_;
   int64_t& decompressTime_;
 
-  facebook::velox::BufferPtr rowBuffer_;
-  char* rowBufferPtr_;
+  facebook::velox::BufferPtr rowBuffer_{nullptr};
+  char* rowBufferPtr_{nullptr};
   uint32_t bytesRead_{0};
   uint32_t lastRowSize_{0};
   std::vector<std::string_view> data_;

--- a/cpp/velox/shuffle/VeloxSortShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxSortShuffleWriter.h
@@ -17,16 +17,13 @@
 
 #pragma once
 
-#include "shuffle/RadixSort.h"
 #include "shuffle/VeloxShuffleWriter.h"
 
 #include <arrow/status.h>
-#include <map>
 #include <vector>
 
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/row/CompactRow.h"
-#include "velox/vector/BaseVector.h"
 
 namespace gluten {
 
@@ -80,7 +77,7 @@ class VeloxSortShuffleWriter final : public VeloxShuffleWriter {
 
   arrow::Status evictPartition(uint32_t partitionId, size_t begin, size_t end);
 
-  arrow::Status evictPartitionInternal(uint32_t partitionId, int32_t numRows, uint8_t* buffer, int64_t rawLength);
+  arrow::Status evictPartitionInternal(uint32_t partitionId, uint8_t* buffer, int64_t rawLength);
 
   facebook::velox::vector_size_t maxRowsToInsert(
       facebook::velox::vector_size_t offset,
@@ -113,8 +110,7 @@ class VeloxSortShuffleWriter final : public VeloxShuffleWriter {
   uint32_t currenPageSize_;
 
   std::unique_ptr<arrow::Buffer> sortedBuffer_;
-  uint8_t* rawBuffer_;
-  std::shared_ptr<arrow::Buffer> compressionBuffer_{nullptr};
+  uint8_t* sortedBufferPtr_;
 
   // Row ID -> Partition ID
   // subscript: The index of row in the current input RowVector

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -68,9 +68,9 @@ std::vector<ShuffleTestParams> createShuffleTestParams() {
   std::vector<int32_t> compressionThresholds = {-1, 0, 3, 4, 10, 4096};
   std::vector<int32_t> mergeBufferSizes = {0, 3, 4, 10, 4096};
 
-  for (const auto& compression : compressions) {
-    for (const auto diskWriteBufferSize : {4, 56, 32 * 1024}) {
-      for (const auto partitionWriterType : {PartitionWriterType::kLocal, PartitionWriterType::kRss}) {
+  for (const auto partitionWriterType : {PartitionWriterType::kLocal, PartitionWriterType::kRss}) {
+    for (const auto& compression : compressions) {
+      for (const auto diskWriteBufferSize : {4, 56, 32 * 1024}) {
         for (auto useRadixSort : {true, false}) {
           params.push_back(
               ShuffleTestParams{
@@ -83,6 +83,7 @@ std::vector<ShuffleTestParams> createShuffleTestParams() {
       }
     }
     params.push_back(ShuffleTestParams{ShuffleWriterType::kRssSortShuffle, PartitionWriterType::kRss, compression});
+
     for (const auto compressionThreshold : compressionThresholds) {
       for (const auto mergeBufferSize : mergeBufferSizes) {
         params.push_back(

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -68,8 +68,8 @@ std::vector<ShuffleTestParams> createShuffleTestParams() {
   std::vector<int32_t> compressionThresholds = {-1, 0, 3, 4, 10, 4096};
   std::vector<int32_t> mergeBufferSizes = {0, 3, 4, 10, 4096};
 
-  for (const auto partitionWriterType : {PartitionWriterType::kLocal, PartitionWriterType::kRss}) {
-    for (const auto& compression : compressions) {
+  for (const auto& compression : compressions) {
+    for (const auto partitionWriterType : {PartitionWriterType::kLocal, PartitionWriterType::kRss}) {
       for (const auto diskWriteBufferSize : {4, 56, 32 * 1024}) {
         for (auto useRadixSort : {true, false}) {
           params.push_back(

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -72,13 +72,12 @@ std::vector<ShuffleTestParams> createShuffleTestParams() {
     for (const auto partitionWriterType : {PartitionWriterType::kLocal, PartitionWriterType::kRss}) {
       for (const auto diskWriteBufferSize : {4, 56, 32 * 1024}) {
         for (auto useRadixSort : {true, false}) {
-          params.push_back(
-              ShuffleTestParams{
-                  .shuffleWriterType = ShuffleWriterType::kSortShuffle,
-                  .partitionWriterType = partitionWriterType,
-                  .compressionType = compression,
-                  .diskWriteBufferSize = diskWriteBufferSize,
-                  .useRadixSort = useRadixSort});
+          params.push_back(ShuffleTestParams{
+              .shuffleWriterType = ShuffleWriterType::kSortShuffle,
+              .partitionWriterType = partitionWriterType,
+              .compressionType = compression,
+              .diskWriteBufferSize = diskWriteBufferSize,
+              .useRadixSort = useRadixSort});
         }
       }
     }
@@ -86,17 +85,15 @@ std::vector<ShuffleTestParams> createShuffleTestParams() {
 
     for (const auto compressionThreshold : compressionThresholds) {
       for (const auto mergeBufferSize : mergeBufferSizes) {
-        params.push_back(
-            ShuffleTestParams{
-                ShuffleWriterType::kHashShuffle,
-                PartitionWriterType::kLocal,
-                compression,
-                compressionThreshold,
-                mergeBufferSize});
+        params.push_back(ShuffleTestParams{
+            ShuffleWriterType::kHashShuffle,
+            PartitionWriterType::kLocal,
+            compression,
+            compressionThreshold,
+            mergeBufferSize});
       }
-      params.push_back(
-          ShuffleTestParams{
-              ShuffleWriterType::kHashShuffle, PartitionWriterType::kRss, compression, compressionThreshold});
+      params.push_back(ShuffleTestParams{
+          ShuffleWriterType::kHashShuffle, PartitionWriterType::kRss, compression, compressionThreshold});
     }
   }
 
@@ -174,7 +171,11 @@ TEST_P(HashPartitioningShuffleWriter, hashPart1Vector) {
       makeFlatVector<int32_t>(
           4, [](vector_size_t row) { return row % 2; }, nullEvery(5), DATE()),
       makeFlatVector<Timestamp>(
-          4, [](vector_size_t row) { return Timestamp{row % 2, 0}; }, nullEvery(5)),
+          4,
+          [](vector_size_t row) {
+            return Timestamp{row % 2, 0};
+          },
+          nullEvery(5)),
   });
 
   auto rowType = facebook::velox::asRowType(vector->type());

--- a/cpp/velox/utils/tests/VeloxShuffleWriterTestBase.h
+++ b/cpp/velox/utils/tests/VeloxShuffleWriterTestBase.h
@@ -68,14 +68,14 @@ struct ShuffleTestParams {
   arrow::Compression::type compressionType;
   int32_t compressionThreshold{0};
   int32_t mergeBufferSize{0};
-  int32_t compressionBufferSize{0};
+  int32_t diskWriteBufferSize{0};
   bool useRadixSort{false};
 
   std::string toString() const {
     std::ostringstream out;
     out << "shuffleWriterType = " << shuffleWriterType << ", partitionWriterType = " << partitionWriterType
         << ", compressionType = " << compressionType << ", compressionThreshold = " << compressionThreshold
-        << ", mergeBufferSize = " << mergeBufferSize << ", compressionBufferSize = " << compressionBufferSize
+        << ", mergeBufferSize = " << mergeBufferSize << ", compressionBufferSize = " << diskWriteBufferSize
         << ", useRadixSort = " << (useRadixSort ? "true" : "false");
     return out.str();
   }
@@ -261,7 +261,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
 
     ShuffleTestParams params = GetParam();
     shuffleWriterOptions_.useRadixSort = params.useRadixSort;
-    shuffleWriterOptions_.sortEvictBufferSize = params.compressionBufferSize;
+    shuffleWriterOptions_.diskWriteBufferSize = params.diskWriteBufferSize;
     partitionWriterOptions_.compressionType = params.compressionType;
     switch (partitionWriterOptions_.compressionType) {
       case arrow::Compression::UNCOMPRESSED:

--- a/cpp/velox/utils/tests/VeloxShuffleWriterTestBase.h
+++ b/cpp/velox/utils/tests/VeloxShuffleWriterTestBase.h
@@ -365,7 +365,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
         std::move(codec),
         veloxCompressionType,
         rowType,
-        std::numeric_limits<int32_t>::max(),
+        kDefaultBatchSize,
         kDefaultReadBufferSize,
         defaultArrowMemoryPool().get(),
         pool_,


### PR DESCRIPTION
For shuffle writer tasks with heavily spill, streaming compression should provide better compression ratio. Currently, spilled data is compressed before writing to the output stream. This patch modifies the compression logic for sort-based shuffle, removes that compression and uses the compressed output stream to do the work.