### PR TITLE
[VL][MINOR] Improve log level in ManagedReservationListener

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
@@ -50,7 +50,7 @@ public class ManagedReservationListener implements ReservationListener {
         sharedUsage.inc(granted);
         return granted;
       } catch (Exception e) {
-        LOG.error("Error reserving memory from target", e);
+        LOG.warn("Error reserving memory from target", e);
         throw e;
       }
     }
@@ -64,7 +64,7 @@ public class ManagedReservationListener implements ReservationListener {
         sharedUsage.inc(-freed);
         return freed;
       } catch (Exception e) {
-        LOG.error("Error unreserving memory from target", e);
+        LOG.warn("Error unreserving memory from target", e);
         throw e;
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The log in ManagedReservationListener does not record the root cause of task failure, so we should use `warn` log level.

## How was this patch tested?

minor fix

