### PR TITLE
[VL] Change isDistinct of distinct aggregateExpression to false

### DIFF
--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark32/16.txt
@@ -145,7 +145,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (21) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -178,7 +178,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (29) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark33/16.txt
@@ -145,7 +145,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (21) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -178,7 +178,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (29) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj-ras/spark34/16.txt
@@ -146,7 +146,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (21) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -179,7 +179,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (29) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark32/16.txt
@@ -145,7 +145,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (21) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -178,7 +178,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (29) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark33/16.txt
@@ -145,7 +145,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (21) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -178,7 +178,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (29) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-bhj/spark34/16.txt
@@ -146,7 +146,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (21) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -179,7 +179,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (29) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark32/16.txt
@@ -189,7 +189,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (30) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -222,7 +222,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (38) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark33/16.txt
@@ -189,7 +189,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (30) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -222,7 +222,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (38) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1-ras/spark34/16.txt
@@ -190,7 +190,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (30) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -223,7 +223,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (38) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark32/16.txt
@@ -189,7 +189,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (30) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -222,7 +222,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (38) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark33/16.txt
@@ -189,7 +189,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (30) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -222,7 +222,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (38) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/16.txt
+++ b/backends-velox/src/test/resources/tpch-approved-plan/v1/spark34/16.txt
@@ -190,7 +190,7 @@ Results [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 (30) FlushableHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, ps_suppkey#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [partial_count(distinct ps_suppkey#X)]
+Functions [1]: [partial_count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 
@@ -223,7 +223,7 @@ Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 (38) RegularHashAggregateExecTransformer
 Input [4]: [p_brand#X, p_type#X, p_size#X, count#X]
 Keys [3]: [p_brand#X, p_type#X, p_size#X]
-Functions [1]: [count(distinct ps_suppkey#X)]
+Functions [1]: [count(ps_suppkey#X)]
 Aggregate Attributes [1]: [count(ps_suppkey#X)#X]
 Results [4]: [p_brand#X, p_type#X, p_size#X, count(ps_suppkey#X)#X AS supplier_cnt#X]
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
@@ -193,12 +193,22 @@ object HashAggregateExecBaseTransformer {
       .genHashAggregateExecTransformer(
         agg.requiredChildDistributionExpressions,
         agg.groupingExpressions,
-        agg.aggregateExpressions,
+        agg.aggregateExpressions.map(rewriteAggregateExpression),
         agg.aggregateAttributes,
         getInitialInputBufferOffset(agg),
         agg.resultExpressions,
         agg.child
       )
+  }
+
+  // Vanilla spark will add an aggregate to remove duplicates for the distinct aggregation
+  // function, so velox does not need to process distinct.
+  def rewriteAggregateExpression(aggregateExpr: AggregateExpression): AggregateExpression = {
+    if (aggregateExpr.isDistinct) {
+      aggregateExpr.copy(isDistinct = false)
+    } else {
+      aggregateExpr
+    }
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Vanilla spark will add an aggregate to remove duplicates for the distinct aggregation function, so velox does not need to process distinct. Moreover, currently velox distinct hash aggregation does not support spill.

## How was this patch tested?

Already existing UT.


