### PR TITLE
[GLUTEN-7652][VL] Support binary as string

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
@@ -22,6 +22,7 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.utils.VeloxFileSystemValidationJniWrapper
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GreaterThan
 import org.apache.spark.sql.execution.ScalarSubquery
 import org.apache.spark.sql.internal.SQLConf
@@ -185,6 +186,25 @@ class VeloxScanSuite extends VeloxWholeStageTransformerSuite {
             assert(scans.head.filterExprs().size == 2)
           }
       }
+    }
+  }
+
+  test("test binary as string") {
+    withTempDir {
+      dir =>
+        val path = dir.getCanonicalPath
+        spark
+          .range(2)
+          .selectExpr("id as a", "to_binary(cast(id + 10 as string), 'utf-8') as b")
+          .write
+          .mode("overwrite")
+          .parquet(path)
+
+        withTable("test") {
+          sql("create table test (a long, b string) using parquet options (path '" + path + "')")
+          val df = sql("select b from test group by b order by b")
+          checkAnswer(df, Seq(Row("10"), Row("11")))
+        }
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxScanSuite.scala
@@ -195,7 +195,7 @@ class VeloxScanSuite extends VeloxWholeStageTransformerSuite {
         val path = dir.getCanonicalPath
         spark
           .range(2)
-          .selectExpr("id as a", "to_binary(cast(id + 10 as string), 'utf-8') as b")
+          .selectExpr("id as a", "cast(cast(id + 10 as string) as binary) as b")
           .write
           .mode("overwrite")
           .parquet(path)

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1292,18 +1292,19 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
   // Velox requires Filter Pushdown must being enabled.
   bool filterPushdownEnabled = true;
+  auto names = colNameList;
+  auto types = veloxTypeList;
+  auto dataColumns = ROW(std::move(names), std::move(types));
   std::shared_ptr<connector::hive::HiveTableHandle> tableHandle;
   if (!readRel.has_filter()) {
     tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
-        kHiveConnectorId, "hive_table", filterPushdownEnabled, common::SubfieldFilters{}, nullptr);
+        kHiveConnectorId, "hive_table", filterPushdownEnabled, common::SubfieldFilters{}, nullptr, dataColumns);
   } else {
     common::SubfieldFilters subfieldFilters;
-    auto names = colNameList;
-    auto types = veloxTypeList;
-    auto remainingFilter = exprConverter_->toVeloxExpr(readRel.filter(), ROW(std::move(names), std::move(types)));
+    auto remainingFilter = exprConverter_->toVeloxExpr(readRel.filter(), dataColumns);
 
     tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
-        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter);
+        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter, dataColumns);
   }
 
   // Get assignments and out names.

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1304,7 +1304,11 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     auto remainingFilter = exprConverter_->toVeloxExpr(readRel.filter(), dataColumns);
 
     tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
-        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter,
+        kHiveConnectorId,
+        "hive_table",
+        filterPushdownEnabled,
+        std::move(subfieldFilters),
+        remainingFilter,
         dataColumns);
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1304,7 +1304,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     auto remainingFilter = exprConverter_->toVeloxExpr(readRel.filter(), dataColumns);
 
     tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
-        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter, dataColumns);
+        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter,
+        dataColumns);
   }
 
   // Get assignments and out names.

