### PR TITLE
[GLUTEN][UT] Disable flaky UT from GlutenCSVv1Suite

### DIFF
--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -319,6 +319,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .excludeCH("SPARK-40496: disable parsing fallback when the date/timestamp format is provided")
     .excludeCH("SPARK-42335: Pass the comment option through to univocity if users set it explicitly in CSV dataSource")
     .excludeCH("SPARK-46862: column pruning in the multi-line mode")
+    // Flaky and already excluded in other cases
+    .exclude("Gluten - test for FAILFAST parsing mode")
+
   enableSuite[GlutenCSVv2Suite]
     .exclude("Gluten - test for FAILFAST parsing mode")
     // Rule org.apache.spark.sql.execution.datasources.v2.V2ScanRelationPushDown in batch

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -234,6 +234,9 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-27873: disabling enforceSchema should not fail columnNameOfCorruptRecord")
     // varchar
     .exclude("SPARK-48241: CSV parsing failure with char/varchar type columns")
+    // Flaky and already excluded in other cases
+    .exclude("Gluten - test for FAILFAST parsing mode")
+
   enableSuite[GlutenCSVv2Suite]
     .exclude("Gluten - test for FAILFAST parsing mode")
     // Rule org.apache.spark.sql.execution.datasources.v2.V2ScanRelationPushDown in batch


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - FAILFAST parsing mode is flaky and excluded from most settings. However still part of 3.5 GlutenCSVv1Suite.
 - Excluding the same to prevent build failures

## How was this patch tested?
 - Existing UT