### PR TITLE
[GLUTEN-9287][VL] Enable array_compact function for Spark 3.4+

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -182,9 +182,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       expr: ArrayFilter): ExpressionTransformer = {
     expr.function match {
       // Transformer for array_compact.
-      case LambdaFunction(function, arguments, _)
-          if function.getClass.getSimpleName.equals("IsNotNull") &&
-            function.children == arguments =>
+      case LambdaFunction(_: IsNotNull, _, _) =>
         GenericExpressionTransformer(ExpressionNames.ARRAY_COMPACT, Seq(argument), expr)
       case LambdaFunction(_, arguments, _) if arguments.size == 2 =>
         throw new GlutenNotSupportException(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -181,6 +181,11 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       function: ExpressionTransformer,
       expr: ArrayFilter): ExpressionTransformer = {
     expr.function match {
+      // Transformer for array_compact.
+      case LambdaFunction(function, arguments, _)
+          if function.getClass.getSimpleName.equals("IsNotNull") &&
+            function.children == arguments =>
+        GenericExpressionTransformer(ExpressionNames.ARRAY_COMPACT, Seq(argument), expr)
       case LambdaFunction(_, arguments, _) if arguments.size == 2 =>
         throw new GlutenNotSupportException(
           "filter on array with lambda using index argument is not supported yet")

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -196,6 +196,27 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  testWithMinSparkVersion("Test array_compact function", "3.4") {
+    withTempPath {
+      path =>
+        Seq[Array[String]](
+          Array("a", "b"),
+          Array(),
+          Array("a", "b", null.asInstanceOf[String]),
+          Array(null.asInstanceOf[String])
+        )
+          .toDF("arr")
+          .write
+          .parquet(path.getCanonicalPath)
+
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("tbl")
+
+        runQueryAndCompare("select arr, array_compact(arr, txt) from tbl") {
+          checkGlutenOperatorMatch[ProjectExecTransformer]
+        }
+    }
+  }
+
   test("Test round function") {
     runQueryAndCompare(
       "SELECT round(cast(l_orderkey as int), 2)" +

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -211,7 +211,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
 
         spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("tbl")
 
-        runQueryAndCompare("select arr, array_compact(arr, txt) from tbl") {
+        runQueryAndCompare("select arr, array_compact(arr) from tbl") {
           checkGlutenOperatorMatch[ProjectExecTransformer]
         }
     }

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -286,6 +286,7 @@ object ExpressionNames {
   final val ARRAY_PREPEND = "array_prepend"
   final val ARRAY_SIZE = "array_size"
   final val GET = "get"
+  final val ARRAY_COMPACT = "array_compact"
 
   // Map functions
   final val CREATE_MAP = "map"

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -105,6 +105,7 @@ class Spark34Shims extends SparkShims {
 
   override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
     Seq(
+      Sig[ArrayCompact](ExpressionNames.ARRAY_COMPACT),
       Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
       Sig[ILike](ExpressionNames.ILIKE),

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -109,6 +109,7 @@ class Spark35Shims extends SparkShims {
 
   override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
     Seq(
+      Sig[ArrayCompact](ExpressionNames.ARRAY_COMPACT),
       Sig[ArrayPrepend](ExpressionNames.ARRAY_PREPEND),
       Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to use the `ArrayRemoveNullFunction` in Velox to implement the Spark `array_compact` function.  

(Fixes: \#9287)

## How was this patch tested?

unit tests

