### PR TITLE
[CORE] Provide an configuration option to completely turn off off-heap memory tracking with Spark memory manager

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -58,7 +58,6 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
       .set("spark.sql.files.maxPartitionBytes", "1g")
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.memory.offHeap.size", "2g")
-      .set("spark.gluten.memory.untracked", "true")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
       .set("spark.sql.sources.useV1SourceList", "avro,parquet,csv")

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -58,6 +58,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
       .set("spark.sql.files.maxPartitionBytes", "1g")
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.memory.offHeap.size", "2g")
+      .set("spark.gluten.memory.untracked", "true")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
       .set("spark.sql.sources.useV1SourceList", "avro,parquet,csv")

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -483,14 +483,17 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
 
     {
       // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.
-      // FIXME this uses process-wise off-heap memory which is not for task
-      // partial aggregation memory config
+      // Partial aggregation memory configurations.
+      // TODO: Move the calculations to Java side.
       auto offHeapMemory = veloxCfg_->get<int64_t>(kSparkTaskOffHeapMemory, facebook::velox::memory::kMaxMemory);
-      auto maxPartialAggregationMemory = veloxCfg_->get<int64_t>(kMaxPartialAggregationMemory).has_value()
-          ? veloxCfg_->get<int64_t>(kMaxPartialAggregationMemory).value()
-          : static_cast<int64_t>((veloxCfg_->get<double>(kMaxPartialAggregationMemoryRatio, 0.1) * offHeapMemory));
-      auto maxExtendedPartialAggregationMemory =
-          static_cast<long>((veloxCfg_->get<double>(kMaxExtendedPartialAggregationMemoryRatio, 0.15) * offHeapMemory));
+      auto maxPartialAggregationMemory = std::max<int64_t>(
+          1 << 24,
+          veloxCfg_->get<int64_t>(kMaxPartialAggregationMemory).has_value()
+              ? veloxCfg_->get<int64_t>(kMaxPartialAggregationMemory).value()
+              : static_cast<int64_t>(veloxCfg_->get<double>(kMaxPartialAggregationMemoryRatio, 0.1) * offHeapMemory));
+      auto maxExtendedPartialAggregationMemory = std::max<int64_t>(
+          1 << 26,
+          static_cast<long>(veloxCfg_->get<double>(kMaxExtendedPartialAggregationMemoryRatio, 0.15) * offHeapMemory));
       configs[velox::core::QueryConfig::kMaxPartialAggregationMemory] = std::to_string(maxPartialAggregationMemory);
       configs[velox::core::QueryConfig::kMaxExtendedPartialAggregationMemory] =
           std::to_string(maxExtendedPartialAggregationMemory);

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -153,6 +153,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
       // enabled. Skip the check.
       return
     }
+
     val minOffHeapSize = "1MB"
     if (
       !conf.getBoolean(GlutenConfig.SPARK_OFFHEAP_ENABLED, false) ||

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -246,6 +246,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def memoryIsolation: Boolean = getConf(COLUMNAR_MEMORY_ISOLATION)
 
+  def memoryUntracked: Boolean = getConf(COLUMNAR_MEMORY_UNTRACKED)
+
   def offHeapMemorySize: Long = getConf(COLUMNAR_OFFHEAP_SIZE_IN_BYTES)
 
   def taskOffHeapMemorySize: Long = getConf(COLUMNAR_TASK_OFFHEAP_SIZE_IN_BYTES)
@@ -1238,6 +1240,16 @@ object GlutenConfig {
         "to set true if Gluten serves concurrent queries within a single session, since not all " +
         "memory Gluten allocated is guaranteed to be spillable. In the case, the feature should " +
         "be enabled to avoid OOM.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val COLUMNAR_MEMORY_UNTRACKED =
+    buildConf("spark.gluten.memory.untracked")
+      .internal()
+      .doc(
+        "Enable to leave all native memory allocations in Gluten untracked. Spark " +
+          "will be unaware of the allocations so will not trigger spill-to-disk operations " +
+          "or managed OOMs. Should only be enabled for testing or other non-production usages.")
       .booleanConf
       .createWithDefault(false)
 

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -1249,7 +1249,7 @@ object GlutenConfig {
       .doc(
         "Enable to leave all native memory allocations in Gluten untracked. Spark " +
           "will be unaware of the allocations so will not trigger spill-to-disk operations " +
-          "or managed OOMs. Should only be enabled for testing or other non-production usages.")
+          "or managed OOMs. Should only be enabled for testing or other non-production use cases.")
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
We noticed some users unexpectedly rely on dynamic off-heap sizing to emulate a case that all the memory allocations are not tracked by Spark for testing or PoC purpose. As the feature dynamic off-heap sizing is not reliable itself (with wrong free on-heap memory calculations), we are providing a new option in this patch, `spark.gluten.memory.untracked` which will completely make all native allocations untracked by Spark when being set to true.

Note the new option is only be used for similar testing or PoC purpose as well. The previous usages on `spark.gluten.memory.dynamic.offHeap.sizing.enabled` can be changed to this new option because we are fixing the existing issues on the dynamic off-heap sizing feature which may cause more OOMs reported when that feature is on.