### PR TITLE
[GLUTEN-8227][VL] fix: Update sort elimination rules for Hash Aggregate

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -159,7 +159,8 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
       aggregateAttributes: Seq[Attribute],
       initialInputBufferOffset: Int,
       resultExpressions: Seq[NamedExpression],
-      child: SparkPlan): HashAggregateExecBaseTransformer = {
+      child: SparkPlan,
+      offloadedSortExec: Boolean = false): HashAggregateExecBaseTransformer = {
     val replacedResultExpressions = CHHashAggregateExecTransformer.getCHAggregateResultExpressions(
       groupingExpressions,
       aggregateExpressions,

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -343,7 +343,31 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       aggregateAttributes,
       initialInputBufferOffset,
       resultExpressions,
-      child)
+      child,
+      offloadedSortExec: Boolean = false): HashAggregateExecBaseTransformer =
+    if (offloadedSortExec) {
+      OffloadedSortHashAggregateExecTransformer(
+        requiredChildDistributionExpressions,
+        groupingExpressions,
+        aggregateExpressions,
+        aggregateAttributes,
+        initialInputBufferOffset,
+        resultExpressions,
+        child,
+        false
+      )
+    } else {
+      RegularHashAggregateExecTransformer(
+        requiredChildDistributionExpressions,
+        groupingExpressions,
+        aggregateExpressions,
+        aggregateAttributes,
+        initialInputBufferOffset,
+        resultExpressions,
+        child,
+        false
+      )
+    }
 
   /** Generate HashAggregateExecPullOutHelper */
   override def genHashAggregateExecPullOutHelper(

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -716,6 +716,46 @@ case class RegularHashAggregateExecTransformer(
     ignoreNullKeys
   ) {
 
+  override def isOffloadedSortExec: Boolean = false
+
+  override protected def allowFlush: Boolean = false
+
+  override def simpleString(maxFields: Int): String =
+    s"${super.simpleString(maxFields)}"
+
+  override def verboseString(maxFields: Int): String =
+    s"${super.verboseString(maxFields)}"
+
+  override protected def withNewChildInternal(newChild: SparkPlan): HashAggregateExecTransformer = {
+    copy(child = newChild)
+  }
+}
+
+// Hash aggregation that is offloaded from sort aggregation.
+// Is identical to RegularHashAggregateExecTransformer but with a 
+// different value of isOffloadedSortExec.
+case class OffloadedSortHashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan,
+    ignoreNullKeys: Boolean = false)
+  extends HashAggregateExecTransformer(
+    requiredChildDistributionExpressions,
+    groupingExpressions,
+    aggregateExpressions,
+    aggregateAttributes,
+    initialInputBufferOffset,
+    resultExpressions,
+    child,
+    ignoreNullKeys
+  ) {
+
+  override def isOffloadedSortExec: Boolean = true
+
   override protected def allowFlush: Boolean = false
 
   override def simpleString(maxFields: Int): String =

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
@@ -83,12 +83,25 @@ case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkP
   }
 
   private def replaceEligibleAggregates(plan: SparkPlan)(
-      func: RegularHashAggregateExecTransformer => SparkPlan): SparkPlan = {
+      func: HashAggregateExecTransformer => SparkPlan): SparkPlan = {
     def transformDown: SparkPlan => SparkPlan = {
       case agg: RegularHashAggregateExecTransformer
           if !agg.aggregateExpressions.forall(p => p.mode == Partial || p.mode == PartialMerge) =>
         // Not a intermediate agg. Skip.
         agg
+      case agg: RegularHashAggregateExecTransformer
+          if isAggInputAlreadyDistributedWithAggKeys(agg) =>
+        // Data already grouped by aggregate keys, Skip.
+        agg
+      case agg: RegularHashAggregateExecTransformer
+          if aggregatesNotSupportFlush(agg.aggregateExpressions) =>
+        agg
+      case agg: RegularHashAggregateExecTransformer =>
+        func(agg)
+      case agg: RegularHashAggregateExecTransformer
+        if !agg.aggregateExpressions.forall(p => p.mode == Partial || p.mode == PartialMerge) =>
+      // Not a intermediate agg. Skip.
+      agg
       case agg: RegularHashAggregateExecTransformer
           if isAggInputAlreadyDistributedWithAggKeys(agg) =>
         // Data already grouped by aggregate keys, Skip.

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -1215,6 +1215,34 @@ class VeloxAggregateFunctionsDefaultSuite extends VeloxAggregateFunctionsSuite {
       }
     }
   }
