### PR TITLE
[VL] Remove unused checks for CollectLimit support

### DIFF
--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -312,8 +312,6 @@ trait SparkShims {
 
   def isParquetFileEncrypted(fileStatus: LocatedFileStatus, conf: Configuration): Boolean
 
-  def isColumnarLimitExecSupported(): Boolean
-
   def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     Map.empty[String, Any].asJava.asInstanceOf[JMap[String, Object]]
 

--- a/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
@@ -314,6 +314,4 @@ class Spark32Shims extends SparkShims {
     }
   }
 
-  override def isColumnarLimitExecSupported(): Boolean = true
-
 }

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -402,6 +402,4 @@ class Spark33Shims extends SparkShims {
     }
   }
 
-  override def isColumnarLimitExecSupported(): Boolean = true
-
 }

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -628,8 +628,6 @@ class Spark34Shims extends SparkShims {
     }
   }
 
-  override def isColumnarLimitExecSupported(): Boolean = true
-
   override def getCollectLimitOffset(plan: CollectLimitExec): Int = {
     plan.offset
   }

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -684,8 +684,6 @@ class Spark35Shims extends SparkShims {
     }
   }
 
-  override def isColumnarLimitExecSupported(): Boolean = true
-
   override def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     file.otherConstantMetadataColumnValues.asJava.asInstanceOf[JMap[String, Object]]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
  - We now support all backends for ColumnarCollectLimit.
  - Remove unused `isColumnarLimitExecSupported` in shim layer.

## How was this patch tested?
 - Existing UTs
