### PR TITLE
[VL] Add additional logging for unclosed objects when the native runtime is being destroyed

### DIFF
--- a/cpp/core/utils/ObjectStore.cc
+++ b/cpp/core/utils/ObjectStore.cc
@@ -29,17 +29,19 @@ gluten::ObjectStore::~ObjectStore() {
   // destructing in reversed order (the last added object destructed first)
   const std::lock_guard<std::mutex> lock(mtx_);
   for (auto itr = aliveObjects_.rbegin(); itr != aliveObjects_.rend(); itr++) {
-    ResourceHandle handle = *itr;
+    const ResourceHandle handle = (*itr).first;
+    const std::string_view description = (*itr).second;
+    VLOG(2)
+        << "Unclosed object ["
+        << "Store ID: " << storeId_ << ", Resource handle ID: " << handle
+        << ", Description: " << description
+        << "] is found when object store is closing. Gluten will"
+           " destroy it automatically but it's recommended to manually close"
+           " the object through the Java closing API after use,"
+           " to minimize peak memory pressure of the application.";
     store_.erase(handle);
   }
   stores().erase(storeId_);
-}
-
-gluten::ObjectHandle gluten::ObjectStore::save(std::shared_ptr<void> obj) {
-  const std::lock_guard<std::mutex> lock(mtx_);
-  ResourceHandle handle = store_.insert(std::move(obj));
-  aliveObjects_.insert(handle);
-  return toObjHandle(handle);
 }
 
 void gluten::ObjectStore::releaseInternal(gluten::ResourceHandle handle) {

--- a/cpp/core/utils/ObjectStore.cc
+++ b/cpp/core/utils/ObjectStore.cc
@@ -31,14 +31,12 @@ gluten::ObjectStore::~ObjectStore() {
   for (auto itr = aliveObjects_.rbegin(); itr != aliveObjects_.rend(); itr++) {
     const ResourceHandle handle = (*itr).first;
     const std::string_view description = (*itr).second;
-    VLOG(2)
-        << "Unclosed object ["
-        << "Store ID: " << storeId_ << ", Resource handle ID: " << handle
-        << ", Description: " << description
-        << "] is found when object store is closing. Gluten will"
-           " destroy it automatically but it's recommended to manually close"
-           " the object through the Java closing API after use,"
-           " to minimize peak memory pressure of the application.";
+    VLOG(2) << "Unclosed object ["
+            << "Store ID: " << storeId_ << ", Resource handle ID: " << handle << ", Description: " << description
+            << "] is found when object store is closing. Gluten will"
+               " destroy it automatically but it's recommended to manually close"
+               " the object through the Java closing API after use,"
+               " to minimize peak memory pressure of the application.";
     store_.erase(handle);
   }
   stores().erase(storeId_);

--- a/cpp/core/utils/ObjectStore.h
+++ b/cpp/core/utils/ObjectStore.h
@@ -71,7 +71,7 @@ class ObjectStore {
   }
 
   template <typename T>
- ObjectHandle save(std::shared_ptr<T> obj) {
+  ObjectHandle save(std::shared_ptr<T> obj) {
     const std::lock_guard<std::mutex> lock(mtx_);
     const std::string_view description = typeid(T).name();
     ResourceHandle handle = store_.insert(std::move(obj));


### PR DESCRIPTION
The change is ported from https://github.com/velox4j/velox4j/pull/152.

The log message is like:

```
I20250428 16:15:48.877297 446254 ObjectStore.cc:34] Unclosed object [Store ID: 4, Resource handle ID: 4, Description: i] is found when object store is closing. Gluten will destroy it automatically but it's recommended to manually close the object through the Java closing API after use, to minimize peak memory pressure of the application.
```

The log is on verbose level 2.

In the future, addressing the unclosed objects in code following the messages in logs may reduce the peak off-heap memory usage of Gluten.

