### PR TITLE
[VL] Remove CollectLimit dependency from Offload Rules

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -27,7 +27,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.CollectLimitExec
 import org.apache.spark.sql.execution.RDDScanTransformer
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec
@@ -343,14 +342,6 @@ object OffloadOthers {
             plan.withReplacement,
             plan.seed,
             child)
-        case plan: CollectLimitExec =>
-          logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-          val offset = SparkShimLoader.getSparkShims.getCollectLimitOffset(plan)
-          BackendsApiManager.getSparkPlanExecApiInstance.genColumnarCollectLimitExec(
-            plan.limit,
-            plan.child,
-            offset
-          )
         case plan: RDDScanExec if RDDScanTransformer.isSupportRDDScanExec(plan) =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           RDDScanTransformer.getRDDScanTransform(plan)


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - In #8914 we moved to post transform rules to allow correct C2C transition for CollectLimit.
 - With this change we don't need to covert the plan through offload rules, since post transform handles it.
 - Removing the same.
 
## How was this patch tested?
 - Existing UTs