### PR TITLE
[VL] Move pre-configuration code of dynamic off-heap sizing to its own place

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
@@ -51,7 +51,7 @@ public final class MemoryTargets {
   @Experimental
   public static MemoryTarget dynamicOffHeapSizingIfEnabled(MemoryTarget memoryTarget) {
     if (GlutenConfig.get().dynamicOffHeapSizingEnabled()) {
-      return new DynamicOffHeapSizingMemoryTarget(memoryTarget);
+      return new DynamicOffHeapSizingMemoryTarget();
     }
 
     return memoryTarget;

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -188,74 +188,25 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     // check memory off-heap enabled and size.
     checkOffHeapSettings(conf)
 
-    // Task slots.
+    // Get the off-heap size set by user.
+    val offHeapSize = conf.getSizeAsBytes(SPARK_OFFHEAP_SIZE_KEY)
+
+    // Set off-heap size in bytes.
+    conf.set(COLUMNAR_OFFHEAP_SIZE_IN_BYTES.key, offHeapSize.toString)
+
+    // Set off-heap size in bytes per task.
     val taskSlots = SparkResourceUtil.getTaskSlots(conf)
     conf.set(NUM_TASK_SLOTS_PER_EXECUTOR.key, taskSlots.toString)
-
-    val onHeapSize: Long = conf.getSizeAsBytes(SPARK_ONHEAP_SIZE_KEY, 1024 * 1024 * 1024)
-
-    // If dynamic off-heap sizing is enabled, the off-heap size is calculated based on the on-heap
-    // size. Otherwise, the off-heap size is set to the value specified by the user (if any).
-    // Note that this means that we will IGNORE the off-heap size specified by the user if the
-    // dynamic off-heap feature is enabled.
-    val offHeapSize: Long =
-      if (
-        conf.getBoolean(
-          DYNAMIC_OFFHEAP_SIZING_ENABLED.key,
-          DYNAMIC_OFFHEAP_SIZING_ENABLED.defaultValue.get)
-      ) {
-        // Since when dynamic off-heap sizing is enabled, we commingle on-heap
-        // and off-heap memory, we set the off-heap size to the usable on-heap size. We will
-        // size it with a memory fraction, which can be aggressively set, but the default
-        // is using the same way that Spark sizes on-heap memory:
-        //
-        // spark.gluten.memory.dynamic.offHeap.sizing.memory.fraction *
-        //    (spark.executor.memory - 300MB).
-        //
-        // We will be careful to use the same configuration settings as Spark to ensure
-        // that we are sizing the off-heap memory in the same way as Spark sizes on-heap memory.
-        // The 300MB value, unfortunately, is hard-coded in Spark code.
-        ((onHeapSize - (300 * 1024 * 1024)) *
-          conf.getDouble(DYNAMIC_OFFHEAP_SIZING_MEMORY_FRACTION.key, 0.6d)).toLong
-      } else {
-        // Optimistic off-heap sizes, assuming all storage memory can be borrowed into execution
-        // memory pool, regardless of Spark option spark.memory.storageFraction.
-        conf.getSizeAsBytes(SPARK_OFFHEAP_SIZE_KEY, 0L)
-      }
-
-    conf.set(COLUMNAR_OFFHEAP_SIZE_IN_BYTES.key, offHeapSize.toString)
-    conf.set(SPARK_OFFHEAP_SIZE_KEY, offHeapSize.toString)
-
     val offHeapPerTask = offHeapSize / taskSlots
     conf.set(COLUMNAR_TASK_OFFHEAP_SIZE_IN_BYTES.key, offHeapPerTask.toString)
 
-    // If we are using dynamic off-heap sizing, we should also enable off-heap memory
-    // officially.
-    if (
-      conf.getBoolean(
-        DYNAMIC_OFFHEAP_SIZING_ENABLED.key,
-        DYNAMIC_OFFHEAP_SIZING_ENABLED.defaultValue.get)
-    ) {
-      conf.set(SPARK_OFFHEAP_ENABLED, "true")
-
-      // We already sized the off-heap per task in a conservative manner, so we can just
-      // use it.
-      conf.set(COLUMNAR_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES.key, offHeapPerTask.toString)
-    } else {
-      // Let's make sure this is set to false explicitly if it is not on as it
-      // is looked up when throwing OOF exceptions.
-      conf.set(
-        DYNAMIC_OFFHEAP_SIZING_ENABLED.key,
-        DYNAMIC_OFFHEAP_SIZING_ENABLED.defaultValueString)
-
-      // Pessimistic off-heap sizes, with the assumption that all non-borrowable storage memory
-      // determined by spark.memory.storageFraction was used.
-      val fraction = 1.0d - conf.getDouble("spark.memory.storageFraction", 0.5d)
-      val conservativeOffHeapPerTask = (offHeapSize * fraction).toLong / taskSlots
-      conf.set(
-        COLUMNAR_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES.key,
-        conservativeOffHeapPerTask.toString)
-    }
+    // Pessimistic off-heap sizes, with the assumption that all non-borrowable storage memory
+    // determined by spark.memory.storageFraction was used.
+    val fraction = 1.0d - conf.getDouble("spark.memory.storageFraction", 0.5d)
+    val conservativeOffHeapPerTask = (offHeapSize * fraction).toLong / taskSlots
+    conf.set(
+      COLUMNAR_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES.key,
+      conservativeOffHeapPerTask.toString)
 
     // Disable vanilla columnar readers, to prevent columnar-to-columnar conversions.
     // FIXME: Do we still need this trick since

--- a/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
@@ -129,7 +129,9 @@ object SparkMemoryUtil {
 
       override def visit(
           dynamicOffHeapSizingMemoryTarget: DynamicOffHeapSizingMemoryTarget): String = {
-        dynamicOffHeapSizingMemoryTarget.delegated().accept(this)
+        prettyPrintStats(
+          "Dynamic off-heap sizing memory target stats: ",
+          dynamicOffHeapSizingMemoryTarget)
       }
 
       override def visit(retryOnOomMemoryTarget: RetryOnOomMemoryTarget): String = {

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -1244,7 +1244,7 @@ object GlutenConfig {
       .createWithDefault(false)
 
   val COLUMNAR_MEMORY_UNTRACKED =
-    buildConf("spark.gluten.memory.untracked")
+    buildStaticConf("spark.gluten.memory.untracked")
       .internal()
       .doc(
         "When enabled, turn all native memory allocations in Gluten into untracked. Spark " +
@@ -1634,7 +1634,7 @@ object GlutenConfig {
       .createWithDefault(true)
 
   val DYNAMIC_OFFHEAP_SIZING_ENABLED =
-    buildConf("spark.gluten.memory.dynamic.offHeap.sizing.enabled")
+    buildStaticConf("spark.gluten.memory.dynamic.offHeap.sizing.enabled")
       .internal()
       .doc(
         "Experimental: When set to true, the offheap config (spark.memory.offHeap.size) will " +
@@ -1651,7 +1651,7 @@ object GlutenConfig {
       .createWithDefault(false)
 
   val DYNAMIC_OFFHEAP_SIZING_MEMORY_FRACTION =
-    buildConf("spark.gluten.memory.dynamic.offHeap.sizing.memory.fraction")
+    buildStaticConf("spark.gluten.memory.dynamic.offHeap.sizing.memory.fraction")
       .internal()
       .doc(
         "Experimental: Determines the memory fraction used to determine the total " +

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -342,6 +342,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def dynamicOffHeapSizingEnabled: Boolean =
     getConf(DYNAMIC_OFFHEAP_SIZING_ENABLED)
 
+  def dynamicOffHeapSizingMemoryFraction: Double =
+    getConf(DYNAMIC_OFFHEAP_SIZING_MEMORY_FRACTION)
+
   def enableHiveFileFormatWriter: Boolean = getConf(NATIVE_HIVEFILEFORMAT_WRITER_ENABLED)
 
   def enableCelebornFallback: Boolean = getConf(CELEBORN_FALLBACK_ENABLED)


### PR DESCRIPTION
Dynamic off-heap sizing was introduced in https://github.com/apache/incubator-gluten/pull/5439. The PR does a few of improvements against the implementation.

1. Move pre-configuration code from `GlutenConfig.scala` to `DynamicOffHeapSizingMemoryTarget`.
2. Avoid chaining `DynamicOffHeapSizingMemoryTarget` with Spark consumer since it basically never triggers spills because of its design. The target will manage OOMs by itself.
3. Do not set off-heap size automatically when dynamic off-heap sizing is enabled. All the memory allocation is from a counter that indicates the remaining unused size from JVM on-heap memory cap.
4. Other minor improvements.