### PR TITLE
[VL] Fix Hudi scan fallback

### DIFF
--- a/gluten-hudi/src/main/scala/org/apache/gluten/execution/HudiScanTransformer.scala
+++ b/gluten-hudi/src/main/scala/org/apache/gluten/execution/HudiScanTransformer.scala
@@ -102,6 +102,6 @@ object HudiScanTransformer {
     // "org.apache.spark.sql.execution.datasources.parquet.HoodieParquetFileFormat"
     // But exclude "NewHoodieParquetFileFormat"
     !fileFormatName.endsWith("NewHoodieParquetFileFormat") &&
-      fileFormatName.endsWith("HoodieParquetFileFormat")
+    fileFormatName.endsWith("HoodieParquetFileFormat")
   }
 }

--- a/gluten-hudi/src/main/scala/org/apache/gluten/execution/HudiScanTransformer.scala
+++ b/gluten-hudi/src/main/scala/org/apache/gluten/execution/HudiScanTransformer.scala
@@ -90,4 +90,17 @@ object HudiScanTransformer {
       scanExec.disableBucketedScan
     )
   }
+
+  /**
+   * Check if the Hudi file format is supported for native engine execution.
+   *
+   * If not, Gluten will fall back to Spark execution.
+   */
+  def isSupportedHudiFileFormat(fileFormatName: String): Boolean = {
+    // Support formats like:
+    // "org.apache.spark.sql.execution.datasources.parquet.Spark35LegacyHoodieParquetFileFormat"
+    // "org.apache.spark.sql.execution.datasources.parquet.HoodieParquetFileFormat"
+    // But exclude "NewHoodieParquetFileFormat"
+    !fileFormatName.endsWith("NewHoodieParquetFileFormat") && fileFormatName.endsWith("HoodieParquetFileFormat")
+  }
 }

--- a/gluten-hudi/src/main/scala/org/apache/gluten/execution/HudiScanTransformer.scala
+++ b/gluten-hudi/src/main/scala/org/apache/gluten/execution/HudiScanTransformer.scala
@@ -101,6 +101,7 @@ object HudiScanTransformer {
     // "org.apache.spark.sql.execution.datasources.parquet.Spark35LegacyHoodieParquetFileFormat"
     // "org.apache.spark.sql.execution.datasources.parquet.HoodieParquetFileFormat"
     // But exclude "NewHoodieParquetFileFormat"
-    !fileFormatName.endsWith("NewHoodieParquetFileFormat") && fileFormatName.endsWith("HoodieParquetFileFormat")
+    !fileFormatName.endsWith("NewHoodieParquetFileFormat") &&
+      fileFormatName.endsWith("HoodieParquetFileFormat")
   }
 }

--- a/gluten-hudi/src/main/scala/org/apache/gluten/execution/OffloadHudiScan.scala
+++ b/gluten-hudi/src/main/scala/org/apache/gluten/execution/OffloadHudiScan.scala
@@ -24,9 +24,9 @@ import org.apache.spark.sql.execution.SparkPlan
 case class OffloadHudiScan() extends OffloadSingleNode {
   override def offload(plan: SparkPlan): SparkPlan = {
     plan match {
-      // Hudi has multiple file format definitions whose names end with "HoodieParquetFileFormat".
       case scan: org.apache.spark.sql.execution.FileSourceScanExec
-          if scan.relation.fileFormat.getClass.getName.endsWith("HoodieParquetFileFormat") =>
+          if HudiScanTransformer.isSupportedHudiFileFormat(
+            scan.relation.fileFormat.getClass.getName) =>
         HudiScanTransformer(scan)
       case other => other
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When file format is `NewHoodieParquetFileFormat`, the condition was matched and the plan was passed to velox for execution. But the result wasn't correct - merging wasn't performed, only parquet records were returned.

We should fallback to spark for `NewHoodieParquetFileFormat`

## How was this patch tested?

Manual tests.


