### PR TITLE
[GLUTEN-9300][DOC] Support replacement expression in gen-function-support-docs

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -626,6 +626,26 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  testWithMinSparkVersion("test map_contains_key function", "3.3") {
+    withTempPath {
+      path =>
+        Seq(
+          Map[Int, String](1 -> null, 2 -> "200"),
+          Map[Int, String](1 -> "100", 2 -> "200", 3 -> "300"),
+          null
+        )
+          .toDF("i")
+          .write
+          .parquet(path.getCanonicalPath)
+
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("map_tbl")
+
+        runQueryAndCompare("select map_contains_key(i, 1) from map_tbl") {
+          checkGlutenOperatorMatch[ProjectExecTransformer]
+        }
+    }
+  }
+
   test("test map_values function") {
     withTempPath {
       path =>
@@ -765,14 +785,37 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test nanvl function") {
-    runQueryAndCompare("""SELECT nanvl(cast('nan' as float), 1f),
-                         | nanvl(l_orderkey, cast('null' as double)),
-                         | nanvl(cast('null' as double), l_orderkey),
-                         | nanvl(l_orderkey, l_orderkey / 0.0d),
-                         | nanvl(cast('nan' as float), l_orderkey)
-                         | from lineitem limit 1""".stripMargin) {
-      checkGlutenOperatorMatch[ProjectExecTransformer]
+  test("Test conditional function") {
+    Seq("nanvl", "nullif", "nvl").foreach {
+      func =>
+        runQueryAndCompare(s"""
+                              |SELECT
+                              | $func(cast('nan' as float), 1f),
+                              | $func(l_orderkey, cast('null' as double)),
+                              | $func(cast('null' as double), l_orderkey),
+                              | $func(l_orderkey, l_orderkey / 0.0d),
+                              | $func(cast('nan' as float), l_orderkey)
+                              | from lineitem limit 1
+                              |""".stripMargin) {
+          checkGlutenOperatorMatch[ProjectExecTransformer]
+        }
+    }
+  }
+
+  test("Test nvl2 function") {
+    Seq("null", "l_orderkey").foreach {
+      expr =>
+        runQueryAndCompare(s"""
+                              |SELECT
+                              | nvl2($expr, cast('nan' as float), 1f),
+                              | nvl2($expr, l_orderkey, cast('null' as double)),
+                              | nvl2($expr, cast('null' as double), l_orderkey),
+                              | nvl2($expr, l_orderkey, l_orderkey / 0.0d),
+                              | nvl2($expr, cast('nan' as float), l_orderkey)
+                              | from lineitem limit 1
+                              |""".stripMargin) {
+          checkGlutenOperatorMatch[ProjectExecTransformer]
+        }
     }
   }
 
@@ -1641,6 +1684,26 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     runQueryAndCompare(
       "select make_date(2025, 2, 7), make_date(2024, 11, null), make_date(2024, 11, 50)") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
+    }
+  }
+
+  testWithMinSparkVersion("equal_null", "3.4") {
+    Seq[(Integer, Integer)]().toDF("a", "b")
+    withTempPath {
+      path =>
+        Seq[(Integer, Integer)](
+          (null, 8),
+          (8, 8)
+        )
+          .toDF("val1", "val2")
+          .write
+          .parquet(path.getCanonicalPath)
+
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("tbl")
+
+        runQueryAndCompare("select equal_null(val1, val2) from tbl") {
+          checkGlutenOperatorMatch[ProjectExecTransformer]
+        }
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
@@ -418,6 +418,18 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
         s"from $LINEITEM_TABLE where l_comment rlike '%$$##@@#&&' limit $LENGTH") { _ => }
   }
 
+  testWithMinSparkVersion("ilike", "3.3") {
+    runQueryAndCompare(
+      s"select l_orderkey, l_comment, ilike(l_comment, 'a*') " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(
+      s"select l_orderkey, ilike(l_comment, ' ') " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
+    runQueryAndCompare(
+      s"select l_orderkey, ilike($NULL_STR_COL, '%a%') " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
+  }
+
   test("regexp") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, regexp(l_comment, 'a*') " +
@@ -637,6 +649,20 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
 
     runQueryAndCompare(
       s"select l_orderkey, left(l_comment, $NULL_STR_COL) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
+  }
+
+  test("right") {
+    runQueryAndCompare(
+      s"select l_orderkey, right(l_comment, 1) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
+
+    runQueryAndCompare(
+      s"select l_orderkey, right($NULL_STR_COL, 1) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
+
+    runQueryAndCompare(
+      s"select l_orderkey, right(l_comment, $NULL_STR_COL) " +
         s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 }

--- a/docs/velox-backend-scalar-function-support.md
+++ b/docs/velox-backend-scalar-function-support.md
@@ -1,6 +1,6 @@
 # Scalar Functions Support Status
 
-**Out of 357 scalar functions in Spark 3.5, Gluten currently fully supports 220 functions and partially supports 20 functions.**
+**Out of 357 scalar functions in Spark 3.5, Gluten currently fully supports 233 functions and partially supports 20 functions.**
 
 ## Array Functions
 
@@ -18,14 +18,14 @@
 | array_max         | ArrayMax            | S        |                |
 | array_min         | ArrayMin            | S        |                |
 | array_position    | ArrayPosition       | S        |                |
-| array_prepend     | ArrayPrepend        |          |                |
+| array_prepend     | ArrayPrepend        | S        |                |
 | array_remove      | ArrayRemove         | S        |                |
 | array_repeat      | ArrayRepeat         | S        |                |
 | array_union       | ArrayUnion          | S        |                |
 | arrays_overlap    | ArraysOverlap       | S        |                |
 | arrays_zip        | ArraysZip           | S        |                |
 | flatten           | Flatten             | S        |                |
-| get               | Get                 |          |                |
+| get               | Get                 | S        |                |
 | sequence          | Sequence            |          |                |
 | shuffle           | Shuffle             | S        |                |
 | slice             | Slice               | S        |                |
@@ -49,7 +49,7 @@
 
 | Spark Functions   | Spark Expressions   | Status   | Restrictions   |
 |-------------------|---------------------|----------|----------------|
-| array_size        | ArraySize           |          |                |
+| array_size        | ArraySize           | S        |                |
 | cardinality       | Size                | S        |                |
 | concat            | Concat              | PS       |                |
 | reverse           | Reverse             | S        |                |
@@ -61,11 +61,11 @@
 |-------------------|---------------------|----------|----------------|
 | coalesce          | Coalesce            | S        |                |
 | if                | If                  | S        |                |
-| ifnull            | Nvl                 |          |                |
+| ifnull            | Nvl                 | S        |                |
 | nanvl             | NaNvl               | S        |                |
-| nullif            | NullIf              |          |                |
-| nvl               | Nvl                 |          |                |
-| nvl2              | Nvl2                |          |                |
+| nullif            | NullIf              | S        |                |
+| nvl               | Nvl                 | S        |                |
+| nvl2              | Nvl2                | S        |                |
 | when              | CaseWhen            | S        |                |
 
 ## Conversion Functions
@@ -180,7 +180,7 @@
 | from_json         | JsonToStructs       | S        |                |
 | get_json_object   | GetJsonObject       | S        |                |
 | json_array_length | LengthOfJsonArray   | S        |                |
-| json_object_keys  | JsonObjectKeys      |          |                |
+| json_object_keys  | JsonObjectKeys      | S        |                |
 | json_tuple        | JsonTuple           | S        |                |
 | schema_of_json    | SchemaOfJson        |          |                |
 | to_json           | StructsToJson       |          |                |
@@ -209,7 +209,7 @@
 | element_at        | ElementAt           | S        |                |
 | map               | CreateMap           | PS       |                |
 | map_concat        | MapConcat           | PS       |                |
-| map_contains_key  | MapContainsKey      |          |                |
+| map_contains_key  | MapContainsKey      | S        |                |
 | map_entries       | MapEntries          | S        |                |
 | map_from_arrays   | MapFromArrays       |          |                |
 | map_from_entries  | MapFromEntries      |          |                |
@@ -296,7 +296,7 @@
 |-----------------------------|---------------------------|----------|----------------|
 | aes_decrypt                 | AesDecrypt                |          |                |
 | aes_encrypt                 | AesEncrypt                |          |                |
-| assert_true                 | AssertTrue                |          |                |
+| assert_true                 | AssertTrue                | S        |                |
 | bitmap_bit_position         | BitmapBitPosition         |          |                |
 | bitmap_bucket_number        | BitmapBucketNumber        |          |                |
 | bitmap_count                | BitmapCount               |          |                |
@@ -304,7 +304,7 @@
 | current_database            | CurrentDatabase           |          |                |
 | current_schema              | CurrentDatabase           |          |                |
 | current_user                | CurrentUser               |          |                |
-| equal_null                  | EqualNull                 |          |                |
+| equal_null                  | EqualNull                 | S        |                |
 | hll_sketch_estimate         | HllSketchEstimate         |          |                |
 | hll_union                   | HllUnion                  |          |                |
 | input_file_block_length     | InputFileBlockLength      |          |                |
@@ -338,7 +338,7 @@
 | and               | And                 | S        |                        |
 | between           |                     | S        |                        |
 | case              |                     | S        |                        |
-| ilike             | ILike               |          |                        |
+| ilike             | ILike               | S        |                        |
 | in                | In                  | PS       |                        |
 | isnan             | IsNaN               | S        |                        |
 | isnotnull         | IsNotNull           | S        |                        |
@@ -396,7 +396,7 @@
 | regexp_substr      | RegExpSubStr                |          |                        |
 | repeat             | StringRepeat                | S        |                        |
 | replace            | StringReplace               | S        |                        |
-| right              | Right                       |          |                        |
+| right              | Right                       | S        |                        |
 | rpad               | RPadExpressionBuilder       | PS       | BinaryType unsupported |
 | rtrim              | StringTrimRight             | S        |                        |
 | sentences          | Sentences                   |          |                        |

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
@@ -343,6 +343,14 @@ object ExpressionMappings {
     Sig[NthValue](NTH_VALUE)
   )
 
+  private val RUNTIME_REPLACEABLE_SIGS: Seq[Sig] = Seq(
+    Sig[AssertTrue](ASSERT_TRUE),
+    Sig[NullIf](NULLIF),
+    Sig[Nvl](NVL),
+    Sig[Nvl2](NVL2),
+    Sig[Right](RIGHT)
+  ) ++ SparkShimLoader.getSparkShims.runtimeReplaceableExpressionMappings
+
   def expressionsMap: Map[Class[_], String] = {
     val blacklist = GlutenConfig.get.expressionBlacklist
     val filtered = (defaultExpressionsMap ++ toMap(
@@ -355,7 +363,9 @@ object ExpressionMappings {
   // functions.
   // Used by gluten/tools/scripts/gen-function-support-docs.py
   def listExpressionMappings(): Array[(String, String)] = {
-    expressionsMap.map(kv => (kv._1.getSimpleName, kv._2)).toArray
+    (expressionsMap ++ toMap(RUNTIME_REPLACEABLE_SIGS))
+      .map(kv => (kv._1.getSimpleName, kv._2))
+      .toArray
   }
 
   private lazy val defaultExpressionsMap: Map[Class[_], String] = {

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -68,12 +68,14 @@ object ExpressionNames {
   final val CAST = "cast"
   final val COALESCE = "coalesce"
   final val LIKE = "like"
+  final val ILIKE = "ilike"
   final val RLIKE = "rlike"
   final val REGEXP_REPLACE = "regexp_replace"
   final val REGEXP_EXTRACT = "regexp_extract"
   final val REGEXP_EXTRACT_ALL = "regexp_extract_all"
   final val EQUAL = "equal"
   final val EQUAL_NULL_SAFE = "equal_null_safe"
+  final val EQUAL_NULL = "equal_null"
   final val LESS_THAN = "lt"
   final val LESS_THAN_OR_EQUAL = "lte"
   final val GREATER_THAN = "gt"
@@ -189,6 +191,7 @@ object ExpressionNames {
   final val FACTORIAL = "factorial"
   final val RAND = "rand"
   final val RINT = "rint"
+  final val RIGHT = "right"
 
   // PrestoSQL Math functions
   final val ACOS = "acos"
@@ -281,6 +284,7 @@ object ExpressionNames {
   final val ARRAY_INSERT = "array_insert"
   final val ARRAY_APPEND = "array_append"
   final val ARRAY_PREPEND = "array_prepend"
+  final val ARRAY_SIZE = "array_size"
 
   // Map functions
   final val CREATE_MAP = "map"
@@ -295,6 +299,7 @@ object ExpressionNames {
   final val TRANSFORM_VALUES = "transform_values"
   final val STR_TO_MAP = "str_to_map"
   final val MAP_FILTER = "map_filter"
+  final val MAP_CONTAINS_KEY = "map_contains_key"
 
   // struct functions
   final val GET_STRUCT_FIELD = "get_struct_field"
@@ -334,6 +339,10 @@ object ExpressionNames {
   final val RAISE_ERROR = "raise_error"
   final val VERSION = "version"
   final val AT_LEAST_N_NON_NULLS = "at_least_n_non_nulls"
+  final val ASSERT_TRUE = "assert_true"
+  final val NULLIF = "nullif"
+  final val NVL = "nvl"
+  final val NVL2 = "nvl2"
 
   // Directly use child expression transformer
   final val KNOWN_NULLABLE = "known_nullable"

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -285,6 +285,7 @@ object ExpressionNames {
   final val ARRAY_APPEND = "array_append"
   final val ARRAY_PREPEND = "array_prepend"
   final val ARRAY_SIZE = "array_size"
+  final val GET = "get"
 
   // Map functions
   final val CREATE_MAP = "map"

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -90,6 +90,8 @@ trait SparkShims {
 
   def aggregateExpressionMappings: Seq[Sig]
 
+  def runtimeReplaceableExpressionMappings: Seq[Sig]
+
   def convertPartitionTransforms(partitions: Seq[Transform]): (Seq[String], Option[BucketSpec])
 
   def generateFileScanRDD(

--- a/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
@@ -72,6 +72,8 @@ class Spark32Shims extends SparkShims {
 
   override def aggregateExpressionMappings: Seq[Sig] = Seq.empty
 
+  override def runtimeReplaceableExpressionMappings: Seq[Sig] = Seq.empty
+
   override def convertPartitionTransforms(
       partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
     CatalogUtil.convertPartitionTransforms(partitions)

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -89,6 +89,14 @@ class Spark33Shims extends SparkShims {
     )
   }
 
+  override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
+    Seq(
+      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
+      Sig[ILike](ExpressionNames.ILIKE),
+      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY)
+    )
+  }
+
   override def convertPartitionTransforms(
       partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
     CatalogUtil.convertPartitionTransforms(partitions)

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -103,6 +103,15 @@ class Spark34Shims extends SparkShims {
     )
   }
 
+  override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
+    Seq(
+      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
+      Sig[EqualNull](ExpressionNames.EQUAL_NULL),
+      Sig[ILike](ExpressionNames.ILIKE),
+      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY)
+    )
+  }
+
   override def convertPartitionTransforms(
       partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
     CatalogUtil.convertPartitionTransforms(partitions)

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -108,7 +108,8 @@ class Spark34Shims extends SparkShims {
       Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
       Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY)
+      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY),
+      Sig[Get](ExpressionNames.GET)
     )
   }
 

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -113,7 +113,8 @@ class Spark35Shims extends SparkShims {
       Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
       Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY)
+      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY),
+      Sig[Get](ExpressionNames.GET)
     )
   }
 

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -107,6 +107,16 @@ class Spark35Shims extends SparkShims {
     )
   }
 
+  override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
+    Seq(
+      Sig[ArrayPrepend](ExpressionNames.ARRAY_PREPEND),
+      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
+      Sig[EqualNull](ExpressionNames.EQUAL_NULL),
+      Sig[ILike](ExpressionNames.ILIKE),
+      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY)
+    )
+  }
+
   override def convertPartitionTransforms(
       partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
     CatalogUtil.convertPartitionTransforms(partitions)

--- a/tools/scripts/gen-function-support-docs.py
+++ b/tools/scripts/gen-function-support-docs.py
@@ -725,8 +725,7 @@ def parse_logs(log_file):
     for category in FUNCTION_CATEGORIES:
         if category == 'scalar':
             for f in functions[category]:
-                # TODO: Remove this filter as it may exclude supported expressions, such as
-                #  RuntimeReplaceable and Builder.
+                # TODO: Remove this filter as it may exclude supported expressions, such as Builder.
                 if f not in builtin_functions and f not in gluten_expressions.values() and function_to_classname[
                     f] not in gluten_expressions.keys():
                     logging.log(logging.WARNING, f"Function not found in gluten expressions: {f}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to add runtime replaceable scalar function map to support replacement expression in doc.

(Fixes: \#9300)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