--- a/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
@@ -88,6 +88,8 @@ class Substrait2VeloxPlanConversionTest : public exec::test::HiveConnectorTestBa
 //
 //  Tested Velox operators: TableScan (Filter Pushdown), Project, Aggregate.
 TEST_F(Substrait2VeloxPlanConversionTest, q6) {
+  FLAGS_velox_exception_user_stacktrace_enabled = true;
+  FLAGS_velox_exception_system_stacktrace_enabled = true;
   // Generate the used ORC file.
   auto type =
       ROW({"l_orderkey",
@@ -257,7 +259,7 @@ TEST_F(Substrait2VeloxPlanConversionTest, ifthenTest) {
   // Convert to Velox PlanNode.
   auto planNode = planConverter_->toVeloxPlan(substraitPlan, std::vector<::substrait::ReadRel_LocalFiles>{split});
   ASSERT_EQ(
-      "-- Project[1][expressions: ] -> \n  -- TableScan[0][table: hive_table, remaining filter: (and(and(and(and(isnotnull(\"hd_vehicle_count\"),or(equalto(\"hd_buy_potential\",\">10000\"),equalto(\"hd_buy_potential\",\"unknown\"))),greaterthan(\"hd_vehicle_count\",0)),if(greaterthan(\"hd_vehicle_count\",0),greaterthan(divide(cast \"hd_dep_count\" as DOUBLE,cast \"hd_vehicle_count\" as DOUBLE),1.2))),isnotnull(\"hd_demo_sk\")))] -> n0_0:BIGINT, n0_1:VARCHAR, n0_2:BIGINT, n0_3:BIGINT\n",
+      "-- Project[1][expressions: ] -> \n  -- TableScan[0][table: hive_table, remaining filter: (and(and(and(and(isnotnull(\"hd_vehicle_count\"),or(equalto(\"hd_buy_potential\",\">10000\"),equalto(\"hd_buy_potential\",\"unknown\"))),greaterthan(\"hd_vehicle_count\",0)),if(greaterthan(\"hd_vehicle_count\",0),greaterthan(divide(cast \"hd_dep_count\" as DOUBLE,cast \"hd_vehicle_count\" as DOUBLE),1.2))),isnotnull(\"hd_demo_sk\"))), data columns: ROW<hd_demo_sk:BIGINT,hd_buy_potential:VARCHAR,hd_dep_count:BIGINT,hd_vehicle_count:BIGINT>] -> n0_0:BIGINT, n0_1:VARCHAR, n0_2:BIGINT, n0_3:BIGINT\n",
       planNode->toString(true, true));
 }
 
@@ -273,7 +275,7 @@ TEST_F(Substrait2VeloxPlanConversionTest, filterUpper) {
   // Convert to Velox PlanNode.
   auto planNode = planConverter_->toVeloxPlan(substraitPlan, std::vector<::substrait::ReadRel_LocalFiles>{split});
   ASSERT_EQ(
-      "-- Project[1][expressions: ] -> \n  -- TableScan[0][table: hive_table, remaining filter: (and(isnotnull(\"key\"),lessthan(\"key\",3)))] -> n0_0:INTEGER\n",
+      "-- Project[1][expressions: ] -> \n  -- TableScan[0][table: hive_table, remaining filter: (and(isnotnull(\"key\"),lessthan(\"key\",3))), data columns: ROW<key:INTEGER>] -> n0_0:INTEGER\n",
       planNode->toString(true, true));
 }
 

--- a/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
@@ -90,6 +90,12 @@ class Substrait2VeloxPlanConversionTest : public exec::test::HiveConnectorTestBa
 TEST_F(Substrait2VeloxPlanConversionTest, q6) {
   FLAGS_velox_exception_user_stacktrace_enabled = true;
   FLAGS_velox_exception_system_stacktrace_enabled = true;
+  std::unordered_map<std::string, std::string> hiveConfig{
+      {"hive.orc.use-column-names",  "true"}};
+  std::shared_ptr<const facebook::velox::config::ConfigBase> config{
+    std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfig))};
+  resetHiveConnector(config);
+
   // Generate the used ORC file.
   auto type =
       ROW({"l_orderkey",

--- a/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
@@ -91,7 +91,8 @@ TEST_F(Substrait2VeloxPlanConversionTest, q6) {
   FLAGS_velox_exception_user_stacktrace_enabled = true;
   FLAGS_velox_exception_system_stacktrace_enabled = true;
   std::unordered_map<std::string, std::string> hiveConfig{
-      {"hive.orc.use-column-names",  "true"}};
+      {"hive.orc.use-column-names", "true"},
+      {"hive.parquet.use-column-names", "true"}};
   std::shared_ptr<const facebook::velox::config::ConfigBase> config{
     std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfig))};
   resetHiveConnector(config);

--- a/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
@@ -91,10 +91,9 @@ TEST_F(Substrait2VeloxPlanConversionTest, q6) {
   FLAGS_velox_exception_user_stacktrace_enabled = true;
   FLAGS_velox_exception_system_stacktrace_enabled = true;
   std::unordered_map<std::string, std::string> hiveConfig{
-      {"hive.orc.use-column-names", "true"},
-      {"hive.parquet.use-column-names", "true"}};
+      {"hive.orc.use-column-names", "true"}, {"hive.parquet.use-column-names", "true"}};
   std::shared_ptr<const facebook::velox::config::ConfigBase> config{
-    std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfig))};
+      std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfig))};
   resetHiveConnector(config);
 
   // Generate the used ORC file.

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -49,18 +49,21 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
   }
 
   testGluten("test binary as string") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      spark.range(2).selectExpr("id as a", "to_binary(cast(id as string), 'utf-8') as b")
