### PR TITLE
[branch-1.4][VL] Fix docker image name for 1.4 branch

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -18,7 +18,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - main
+      - branch-1.4
     paths:
       - '.github/workflows/docker_image.yml'
       - '.github/workflows/util/install_spark_resources.sh'
@@ -57,7 +57,7 @@ jobs:
           context: .
           file: dev/docker/Dockerfile.centos7-static-build
           push: true
-          tags: ${{ env.DOCKERHUB_REPO }}:vcpkg-centos-7
+          tags: ${{ env.DOCKERHUB_REPO }}:1.4-vcpkg-centos-7
 
   build-vcpkg-centos-8:
     if: ${{ startsWith(github.repository, 'apache/') }}
@@ -75,7 +75,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_REPO }}
-          tags: vcpkg-centos-8
+          tags: 1.4-vcpkg-centos-8
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -125,7 +125,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_REPO }}
-          tags: centos-8-jdk8
+          tags: 1.4-centos-8-jdk8
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -175,7 +175,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_REPO }}
-          tags: centos-8-jdk11
+          tags: 1.4-centos-8-jdk11
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -225,7 +225,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_REPO }}
-          tags: centos-8-jdk17
+          tags: 1.4-centos-8-jdk17
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding "1.4" to docker image name used in branch-1.4, so the changes in main branch does not impact the branch-1.4

A follow-up patch will modify the CI to use the right docker

## How was this patch tested?

no tests required

