### PR TITLE
[GLUTEN-8851][VL] Use separate debug config for cudf

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -161,7 +161,7 @@ void VeloxBackend::init(
 #endif
 
 #ifdef GLUTEN_ENABLE_GPU
-  FLAGS_velox_cudf_debug = backendConf_->get<bool>(kDebugModeEnabled, false);
+  FLAGS_velox_cudf_debug = backendConf_->get<bool>(kDebugCudf, kDebugCudfDefault);
   if (backendConf_->get<bool>(kCudfEnabled, kCudfEnabledDefault)) {
     velox::cudf_velox::registerCudf();
   }

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -150,6 +150,8 @@ const uint32_t kGlogSeverityLevelDefault = 1;
 #ifdef GLUTEN_ENABLE_GPU
 const std::string kCudfEnabled = "spark.gluten.sql.columnar.cudf";
 const bool kCudfEnabledDefault = "false";
+const std::string kDebugCudf = "spark.gluten.sql.debug.cudf";
+const bool kDebugCudfDefault = "false";
 #endif
 
 // Query trace

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -1388,6 +1388,12 @@ object GlutenConfig {
       .stringConf
       .createWithDefault("/tmp")
 
+  val DEBUG_CUDF =
+    buildStaticConf("spark.gluten.sql.debug.cudf")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val UT_STATISTIC =
     buildStaticConf("spark.gluten.sql.ut.statistic")
       .internal()


### PR DESCRIPTION
This config is used to print cudf operator information.
```
Calling CudfHashJoinBridgeTranslator::toOperatorSupplierCalling CudfHashJoinBridgeTranslator::toOperatorSupplier

Calling CudfHashJoinBridgeTranslator::toJoinBridge
Calling CudfHashJoinBridgeTranslator::toJoinBridge
Calling CudfHashJoinBridgeTranslator::toJoinBridge
Calling CudfHashJoinBridgeTranslator::toJoinBridge
Operators before adapting for cuDF: count [2]
  Operator: ID 0: TableScan[0] 0
  Operator: ID 1: FilterProject[1] 1
Operators after adapting for cuDF: count [4]
  Operator: ID 0: TableScan[0] 0
  Operator: ID 1: CudfFromVelox[1-from-velox] 1
  Operator: ID 2: CudfFilterProject[1] 2
  Operator: ID 3: CudfToVelox[1-to-velox] 3

```