+
+  test("test collect_list with ordering") {
+    withTempView("t1") {
+      Seq((2, "d"), (2, "e"), (2, "f"), (1, "b"), (1, "a"), (1, "c"), (3, "i"), (3, "h"), (3, "g"))
+        .toDF("id", "value")
+        .createOrReplaceTempView("t1")
+      runQueryAndCompare("""
+                           | SELECT 1 - id, collect_list(value) AS values_list
+                           |        FROM (
+                           |        select * from
+                           |        (SELECT id, value
+                           |          FROM t1
+                           |          DISTRIBUTE BY rand())
+                           |          DISTRIBUTE BY id sort by id,value
+                           |        ) t
+                           |        GROUP BY 1
+                           |""".stripMargin) {
+        df =>
+          {
+            assert(
+              getExecutedPlan(df).count(
+                plan => {
+                  plan.isInstanceOf[OffloadedSortHashAggregateExecTransformer]
+                }) == 2)
+          }
+      }
+    }
+  }
 }
 
 class VeloxAggregateFunctionsFlushSuite extends VeloxAggregateFunctionsSuite {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -78,7 +78,8 @@ trait SparkPlanExecApi {
       aggregateAttributes: Seq[Attribute],
       initialInputBufferOffset: Int,
       resultExpressions: Seq[NamedExpression],
-      child: SparkPlan): HashAggregateExecBaseTransformer
+      child: SparkPlan,
+      offloadedSortExec: Boolean = false): HashAggregateExecBaseTransformer
 
   /** Generate HashAggregateExecPullOutHelper */
   def genHashAggregateExecPullOutHelper(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
@@ -45,6 +45,8 @@ abstract class HashAggregateExecBaseTransformer(
   extends BaseAggregateExec
   with UnaryTransformSupport {
 
+  def isOffloadedSortExec: Boolean = false
+
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
       aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
@@ -188,7 +190,9 @@ object HashAggregateExecBaseTransformer {
     case a: SortAggregateExec => a.initialInputBufferOffset
   }
 
-  def from(agg: BaseAggregateExec): HashAggregateExecBaseTransformer = {
+  def from(
+      agg: BaseAggregateExec,
+      offloadedSortExec: Boolean = false): HashAggregateExecBaseTransformer = {
     BackendsApiManager.getSparkPlanExecApiInstance
       .genHashAggregateExecTransformer(
         agg.requiredChildDistributionExpressions,
@@ -197,7 +201,8 @@ object HashAggregateExecBaseTransformer {
         agg.aggregateAttributes,
         getInitialInputBufferOffset(agg),
         agg.resultExpressions,
-        agg.child
+        agg.child,
+        offloadedSortExec
       )
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EliminateLocalSort.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EliminateLocalSort.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.{ProjectExec, SortExec, SparkPlan, UnaryEx
  */
 object EliminateLocalSort extends Rule[SparkPlan] {
   private def canEliminateLocalSort(p: SparkPlan): Boolean = p match {
-    case _: HashAggregateExecBaseTransformer => true
+    case h: HashAggregateExecBaseTransformer => h.isOffloadedSortExec
     case _: ShuffledHashJoinExecTransformerBase => true
     case _: WindowGroupLimitExecTransformer => true
     case _: WindowExecTransformer => true

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RemoveSort.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RemoveSort.scala
@@ -37,15 +37,19 @@ object RemoveSort extends RasRule[SparkPlan] {
 
   override def shift(node: SparkPlan): Iterable[SparkPlan] = {
     assert(node.isInstanceOf[GlutenPlan])
-    val newChildren = node.requiredChildOrdering.zip(node.children).map {
-      case (Nil, sort: SortExecTransformer) =>
-        // Parent doesn't ask for sorted input from this child but a sort op was somehow added.
-        // Remove it.
-        sort.child
-      case (req, child) =>
-        // Parent asks for sorted input from this child. Do nothing but an assertion.
-        assert(SortOrder.orderingSatisfies(child.outputOrdering, req))
-        child
+    val newChildren = node match {
+      case h: HashAggregateExecBaseTransformer if h.isOffloadedSortExec =>
+        node.requiredChildOrdering.zip(node.children).map {
+          case (Nil, sort: SortExecTransformer) =>
+            // Parent doesn't ask for sorted input from this child but a sort op was somehow added.
+            // Remove it.
+            sort.child
+          case (req, child) =>
+            // Parent asks for sorted input from this child. Do nothing but an assertion.
+            assert(SortOrder.orderingSatisfies(child.outputOrdering, req))
+            child
+        }
+      case _ => return List(node) // Return the node as is if no match occurs
     }
     val out = List(node.withNewChildren(newChildren))
     out

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -221,7 +221,7 @@ object OffloadOthers {
           HashAggregateExecBaseTransformer.from(plan)
         case plan: SortAggregateExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-          HashAggregateExecBaseTransformer.from(plan)
+          HashAggregateExecBaseTransformer.from(plan, true)
         case plan: ObjectHashAggregateExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           HashAggregateExecBaseTransformer.from(plan)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update sort elimination rules for hash aggregate only when the base aggregate was a sort aggregate. Only if a sort aggregate is transformed into a hash aggregate, can we safely assume that the aggregation does not depend on input order 


(Part of fix for: \#8227)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


