### PR TITLE
[VL][CI] Upgrade ubuntu runner to fix weekly build error

### DIFF
--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         os: [ "centos:7", "centos:8", "quay.io/centos/centos:stream9" ]
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ${{ matrix.os }}
     steps:
       - name: Update mirror list
@@ -81,7 +81,7 @@ jobs:
       matrix:
         os: [ "ubuntu:20.04", "ubuntu:22.04" ]
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix: This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. 


