### PR TITLE
Fix the backends-velox/src-xxx code style missed

### DIFF
--- a/backends-velox/src-delta/main/scala/org/apache/gluten/component/VeloxDeltaComponent.scala
+++ b/backends-velox/src-delta/main/scala/org/apache/gluten/component/VeloxDeltaComponent.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.gluten.component
 
 import org.apache.gluten.backendsapi.velox.VeloxBackend
@@ -24,6 +23,7 @@ import org.apache.gluten.extension.columnar.enumerated.RasOffload
 import org.apache.gluten.extension.columnar.heuristic.HeuristicTransform
 import org.apache.gluten.extension.columnar.validator.Validators
 import org.apache.gluten.extension.injector.Injector
+
 import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec}
 
 class VeloxDeltaComponent extends Component {
@@ -43,7 +43,8 @@ class VeloxDeltaComponent extends Component {
     val offloads: Seq[RasOffload] = Seq(
       RasOffload.from[FileSourceScanExec](OffloadDeltaScan()),
       RasOffload.from[ProjectExec](OffloadDeltaProject()),
-      RasOffload.from[FilterExec](OffloadDeltaFilter()))
+      RasOffload.from[FilterExec](OffloadDeltaFilter())
+    )
     offloads.foreach(
       offload =>
         ras.injectRasRule(

--- a/backends-velox/src-hudi/main/scala/org/apache/gluten/component/VeloxHudiComponent.scala
+++ b/backends-velox/src-hudi/main/scala/org/apache/gluten/component/VeloxHudiComponent.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.gluten.component
 
 import org.apache.gluten.backendsapi.velox.VeloxBackend

--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/component/VeloxIcebergComponent.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/component/VeloxIcebergComponent.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.gluten.component
 import org.apache.gluten.backendsapi.velox.VeloxBackend
 import org.apache.gluten.execution.OffloadIcebergScan

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/TestConfUtil.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/TestConfUtil.java
@@ -16,16 +16,16 @@
  */
 package org.apache.gluten.spark34;
 
-
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
 public class TestConfUtil {
-    public static Map<String, Object> GLUTEN_CONF = ImmutableMap.of(
-            "spark.plugins", "org.apache.gluten.GlutenPlugin",
-            "spark.memory.offHeap.enabled", "true",
-            "spark.memory.offHeap.size", "1024MB",
-            "spark.ui.enabled", "false",
-            "spark.gluten.ui.enabled", "false");
+  public static Map<String, Object> GLUTEN_CONF =
+      ImmutableMap.of(
+          "spark.plugins", "org.apache.gluten.GlutenPlugin",
+          "spark.memory.offHeap.enabled", "true",
+          "spark.memory.offHeap.size", "1024MB",
+          "spark.ui.enabled", "false",
+          "spark.gluten.ui.enabled", "false");
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/execution/TestTPCHStoragePartitionedJoins.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/execution/TestTPCHStoragePartitionedJoins.java
@@ -16,9 +16,9 @@
  */
 package org.apache.gluten.spark34.execution;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.gluten.config.GlutenConfig;
-import org.apache.gluten.utils.Arm;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -31,7 +31,6 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import scala.io.Source;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,176 +41,210 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTPCHStoragePartitionedJoins extends SparkTestBaseWithCatalog {
-    protected String rootPath = this.getClass().getResource("/").getPath();
-    protected String tpchBasePath = rootPath + "../../../src/test/resources";
+  protected String rootPath = this.getClass().getResource("/").getPath();
+  protected String tpchBasePath = rootPath + "../../../src/test/resources";
 
-    protected String tpchQueries = rootPath + "../../../../tools/gluten-it/common/src/main/resources/tpch-queries";
+  protected String tpchQueries =
+      rootPath + "../../../../tools/gluten-it/common/src/main/resources/tpch-queries";
 
-    // open file cost and split size are set as 16 MB to produce a split per file
-    private static final Map<String, String> TABLE_PROPERTIES =
-            ImmutableMap.of(
-                    TableProperties.SPLIT_SIZE, "16777216", TableProperties.SPLIT_OPEN_FILE_COST, "16777216");
+  // open file cost and split size are set as 16 MB to produce a split per file
+  private static final Map<String, String> TABLE_PROPERTIES =
+      ImmutableMap.of(
+          TableProperties.SPLIT_SIZE, "16777216", TableProperties.SPLIT_OPEN_FILE_COST, "16777216");
 
-    // only v2 bucketing and preserve data grouping properties have to be enabled to trigger SPJ
-    // other properties are only to simplify testing and validation
-    private static final Map<String, String> ENABLED_SPJ_SQL_CONF =
-            ImmutableMap.of(
-                    SQLConf.V2_BUCKETING_ENABLED().key(),
-                    "true",
-                    SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED().key(),
-                    "true",
-                    SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION().key(),
-                    "false",
-                    SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(),
-                    "false",
-                    SQLConf.AUTO_BROADCASTJOIN_THRESHOLD().key(),
-                    "-1",
-                    SparkSQLProperties.PRESERVE_DATA_GROUPING,
-                    "true",
-                    SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED().key(),
-                    "true");
-    protected static String PARQUET_TABLE_PREFIX = "p_";
-    protected static List<String> tableNames = ImmutableList.of("part", "supplier", "partsupp",
-            "customer", "orders", "lineitem", "nation", "region");
+  // only v2 bucketing and preserve data grouping properties have to be enabled to trigger SPJ
+  // other properties are only to simplify testing and validation
+  private static final Map<String, String> ENABLED_SPJ_SQL_CONF =
+      ImmutableMap.of(
+          SQLConf.V2_BUCKETING_ENABLED().key(),
+          "true",
+          SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED().key(),
+          "true",
+          SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION().key(),
+          "false",
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(),
+          "false",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD().key(),
+          "-1",
+          SparkSQLProperties.PRESERVE_DATA_GROUPING,
+          "true",
+          SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED().key(),
+          "true");
+  protected static String PARQUET_TABLE_PREFIX = "p_";
+  protected static List<String> tableNames =
+      ImmutableList.of(
+          "part", "supplier", "partsupp", "customer", "orders", "lineitem", "nation", "region");
 
-    // If we test all the catalog, we need to create the table in that catalog,
-    // we don't need to test the catalog, so only test the testhadoop catalog
-    @Before
-    public void createTPCHNotNullTables() {
-        tableNames.forEach(table -> {
-            String tableDir = tpchBasePath + "/tpch-data-parquet";
-//            String tableDir = "/Users/chengchengjin/code/gluten/backends-velox/src/test/resources/tpch-data-parquet";
-            String tablePath = new File(tableDir, table).getAbsolutePath();
-            Dataset<Row> tableDF = spark.read().format("parquet").load(tablePath);
-            tableDF.createOrReplaceTempView(PARQUET_TABLE_PREFIX + table);
+  // If we test all the catalog, we need to create the table in that catalog,
+  // we don't need to test the catalog, so only test the testhadoop catalog
+  @Before
+  public void createTPCHNotNullTables() {
+    tableNames.forEach(
+        table -> {
+          String tableDir = tpchBasePath + "/tpch-data-parquet";
+          //            String tableDir =
+          // "/Users/chengchengjin/code/gluten/backends-velox/src/test/resources/tpch-data-parquet";
+          String tablePath = new File(tableDir, table).getAbsolutePath();
+          Dataset<Row> tableDF = spark.read().format("parquet").load(tablePath);
+          tableDF.createOrReplaceTempView(PARQUET_TABLE_PREFIX + table);
         });
 
+    sql(
+        createIcebergTable(
+            "part",
+            "`p_partkey`     INT,\n"
+                + "  `p_name`        string,\n"
+                + "  `p_mfgr`        string,\n"
+                + "  `p_brand`       string,\n"
+                + "  `p_type`        string,\n"
+                + "  `p_size`        INT,\n"
+                + "  `p_container`   string,\n"
+                + "  `p_retailprice` DECIMAL(15,2) ,\n"
+                + "  `p_comment`     string ",
+            null));
+    sql(
+        createIcebergTable(
+            "nation",
+            "`n_nationkey`  INT,\n"
+                + "  `n_name`       CHAR(25),\n"
+                + "  `n_regionkey`  INT,\n"
+                + "  `n_comment`    VARCHAR(152)"));
+    sql(
+        createIcebergTable(
+            "region",
+            "`r_regionkey`  INT,\n"
+                + "  `r_name`       CHAR(25),\n"
+                + "  `r_comment`    VARCHAR(152)"));
+    sql(
+        createIcebergTable(
+            "supplier",
+            "`s_suppkey`     INT,\n"
+                + "  `s_name`        CHAR(25),\n"
+                + "  `s_address`     VARCHAR(40),\n"
+                + "  `s_nationkey`   INT,\n"
+                + "  `s_phone`       CHAR(15),\n"
+                + "  `s_acctbal`     DECIMAL(15,2),\n"
+                + "  `s_comment`     VARCHAR(101)"));
+    sql(
+        createIcebergTable(
+            "customer",
+            "`c_custkey`     INT,\n"
+                + "  `c_name`        string,\n"
+                + "  `c_address`     string,\n"
+                + "  `c_nationkey`   INT,\n"
+                + "  `c_phone`       string,\n"
+                + "  `c_acctbal`     DECIMAL(15,2),\n"
+                + "  `c_mktsegment`  string,\n"
+                + "  `c_comment`     string",
+            "bucket(16, c_custkey)"));
+    sql(
+        createIcebergTable(
+            "partsupp",
+            "`ps_partkey`     INT,\n"
+                + "  `ps_suppkey`     INT,\n"
+                + "  `ps_availqty`    INT,\n"
+                + "  `ps_supplycost`  DECIMAL(15,2),\n"
+                + "  `ps_comment`     VARCHAR(199)"));
+    sql(
+        createIcebergTable(
+            "orders",
+            "`o_orderkey`       INT,\n"
+                + "  `o_custkey`        INT,\n"
+                + "  `o_orderstatus`    string,\n"
+                + "  `o_totalprice`     DECIMAL(15,2),\n"
+                + "  `o_orderdate`      DATE,\n"
+                + "  `o_orderpriority`  string,\n"
+                + "  `o_clerk`          string,\n"
+                + "  `o_shippriority`   INT,\n"
+                + "  `o_comment`        string",
+            "bucket(16, o_custkey)"));
 
-        sql(createIcebergTable("part", "`p_partkey`     INT,\n" +
-                "  `p_name`        string,\n" +
-                "  `p_mfgr`        string,\n" +
-                "  `p_brand`       string,\n" +
-                "  `p_type`        string,\n" +
-                "  `p_size`        INT,\n" +
-                "  `p_container`   string,\n" +
-                "  `p_retailprice` DECIMAL(15,2) ,\n" +
-                "  `p_comment`     string ", null));
-        sql(createIcebergTable("nation", "`n_nationkey`  INT,\n" +
-                "  `n_name`       CHAR(25),\n" +
-                "  `n_regionkey`  INT,\n" +
-                "  `n_comment`    VARCHAR(152)"));
-        sql(createIcebergTable("region", "`r_regionkey`  INT,\n" +
-                "  `r_name`       CHAR(25),\n" +
-                "  `r_comment`    VARCHAR(152)"));
-        sql(createIcebergTable("supplier", "`s_suppkey`     INT,\n" +
-                "  `s_name`        CHAR(25),\n" +
-                "  `s_address`     VARCHAR(40),\n" +
-                "  `s_nationkey`   INT,\n" +
-                "  `s_phone`       CHAR(15),\n" +
-                "  `s_acctbal`     DECIMAL(15,2),\n" +
-                "  `s_comment`     VARCHAR(101)"));
-        sql(createIcebergTable("customer", "`c_custkey`     INT,\n" +
-                "  `c_name`        string,\n" +
-                "  `c_address`     string,\n" +
-                "  `c_nationkey`   INT,\n" +
-                "  `c_phone`       string,\n" +
-                "  `c_acctbal`     DECIMAL(15,2),\n" +
-                "  `c_mktsegment`  string,\n" +
-                "  `c_comment`     string", "bucket(16, c_custkey)"));
-        sql(createIcebergTable("partsupp", "`ps_partkey`     INT,\n" +
-                "  `ps_suppkey`     INT,\n" +
-                "  `ps_availqty`    INT,\n" +
-                "  `ps_supplycost`  DECIMAL(15,2),\n" +
-                "  `ps_comment`     VARCHAR(199)"));
-        sql(createIcebergTable("orders", "`o_orderkey`       INT,\n" +
-                "  `o_custkey`        INT,\n" +
-                "  `o_orderstatus`    string,\n" +
-                "  `o_totalprice`     DECIMAL(15,2),\n" +
-                "  `o_orderdate`      DATE,\n" +
-                "  `o_orderpriority`  string,\n" +
-                "  `o_clerk`          string,\n" +
-                "  `o_shippriority`   INT,\n" +
-                "  `o_comment`        string", "bucket(16, o_custkey)"));
+    sql(
+        createIcebergTable(
+            "lineitem",
+            "`l_orderkey`    INT,\n"
+                + "  `l_partkey`     INT,\n"
+                + "  `l_suppkey`     INT,\n"
+                + "  `l_linenumber`  INT,\n"
+                + "  `l_quantity`    DECIMAL(15,2),\n"
+                + "  `l_extendedprice`  DECIMAL(15,2),\n"
+                + "  `l_discount`    DECIMAL(15,2),\n"
+                + "  `l_tax`         DECIMAL(15,2),\n"
+                + "  `l_returnflag`  string,\n"
+                + "  `l_linestatus`  string,\n"
+                + "  `l_shipdate`    DATE,\n"
+                + "  `l_commitdate`  DATE,\n"
+                + "  `l_receiptdate` DATE,\n"
+                + "  `l_shipinstruct` string,\n"
+                + "  `l_shipmode`    string,\n"
+                + "  `l_comment`     string",
+            null));
 
-        sql(createIcebergTable("lineitem", "`l_orderkey`    INT,\n" +
-                "  `l_partkey`     INT,\n" +
-                "  `l_suppkey`     INT,\n" +
-                "  `l_linenumber`  INT,\n" +
-                "  `l_quantity`    DECIMAL(15,2),\n" +
-                "  `l_extendedprice`  DECIMAL(15,2),\n" +
-                "  `l_discount`    DECIMAL(15,2),\n" +
-                "  `l_tax`         DECIMAL(15,2),\n" +
-                "  `l_returnflag`  string,\n" +
-                "  `l_linestatus`  string,\n" +
-                "  `l_shipdate`    DATE,\n" +
-                "  `l_commitdate`  DATE,\n" +
-                "  `l_receiptdate` DATE,\n" +
-                "  `l_shipinstruct` string,\n" +
-                "  `l_shipmode`    string,\n" +
-                "  `l_comment`     string", null));
+    String insertStmt = "INSERT INTO %s select * from %s%s";
+    tableNames.forEach(
+        table -> sql(String.format(insertStmt, tableName(table), PARQUET_TABLE_PREFIX, table)));
+  }
 
-        String insertStmt = "INSERT INTO %s select * from %s%s";
-        tableNames.forEach(table -> sql(String.format(insertStmt, tableName(table), PARQUET_TABLE_PREFIX, table)));
-
-    }
-
-    @After
-    public void dropTPCHNotNullTables() {
-        tableNames.forEach(table -> {
-            sql("DROP TABLE IF EXISTS " + tableName(table));
-            sql("DROP VIEW IF EXISTS " + PARQUET_TABLE_PREFIX + table);
+  @After
+  public void dropTPCHNotNullTables() {
+    tableNames.forEach(
+        table -> {
+          sql("DROP TABLE IF EXISTS " + tableName(table));
+          sql("DROP VIEW IF EXISTS " + PARQUET_TABLE_PREFIX + table);
         });
+  }
 
+  private String createIcebergTable(String name, String columns) {
+    return createIcebergTable(name, columns, null);
+  }
+
+  private String createIcebergTable(String name, String columns, String transform) {
+    // create TPCH iceberg table
+    String createTableStmt =
+        "CREATE TABLE %s (%s)" + "USING iceberg " + "PARTITIONED BY (%s)" + "TBLPROPERTIES (%s)";
+    String createUnpartitionTableStmt =
+        "CREATE TABLE %s (%s)" + "USING iceberg " + "TBLPROPERTIES (%s)";
+    if (transform != null) {
+      return String.format(
+          createTableStmt,
+          tableName(name),
+          columns,
+          transform,
+          tablePropsAsString(TABLE_PROPERTIES));
+    } else {
+      return String.format(
+          createUnpartitionTableStmt,
+          tableName(name),
+          columns,
+          tablePropsAsString(TABLE_PROPERTIES));
     }
+  }
 
-    private String createIcebergTable(String name, String columns) {
-        return createIcebergTable(name, columns, null);
+  protected String tpchSQL(int queryNum) {
+    try {
+      return FileUtils.readFileToString(new File(tpchQueries + "/q" + queryNum + ".sql"), "UTF-8");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    private String createIcebergTable(String name, String columns, String transform) {
-        // create TPCH iceberg table
-        String createTableStmt =
-                "CREATE TABLE %s (%s)"
-                        + "USING iceberg "
-                        + "PARTITIONED BY (%s)"
-                        + "TBLPROPERTIES (%s)";
-        String createUnpartitionTableStmt =
-                "CREATE TABLE %s (%s)"
-                        + "USING iceberg "
-                        + "TBLPROPERTIES (%s)";
-        if (transform != null) {
-            return String.format(createTableStmt, tableName(name), columns, transform,
-                    tablePropsAsString(TABLE_PROPERTIES));
-        } else {
-            return String.format(createUnpartitionTableStmt, tableName(name), columns,
-                    tablePropsAsString(TABLE_PROPERTIES));
-        }
-
-    }
-
-    protected String tpchSQL(int queryNum) {
-        try {
-            return FileUtils.readFileToString(new File(tpchQueries + "/q" + queryNum + ".sql"),  "UTF-8");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    public void testTPCH() {
-        spark.conf().set("spark.sql.defaultCatalog", catalogName);
-        spark.conf().set("spark.sql.catalog." + catalogName + ".default-namespace", "default");
-        sql("use namespace default");
-        withSQLConf(ENABLED_SPJ_SQL_CONF, () -> {
-            for (int i = 1; i <= 22; i++) {
-                List<Row> rows = spark.sql(tpchSQL(i)).collectAsList();
-                AtomicReference<List<Row>> rowsSpark = new AtomicReference<>();
-                int finalI = i;
-                withSQLConf(ImmutableMap.of(GlutenConfig.GLUTEN_ENABLED().key(), "false"), () ->
-                        rowsSpark.set(spark.sql(tpchSQL(finalI)).collectAsList()
-                        ));
-                assertThat(rows).containsExactlyInAnyOrderElementsOf(Iterables.concat(rowsSpark.get()));
-            }
+  @Test
+  public void testTPCH() {
+    spark.conf().set("spark.sql.defaultCatalog", catalogName);
+    spark.conf().set("spark.sql.catalog." + catalogName + ".default-namespace", "default");
+    sql("use namespace default");
+    withSQLConf(
+        ENABLED_SPJ_SQL_CONF,
+        () -> {
+          for (int i = 1; i <= 22; i++) {
+            List<Row> rows = spark.sql(tpchSQL(i)).collectAsList();
+            AtomicReference<List<Row>> rowsSpark = new AtomicReference<>();
+            int finalI = i;
+            withSQLConf(
+                ImmutableMap.of(GlutenConfig.GLUTEN_ENABLED().key(), "false"),
+                () -> rowsSpark.set(spark.sql(tpchSQL(finalI)).collectAsList()));
+            assertThat(rows).containsExactlyInAnyOrderElementsOf(Iterables.concat(rowsSpark.get()));
+          }
         });
-    }
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestCopyOnWriteDelete.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestCopyOnWriteDelete.java
@@ -24,22 +24,40 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class GlutenTestCopyOnWriteDelete extends TestCopyOnWriteDelete {
-    public GlutenTestCopyOnWriteDelete(String catalogName, String implementation, Map<String, String> config, String fileFormat, Boolean vectorized, String distributionMode, boolean fanoutEnabled, String branch, PlanningMode planningMode) {
-        super(catalogName, implementation, config, fileFormat, vectorized, distributionMode, fanoutEnabled, branch, planningMode);
-    }
+  public GlutenTestCopyOnWriteDelete(
+      String catalogName,
+      String implementation,
+      Map<String, String> config,
+      String fileFormat,
+      Boolean vectorized,
+      String distributionMode,
+      boolean fanoutEnabled,
+      String branch,
+      PlanningMode planningMode) {
+    super(
+        catalogName,
+        implementation,
+        config,
+        fileFormat,
+        vectorized,
+        distributionMode,
+        fanoutEnabled,
+        branch,
+        planningMode);
+  }
 
-    @Test
-    public synchronized void testDeleteWithConcurrentTableRefresh() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testDeleteWithConcurrentTableRefresh() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testDeleteWithSerializableIsolation() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testDeleteWithSerializableIsolation() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testDeleteWithSnapshotIsolation() throws ExecutionException {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testDeleteWithSnapshotIsolation() throws ExecutionException {
+    System.out.println("Run timeout");
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestMergeOnReadDelete.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestMergeOnReadDelete.java
@@ -24,22 +24,40 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class GlutenTestMergeOnReadDelete extends TestMergeOnReadDelete {
-    public GlutenTestMergeOnReadDelete(String catalogName, String implementation, Map<String, String> config, String fileFormat, Boolean vectorized, String distributionMode, boolean fanoutEnabled, String branch, PlanningMode planningMode) {
-        super(catalogName, implementation, config, fileFormat, vectorized, distributionMode, fanoutEnabled, branch, planningMode);
-    }
+  public GlutenTestMergeOnReadDelete(
+      String catalogName,
+      String implementation,
+      Map<String, String> config,
+      String fileFormat,
+      Boolean vectorized,
+      String distributionMode,
+      boolean fanoutEnabled,
+      String branch,
+      PlanningMode planningMode) {
+    super(
+        catalogName,
+        implementation,
+        config,
+        fileFormat,
+        vectorized,
+        distributionMode,
+        fanoutEnabled,
+        branch,
+        planningMode);
+  }
 
-    @Test
-    public synchronized void testDeleteWithConcurrentTableRefresh() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testDeleteWithConcurrentTableRefresh() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testDeleteWithSerializableIsolation() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testDeleteWithSerializableIsolation() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testDeleteWithSnapshotIsolation() throws ExecutionException {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testDeleteWithSnapshotIsolation() throws ExecutionException {
+    System.out.println("Run timeout");
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestMergeOnReadMerge.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestMergeOnReadMerge.java
@@ -21,26 +21,42 @@ import org.apache.iceberg.spark.extensions.TestMergeOnReadMerge;
 import org.junit.Test;
 
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 public class GlutenTestMergeOnReadMerge extends TestMergeOnReadMerge {
-    public GlutenTestMergeOnReadMerge(String catalogName, String implementation, Map<String, String> config, String fileFormat, boolean vectorized, String distributionMode, boolean fanoutEnabled, String branch, PlanningMode planningMode) {
-        super(catalogName, implementation, config, fileFormat, vectorized, distributionMode, fanoutEnabled, branch, planningMode);
-    }
+  public GlutenTestMergeOnReadMerge(
+      String catalogName,
+      String implementation,
+      Map<String, String> config,
+      String fileFormat,
+      boolean vectorized,
+      String distributionMode,
+      boolean fanoutEnabled,
+      String branch,
+      PlanningMode planningMode) {
+    super(
+        catalogName,
+        implementation,
+        config,
+        fileFormat,
+        vectorized,
+        distributionMode,
+        fanoutEnabled,
+        branch,
+        planningMode);
+  }
 
-    @Test
-    public synchronized void testMergeWithConcurrentTableRefresh() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testMergeWithConcurrentTableRefresh() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testMergeWithSerializableIsolation() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testMergeWithSerializableIsolation() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testMergeWithSnapshotIsolation() {
-        System.out.println("Run timeout");
-    }
-    
+  @Test
+  public synchronized void testMergeWithSnapshotIsolation() {
+    System.out.println("Run timeout");
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestMergeOnReadUpdate.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestMergeOnReadUpdate.java
@@ -24,22 +24,40 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class GlutenTestMergeOnReadUpdate extends TestMergeOnReadUpdate {
-    public GlutenTestMergeOnReadUpdate(String catalogName, String implementation, Map<String, String> config, String fileFormat, boolean vectorized, String distributionMode, boolean fanoutEnabled, String branch, PlanningMode planningMode) {
-        super(catalogName, implementation, config, fileFormat, vectorized, distributionMode, fanoutEnabled, branch, planningMode);
-    }
+  public GlutenTestMergeOnReadUpdate(
+      String catalogName,
+      String implementation,
+      Map<String, String> config,
+      String fileFormat,
+      boolean vectorized,
+      String distributionMode,
+      boolean fanoutEnabled,
+      String branch,
+      PlanningMode planningMode) {
+    super(
+        catalogName,
+        implementation,
+        config,
+        fileFormat,
+        vectorized,
+        distributionMode,
+        fanoutEnabled,
+        branch,
+        planningMode);
+  }
 
-    @Test
-    public synchronized void testUpdateWithConcurrentTableRefresh() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testUpdateWithConcurrentTableRefresh() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testUpdateWithSerializableIsolation() {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testUpdateWithSerializableIsolation() {
+    System.out.println("Run timeout");
+  }
 
-    @Test
-    public synchronized void testUpdateWithSnapshotIsolation() throws ExecutionException {
-        System.out.println("Run timeout");
-    }
+  @Test
+  public synchronized void testUpdateWithSnapshotIsolation() throws ExecutionException {
+    System.out.println("Run timeout");
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestStoragePartitionedJoinsInRowLevelOperations.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestStoragePartitionedJoinsInRowLevelOperations.java
@@ -20,8 +20,10 @@ import org.apache.iceberg.spark.extensions.TestStoragePartitionedJoinsInRowLevel
 
 import java.util.Map;
 
-public class GlutenTestStoragePartitionedJoinsInRowLevelOperations extends TestStoragePartitionedJoinsInRowLevelOperations {
-    public GlutenTestStoragePartitionedJoinsInRowLevelOperations(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+public class GlutenTestStoragePartitionedJoinsInRowLevelOperations
+    extends TestStoragePartitionedJoinsInRowLevelOperations {
+  public GlutenTestStoragePartitionedJoinsInRowLevelOperations(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestSystemFunctionPushDownDQL.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestSystemFunctionPushDownDQL.java
@@ -21,7 +21,8 @@ import org.apache.iceberg.spark.extensions.TestSystemFunctionPushDownDQL;
 import java.util.Map;
 
 public class GlutenTestSystemFunctionPushDownDQL extends TestSystemFunctionPushDownDQL {
-    public GlutenTestSystemFunctionPushDownDQL(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestSystemFunctionPushDownDQL(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestSystemFunctionPushDownInRowLevelOperations.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/extensions/GlutenTestSystemFunctionPushDownInRowLevelOperations.java
@@ -18,8 +18,10 @@ package org.apache.gluten.spark34.extensions;
 
 import java.util.Map;
 
-public class GlutenTestSystemFunctionPushDownInRowLevelOperations extends GlutenTestSystemFunctionPushDownDQL {
-    public GlutenTestSystemFunctionPushDownInRowLevelOperations(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+public class GlutenTestSystemFunctionPushDownInRowLevelOperations
+    extends GlutenTestSystemFunctionPushDownDQL {
+  public GlutenTestSystemFunctionPushDownInRowLevelOperations(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestDataFrameWriterV2.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestDataFrameWriterV2.java
@@ -18,5 +18,4 @@ package org.apache.gluten.spark34.source;
 
 import org.apache.iceberg.spark.source.TestDataFrameWriterV2;
 
-public class GlutenTestDataFrameWriterV2 extends TestDataFrameWriterV2 {
-}
+public class GlutenTestDataFrameWriterV2 extends TestDataFrameWriterV2 {}

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestDataFrameWriterV2Coercion.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestDataFrameWriterV2Coercion.java
@@ -17,7 +17,6 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.iceberg.FileFormat;
-
 import org.apache.iceberg.spark.source.TestDataFrameWriterV2Coercion;
 
 public class GlutenTestDataFrameWriterV2Coercion extends TestDataFrameWriterV2Coercion {

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestDataSourceOptions.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestDataSourceOptions.java
@@ -18,5 +18,4 @@ package org.apache.gluten.spark34.source;
 
 import org.apache.iceberg.spark.source.TestDataSourceOptions;
 
-public class GlutenTestDataSourceOptions extends TestDataSourceOptions {
-}
+public class GlutenTestDataSourceOptions extends TestDataSourceOptions {}

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestIcebergSourceHiveTables.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestIcebergSourceHiveTables.java
@@ -19,5 +19,4 @@ package org.apache.gluten.spark34.source;
 import org.apache.iceberg.spark.source.TestIcebergSourceHiveTables;
 
 // Fallback all the table scan because source table is metadata table with format avro.
-public class GlutenTestIcebergSourceHiveTables extends TestIcebergSourceHiveTables {
-}
+public class GlutenTestIcebergSourceHiveTables extends TestIcebergSourceHiveTables {}

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestIdentityPartitionData.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestIdentityPartitionData.java
@@ -20,7 +20,8 @@ import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.spark.source.TestIdentityPartitionData;
 
 public class GlutenTestIdentityPartitionData extends TestIdentityPartitionData {
-    public GlutenTestIdentityPartitionData(String format, boolean vectorized, PlanningMode planningMode) {
-        super(format, vectorized, planningMode);
-    }
+  public GlutenTestIdentityPartitionData(
+      String format, boolean vectorized, PlanningMode planningMode) {
+    super(format, vectorized, planningMode);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestPositionDeletesTable.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestPositionDeletesTable.java
@@ -22,7 +22,8 @@ import org.apache.iceberg.spark.source.TestPositionDeletesTable;
 import java.util.Map;
 
 public class GlutenTestPositionDeletesTable extends TestPositionDeletesTable {
-    public GlutenTestPositionDeletesTable(String catalogName, String implementation, Map<String, String> config, FileFormat format) {
-        super(catalogName, implementation, config, format);
-    }
+  public GlutenTestPositionDeletesTable(
+      String catalogName, String implementation, Map<String, String> config, FileFormat format) {
+    super(catalogName, implementation, config, format);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestRuntimeFiltering.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestRuntimeFiltering.java
@@ -20,7 +20,7 @@ import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.spark.source.TestRuntimeFiltering;
 
 public class GlutenTestRuntimeFiltering extends TestRuntimeFiltering {
-    public GlutenTestRuntimeFiltering(PlanningMode planningMode) {
-        super(planningMode);
-    }
+  public GlutenTestRuntimeFiltering(PlanningMode planningMode) {
+    super(planningMode);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestSparkMetadataColumns.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestSparkMetadataColumns.java
@@ -20,7 +20,8 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.spark.source.TestSparkMetadataColumns;
 
 public class GlutenTestSparkMetadataColumns extends TestSparkMetadataColumns {
-    public GlutenTestSparkMetadataColumns(FileFormat fileFormat, boolean vectorized, int formatVersion) {
-        super(fileFormat, vectorized, formatVersion);
-    }
+  public GlutenTestSparkMetadataColumns(
+      FileFormat fileFormat, boolean vectorized, int formatVersion) {
+    super(fileFormat, vectorized, formatVersion);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestSparkStagedScan.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/GlutenTestSparkStagedScan.java
@@ -21,7 +21,8 @@ import org.apache.iceberg.spark.source.TestSparkStagedScan;
 import java.util.Map;
 
 public class GlutenTestSparkStagedScan extends TestSparkStagedScan {
-    public GlutenTestSparkStagedScan(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestSparkStagedScan(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestDataFrameWrites.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestDataFrameWrites.java
@@ -16,7 +16,6 @@
  */
 package org.apache.gluten.spark34.source;
 
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.*;
 import org.apache.iceberg.avro.Avro;
@@ -25,6 +24,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestFilteredScan.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestFilteredScan.java
@@ -16,25 +16,8 @@
  */
 package org.apache.gluten.spark34.source;
 
-import static org.apache.iceberg.Files.localOutput;
-import static org.apache.iceberg.PlanningMode.DISTRIBUTED;
-import static org.apache.iceberg.PlanningMode.LOCAL;
-import static org.apache.spark.sql.catalyst.util.DateTimeUtils.fromJavaTimestamp;
-import static org.apache.spark.sql.functions.callUDF;
-import static org.apache.spark.sql.functions.column;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.File;
-import java.io.IOException;
-import java.sql.Timestamp;
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -90,630 +73,654 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.File;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.iceberg.Files.localOutput;
+import static org.apache.iceberg.PlanningMode.DISTRIBUTED;
+import static org.apache.iceberg.PlanningMode.LOCAL;
+import static org.apache.spark.sql.catalyst.util.DateTimeUtils.fromJavaTimestamp;
+import static org.apache.spark.sql.functions.callUDF;
+import static org.apache.spark.sql.functions.column;
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SuppressWarnings("checkstyle:LineLegth")
-//Timestamp with timezone for orc format is bot supported, but cannot fallback in BatchScanTransformer
-//because we cannot distinguish file format but can only get the schema
-//Error Source: RUNTIME
-//Error Code: INVALID_STATE
-//Reason: TIMESTAMP_INSTANT not supported yet.
-//Retriable: False
-//Context: Split [Hive: /var/folders/63/845y6pk53dx_83hpw8ztdchw0000gn/T/junit10976573641877215189/TestFilteredScan/unpartitioned/data/b464438c-e706-412b-bcc9-71321ff4aead.orc 0 - 629] Task Gluten_Stage_6_TID_6_VTID_4
-//Additional Context: Operator: TableScan[0] 0
-//Function: kind
-//File: code/gluten/ep/build-velox/build/velox_ep/velox/dwio/dwrf/common/FileMetadata.cpp
-//Line: 107
-//Stack trace:
+// Timestamp with timezone for orc format is bot supported, but cannot fallback in
+// BatchScanTransformer
+// because we cannot distinguish file format but can only get the schema
+// Error Source: RUNTIME
+// Error Code: INVALID_STATE
+// Reason: TIMESTAMP_INSTANT not supported yet.
+// Retriable: False
+// Context: Split [Hive:
+// /var/folders/63/845y6pk53dx_83hpw8ztdchw0000gn/T/junit10976573641877215189/TestFilteredScan/unpartitioned/data/b464438c-e706-412b-bcc9-71321ff4aead.orc 0 - 629] Task Gluten_Stage_6_TID_6_VTID_4
+// Additional Context: Operator: TableScan[0] 0
+// Function: kind
+// File: code/gluten/ep/build-velox/build/velox_ep/velox/dwio/dwrf/common/FileMetadata.cpp
+// Line: 107
+// Stack trace:
 @RunWith(Parameterized.class)
 public class TestFilteredScan {
-    private static final Configuration CONF = new Configuration();
-    private static final HadoopTables TABLES = new HadoopTables(CONF);
+  private static final Configuration CONF = new Configuration();
+  private static final HadoopTables TABLES = new HadoopTables(CONF);
 
-    private static final Schema SCHEMA =
-            new Schema(
-                    Types.NestedField.required(1, "id", Types.LongType.get()),
-                    Types.NestedField.optional(2, "ts", Types.TimestampType.withZone()),
-                    Types.NestedField.optional(3, "data", Types.StringType.get()));
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "ts", Types.TimestampType.withZone()),
+          Types.NestedField.optional(3, "data", Types.StringType.get()));
 
-    private static final PartitionSpec BUCKET_BY_ID =
-            PartitionSpec.builderFor(SCHEMA).bucket("id", 4).build();
+  private static final PartitionSpec BUCKET_BY_ID =
+      PartitionSpec.builderFor(SCHEMA).bucket("id", 4).build();
 
-    private static final PartitionSpec PARTITION_BY_DAY =
-            PartitionSpec.builderFor(SCHEMA).day("ts").build();
+  private static final PartitionSpec PARTITION_BY_DAY =
+      PartitionSpec.builderFor(SCHEMA).day("ts").build();
 
-    private static final PartitionSpec PARTITION_BY_HOUR =
-            PartitionSpec.builderFor(SCHEMA).hour("ts").build();
+  private static final PartitionSpec PARTITION_BY_HOUR =
+      PartitionSpec.builderFor(SCHEMA).hour("ts").build();
 
-    private static final PartitionSpec PARTITION_BY_DATA =
-            PartitionSpec.builderFor(SCHEMA).identity("data").build();
+  private static final PartitionSpec PARTITION_BY_DATA =
+      PartitionSpec.builderFor(SCHEMA).identity("data").build();
 
-    private static final PartitionSpec PARTITION_BY_ID =
-            PartitionSpec.builderFor(SCHEMA).identity("id").build();
+  private static final PartitionSpec PARTITION_BY_ID =
+      PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-    private static SparkSession spark = null;
+  private static SparkSession spark = null;
 
-    @BeforeClass
-    public static void startSpark() {
-        TestFilteredScan.spark = SparkSession.builder().master("local[2]")
-                .config(TestConfUtil.GLUTEN_CONF)
-                .getOrCreate();
+  @BeforeClass
+  public static void startSpark() {
+    TestFilteredScan.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
 
-        // define UDFs used by partition tests
-        Function<Object, Integer> bucket4 = Transforms.bucket(4).bind(Types.LongType.get());
-        spark.udf().register("bucket4", (UDF1<Long, Integer>) bucket4::apply, IntegerType$.MODULE$);
+    // define UDFs used by partition tests
+    Function<Object, Integer> bucket4 = Transforms.bucket(4).bind(Types.LongType.get());
+    spark.udf().register("bucket4", (UDF1<Long, Integer>) bucket4::apply, IntegerType$.MODULE$);
 
-        Function<Object, Integer> day = Transforms.day().bind(Types.TimestampType.withZone());
-        spark
-                .udf()
-                .register(
-                        "ts_day",
-                        (UDF1<Timestamp, Integer>) timestamp -> day.apply(fromJavaTimestamp(timestamp)),
-                        IntegerType$.MODULE$);
+    Function<Object, Integer> day = Transforms.day().bind(Types.TimestampType.withZone());
+    spark
+        .udf()
+        .register(
+            "ts_day",
+            (UDF1<Timestamp, Integer>) timestamp -> day.apply(fromJavaTimestamp(timestamp)),
+            IntegerType$.MODULE$);
 
-        Function<Object, Integer> hour = Transforms.hour().bind(Types.TimestampType.withZone());
-        spark
-                .udf()
-                .register(
-                        "ts_hour",
-                        (UDF1<Timestamp, Integer>) timestamp -> hour.apply(fromJavaTimestamp(timestamp)),
-                        IntegerType$.MODULE$);
+    Function<Object, Integer> hour = Transforms.hour().bind(Types.TimestampType.withZone());
+    spark
+        .udf()
+        .register(
+            "ts_hour",
+            (UDF1<Timestamp, Integer>) timestamp -> hour.apply(fromJavaTimestamp(timestamp)),
+            IntegerType$.MODULE$);
 
-        spark.udf().register("data_ident", (UDF1<String, String>) data -> data, StringType$.MODULE$);
-        spark.udf().register("id_ident", (UDF1<Long, Long>) id -> id, LongType$.MODULE$);
+    spark.udf().register("data_ident", (UDF1<String, String>) data -> data, StringType$.MODULE$);
+    spark.udf().register("id_ident", (UDF1<Long, Long>) id -> id, LongType$.MODULE$);
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestFilteredScan.spark;
+    TestFilteredScan.spark = null;
+    currentSpark.stop();
+  }
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private final String format;
+  private final boolean vectorized;
+  private final PlanningMode planningMode;
+
+  @Parameterized.Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"parquet", false, LOCAL},
+      {"parquet", true, DISTRIBUTED},
+      {"avro", false, LOCAL},
+      // TODO, support orc timestamp with time zone
+      //                {"orc", false, DISTRIBUTED},
+      //                {"orc", true, LOCAL}
+    };
+  }
+
+  public TestFilteredScan(String format, boolean vectorized, PlanningMode planningMode) {
+    this.format = format;
+    this.vectorized = vectorized;
+    this.planningMode = planningMode;
+  }
+
+  private File parent = null;
+  private File unpartitioned = null;
+  private List<Record> records = null;
+
+  @Before
+  public void writeUnpartitionedTable() throws IOException {
+    this.parent = temp.newFolder("TestFilteredScan");
+    this.unpartitioned = new File(parent, "unpartitioned");
+    File dataFolder = new File(unpartitioned, "data");
+    Assert.assertTrue("Mkdir should succeed", dataFolder.mkdirs());
+
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(
+                TableProperties.DATA_PLANNING_MODE,
+                planningMode.modeName(),
+                TableProperties.DELETE_PLANNING_MODE,
+                planningMode.modeName()),
+            unpartitioned.toString());
+    Schema tableSchema = table.schema(); // use the table schema because ids are reassigned
+
+    FileFormat fileFormat = FileFormat.fromString(format);
+
+    File testFile = new File(dataFolder, fileFormat.addExtension(UUID.randomUUID().toString()));
+
+    this.records = testRecords(tableSchema);
+
+    try (FileAppender<Record> writer =
+        new GenericAppenderFactory(tableSchema).newAppender(localOutput(testFile), fileFormat)) {
+      writer.addAll(records);
     }
 
-    @AfterClass
-    public static void stopSpark() {
-        SparkSession currentSpark = TestFilteredScan.spark;
-        TestFilteredScan.spark = null;
-        currentSpark.stop();
+    DataFile file =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withRecordCount(records.size())
+            .withFileSizeInBytes(testFile.length())
+            .withPath(testFile.toString())
+            .build();
+
+    table.newAppend().appendFile(file).commit();
+  }
+
+  @Test
+  public void testUnpartitionedIDFilters() {
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
+    GlutenSparkScanBuilder builder =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+    for (int i = 0; i < 10; i += 1) {
+      pushFilters(builder, EqualTo.apply("id", i));
+      Batch scan = builder.build().toBatch();
+
+      InputPartition[] partitions = scan.planInputPartitions();
+      Assert.assertEquals("Should only create one task for a small file", 1, partitions.length);
+
+      // validate row filtering
+      assertEqualsSafe(
+          SCHEMA.asStruct(), expected(i), read(unpartitioned.toString(), vectorized, "id = " + i));
     }
+  }
 
-    @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @Test
+  public void testUnpartitionedCaseInsensitiveIDFilters() {
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
 
-    private final String format;
-    private final boolean vectorized;
-    private final PlanningMode planningMode;
+    // set spark.sql.caseSensitive to false
+    String caseSensitivityBeforeTest = TestFilteredScan.spark.conf().get("spark.sql.caseSensitive");
+    TestFilteredScan.spark.conf().set("spark.sql.caseSensitive", "false");
 
-    @Parameterized.Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-                {"parquet", false, LOCAL},
-                {"parquet", true, DISTRIBUTED},
-                {"avro", false, LOCAL},
-                // TODO, support orc timestamp with time zone
-//                {"orc", false, DISTRIBUTED},
-//                {"orc", true, LOCAL}
-        };
-    }
+    try {
 
-    public TestFilteredScan(String format, boolean vectorized, PlanningMode planningMode) {
-        this.format = format;
-        this.vectorized = vectorized;
-        this.planningMode = planningMode;
-    }
+      for (int i = 0; i < 10; i += 1) {
+        SparkScanBuilder builder =
+            new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options)
+                .caseSensitive(false);
 
-    private File parent = null;
-    private File unpartitioned = null;
-    private List<Record> records = null;
-
-    @Before
-    public void writeUnpartitionedTable() throws IOException {
-        this.parent = temp.newFolder("TestFilteredScan");
-        this.unpartitioned = new File(parent, "unpartitioned");
-        File dataFolder = new File(unpartitioned, "data");
-        Assert.assertTrue("Mkdir should succeed", dataFolder.mkdirs());
-
-        Table table =
-                TABLES.create(
-                        SCHEMA,
-                        PartitionSpec.unpartitioned(),
-                        ImmutableMap.of(
-                                TableProperties.DATA_PLANNING_MODE,
-                                planningMode.modeName(),
-                                TableProperties.DELETE_PLANNING_MODE,
-                                planningMode.modeName()),
-                        unpartitioned.toString());
-        Schema tableSchema = table.schema(); // use the table schema because ids are reassigned
-
-        FileFormat fileFormat = FileFormat.fromString(format);
-
-        File testFile = new File(dataFolder, fileFormat.addExtension(UUID.randomUUID().toString()));
-
-        this.records = testRecords(tableSchema);
-
-        try (FileAppender<Record> writer =
-                     new GenericAppenderFactory(tableSchema).newAppender(localOutput(testFile), fileFormat)) {
-            writer.addAll(records);
-        }
-
-        DataFile file =
-                DataFiles.builder(PartitionSpec.unpartitioned())
-                        .withRecordCount(records.size())
-                        .withFileSizeInBytes(testFile.length())
-                        .withPath(testFile.toString())
-                        .build();
-
-        table.newAppend().appendFile(file).commit();
-    }
-
-    @Test
-    public void testUnpartitionedIDFilters() {
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
-        GlutenSparkScanBuilder builder =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-        for (int i = 0; i < 10; i += 1) {
-            pushFilters(builder, EqualTo.apply("id", i));
-            Batch scan = builder.build().toBatch();
-
-            InputPartition[] partitions = scan.planInputPartitions();
-            Assert.assertEquals("Should only create one task for a small file", 1, partitions.length);
-
-            // validate row filtering
-            assertEqualsSafe(
-                    SCHEMA.asStruct(), expected(i), read(unpartitioned.toString(), vectorized, "id = " + i));
-        }
-    }
-
-    @Test
-    public void testUnpartitionedCaseInsensitiveIDFilters() {
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
-
-        // set spark.sql.caseSensitive to false
-        String caseSensitivityBeforeTest = TestFilteredScan.spark.conf().get("spark.sql.caseSensitive");
-        TestFilteredScan.spark.conf().set("spark.sql.caseSensitive", "false");
-
-        try {
-
-            for (int i = 0; i < 10; i += 1) {
-                SparkScanBuilder builder =
-                        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options)
-                                .caseSensitive(false);
-
-                pushFilters(
-                        builder,
-                        EqualTo.apply("ID", i)); // note lower(ID) == lower(id), so there must be a match
-                Batch scan = builder.build().toBatch();
-
-                InputPartition[] tasks = scan.planInputPartitions();
-                Assert.assertEquals("Should only create one task for a small file", 1, tasks.length);
-
-                // validate row filtering
-                assertEqualsSafe(
-                        SCHEMA.asStruct(),
-                        expected(i),
-                        read(unpartitioned.toString(), vectorized, "id = " + i));
-            }
-        } finally {
-            // return global conf to previous state
-            TestFilteredScan.spark.conf().set("spark.sql.caseSensitive", caseSensitivityBeforeTest);
-        }
-    }
-
-    @Test
-    public void testUnpartitionedTimestampFilter() {
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
-
-        GlutenSparkScanBuilder builder =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-        pushFilters(builder, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+        pushFilters(
+            builder,
+            EqualTo.apply("ID", i)); // note lower(ID) == lower(id), so there must be a match
         Batch scan = builder.build().toBatch();
 
         InputPartition[] tasks = scan.planInputPartitions();
         Assert.assertEquals("Should only create one task for a small file", 1, tasks.length);
 
+        // validate row filtering
         assertEqualsSafe(
-                SCHEMA.asStruct(),
-                expected(5, 6, 7, 8, 9),
-                read(
-                        unpartitioned.toString(),
-                        vectorized,
-                        "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
+            SCHEMA.asStruct(),
+            expected(i),
+            read(unpartitioned.toString(), vectorized, "id = " + i));
+      }
+    } finally {
+      // return global conf to previous state
+      TestFilteredScan.spark.conf().set("spark.sql.caseSensitive", caseSensitivityBeforeTest);
+    }
+  }
+
+  @Test
+  public void testUnpartitionedTimestampFilter() {
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
+
+    GlutenSparkScanBuilder builder =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+    pushFilters(builder, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+    Batch scan = builder.build().toBatch();
+
+    InputPartition[] tasks = scan.planInputPartitions();
+    Assert.assertEquals("Should only create one task for a small file", 1, tasks.length);
+
+    assertEqualsSafe(
+        SCHEMA.asStruct(),
+        expected(5, 6, 7, 8, 9),
+        read(
+            unpartitioned.toString(),
+            vectorized,
+            "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
+  }
+
+  @Test
+  public void testBucketPartitionedIDFilters() {
+    Table table = buildPartitionedTable("bucketed_by_id", BUCKET_BY_ID, "bucket4", "id");
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+
+    Batch unfiltered =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options)
+            .build()
+            .toBatch();
+    Assert.assertEquals(
+        "Unfiltered table should created 4 read tasks", 4, unfiltered.planInputPartitions().length);
+
+    for (int i = 0; i < 10; i += 1) {
+      GlutenSparkScanBuilder builder =
+          new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+      pushFilters(builder, EqualTo.apply("id", i));
+      Batch scan = builder.build().toBatch();
+
+      InputPartition[] tasks = scan.planInputPartitions();
+
+      // validate predicate push-down
+      Assert.assertEquals("Should create one task for a single bucket", 1, tasks.length);
+
+      // validate row filtering
+      assertEqualsSafe(
+          SCHEMA.asStruct(), expected(i), read(table.location(), vectorized, "id = " + i));
+    }
+  }
+
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+  @Test
+  public void testDayPartitionedTimestampFilters() {
+    Table table = buildPartitionedTable("partitioned_by_day", PARTITION_BY_DAY, "ts_day", "ts");
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+    Batch unfiltered =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options)
+            .build()
+            .toBatch();
+
+    Assert.assertEquals(
+        "Unfiltered table should created 2 read tasks", 2, unfiltered.planInputPartitions().length);
+
+    {
+      GlutenSparkScanBuilder builder =
+          new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+      pushFilters(builder, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+      Batch scan = builder.build().toBatch();
+
+      InputPartition[] tasks = scan.planInputPartitions();
+      Assert.assertEquals("Should create one task for 2017-12-21", 1, tasks.length);
+
+      assertEqualsSafe(
+          SCHEMA.asStruct(),
+          expected(5, 6, 7, 8, 9),
+          read(
+              table.location(), vectorized, "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
     }
 
-    @Test
-    public void testBucketPartitionedIDFilters() {
-        Table table = buildPartitionedTable("bucketed_by_id", BUCKET_BY_ID, "bucket4", "id");
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+    {
+      GlutenSparkScanBuilder builder =
+          new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
 
-        Batch unfiltered =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options).build().toBatch();
-        Assert.assertEquals(
-                "Unfiltered table should created 4 read tasks", 4, unfiltered.planInputPartitions().length);
+      pushFilters(
+          builder,
+          And.apply(
+              GreaterThan.apply("ts", "2017-12-22T06:00:00+00:00"),
+              LessThan.apply("ts", "2017-12-22T08:00:00+00:00")));
+      Batch scan = builder.build().toBatch();
 
-        for (int i = 0; i < 10; i += 1) {
-            GlutenSparkScanBuilder builder =
-                    new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+      InputPartition[] tasks = scan.planInputPartitions();
+      Assert.assertEquals("Should create one task for 2017-12-22", 1, tasks.length);
 
-            pushFilters(builder, EqualTo.apply("id", i));
-            Batch scan = builder.build().toBatch();
+      assertEqualsSafe(
+          SCHEMA.asStruct(),
+          expected(1, 2),
+          read(
+              table.location(),
+              vectorized,
+              "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and "
+                  + "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)"));
+    }
+  }
 
-            InputPartition[] tasks = scan.planInputPartitions();
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+  @Test
+  public void testHourPartitionedTimestampFilters() {
+    Table table = buildPartitionedTable("partitioned_by_hour", PARTITION_BY_HOUR, "ts_hour", "ts");
 
-            // validate predicate push-down
-            Assert.assertEquals("Should create one task for a single bucket", 1, tasks.length);
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+    Batch unfiltered =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options)
+            .build()
+            .toBatch();
 
-            // validate row filtering
-            assertEqualsSafe(
-                    SCHEMA.asStruct(), expected(i), read(table.location(), vectorized, "id = " + i));
-        }
+    Assert.assertEquals(
+        "Unfiltered table should created 9 read tasks", 9, unfiltered.planInputPartitions().length);
+
+    {
+      GlutenSparkScanBuilder builder =
+          new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+      pushFilters(builder, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+      Batch scan = builder.build().toBatch();
+
+      InputPartition[] tasks = scan.planInputPartitions();
+      Assert.assertEquals("Should create 4 tasks for 2017-12-21: 15, 17, 21, 22", 4, tasks.length);
+
+      assertEqualsSafe(
+          SCHEMA.asStruct(),
+          expected(8, 9, 7, 6, 5),
+          read(
+              table.location(), vectorized, "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
     }
 
-    @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-    @Test
-    public void testDayPartitionedTimestampFilters() {
-        Table table = buildPartitionedTable("partitioned_by_day", PARTITION_BY_DAY, "ts_day", "ts");
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
-        Batch unfiltered =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options).build().toBatch();
+    {
+      GlutenSparkScanBuilder builder =
+          new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
 
-        Assert.assertEquals(
-                "Unfiltered table should created 2 read tasks", 2, unfiltered.planInputPartitions().length);
+      pushFilters(
+          builder,
+          And.apply(
+              GreaterThan.apply("ts", "2017-12-22T06:00:00+00:00"),
+              LessThan.apply("ts", "2017-12-22T08:00:00+00:00")));
+      Batch scan = builder.build().toBatch();
 
-        {
-            GlutenSparkScanBuilder builder =
-                    new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+      InputPartition[] tasks = scan.planInputPartitions();
+      Assert.assertEquals("Should create 2 tasks for 2017-12-22: 6, 7", 2, tasks.length);
 
-            pushFilters(builder, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
-            Batch scan = builder.build().toBatch();
+      assertEqualsSafe(
+          SCHEMA.asStruct(),
+          expected(2, 1),
+          read(
+              table.location(),
+              vectorized,
+              "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and "
+                  + "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)"));
+    }
+  }
 
-            InputPartition[] tasks = scan.planInputPartitions();
-            Assert.assertEquals("Should create one task for 2017-12-21", 1, tasks.length);
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+  @Test
+  public void testFilterByNonProjectedColumn() {
+    {
+      Schema actualProjection = SCHEMA.select("id", "data");
+      List<Record> expected = Lists.newArrayList();
+      for (Record rec : expected(5, 6, 7, 8, 9)) {
+        expected.add(projectFlat(actualProjection, rec));
+      }
 
-            assertEqualsSafe(
-                    SCHEMA.asStruct(),
-                    expected(5, 6, 7, 8, 9),
-                    read(
-                            table.location(), vectorized, "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
-        }
-
-        {
-            GlutenSparkScanBuilder builder =
-                    new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-            pushFilters(
-                    builder,
-                    And.apply(
-                            GreaterThan.apply("ts", "2017-12-22T06:00:00+00:00"),
-                            LessThan.apply("ts", "2017-12-22T08:00:00+00:00")));
-            Batch scan = builder.build().toBatch();
-
-            InputPartition[] tasks = scan.planInputPartitions();
-            Assert.assertEquals("Should create one task for 2017-12-22", 1, tasks.length);
-
-            assertEqualsSafe(
-                    SCHEMA.asStruct(),
-                    expected(1, 2),
-                    read(
-                            table.location(),
-                            vectorized,
-                            "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and "
-                                    + "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)"));
-        }
+      assertEqualsSafe(
+          actualProjection.asStruct(),
+          expected,
+          read(
+              unpartitioned.toString(),
+              vectorized,
+              "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)",
+              "id",
+              "data"));
     }
 
-    @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-    @Test
-    public void testHourPartitionedTimestampFilters() {
-        Table table = buildPartitionedTable("partitioned_by_hour", PARTITION_BY_HOUR, "ts_hour", "ts");
+    {
+      // only project id: ts will be projected because of the filter, but data will not be included
 
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
-        Batch unfiltered =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options).build().toBatch();
+      Schema actualProjection = SCHEMA.select("id");
+      List<Record> expected = Lists.newArrayList();
+      for (Record rec : expected(1, 2)) {
+        expected.add(projectFlat(actualProjection, rec));
+      }
 
-        Assert.assertEquals(
-                "Unfiltered table should created 9 read tasks", 9, unfiltered.planInputPartitions().length);
-
-        {
-            GlutenSparkScanBuilder builder =
-                    new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-            pushFilters(builder, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
-            Batch scan = builder.build().toBatch();
-
-            InputPartition[] tasks = scan.planInputPartitions();
-            Assert.assertEquals("Should create 4 tasks for 2017-12-21: 15, 17, 21, 22", 4, tasks.length);
-
-            assertEqualsSafe(
-                    SCHEMA.asStruct(),
-                    expected(8, 9, 7, 6, 5),
-                    read(
-                            table.location(), vectorized, "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
-        }
-
-        {
-            GlutenSparkScanBuilder builder =
-                    new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-            pushFilters(
-                    builder,
-                    And.apply(
-                            GreaterThan.apply("ts", "2017-12-22T06:00:00+00:00"),
-                            LessThan.apply("ts", "2017-12-22T08:00:00+00:00")));
-            Batch scan = builder.build().toBatch();
-
-            InputPartition[] tasks = scan.planInputPartitions();
-            Assert.assertEquals("Should create 2 tasks for 2017-12-22: 6, 7", 2, tasks.length);
-
-            assertEqualsSafe(
-                    SCHEMA.asStruct(),
-                    expected(2, 1),
-                    read(
-                            table.location(),
-                            vectorized,
-                            "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and "
-                                    + "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)"));
-        }
+      assertEqualsSafe(
+          actualProjection.asStruct(),
+          expected,
+          read(
+              unpartitioned.toString(),
+              vectorized,
+              "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and "
+                  + "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)",
+              "id"));
     }
+  }
 
-    @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-    @Test
-    public void testFilterByNonProjectedColumn() {
-        {
-            Schema actualProjection = SCHEMA.select("id", "data");
-            List<Record> expected = Lists.newArrayList();
-            for (Record rec : expected(5, 6, 7, 8, 9)) {
-                expected.add(projectFlat(actualProjection, rec));
-            }
+  @Test
+  public void testPartitionedByDataStartsWithFilter() {
+    Table table =
+        buildPartitionedTable("partitioned_by_data", PARTITION_BY_DATA, "data_ident", "data");
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
 
-            assertEqualsSafe(
-                    actualProjection.asStruct(),
-                    expected,
-                    read(
-                            unpartitioned.toString(),
-                            vectorized,
-                            "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)",
-                            "id",
-                            "data"));
-        }
+    GlutenSparkScanBuilder builder =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
 
-        {
-            // only project id: ts will be projected because of the filter, but data will not be included
+    pushFilters(builder, new StringStartsWith("data", "junc"));
+    Batch scan = builder.build().toBatch();
 
-            Schema actualProjection = SCHEMA.select("id");
-            List<Record> expected = Lists.newArrayList();
-            for (Record rec : expected(1, 2)) {
-                expected.add(projectFlat(actualProjection, rec));
-            }
+    Assert.assertEquals(1, scan.planInputPartitions().length);
+  }
 
-            assertEqualsSafe(
-                    actualProjection.asStruct(),
-                    expected,
-                    read(
-                            unpartitioned.toString(),
-                            vectorized,
-                            "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and "
-                                    + "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)",
-                            "id"));
-        }
+  @Test
+  public void testPartitionedByDataNotStartsWithFilter() {
+    Table table =
+        buildPartitionedTable("partitioned_by_data", PARTITION_BY_DATA, "data_ident", "data");
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+
+    GlutenSparkScanBuilder builder =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+    pushFilters(builder, new Not(new StringStartsWith("data", "junc")));
+    Batch scan = builder.build().toBatch();
+
+    Assert.assertEquals(9, scan.planInputPartitions().length);
+  }
+
+  @Test
+  public void testPartitionedByIdStartsWith() {
+    Table table = buildPartitionedTable("partitioned_by_id", PARTITION_BY_ID, "id_ident", "id");
+
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+
+    GlutenSparkScanBuilder builder =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+    pushFilters(builder, new StringStartsWith("data", "junc"));
+    Batch scan = builder.build().toBatch();
+
+    Assert.assertEquals(1, scan.planInputPartitions().length);
+  }
+
+  @Test
+  public void testPartitionedByIdNotStartsWith() {
+    Table table = buildPartitionedTable("partitioned_by_id", PARTITION_BY_ID, "id_ident", "id");
+
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+
+    GlutenSparkScanBuilder builder =
+        new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+
+    pushFilters(builder, new Not(new StringStartsWith("data", "junc")));
+    Batch scan = builder.build().toBatch();
+
+    Assert.assertEquals(9, scan.planInputPartitions().length);
+  }
+
+  @Test
+  public void testUnpartitionedStartsWith() {
+    Dataset<Row> df =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
+            .load(unpartitioned.toString());
+
+    List<String> matchedData =
+        df.select("data").where("data LIKE 'jun%'").as(Encoders.STRING()).collectAsList();
+
+    Assert.assertEquals(1, matchedData.size());
+    Assert.assertEquals("junction", matchedData.get(0));
+  }
+
+  @Test
+  public void testUnpartitionedNotStartsWith() {
+    Dataset<Row> df =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
+            .load(unpartitioned.toString());
+
+    List<String> matchedData =
+        df.select("data").where("data NOT LIKE 'jun%'").as(Encoders.STRING()).collectAsList();
+
+    List<String> expected =
+        testRecords(SCHEMA).stream()
+            .map(r -> r.getField("data").toString())
+            .filter(d -> !d.startsWith("jun"))
+            .collect(Collectors.toList());
+
+    Assert.assertEquals(9, matchedData.size());
+    Assert.assertEquals(Sets.newHashSet(expected), Sets.newHashSet(matchedData));
+  }
+
+  private static Record projectFlat(Schema projection, Record record) {
+    Record result = GenericRecord.create(projection);
+    List<Types.NestedField> fields = projection.asStruct().fields();
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+      result.set(i, record.getField(field.name()));
     }
+    return result;
+  }
 
-    @Test
-    public void testPartitionedByDataStartsWithFilter() {
-        Table table =
-                buildPartitionedTable("partitioned_by_data", PARTITION_BY_DATA, "data_ident", "data");
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
-
-        GlutenSparkScanBuilder builder =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-        pushFilters(builder, new StringStartsWith("data", "junc"));
-        Batch scan = builder.build().toBatch();
-
-        Assert.assertEquals(1, scan.planInputPartitions().length);
+  public static void assertEqualsUnsafe(
+      Types.StructType struct, List<Record> expected, List<UnsafeRow> actual) {
+    // TODO: match records by ID
+    int numRecords = Math.min(expected.size(), actual.size());
+    for (int i = 0; i < numRecords; i += 1) {
+      GenericsHelpers.assertEqualsUnsafe(struct, expected.get(i), actual.get(i));
     }
+    Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
+  }
 
-    @Test
-    public void testPartitionedByDataNotStartsWithFilter() {
-        Table table =
-                buildPartitionedTable("partitioned_by_data", PARTITION_BY_DATA, "data_ident", "data");
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
-
-        GlutenSparkScanBuilder builder =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-        pushFilters(builder, new Not(new StringStartsWith("data", "junc")));
-        Batch scan = builder.build().toBatch();
-
-        Assert.assertEquals(9, scan.planInputPartitions().length);
+  public static void assertEqualsSafe(
+      Types.StructType struct, List<Record> expected, List<Row> actual) {
+    // TODO: match records by ID
+    int numRecords = Math.min(expected.size(), actual.size());
+    for (int i = 0; i < numRecords; i += 1) {
+      GenericsHelpers.assertEqualsSafe(struct, expected.get(i), actual.get(i));
     }
+    Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
+  }
 
-    @Test
-    public void testPartitionedByIdStartsWith() {
-        Table table = buildPartitionedTable("partitioned_by_id", PARTITION_BY_ID, "id_ident", "id");
-
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
-
-        GlutenSparkScanBuilder builder =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
-
-        pushFilters(builder, new StringStartsWith("data", "junc"));
-        Batch scan = builder.build().toBatch();
-
-        Assert.assertEquals(1, scan.planInputPartitions().length);
+  private List<Record> expected(int... ordinals) {
+    List<Record> expected = Lists.newArrayListWithExpectedSize(ordinals.length);
+    for (int ord : ordinals) {
+      expected.add(records.get(ord));
     }
+    return expected;
+  }
 
-    @Test
-    public void testPartitionedByIdNotStartsWith() {
-        Table table = buildPartitionedTable("partitioned_by_id", PARTITION_BY_ID, "id_ident", "id");
+  private void pushFilters(ScanBuilder scan, Filter... filters) {
+    assertThat(scan).isInstanceOf(SupportsPushDownV2Filters.class);
+    SupportsPushDownV2Filters filterable = (SupportsPushDownV2Filters) scan;
+    filterable.pushPredicates(Arrays.stream(filters).map(Filter::toV2).toArray(Predicate[]::new));
+  }
 
-        CaseInsensitiveStringMap options =
-                new CaseInsensitiveStringMap(ImmutableMap.of("path", table.location()));
+  private Table buildPartitionedTable(
+      String desc, PartitionSpec spec, String udf, String partitionColumn) {
+    File location = new File(parent, desc);
+    Table table = TABLES.create(SCHEMA, spec, location.toString());
 
-        GlutenSparkScanBuilder builder =
-                new GlutenSparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+    // Do not combine or split files because the tests expect a split per partition.
+    // A target split size of 2048 helps us achieve that.
+    table.updateProperties().set("read.split.target-size", "2048").commit();
 
-        pushFilters(builder, new Not(new StringStartsWith("data", "junc")));
-        Batch scan = builder.build().toBatch();
+    // copy the unpartitioned table into the partitioned table to produce the partitioned data
+    Dataset<Row> allRows =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
+            .load(unpartitioned.toString());
 
-        Assert.assertEquals(9, scan.planInputPartitions().length);
+    allRows
+        .coalesce(1) // ensure only 1 file per partition is written
+        .withColumn("part", callUDF(udf, column(partitionColumn)))
+        .sortWithinPartitions("part")
+        .drop("part")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(table.location());
+
+    table.refresh();
+
+    return table;
+  }
+
+  private List<Record> testRecords(Schema schema) {
+    return Lists.newArrayList(
+        record(schema, 0L, parse("2017-12-22T09:20:44.294658+00:00"), "junction"),
+        record(schema, 1L, parse("2017-12-22T07:15:34.582910+00:00"), "alligator"),
+        record(schema, 2L, parse("2017-12-22T06:02:09.243857+00:00"), ""),
+        record(schema, 3L, parse("2017-12-22T03:10:11.134509+00:00"), "clapping"),
+        record(schema, 4L, parse("2017-12-22T00:34:00.184671+00:00"), "brush"),
+        record(schema, 5L, parse("2017-12-21T22:20:08.935889+00:00"), "trap"),
+        record(schema, 6L, parse("2017-12-21T21:55:30.589712+00:00"), "element"),
+        record(schema, 7L, parse("2017-12-21T17:31:14.532797+00:00"), "limited"),
+        record(schema, 8L, parse("2017-12-21T15:21:51.237521+00:00"), "global"),
+        record(schema, 9L, parse("2017-12-21T15:02:15.230570+00:00"), "goldfish"));
+  }
+
+  private static List<Row> read(String table, boolean vectorized, String expr) {
+    return read(table, vectorized, expr, "*");
+  }
+
+  private static List<Row> read(
+      String table, boolean vectorized, String expr, String select0, String... selectN) {
+    Dataset<Row> dataset =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
+            .load(table)
+            .filter(expr)
+            .select(select0, selectN);
+    return dataset.collectAsList();
+  }
+
+  private static OffsetDateTime parse(String timestamp) {
+    return OffsetDateTime.parse(timestamp);
+  }
+
+  private static Record record(Schema schema, Object... values) {
+    Record rec = GenericRecord.create(schema);
+    for (int i = 0; i < values.length; i += 1) {
+      rec.set(i, values[i]);
     }
-
-    @Test
-    public void testUnpartitionedStartsWith() {
-        Dataset<Row> df =
-                spark
-                        .read()
-                        .format("iceberg")
-                        .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
-                        .load(unpartitioned.toString());
-
-        List<String> matchedData =
-                df.select("data").where("data LIKE 'jun%'").as(Encoders.STRING()).collectAsList();
-
-        Assert.assertEquals(1, matchedData.size());
-        Assert.assertEquals("junction", matchedData.get(0));
-    }
-
-    @Test
-    public void testUnpartitionedNotStartsWith() {
-        Dataset<Row> df =
-                spark
-                        .read()
-                        .format("iceberg")
-                        .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
-                        .load(unpartitioned.toString());
-
-        List<String> matchedData =
-                df.select("data").where("data NOT LIKE 'jun%'").as(Encoders.STRING()).collectAsList();
-
-        List<String> expected =
-                testRecords(SCHEMA).stream()
-                        .map(r -> r.getField("data").toString())
-                        .filter(d -> !d.startsWith("jun"))
-                        .collect(Collectors.toList());
-
-        Assert.assertEquals(9, matchedData.size());
-        Assert.assertEquals(Sets.newHashSet(expected), Sets.newHashSet(matchedData));
-    }
-
-    private static Record projectFlat(Schema projection, Record record) {
-        Record result = GenericRecord.create(projection);
-        List<Types.NestedField> fields = projection.asStruct().fields();
-        for (int i = 0; i < fields.size(); i += 1) {
-            Types.NestedField field = fields.get(i);
-            result.set(i, record.getField(field.name()));
-        }
-        return result;
-    }
-
-    public static void assertEqualsUnsafe(
-            Types.StructType struct, List<Record> expected, List<UnsafeRow> actual) {
-        // TODO: match records by ID
-        int numRecords = Math.min(expected.size(), actual.size());
-        for (int i = 0; i < numRecords; i += 1) {
-            GenericsHelpers.assertEqualsUnsafe(struct, expected.get(i), actual.get(i));
-        }
-        Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
-    }
-
-    public static void assertEqualsSafe(
-            Types.StructType struct, List<Record> expected, List<Row> actual) {
-        // TODO: match records by ID
-        int numRecords = Math.min(expected.size(), actual.size());
-        for (int i = 0; i < numRecords; i += 1) {
-            GenericsHelpers.assertEqualsSafe(struct, expected.get(i), actual.get(i));
-        }
-        Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
-    }
-
-    private List<Record> expected(int... ordinals) {
-        List<Record> expected = Lists.newArrayListWithExpectedSize(ordinals.length);
-        for (int ord : ordinals) {
-            expected.add(records.get(ord));
-        }
-        return expected;
-    }
-
-    private void pushFilters(ScanBuilder scan, Filter... filters) {
-        assertThat(scan).isInstanceOf(SupportsPushDownV2Filters.class);
-        SupportsPushDownV2Filters filterable = (SupportsPushDownV2Filters) scan;
-        filterable.pushPredicates(Arrays.stream(filters).map(Filter::toV2).toArray(Predicate[]::new));
-    }
-
-    private Table buildPartitionedTable(
-            String desc, PartitionSpec spec, String udf, String partitionColumn) {
-        File location = new File(parent, desc);
-        Table table = TABLES.create(SCHEMA, spec, location.toString());
-
-        // Do not combine or split files because the tests expect a split per partition.
-        // A target split size of 2048 helps us achieve that.
-        table.updateProperties().set("read.split.target-size", "2048").commit();
-
-        // copy the unpartitioned table into the partitioned table to produce the partitioned data
-        Dataset<Row> allRows =
-                spark
-                        .read()
-                        .format("iceberg")
-                        .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
-                        .load(unpartitioned.toString());
-
-        allRows
-                .coalesce(1) // ensure only 1 file per partition is written
-                .withColumn("part", callUDF(udf, column(partitionColumn)))
-                .sortWithinPartitions("part")
-                .drop("part")
-                .write()
-                .format("iceberg")
-                .mode("append")
-                .save(table.location());
-
-        table.refresh();
-
-        return table;
-    }
-
-    private List<Record> testRecords(Schema schema) {
-        return Lists.newArrayList(
-                record(schema, 0L, parse("2017-12-22T09:20:44.294658+00:00"), "junction"),
-                record(schema, 1L, parse("2017-12-22T07:15:34.582910+00:00"), "alligator"),
-                record(schema, 2L, parse("2017-12-22T06:02:09.243857+00:00"), ""),
-                record(schema, 3L, parse("2017-12-22T03:10:11.134509+00:00"), "clapping"),
-                record(schema, 4L, parse("2017-12-22T00:34:00.184671+00:00"), "brush"),
-                record(schema, 5L, parse("2017-12-21T22:20:08.935889+00:00"), "trap"),
-                record(schema, 6L, parse("2017-12-21T21:55:30.589712+00:00"), "element"),
-                record(schema, 7L, parse("2017-12-21T17:31:14.532797+00:00"), "limited"),
-                record(schema, 8L, parse("2017-12-21T15:21:51.237521+00:00"), "global"),
-                record(schema, 9L, parse("2017-12-21T15:02:15.230570+00:00"), "goldfish"));
-    }
-
-    private static List<Row> read(String table, boolean vectorized, String expr) {
-        return read(table, vectorized, expr, "*");
-    }
-
-    private static List<Row> read(
-            String table, boolean vectorized, String expr, String select0, String... selectN) {
-        Dataset<Row> dataset =
-                spark
-                        .read()
-                        .format("iceberg")
-                        .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
-                        .load(table)
-                        .filter(expr)
-                        .select(select0, selectN);
-        return dataset.collectAsList();
-    }
-
-    private static OffsetDateTime parse(String timestamp) {
-        return OffsetDateTime.parse(timestamp);
-    }
-
-    private static Record record(Schema schema, Object... values) {
-        Record rec = GenericRecord.create(schema);
-        for (int i = 0; i < values.length; i += 1) {
-            rec.set(i, values[i]);
-        }
-        return rec;
-    }
+    return rec;
+  }
 }
-

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestForwardCompatibility.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestForwardCompatibility.java
@@ -17,7 +17,7 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.*;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -25,6 +25,7 @@ import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -35,14 +36,15 @@ import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
-import scala.Option;
-import scala.collection.JavaConverters;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+
+import scala.Option;
+import scala.collection.JavaConverters;
 
 import static org.apache.iceberg.Files.localInput;
 import static org.apache.iceberg.Files.localOutput;
@@ -78,8 +80,8 @@ public class TestForwardCompatibility {
 
   @BeforeClass
   public static void startSpark() {
-    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF).getOrCreate();
+    TestForwardCompatibility.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
   }
 
   @AfterClass

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestIcebergSpark.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestIcebergSpark.java
@@ -16,15 +16,8 @@
  */
 package org.apache.gluten.spark34.source;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.sql.Date;
-import java.sql.Timestamp;
-import java.util.List;
-
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.iceberg.spark.IcebergSpark;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
@@ -40,14 +33,22 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class TestIcebergSpark {
 
   private static SparkSession spark = null;
 
   @BeforeClass
   public static void startSpark() {
-    TestIcebergSpark.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF).getOrCreate();
+    TestIcebergSpark.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
   }
 
   @AfterClass

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestParquetScan.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestParquetScan.java
@@ -17,34 +17,32 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.*;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
 import org.apache.iceberg.spark.data.AvroDataTest;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
-import org.apache.iceberg.types.Type;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import scala.collection.JavaConverters;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import static org.apache.iceberg.Files.localOutput;
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -60,29 +58,28 @@ public class TestParquetScan extends AvroDataTest {
   private static SparkSession spark = null;
 
   protected static final Types.StructType GLUTEN_SUPPORTED_PRIMITIVES =
-          Types.StructType.of(
-                  required(100, "id", Types.LongType.get()),
-                  optional(101, "data", Types.StringType.get()),
-                  required(102, "b", Types.BooleanType.get()),
-                  optional(103, "i", Types.IntegerType.get()),
-                  required(104, "l", Types.LongType.get()),
-                  optional(105, "f", Types.FloatType.get()),
-                  required(106, "d", Types.DoubleType.get()),
-                  optional(107, "date", Types.DateType.get()),
-                  required(108, "ts", Types.TimestampType.withZone()),
-                  required(110, "s", Types.StringType.get()),
-                  optional(113, "bytes", Types.BinaryType.get()),
-                  required(114, "dec_9_0", Types.DecimalType.of(9, 0)), // int encoded
-                  required(115, "dec_11_2", Types.DecimalType.of(11, 2)), // long encoded
-                  required(116, "dec_20_5", Types.DecimalType.of(20, 5)), // requires padding
-                  required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
+      Types.StructType.of(
+          required(100, "id", Types.LongType.get()),
+          optional(101, "data", Types.StringType.get()),
+          required(102, "b", Types.BooleanType.get()),
+          optional(103, "i", Types.IntegerType.get()),
+          required(104, "l", Types.LongType.get()),
+          optional(105, "f", Types.FloatType.get()),
+          required(106, "d", Types.DoubleType.get()),
+          optional(107, "date", Types.DateType.get()),
+          required(108, "ts", Types.TimestampType.withZone()),
+          required(110, "s", Types.StringType.get()),
+          optional(113, "bytes", Types.BinaryType.get()),
+          required(114, "dec_9_0", Types.DecimalType.of(9, 0)), // int encoded
+          required(115, "dec_11_2", Types.DecimalType.of(11, 2)), // long encoded
+          required(116, "dec_20_5", Types.DecimalType.of(20, 5)), // requires padding
+          required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
           );
 
   @BeforeClass
   public static void startSpark() {
-    TestParquetScan.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF)
-            .getOrCreate();
+    TestParquetScan.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
   }
 
   @AfterClass
@@ -132,9 +129,9 @@ public class TestParquetScan extends AvroDataTest {
 
     spark.conf().set("spark.gluten.enabled", "true");
     // Cannot use this helper test function because the order is not same.
-//    for (int i = 0; i < expected.size(); i += 1) {
-//      TestHelpers.assertEqualsSafe(table.schema().asStruct(), expected.get(i), rows.get(i));
-//    }
+    //    for (int i = 0; i < expected.size(); i += 1) {
+    //      TestHelpers.assertEqualsSafe(table.schema().asStruct(), expected.get(i), rows.get(i));
+    //    }
   }
 
   @Test
@@ -164,108 +161,141 @@ public class TestParquetScan extends AvroDataTest {
 
   @Test
   public void testGlutenSimpleStruct() throws IOException {
-    this.writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(GLUTEN_SUPPORTED_PRIMITIVES.fields())));
+    this.writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(new Schema(GLUTEN_SUPPORTED_PRIMITIVES.fields())));
   }
 
   @Test
   public void testSimpleStruct() throws IOException {
-    this.writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(SUPPORTED_PRIMITIVES.fields())));
+    this.writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(new Schema(SUPPORTED_PRIMITIVES.fields())));
   }
 
   @Test
   public void testArray() throws IOException {
-    Schema schema = new Schema(new Types.NestedField[]{Types.NestedField.required(0, "id", Types.LongType.get()), Types.NestedField.optional(1, "data", Types.ListType.ofOptional(2, Types.StringType.get()))});
+    Schema schema =
+        new Schema(
+            new Types.NestedField[] {
+              Types.NestedField.required(0, "id", Types.LongType.get()),
+              Types.NestedField.optional(
+                  1, "data", Types.ListType.ofOptional(2, Types.StringType.get()))
+            });
     this.writeAndValidate(schema);
   }
 
   // The result is right but order is not same.
   // Use @Test to overwrite the super class test
   @Test
-  public void testMap() throws IOException {
-  }
+  public void testMap() throws IOException {}
 
   // The result is right but order is not same.
   // Use @Test to overwrite the super class test
   @Test
-  public void testMapOfStructs() throws IOException {
-  }
+  public void testMapOfStructs() throws IOException {}
 
   @Test
   public void testMixedTypes() throws IOException {
     Types.StructType structType =
-            Types.StructType.of(
-                    required(0, "id", Types.LongType.get()),
-                    optional(
-                            1,
-                            "list_of_maps",
-                            Types.ListType.ofOptional(
-                                    2, Types.MapType.ofOptional(3, 4, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES))),
-                    optional(
-                            5,
-                            "map_of_lists",
+        Types.StructType.of(
+            required(0, "id", Types.LongType.get()),
+            optional(
+                1,
+                "list_of_maps",
+                Types.ListType.ofOptional(
+                    2,
+                    Types.MapType.ofOptional(
+                        3, 4, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES))),
+            optional(
+                5,
+                "map_of_lists",
+                Types.MapType.ofOptional(
+                    6,
+                    7,
+                    Types.StringType.get(),
+                    Types.ListType.ofOptional(8, GLUTEN_SUPPORTED_PRIMITIVES))),
+            required(
+                9,
+                "list_of_lists",
+                Types.ListType.ofOptional(
+                    10, Types.ListType.ofOptional(11, GLUTEN_SUPPORTED_PRIMITIVES))),
+            required(
+                12,
+                "map_of_maps",
+                Types.MapType.ofOptional(
+                    13,
+                    14,
+                    Types.StringType.get(),
+                    Types.MapType.ofOptional(
+                        15, 16, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES))),
+            required(
+                17,
+                "list_of_struct_of_nested_types",
+                Types.ListType.ofOptional(
+                    19,
+                    Types.StructType.of(
+                        Types.NestedField.required(
+                            20,
+                            "m1",
                             Types.MapType.ofOptional(
-                                    6, 7, Types.StringType.get(), Types.ListType.ofOptional(8, GLUTEN_SUPPORTED_PRIMITIVES))),
-                    required(
-                            9,
-                            "list_of_lists",
-                            Types.ListType.ofOptional(10, Types.ListType.ofOptional(11, GLUTEN_SUPPORTED_PRIMITIVES))),
-                    required(
-                            12,
-                            "map_of_maps",
+                                21, 22, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES)),
+                        Types.NestedField.optional(
+                            23, "l1", Types.ListType.ofRequired(24, GLUTEN_SUPPORTED_PRIMITIVES)),
+                        Types.NestedField.required(
+                            25, "l2", Types.ListType.ofRequired(26, GLUTEN_SUPPORTED_PRIMITIVES)),
+                        Types.NestedField.optional(
+                            27,
+                            "m2",
                             Types.MapType.ofOptional(
-                                    13,
-                                    14,
-                                    Types.StringType.get(),
-                                    Types.MapType.ofOptional(15, 16, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES))),
-                    required(
-                            17,
-                            "list_of_struct_of_nested_types",
-                            Types.ListType.ofOptional(
-                                    19,
-                                    Types.StructType.of(
-                                            Types.NestedField.required(
-                                                    20,
-                                                    "m1",
-                                                    Types.MapType.ofOptional(
-                                                            21, 22, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES)),
-                                            Types.NestedField.optional(
-                                                    23, "l1", Types.ListType.ofRequired(24, GLUTEN_SUPPORTED_PRIMITIVES)),
-                                            Types.NestedField.required(
-                                                    25, "l2", Types.ListType.ofRequired(26, GLUTEN_SUPPORTED_PRIMITIVES)),
-                                            Types.NestedField.optional(
-                                                    27,
-                                                    "m2",
-                                                    Types.MapType.ofOptional(
-                                                            28, 29, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES))))));
+                                28, 29, Types.StringType.get(), GLUTEN_SUPPORTED_PRIMITIVES))))));
 
     Schema schema =
-            new Schema(
-                    TypeUtil.assignFreshIds(structType, new AtomicInteger(0)::incrementAndGet)
-                            .asStructType()
-                            .fields());
+        new Schema(
+            TypeUtil.assignFreshIds(structType, new AtomicInteger(0)::incrementAndGet)
+                .asStructType()
+                .fields());
 
     writeAndValidate(schema);
   }
 
   @Test
   public void testStructWithOptionalFields() throws IOException {
-    this.writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(Lists.transform(GLUTEN_SUPPORTED_PRIMITIVES.fields(), Types.NestedField::asOptional))));
+    this.writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                Lists.transform(
+                    GLUTEN_SUPPORTED_PRIMITIVES.fields(), Types.NestedField::asOptional))));
   }
 
   @Test
   public void testStructWithRequiredFields() throws IOException {
-    this.writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(Lists.transform(GLUTEN_SUPPORTED_PRIMITIVES.fields(), Types.NestedField::asRequired))));
+    this.writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                Lists.transform(
+                    GLUTEN_SUPPORTED_PRIMITIVES.fields(), Types.NestedField::asRequired))));
   }
 
   @Test
   public void testArrayOfStructs() throws IOException {
-    Schema schema = TypeUtil.assignIncreasingFreshIds(new Schema(new Types.NestedField[]{Types.NestedField.required(0, "id", Types.LongType.get()), Types.NestedField.optional(1, "data", Types.ListType.ofOptional(2, GLUTEN_SUPPORTED_PRIMITIVES))}));
+    Schema schema =
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                new Types.NestedField[] {
+                  Types.NestedField.required(0, "id", Types.LongType.get()),
+                  Types.NestedField.optional(
+                      1, "data", Types.ListType.ofOptional(2, GLUTEN_SUPPORTED_PRIMITIVES))
+                }));
     this.writeAndValidate(schema);
   }
 
   @Test
   public void testNestedStruct() throws IOException {
-    this.writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(new Types.NestedField[]{Types.NestedField.required(1, "struct", GLUTEN_SUPPORTED_PRIMITIVES)})));
+    this.writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                new Types.NestedField[] {
+                  Types.NestedField.required(1, "struct", GLUTEN_SUPPORTED_PRIMITIVES)
+                })));
   }
 
   private Table createTable(Schema schema) throws IOException {

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestPartitionPruning.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestPartitionPruning.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
@@ -71,8 +72,8 @@ public class TestPartitionPruning {
   @Parameterized.Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
-//      {"parquet", false, DISTRIBUTED},
-//      {"parquet", true, LOCAL},
+      //      {"parquet", false, DISTRIBUTED},
+      //      {"parquet", true, LOCAL},
       {"avro", false, DISTRIBUTED},
       {"orc", false, LOCAL},
       {"orc", true, DISTRIBUTED}
@@ -101,9 +102,8 @@ public class TestPartitionPruning {
 
   @BeforeClass
   public static void startSpark() {
-    TestPartitionPruning.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF)
-            .getOrCreate();
+    TestPartitionPruning.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
 
     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
@@ -275,7 +275,8 @@ public class TestPartitionPruning {
             .orderBy("id")
             .collectAsList();
 
-    Dataset<Row> ros = spark
+    Dataset<Row> ros =
+        spark
             .read()
             .format("iceberg")
             .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestPartitionValues.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestPartitionValues.java
@@ -17,12 +17,13 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
+
 import org.apache.iceberg.*;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.SparkWriteOptions;
@@ -96,8 +97,8 @@ public class TestPartitionValues extends SparkTestBase {
 
   @BeforeClass
   public static void startSpark() {
-    TestPartitionValues.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF).getOrCreate();
+    TestPartitionValues.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
   }
 
   @AfterClass
@@ -305,17 +306,18 @@ public class TestPartitionValues extends SparkTestBase {
               .collectAsList();
 
       Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-      Dataset<Row> df = spark
+      Dataset<Row> df =
+          spark
               .read()
               .format("iceberg")
               .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
               .load(location.toString());
       checkAnswer(df);
       // Remove because the order is changed
-//      for (int i = 0; i < expected.size(); i += 1) {
-//        TestHelpers.assertEqualsSafe(
-//            SUPPORTED_PRIMITIVES.asStruct(), expected.get(i), actual.get(i));
-//      }
+      //      for (int i = 0; i < expected.size(); i += 1) {
+      //        TestHelpers.assertEqualsSafe(
+      //            SUPPORTED_PRIMITIVES.asStruct(), expected.get(i), actual.get(i));
+      //      }
     }
   }
 

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestSparkDataFile.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestSparkDataFile.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.*;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -91,8 +92,8 @@ public class TestSparkDataFile {
 
   @BeforeClass
   public static void startSpark() {
-    TestSparkDataFile.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF).getOrCreate();
+    TestSparkDataFile.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
   }
 

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestSparkReaderWithBloomFilter.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestSparkReaderWithBloomFilter.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.*;
 import org.apache.iceberg.TestHelpers.Row;
@@ -155,7 +156,7 @@ public class TestSparkReaderWithBloomFilter {
         SparkSession.builder()
             .master("local[2]")
             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-                .config(TestConfUtil.GLUTEN_CONF)
+            .config(TestConfUtil.GLUTEN_CONF)
             .enableHiveSupport()
             .getOrCreate();
 

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestStructuredStreaming.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestStructuredStreaming.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.spark34.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -33,11 +34,12 @@ import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
-import scala.Option;
-import scala.collection.JavaConverters;
 
 import java.io.File;
 import java.util.List;
+
+import scala.Option;
+import scala.collection.JavaConverters;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -58,7 +60,7 @@ public class TestStructuredStreaming {
         SparkSession.builder()
             .master("local[2]")
             .config("spark.sql.shuffle.partitions", 4)
-                .config(TestConfUtil.GLUTEN_CONF)
+            .config(TestConfUtil.GLUTEN_CONF)
             .getOrCreate();
   }
 

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestTimestampWithoutZone.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/source/TestTimestampWithoutZone.java
@@ -16,15 +16,6 @@
  */
 package org.apache.gluten.spark34.source;
 
-import static org.apache.iceberg.Files.localOutput;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -55,6 +46,16 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.iceberg.Files.localOutput;
 
 @RunWith(Parameterized.class)
 public class TestTimestampWithoutZone extends SparkTestBase {

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestDeleteFrom.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestDeleteFrom.java
@@ -21,7 +21,8 @@ import org.apache.iceberg.spark.sql.TestDeleteFrom;
 import java.util.Map;
 
 public class GlutenTestDeleteFrom extends TestDeleteFrom {
-    public GlutenTestDeleteFrom(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestDeleteFrom(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestPartitionedWritesAsSelect.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestPartitionedWritesAsSelect.java
@@ -18,5 +18,4 @@ package org.apache.gluten.spark34.sql;
 
 import org.apache.iceberg.spark.sql.TestPartitionedWritesAsSelect;
 
-public class GlutenTestPartitionedWritesAsSelect extends TestPartitionedWritesAsSelect {
-}
+public class GlutenTestPartitionedWritesAsSelect extends TestPartitionedWritesAsSelect {}

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestPartitionedWritesToBranch.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestPartitionedWritesToBranch.java
@@ -21,7 +21,8 @@ import org.apache.iceberg.spark.sql.TestPartitionedWritesToBranch;
 import java.util.Map;
 
 public class GlutenTestPartitionedWritesToBranch extends TestPartitionedWritesToBranch {
-    public GlutenTestPartitionedWritesToBranch(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestPartitionedWritesToBranch(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestPartitionedWritesToWapBranch.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestPartitionedWritesToWapBranch.java
@@ -21,7 +21,8 @@ import org.apache.iceberg.spark.sql.TestPartitionedWritesToWapBranch;
 import java.util.Map;
 
 public class GlutenTestPartitionedWritesToWapBranch extends TestPartitionedWritesToWapBranch {
-    public GlutenTestPartitionedWritesToWapBranch(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestPartitionedWritesToWapBranch(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestSelect.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestSelect.java
@@ -21,7 +21,7 @@ import org.apache.iceberg.spark.sql.TestSelect;
 import java.util.Map;
 
 public class GlutenTestSelect extends TestSelect {
-    public GlutenTestSelect(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestSelect(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestTimestampWithoutZone.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/gluten/spark34/sql/GlutenTestTimestampWithoutZone.java
@@ -21,7 +21,8 @@ import org.apache.iceberg.spark.sql.TestTimestampWithoutZone;
 import java.util.Map;
 
 public class GlutenTestTimestampWithoutZone extends TestTimestampWithoutZone {
-    public GlutenTestTimestampWithoutZone(String catalogName, String implementation, Map<String, String> config) {
-        super(catalogName, implementation, config);
-    }
+  public GlutenTestTimestampWithoutZone(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -16,23 +16,9 @@
  */
 package org.apache.iceberg.spark;
 
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TimeZone;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.gluten.config.GlutenConfig;
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
@@ -55,247 +41,265 @@ import org.apache.spark.sql.util.QueryExecutionListener;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import scala.Option;
 import scala.collection.JavaConversions;
 
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+
 public abstract class SparkTestBase extends SparkTestHelperBase {
 
-    protected static TestHiveMetastore metastore = null;
-    protected static HiveConf hiveConf = null;
-    protected static SparkSession spark = null;
-    protected static JavaSparkContext sparkContext = null;
-    protected static HiveCatalog catalog = null;
+  protected static TestHiveMetastore metastore = null;
+  protected static HiveConf hiveConf = null;
+  protected static SparkSession spark = null;
+  protected static JavaSparkContext sparkContext = null;
+  protected static HiveCatalog catalog = null;
 
-    @BeforeClass
-    public static void startMetastoreAndSpark() {
-        SparkTestBase.metastore = new TestHiveMetastore();
-        metastore.start();
-        SparkTestBase.hiveConf = metastore.hiveConf();
+  @BeforeClass
+  public static void startMetastoreAndSpark() {
+    SparkTestBase.metastore = new TestHiveMetastore();
+    metastore.start();
+    SparkTestBase.hiveConf = metastore.hiveConf();
 
-        SparkTestBase.spark =
-                SparkSession.builder()
-                        .master("local[2]")
-                        .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
-                        .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-                        .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
-                        .config(TestConfUtil.GLUTEN_CONF)
-                        .enableHiveSupport()
-                        .getOrCreate();
+    SparkTestBase.spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+            .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+            .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+            .config(TestConfUtil.GLUTEN_CONF)
+            .enableHiveSupport()
+            .getOrCreate();
 
-        SparkTestBase.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    SparkTestBase.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
 
-        SparkTestBase.catalog =
-                (HiveCatalog)
-                        CatalogUtil.loadCatalog(
-                                HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
+    SparkTestBase.catalog =
+        (HiveCatalog)
+            CatalogUtil.loadCatalog(
+                HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-        try {
-            catalog.createNamespace(Namespace.of("default"));
-        } catch (AlreadyExistsException ignored) {
-            // the default namespace already exists. ignore the create error
-        }
+    try {
+      catalog.createNamespace(Namespace.of("default"));
+    } catch (AlreadyExistsException ignored) {
+      // the default namespace already exists. ignore the create error
+    }
+  }
+
+  @AfterClass
+  public static void stopMetastoreAndSpark() throws Exception {
+    SparkTestBase.catalog = null;
+    if (metastore != null) {
+      metastore.stop();
+      SparkTestBase.metastore = null;
+    }
+    if (spark != null) {
+      spark.stop();
+      SparkTestBase.spark = null;
+      SparkTestBase.sparkContext = null;
+    }
+  }
+
+  protected long waitUntilAfter(long timestampMillis) {
+    long current = System.currentTimeMillis();
+    while (current <= timestampMillis) {
+      current = System.currentTimeMillis();
+    }
+    return current;
+  }
+
+  protected List<Object[]> sql(String query, Object... args) {
+    List<Row> rows = spark.sql(String.format(query, args)).collectAsList();
+    if (rows.size() < 1) {
+      return ImmutableList.of();
     }
 
-    @AfterClass
-    public static void stopMetastoreAndSpark() throws Exception {
-        SparkTestBase.catalog = null;
-        if (metastore != null) {
-            metastore.stop();
-            SparkTestBase.metastore = null;
-        }
-        if (spark != null) {
-            spark.stop();
-            SparkTestBase.spark = null;
-            SparkTestBase.sparkContext = null;
-        }
+    return rowsToJava(rows);
+  }
+
+  protected Object scalarSql(String query, Object... args) {
+    List<Object[]> rows = sql(query, args);
+    Assert.assertEquals("Scalar SQL should return one row", 1, rows.size());
+    Object[] row = Iterables.getOnlyElement(rows);
+    Assert.assertEquals("Scalar SQL should return one value", 1, row.length);
+    return row[0];
+  }
+
+  protected Object[] row(Object... values) {
+    return values;
+  }
+
+  protected static String dbPath(String dbName) {
+    return metastore.getDatabasePath(dbName);
+  }
+
+  protected void withUnavailableFiles(Iterable<? extends ContentFile<?>> files, Action action) {
+    Iterable<String> fileLocations = Iterables.transform(files, file -> file.path().toString());
+    withUnavailableLocations(fileLocations, action);
+  }
+
+  private void move(String location, String newLocation) {
+    Path path = Paths.get(URI.create(location));
+    Path tempPath = Paths.get(URI.create(newLocation));
+
+    try {
+      Files.move(path, tempPath);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to move: " + location, e);
+    }
+  }
+
+  protected void withUnavailableLocations(Iterable<String> locations, Action action) {
+    for (String location : locations) {
+      move(location, location + "_temp");
     }
 
-    protected long waitUntilAfter(long timestampMillis) {
-        long current = System.currentTimeMillis();
-        while (current <= timestampMillis) {
-            current = System.currentTimeMillis();
-        }
-        return current;
+    try {
+      action.invoke();
+    } finally {
+      for (String location : locations) {
+        move(location + "_temp", location);
+      }
     }
+  }
 
-    protected List<Object[]> sql(String query, Object... args) {
-        List<Row> rows = spark.sql(String.format(query, args)).collectAsList();
-        if (rows.size() < 1) {
-            return ImmutableList.of();
-        }
-
-        return rowsToJava(rows);
+  protected void withDefaultTimeZone(String zoneId, Action action) {
+    TimeZone currentZone = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+      action.invoke();
+    } finally {
+      TimeZone.setDefault(currentZone);
     }
+  }
 
-    protected Object scalarSql(String query, Object... args) {
-        List<Object[]> rows = sql(query, args);
-        Assert.assertEquals("Scalar SQL should return one row", 1, rows.size());
-        Object[] row = Iterables.getOnlyElement(rows);
-        Assert.assertEquals("Scalar SQL should return one value", 1, row.length);
-        return row[0];
-    }
+  protected void withSQLConf(Map<String, String> conf, Action action) {
+    SQLConf sqlConf = SQLConf.get();
 
-    protected Object[] row(Object... values) {
-        return values;
-    }
+    Map<String, String> currentConfValues = Maps.newHashMap();
+    conf.keySet()
+        .forEach(
+            confKey -> {
+              if (sqlConf.contains(confKey)) {
+                String currentConfValue = sqlConf.getConfString(confKey);
+                currentConfValues.put(confKey, currentConfValue);
+              }
+            });
 
-    protected static String dbPath(String dbName) {
-        return metastore.getDatabasePath(dbName);
-    }
-
-    protected void withUnavailableFiles(Iterable<? extends ContentFile<?>> files, Action action) {
-        Iterable<String> fileLocations = Iterables.transform(files, file -> file.path().toString());
-        withUnavailableLocations(fileLocations, action);
-    }
-
-    private void move(String location, String newLocation) {
-        Path path = Paths.get(URI.create(location));
-        Path tempPath = Paths.get(URI.create(newLocation));
-
-        try {
-            Files.move(path, tempPath);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to move: " + location, e);
-        }
-    }
-
-    protected void withUnavailableLocations(Iterable<String> locations, Action action) {
-        for (String location : locations) {
-            move(location, location + "_temp");
-        }
-
-        try {
-            action.invoke();
-        } finally {
-            for (String location : locations) {
-                move(location + "_temp", location);
-            }
-        }
-    }
-
-    protected void withDefaultTimeZone(String zoneId, Action action) {
-        TimeZone currentZone = TimeZone.getDefault();
-        try {
-            TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
-            action.invoke();
-        } finally {
-            TimeZone.setDefault(currentZone);
-        }
-    }
-
-    protected void withSQLConf(Map<String, String> conf, Action action) {
-        SQLConf sqlConf = SQLConf.get();
-
-        Map<String, String> currentConfValues = Maps.newHashMap();
-        conf.keySet()
-                .forEach(
-                        confKey -> {
-                            if (sqlConf.contains(confKey)) {
-                                String currentConfValue = sqlConf.getConfString(confKey);
-                                currentConfValues.put(confKey, currentConfValue);
-                            }
-                        });
-
-        conf.forEach(
-                (confKey, confValue) -> {
-                    if (SQLConf.isStaticConfigKey(confKey)) {
-                        throw new RuntimeException("Cannot modify the value of a static config: " + confKey);
-                    }
-                    sqlConf.setConfString(confKey, confValue);
-                });
-
-        try {
-            action.invoke();
-        } finally {
-            conf.forEach(
-                    (confKey, confValue) -> {
-                        if (currentConfValues.containsKey(confKey)) {
-                            sqlConf.setConfString(confKey, currentConfValues.get(confKey));
-                        } else {
-                            sqlConf.unsetConf(confKey);
-                        }
-                    });
-        }
-    }
-
-    protected Dataset<Row> jsonToDF(String schema, String... records) {
-        Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
-        return spark.read().schema(schema).json(jsonDF);
-    }
-
-    protected void append(String table, String... jsonRecords) {
-        try {
-            String schema = spark.table(table).schema().toDDL();
-            Dataset<Row> df = jsonToDF(schema, jsonRecords);
-            df.coalesce(1).writeTo(table).append();
-        } catch (NoSuchTableException e) {
-            throw new RuntimeException("Failed to write data", e);
-        }
-    }
-
-    protected String tablePropsAsString(Map<String, String> tableProps) {
-        StringBuilder stringBuilder = new StringBuilder();
-
-        for (Map.Entry<String, String> property : tableProps.entrySet()) {
-            if (stringBuilder.length() > 0) {
-                stringBuilder.append(", ");
-            }
-            stringBuilder.append(String.format("'%s' '%s'", property.getKey(), property.getValue()));
-        }
-
-        return stringBuilder.toString();
-    }
-
-    protected SparkPlan executeAndKeepPlan(String query, Object... args) {
-        return executeAndKeepPlan(() -> sql(query, args));
-    }
-
-    protected SparkPlan executeAndKeepPlan(Action action) {
-        AtomicReference<SparkPlan> executedPlanRef = new AtomicReference<>();
-
-        QueryExecutionListener listener =
-                new QueryExecutionListener() {
-                    @Override
-                    public void onSuccess(String funcName, QueryExecution qe, long durationNs) {
-                        executedPlanRef.set(qe.executedPlan());
-                    }
-
-                    @Override
-                    public void onFailure(String funcName, QueryExecution qe, Exception exception) {}
-                };
-
-        spark.listenerManager().register(listener);
-
-        action.invoke();
-
-        try {
-            spark.sparkContext().listenerBus().waitUntilEmpty();
-        } catch (TimeoutException e) {
-            throw new RuntimeException("Timeout while waiting for processing events", e);
-        }
-
-        SparkPlan executedPlan = executedPlanRef.get();
-        if (executedPlan instanceof AdaptiveSparkPlanExec) {
-            return ((AdaptiveSparkPlanExec) executedPlan).executedPlan();
-        } else {
-            return executedPlan;
-        }
-    }
-
-    protected boolean checkAnswer(Dataset<Row> df) {
-        List<Row> rows = df.collectAsList();
-        withSQLConf(ImmutableMap.of(GlutenConfig.GLUTEN_ENABLED().key(), "false"), () -> {
-            Option<String> msg = QueryTest.getErrorMessageInCheckAnswer(df,
-                    JavaConversions.asScalaBuffer(rows).toSeq(), true);
-            if (msg.isDefined()) {
-                throw new RuntimeException(msg.get());
-            }
+    conf.forEach(
+        (confKey, confValue) -> {
+          if (SQLConf.isStaticConfigKey(confKey)) {
+            throw new RuntimeException("Cannot modify the value of a static config: " + confKey);
+          }
+          sqlConf.setConfString(confKey, confValue);
         });
-        return true;
+
+    try {
+      action.invoke();
+    } finally {
+      conf.forEach(
+          (confKey, confValue) -> {
+            if (currentConfValues.containsKey(confKey)) {
+              sqlConf.setConfString(confKey, currentConfValues.get(confKey));
+            } else {
+              sqlConf.unsetConf(confKey);
+            }
+          });
+    }
+  }
+
+  protected Dataset<Row> jsonToDF(String schema, String... records) {
+    Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
+    return spark.read().schema(schema).json(jsonDF);
+  }
+
+  protected void append(String table, String... jsonRecords) {
+    try {
+      String schema = spark.table(table).schema().toDDL();
+      Dataset<Row> df = jsonToDF(schema, jsonRecords);
+      df.coalesce(1).writeTo(table).append();
+    } catch (NoSuchTableException e) {
+      throw new RuntimeException("Failed to write data", e);
+    }
+  }
+
+  protected String tablePropsAsString(Map<String, String> tableProps) {
+    StringBuilder stringBuilder = new StringBuilder();
+
+    for (Map.Entry<String, String> property : tableProps.entrySet()) {
+      if (stringBuilder.length() > 0) {
+        stringBuilder.append(", ");
+      }
+      stringBuilder.append(String.format("'%s' '%s'", property.getKey(), property.getValue()));
     }
 
-    @FunctionalInterface
-    protected interface Action {
-        void invoke();
+    return stringBuilder.toString();
+  }
+
+  protected SparkPlan executeAndKeepPlan(String query, Object... args) {
+    return executeAndKeepPlan(() -> sql(query, args));
+  }
+
+  protected SparkPlan executeAndKeepPlan(Action action) {
+    AtomicReference<SparkPlan> executedPlanRef = new AtomicReference<>();
+
+    QueryExecutionListener listener =
+        new QueryExecutionListener() {
+          @Override
+          public void onSuccess(String funcName, QueryExecution qe, long durationNs) {
+            executedPlanRef.set(qe.executedPlan());
+          }
+
+          @Override
+          public void onFailure(String funcName, QueryExecution qe, Exception exception) {}
+        };
+
+    spark.listenerManager().register(listener);
+
+    action.invoke();
+
+    try {
+      spark.sparkContext().listenerBus().waitUntilEmpty();
+    } catch (TimeoutException e) {
+      throw new RuntimeException("Timeout while waiting for processing events", e);
     }
+
+    SparkPlan executedPlan = executedPlanRef.get();
+    if (executedPlan instanceof AdaptiveSparkPlanExec) {
+      return ((AdaptiveSparkPlanExec) executedPlan).executedPlan();
+    } else {
+      return executedPlan;
+    }
+  }
+
+  protected boolean checkAnswer(Dataset<Row> df) {
+    List<Row> rows = df.collectAsList();
+    withSQLConf(
+        ImmutableMap.of(GlutenConfig.GLUTEN_ENABLED().key(), "false"),
+        () -> {
+          Option<String> msg =
+              QueryTest.getErrorMessageInCheckAnswer(
+                  df, JavaConversions.asScalaBuffer(rows).toSeq(), true);
+          if (msg.isDefined()) {
+            throw new RuntimeException(msg.get());
+          }
+        });
+    return true;
+  }
+
+  @FunctionalInterface
+  protected interface Action {
+    void invoke();
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -16,14 +16,14 @@
  */
 package org.apache.iceberg.spark.data;
 
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -16,13 +16,13 @@
  */
 package org.apache.iceberg.spark.data;
 
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.*;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -40,7 +40,6 @@ import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.Assert;
-import scala.collection.Seq;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -51,6 +50,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import scala.collection.Seq;
 
 import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -17,6 +17,7 @@
 package org.apache.iceberg.spark.extensions;
 
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
@@ -60,7 +61,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
             .config(
                 SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
-                .config(TestConfUtil.GLUTEN_CONF)
+            .config(TestConfUtil.GLUTEN_CONF)
             .enableHiveSupport()
             .getOrCreate();
 

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/GlutenSparkScanBuilder.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/GlutenSparkScanBuilder.java
@@ -23,19 +23,26 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class GlutenSparkScanBuilder extends SparkScanBuilder {
-    public GlutenSparkScanBuilder(SparkSession spark, Table table, String branch, Schema schema, CaseInsensitiveStringMap options) {
-        super(spark, table, branch, schema, options);
-    }
+  public GlutenSparkScanBuilder(
+      SparkSession spark,
+      Table table,
+      String branch,
+      Schema schema,
+      CaseInsensitiveStringMap options) {
+    super(spark, table, branch, schema, options);
+  }
 
-    public GlutenSparkScanBuilder(SparkSession spark, Table table, CaseInsensitiveStringMap options) {
-        this(spark, table, table.schema(), options);
-    }
+  public GlutenSparkScanBuilder(SparkSession spark, Table table, CaseInsensitiveStringMap options) {
+    this(spark, table, table.schema(), options);
+  }
 
-    public GlutenSparkScanBuilder(SparkSession spark, Table table, String branch, CaseInsensitiveStringMap options) {
-        this(spark, table, branch, SnapshotUtil.schemaFor(table, branch), options);
-    }
+  public GlutenSparkScanBuilder(
+      SparkSession spark, Table table, String branch, CaseInsensitiveStringMap options) {
+    this(spark, table, branch, SnapshotUtil.schemaFor(table, branch), options);
+  }
 
-    public GlutenSparkScanBuilder(SparkSession spark, Table table, Schema schema, CaseInsensitiveStringMap options) {
-        this(spark, table, (String)null, schema, options);
-    }
+  public GlutenSparkScanBuilder(
+      SparkSession spark, Table table, Schema schema, CaseInsensitiveStringMap options) {
+    this(spark, table, (String) null, schema, options);
+  }
 }

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -16,8 +16,6 @@
  */
 package org.apache.iceberg.spark.source;
 
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
-import org.apache.iceberg.shaded.org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.*;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.RewriteManifests;
@@ -41,6 +39,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericData;
+import org.apache.iceberg.shaded.org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.spark.*;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.data.TestHelpers;
@@ -1995,13 +1995,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     List<Integer> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "files"))
-            .sort(DataFile.SPEC_ID.name())
-            .collectAsList()
-            .stream()
+        spark.read().format("iceberg").load(loadLocation(tableIdentifier, "files"))
+            .sort(DataFile.SPEC_ID.name()).collectAsList().stream()
             .map(r -> (Integer) r.getAs(DataFile.SPEC_ID.name()))
             .collect(Collectors.toList());
 

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
@@ -17,6 +17,7 @@
 package org.apache.iceberg.spark.source;
 
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.iceberg.*;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
@@ -79,8 +80,8 @@ public class TestSparkReadProjection extends TestReadProjection {
 
   @BeforeClass
   public static void startSpark() {
-    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]")
-            .config(TestConfUtil.GLUTEN_CONF).getOrCreate();
+    TestSparkReadProjection.spark =
+        SparkSession.builder().master("local[2]").config(TestConfUtil.GLUTEN_CONF).getOrCreate();
     ImmutableMap<String, String> config =
         ImmutableMap.of(
             "type", "hive",

--- a/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/backends-velox/src-iceberg/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -18,14 +18,15 @@ package org.apache.iceberg.spark.source;
 
 import org.apache.gluten.config.GlutenConfig;
 import org.apache.gluten.spark34.TestConfUtil;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.*;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.*;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
@@ -36,6 +37,7 @@ import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkStructLike;
@@ -44,7 +46,6 @@ import org.apache.iceberg.spark.data.SparkParquetWriters;
 import org.apache.iceberg.spark.source.metrics.NumDeletes;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.*;
-import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -406,22 +407,27 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     checkDeleteCount(3L);
     // TODO, the query fallbacks because not supports equality delete.
     // Error Source: RUNTIME
-    //Error Code: NOT_IMPLEMENTED
-    //Retriable: False
-    //Context: Split [Hive: /var/folders/63/845y6pk53dx_83hpw8ztdchw0000gn/T/junit-17345315326614809092/junit4173952394189821024.tmp 4 - 647] Task Gluten_Stage_5_TID_5_VTID_1
-    //Additional Context: Operator: TableScan[0] 0
-    //Function: prepareSplit
-    //File: /Users/chengchengjin/code/gluten/ep/build-velox/build/velox_ep/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
-    //Line: 95
-    //Stack trace:
+    // Error Code: NOT_IMPLEMENTED
+    // Retriable: False
+    // Context: Split [Hive:
+    // /var/folders/63/845y6pk53dx_83hpw8ztdchw0000gn/T/junit-17345315326614809092/junit4173952394189821024.tmp 4 - 647] Task Gluten_Stage_5_TID_5_VTID_1
+    // Additional Context: Operator: TableScan[0] 0
+    // Function: prepareSplit
+    // File:
+    // /Users/chengchengjin/code/gluten/ep/build-velox/build/velox_ep/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+    // Line: 95
+    // Stack trace:
     // Check the table query data because above query is fallback by column _deleted.
-    // This query is fallback by equality delete files, remove this check after equality reader is supported.
+    // This query is fallback by equality delete files, remove this check after equality reader is
+    // supported.
     StructLikeSet actualWithoutMetadata =
-            rowSet(tableName, PROJECTION_SCHEMA_WITHOUT_DELETED.asStruct(), "id", "data");
+        rowSet(tableName, PROJECTION_SCHEMA_WITHOUT_DELETED.asStruct(), "id", "data");
     spark.conf().set(GlutenConfig.GLUTEN_ENABLED().key(), "false");
-    StructLikeSet  expectWithoutMetadata =
-            rowSet(tableName, PROJECTION_SCHEMA_WITHOUT_DELETED.asStruct(), "id", "data");
-    assertThat(actualWithoutMetadata).as("Table should contain expected row").isEqualTo(expectWithoutMetadata);
+    StructLikeSet expectWithoutMetadata =
+        rowSet(tableName, PROJECTION_SCHEMA_WITHOUT_DELETED.asStruct(), "id", "data");
+    assertThat(actualWithoutMetadata)
+        .as("Table should contain expected row")
+        .isEqualTo(expectWithoutMetadata);
     spark.conf().set(GlutenConfig.GLUTEN_ENABLED().key(), "true");
   }
 
@@ -624,9 +630,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
           MetadataColumns.IS_DELETED);
 
   private static final Schema PROJECTION_SCHEMA_WITHOUT_DELETED =
-          new Schema(
-                  required(1, "id", Types.IntegerType.get()),
-                  required(2, "data", Types.StringType.get()));
+      new Schema(
+          required(1, "id", Types.IntegerType.get()), required(2, "data", Types.StringType.get()));
 
   private static StructLikeSet expectedRowSet(int... idsToRemove) {
     return expectedRowSet(false, false, idsToRemove);

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.gluten.execution
 
 class VeloxIcebergSuite extends IcebergSuite

--- a/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -16,10 +16,10 @@
  */
 package org.apache.spark.shuffle.writer;
 
-import org.apache.gluten.config.GlutenConfig;
-import org.apache.gluten.config.ReservedKeys;
 import org.apache.gluten.backendsapi.BackendsApiManager;
 import org.apache.gluten.columnarbatch.ColumnarBatches;
+import org.apache.gluten.config.GlutenConfig;
+import org.apache.gluten.config.ReservedKeys;
 import org.apache.gluten.memory.memtarget.MemoryTarget;
 import org.apache.gluten.memory.memtarget.Spiller;
 import org.apache.gluten.memory.memtarget.Spillers;
@@ -64,8 +64,7 @@ public class VeloxUniffleColumnarShuffleWriter<K, V> extends RssShuffleWriter<K,
   private long nativeShuffleWriter = -1L;
 
   private boolean stopping = false;
-  private final int compressThreshold =
-      GlutenConfig.get().columnarShuffleCompressionThreshold();
+  private final int compressThreshold = GlutenConfig.get().columnarShuffleCompressionThreshold();
   private final double reallocThreshold = GlutenConfig.get().columnarShuffleReallocThreshold();
   private String compressionCodec;
   private int compressionLevel;

--- a/pom.xml
+++ b/pom.xml
@@ -1543,6 +1543,20 @@
                 <content>${spotless.license.header}</content>
                 <delimiter>${spotless.delimiter}</delimiter>
               </licenseHeader>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+                <include>src-celeborn/main/java/**/*.java</include>
+                <include>src-celeborn/test/java/**/*.java</include>
+                <include>src-delta/main/java/**/*.java</include>
+                <include>src-delta/test/java/**/*.java</include>
+                <include>src-hudi/main/java/**/*.java</include>
+                <include>src-hudi/test/java/**/*.java</include>
+                <include>src-iceberg/main/java/**/*.java</include>
+                <include>src-iceberg/test/java/**/*.java</include>
+                <include>src-uniffle/main/java/**/*.java</include>
+                <include>src-uniffle/test/java/**/*.java</include>
+              </includes>
             </java>
             <scala>
               <!--  make it works `// spotless:off `  -->
@@ -1556,6 +1570,20 @@
                 <content>${spotless.license.header}</content>
                 <delimiter>${spotless.delimiter}</delimiter>
               </licenseHeader>
+              <includes>
+                <include>src/main/scala/**/*.scala</include>
+                <include>src/test/scala/**/*.scala</include>
+                <include>src-celeborn/main/scala/**/*.scala</include>>
+                <include>src-celeborn/test/scala/**/*.scala</include>
+                <include>src-delta/main/scala/**/*.scala</include>>
+                <include>src-delta/test/scala/**/*.scala</include>
+                <include>src-hudi/main/scala/**/*.scala</include>>
+                <include>src-hudi/test/scala/**/*.scala</include>
+                <include>src-iceberg/main/scala/**/*.scala</include>>
+                <include>src-iceberg/test/scala/**/*.scala</include>
+                <include>src-uniffle/main/scala/**/*.scala</include>>
+                <include>src-uniffle/test/scala/**/*.scala</include>
+              </includes>
             </scala>
           </configuration>
           <executions>


### PR DESCRIPTION
com.diffplug.spotless:spotless-maven-plugin:2.27.2:check can check the module gluten-iceberg, but cannot check the backends-velox/src/iceberg introduced by build-helper-maven-plugin because spotless-maven-plugin applies for the specified name format. https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#scala