-        .write
-        .mode("overwrite")
-        .parquet(path)
+    withTempDir {
+      dir =>
+        val path = dir.getCanonicalPath
+        spark
+          .range(2)
+          .selectExpr("id as a", "to_binary(cast(id as string), 'utf-8') as b")
+          .write
+          .mode("overwrite")
+          .parquet(path)
 
-      withTable("test") {
-        sql("create table test (a long, b string) using parquet options (path '" + path + "')")
-        val df = sql("select * from test group by a, b order by a, b")
-        checkAnswer(df, Seq(Row(0, "0"), Row(1, "1")))
-      }
+        withTable("test") {
+          sql("create table test (a long, b string) using parquet options (path '" + path + "')")
+          val df = sql("select * from test group by a, b order by a, b")
+          checkAnswer(df, Seq(Row(0, "0"), Row(1, "1")))
+        }
     }
   }
 

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -47,24 +47,4 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       ignoreIfNotExists = true,
       purge = false)
   }
-
-  testGluten("test binary as string") {
-    withTempDir {
-      dir =>
-        val path = dir.getCanonicalPath
-        spark
-          .range(2)
-          .selectExpr("id as a", "to_binary(cast(id + 10 as string), 'utf-8') as b")
-          .write
-          .mode("overwrite")
-          .parquet(path)
-
-        withTable("test") {
-          sql("create table test (a long, b string) using parquet options (path '" + path + "')")
-          val df = sql("select b from test group by b order by b")
-          checkAnswer(df, Seq(Row("10"), Row("11")))
-        }
-    }
-  }
-
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -54,7 +54,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
         val path = dir.getCanonicalPath
         spark
           .range(2)
-          .selectExpr("id as a", "to_binary(cast(id + 1 as string), 'utf-8') as b")
+          .selectExpr("id as a", "to_binary(cast(id + 10 as string), 'utf-8') as b")
           .write
           .mode("overwrite")
           .parquet(path)
@@ -62,7 +62,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
         withTable("test") {
           sql("create table test (a long, b string) using parquet options (path '" + path + "')")
           val df = sql("select b from test group by b order by b")
-          checkAnswer(df, Seq(Row(0, "0"), Row(1, "1")))
+          checkAnswer(df, Seq(Row("10"), Row("11")))
         }
     }
   }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -54,14 +54,14 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
         val path = dir.getCanonicalPath
         spark
           .range(2)
-          .selectExpr("id as a", "to_binary(cast(id as string), 'utf-8') as b")
+          .selectExpr("id as a", "to_binary(cast(id + 1 as string), 'utf-8') as b")
           .write
           .mode("overwrite")
           .parquet(path)
 
         withTable("test") {
           sql("create table test (a long, b string) using parquet options (path '" + path + "')")
-          val df = sql("select * from test group by a, b order by a, b")
+          val df = sql("select b from test group by b order by b")
           checkAnswer(df, Seq(Row(0, "0"), Row(1, "1")))
         }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox supports binary as string of parquet after https://github.com/facebookincubator/velox/pull/10399, we need to pass hive columns type to HiveTableHandle

Fixes: #7652

## How was this patch tested?

added unit test
