### PR TITLE
Fix ColumnarToRowRemovalGuard not able to be copied

### DIFF
--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/MiscColumnarRulesSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/MiscColumnarRulesSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar
+
+import org.apache.gluten.extension.columnar.MiscColumnarRules.PreventBatchTypeMismatchInTableCache
+import org.apache.gluten.extension.columnar.transition.Convention
+import org.apache.gluten.extension.columnar.transition.TransitionSuite.BatchToRow
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+class MiscColumnarRulesSuite extends SharedSparkSession {
+
+  test("Fix ColumnarToRowRemovalGuard not able to be copied") {
+    val dummyPlan =
+      BatchToRow(Convention.BatchType.VanillaBatch, spark.range(1).queryExecution.sparkPlan)
+    val cloned =
+      PreventBatchTypeMismatchInTableCache(isCalledByTableCachePlaning = true, Set.empty)
+        .apply(dummyPlan)
+        .clone()
+    assert(cloned.isInstanceOf[ColumnarToRowRemovalGuard])
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a wrong constructor bug 

```
  java.lang.IllegalStateException: Failed to copy node.
Is otherCopyArgs specified correctly for ColumnarToRowRemovalGuard.
Exception message: wrong number of arguments
ctor: public org.apache.gluten.extension.columnar.MiscColumnarRules$PreventBatchTypeMismatchInTableCache$PreventColumnarTypeMismatchInTableCache$ColumnarToRowRemovalGuard(org.apache.gluten.extension.columnar.MiscColumnarRules$PreventBatchTypeMismatchInTableCache$PreventColumnarTypeMismatchInTableCache$,org.apache.spark.sql.execution.SparkPlan)?
types: class org.apache.gluten.extension.columnar.transition.TransitionSuite$BatchToRow
args: BatchToRow VanillaBatch$
+- Range (0, 1, step=1, splits=2)
  at org.apache.spark.sql.catalyst.trees.TreeNode.makeCopy(TreeNode.scala:854)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:781)
  at org.apache.spark.sql.catalyst.trees.TreeNode.clone(TreeNode.scala:860)
  at org.apache.gluten.extension.columnar.MiscColumnarRulesSuite.$anonfun$new$1(MiscColumnarRulesSuite.scala:32)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
  at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
  at org.scalatest.Transformer.apply(Transformer.scala:22)
  at org.scalatest.Transformer.apply(Transformer.scala:20)
  at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
```


## How was this patch tested?

new ut

