### PR TITLE
[GLUTEN-9435][VL] Fix [Unsafe]ColumnarBuildSideRelation not found ResourceHandle in resource map

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
@@ -23,7 +23,7 @@ import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.ArrowAbiUtil
-import org.apache.gluten.vectorized.{ColumnarBatchSerializerJniWrapper, NativeColumnarToRowJniWrapper}
+import org.apache.gluten.vectorized.{ColumnarBatchSerializerJniWrapper, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper}
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.internal.Logging
@@ -260,27 +260,32 @@ case class UnsafeColumnarBuildSideRelation(
           } else {
             val cols = batch.numCols()
             val rows = batch.numRows()
-            var info =
-              jniWrapper.nativeColumnarToRowConvert(
-                c2rId,
-                ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, batch),
-                0)
-            batch.close()
+            var info: NativeColumnarToRowInfo = null
 
             new Iterator[InternalRow] {
               var rowId = 0
               var baseLength = 0
               val row = new UnsafeRow(cols)
+              var closed = false
 
               override def hasNext: Boolean = {
-                rowId < rows
+                val hasNext = rowId < rows
+                if (!hasNext && !closed) {
+                  batch.close()
+                  closed = true
+                }
+                hasNext
               }
 
               override def next: UnsafeRow = {
                 if (rowId >= rows) throw new NoSuchElementException
-                if (rowId == baseLength + info.lengths.length) {
-                  baseLength += info.lengths.length
-                  info = jniWrapper.nativeColumnarToRowConvert(batchHandle, c2rId, rowId)
+                if (rowId == 0 || rowId == baseLength + info.lengths.length) {
+                  baseLength = if (info == null) {
+                    baseLength
+                  } else {
+                    baseLength + info.lengths.length
+                  }
+                  info = jniWrapper.nativeColumnarToRowConvert(c2rId, batchHandle, rowId)
                 }
                 val (offset, length) =
                   (info.offsets(rowId - baseLength), info.lengths(rowId - baseLength))

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxHashJoinSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxHashJoinSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.VeloxConfig
+import org.apache.gluten.config.{GlutenConfig, VeloxConfig}
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
@@ -150,6 +150,40 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
             assert(collect(df.queryExecution.executedPlan) {
               case r @ ReusedExchangeExec(_, _: ColumnarBroadcastExchangeExec) => r
             }.size == 1)
+          }
+        })
+  }
+
+  test("ColumnarBuildSideRelation with small columnar to row memory") {
+    Seq("true", "false").foreach(
+      enabledOffheapBroadcast =>
+        withSQLConf(
+          (GlutenConfig.GLUTEN_COLUMNAR_TO_ROW_MEM_THRESHOLD.key -> "16"),
+          (VeloxConfig.VELOX_BROADCAST_BUILD_RELATION_USE_OFFHEAP.key -> enabledOffheapBroadcast)) {
+          withTable("t1", "t2") {
+            spark.sql("""
+                        |CREATE TABLE t1 USING PARQUET
+                        |AS SELECT id as c1, id as c2 FROM range(10)
+                        |""".stripMargin)
+
+            spark.sql("""
+                        |CREATE TABLE t2 USING PARQUET PARTITIONED BY (c1)
+                        |AS SELECT id as c1, id as c2 FROM range(30)
+                        |""".stripMargin)
+
+            val df = spark.sql("""
+                                 |SELECT t1.c2
+                                 |FROM t1, t2
+                                 |WHERE t1.c1 = t2.c1
+                                 |AND t1.c2 < 4
+                                 |""".stripMargin)
+
+            checkAnswer(df, Row(0) :: Row(1) :: Row(2) :: Row(3) :: Nil)
+
+            val subqueryBroadcastExecs = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case subqueryBroadcast: ColumnarSubqueryBroadcastExec => subqueryBroadcast
+            }
+            assert(subqueryBroadcastExecs.size == 1)
           }
         })
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `ColumnarBuildSideRelation\UnsafeColumnarBuildSideRelation` calls `NativeColumnarToRowJniWrapper#nativeColumnarToRowConvert`, the `c2rId` and `batchHandle` parameters are passed in the wrong order.

(Fixes: \#9435)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

