### PR TITLE
[GLUTEN-9329][DOC] Fix log path when parsing log in gen-function-support-docs.py

### DIFF
--- a/tools/scripts/gen-function-support-docs.py
+++ b/tools/scripts/gen-function-support-docs.py
@@ -1058,9 +1058,8 @@ if __name__ == '__main__':
 
     spark_function_map = create_spark_function_map()
 
-    # support_list, unresolved = parse_logs(
-    #     os.path.join(gluten_home, 'gluten-ut', 'spark35', 'target', 'gen-function-support-docs-tests.log'))
-    support_list, unresolved = parse_logs('/Users/rong/workspace/log/tmp5.log')
+    support_list, unresolved = parse_logs(
+        os.path.join(gluten_home, 'gluten-ut', 'spark35', 'target', 'gen-function-support-docs-tests.log'))
 
     for category in args.categories.split(','):
         generate_function_doc(category,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to fix log path when parsing log in gen-function-support-docs.py.  
https://github.com/apache/incubator-gluten/blob/65ad57add72e665b4e07b2d994347c9881d9fc13/tools/scripts/log4j2.properties#L25

(Fixes: \#9329)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

