### PR TITLE
[GLUTEN-9383][VL] Fix leak when growing capacity

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -168,7 +168,13 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
     }
     auto reclaimedFreeBytes = shrinkPool(pool, 0);
     auto neededBytes = velox::bits::roundUp(bytes - reclaimedFreeBytes, memoryPoolTransferCapacity_);
-    listener_->allocationChanged(neededBytes);
+    try {
+      listener_->allocationChanged(neededBytes);
+    } catch (const std::exception& e) {
+      // if allocationChanged failed, we need to free the reclaimed bytes
+      listener_->allocationChanged(-reclaimedFreeBytes);
+      throw e;
+    }
     auto ret = growPool(pool, reclaimedFreeBytes + neededBytes, bytes);
     VELOX_CHECK(
         ret,


### PR DESCRIPTION
## What changes were proposed in this pull request?

When allocationChanged fails in growCapacity, we should free reclaimed bytes

Fixes: #9383

## How was this patch tested?

After this repair, the failed job of #9383 succeeded

