### PR TITLE
[VL] Refactor the HiveConfig to set once

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -287,35 +287,6 @@ void VeloxBackend::initConnector() {
   std::unordered_map<std::string, std::string> connectorConfMap = backendConf_->rawConfigs();
 
   auto hiveConf = getHiveConfig(backendConf_);
-  for (auto& [k, v] : hiveConf->rawConfigsCopy()) {
-    connectorConfMap[k] = v;
-  }
-
-  connectorConfMap[velox::connector::hive::HiveConfig::kEnableFileHandleCache] =
-      backendConf_->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false";
-
-  connectorConfMap[velox::connector::hive::HiveConfig::kMaxCoalescedBytes] =
-      backendConf_->get<std::string>(kMaxCoalescedBytes, "67108864"); // 64M
-  connectorConfMap[velox::connector::hive::HiveConfig::kMaxCoalescedDistance] =
-      backendConf_->get<std::string>(kMaxCoalescedDistance, "512KB"); // 512KB
-  connectorConfMap[velox::connector::hive::HiveConfig::kPrefetchRowGroups] =
-      backendConf_->get<std::string>(kPrefetchRowGroups, "1");
-  connectorConfMap[velox::connector::hive::HiveConfig::kLoadQuantum] =
-      backendConf_->get<std::string>(kLoadQuantum, "268435456"); // 256M
-  connectorConfMap[velox::connector::hive::HiveConfig::kFooterEstimatedSize] =
-      backendConf_->get<std::string>(kDirectorySizeGuess, "32768"); // 32K
-  connectorConfMap[velox::connector::hive::HiveConfig::kFilePreloadThreshold] =
-      backendConf_->get<std::string>(kFilePreloadThreshold, "1048576"); // 1M
-
-  // read as UTC
-  connectorConfMap[velox::connector::hive::HiveConfig::kReadTimestampPartitionValueAsLocalTime] = "false";
-
-  // Maps table field names to file field names using names, not indices.
-  connectorConfMap[velox::connector::hive::HiveConfig::kParquetUseColumnNames] = "true";
-  connectorConfMap[velox::connector::hive::HiveConfig::kOrcUseColumnNames] = "true";
-
-  // set cache_prefetch_min_pct default as 0 to force all loads are prefetched in DirectBufferInput.
-  FLAGS_cache_prefetch_min_pct = backendConf_->get<int>(kCachePrefetchMinPct, 0);
 
   auto ioThreads = backendConf_->get<int32_t>(kVeloxIOThreads, kVeloxIOThreadsDefault);
   GLUTEN_CHECK(

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -37,7 +37,6 @@
 DECLARE_bool(velox_exception_user_stacktrace_enabled);
 DECLARE_bool(velox_memory_use_hugepages);
 DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
-DECLARE_int32(cache_prefetch_min_pct);
 
 #ifdef ENABLE_HDFS
 #include "operators/writer/VeloxParquetDataSourceHDFS.h"
@@ -75,7 +74,6 @@ VeloxRuntime::VeloxRuntime(
   FLAGS_velox_exception_system_stacktrace_enabled =
       veloxCfg_->get<bool>(kEnableSystemExceptionStacktrace, FLAGS_velox_exception_system_stacktrace_enabled);
   FLAGS_velox_memory_use_hugepages = veloxCfg_->get<bool>(kMemoryUseHugePages, FLAGS_velox_memory_use_hugepages);
-  FLAGS_cache_prefetch_min_pct = veloxCfg_->get<bool>(kCachePrefetchMinPct, FLAGS_cache_prefetch_min_pct);
   FLAGS_velox_memory_pool_capacity_transfer_across_tasks = veloxCfg_->get<bool>(
       kMemoryPoolCapacityTransferAcrossTasks, FLAGS_velox_memory_pool_capacity_transfer_across_tasks);
 }

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -139,6 +139,8 @@ const std::string kMemoryPoolCapacityTransferAcrossTasks =
 
 // write fies
 const std::string kMaxPartitions = "spark.gluten.sql.columnar.backend.velox.maxPartitionsPerWritersSession";
+const std::string kVeloxFileHandleCacheEnabled = "spark.gluten.sql.columnar.backend.velox.fileHandleCacheEnabled";
+const bool kVeloxFileHandleCacheEnabledDefault = false;
 
 const std::string kGlogVerboseLevel = "spark.gluten.sql.columnar.backend.velox.glogVerboseLevel";
 const uint32_t kGlogVerboseLevelDefault = 0;

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -20,15 +20,10 @@
 #include "ConfigExtractor.h"
 #include <stdexcept>
 
+#include "config/VeloxConfig.h"
 #include "utils/Exception.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
-
-namespace {
-
-const std::string kVeloxFileHandleCacheEnabled = "spark.gluten.sql.columnar.backend.velox.fileHandleCacheEnabled";
-const bool kVeloxFileHandleCacheEnabledDefault = false;
-} // namespace
 
 namespace gluten {
 
@@ -221,6 +216,28 @@ std::shared_ptr<facebook::velox::config::ConfigBase> getHiveConfig(
 
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kEnableFileHandleCache] =
       conf->get<bool>(kVeloxFileHandleCacheEnabled, kVeloxFileHandleCacheEnabledDefault) ? "true" : "false";
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kMaxCoalescedBytes] =
+      conf->get<std::string>(kMaxCoalescedBytes, "67108864"); // 64M
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kMaxCoalescedDistance] =
+      conf->get<std::string>(kMaxCoalescedDistance, "512KB"); // 512KB
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kPrefetchRowGroups] =
+      conf->get<std::string>(kPrefetchRowGroups, "1");
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kLoadQuantum] =
+      conf->get<std::string>(kLoadQuantum, "268435456"); // 256M
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kFooterEstimatedSize] =
+      conf->get<std::string>(kDirectorySizeGuess, "32768"); // 32K
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kFilePreloadThreshold] =
+      conf->get<std::string>(kFilePreloadThreshold, "1048576"); // 1M
+
+  // read as UTC
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kReadTimestampPartitionValueAsLocalTime] = "false";
+
+  // Maps table field names to file field names using names, not indices.
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kParquetUseColumnNames] = "true";
+  hiveConfMap[facebook::velox::connector::hive::HiveConfig::kOrcUseColumnNames] = "true";
+
+  // set cache_prefetch_min_pct default as 0 to force all loads are prefetched in DirectBufferInput.
+  FLAGS_cache_prefetch_min_pct = conf->get<int>(kCachePrefetchMinPct, 0);
 
   return std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfMap));
 }


### PR DESCRIPTION
The getHiveConfig is extracted to get data source config, but it's not certain which config should be used or will be used in data source, furthermore, Iceberg write need a HiveConfig too.
Remove cache_prefetch_min_pct from VeloxRuntime because it is a static config.