### PR TITLE
[GLUTEN-8877] Port [SPARK-32985][SQL] Decouple bucket scan and bucket filter pruning

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/InputPartitionsUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/InputPartitionsUtil.scala
@@ -17,11 +17,11 @@
 package org.apache.gluten.utils
 
 import org.apache.gluten.sql.shims.SparkShimLoader
-
+import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.datasources.{FilePartition, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{BucketingUtils, FilePartition, HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
 
@@ -52,6 +52,22 @@ case class InputPartitionsUtil(
       s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
         s"open cost is considered as scanning $openCostInBytes bytes.")
 
+    // Filter files with bucket pruning if possible
+    val bucketingEnabled = relation.sparkSession.sessionState.conf.bucketingEnabled
+    val shouldProcess: Path => Boolean = optionalBucketSet match {
+      case Some(bucketSet) if bucketingEnabled =>
+        filePath => {
+          BucketingUtils.getBucketId(filePath.getName) match {
+            case Some(id) => bucketSet.get(id)
+            case None =>
+              // Do not prune the file if bucket file name is invalid
+              true
+          }
+        }
+      case _ =>
+        _ => true
+    }
+
     val splitFiles = selectedPartitions
       .flatMap {
         partition =>
@@ -59,17 +75,21 @@ case class InputPartitionsUtil(
             file =>
               // getPath() is very expensive so we only want to call it once in this block:
               val filePath = file._1.getPath
-              val isSplitable =
-                SparkShimLoader.getSparkShims.isFileSplittable(relation, filePath, requiredSchema)
-              SparkShimLoader.getSparkShims.splitFiles(
-                sparkSession = relation.sparkSession,
-                file = file._1,
-                filePath = filePath,
-                isSplitable = isSplitable,
-                maxSplitBytes = maxSplitBytes,
-                partitionValues = partition.values,
-                metadata = file._2
-              )
+              if (shouldProcess(filePath)) {
+                val isSplitable =
+                  SparkShimLoader.getSparkShims.isFileSplittable(relation, filePath, requiredSchema)
+                SparkShimLoader.getSparkShims.splitFiles(
+                  sparkSession = relation.sparkSession,
+                  file = file._1,
+                  filePath = filePath,
+                  isSplitable = isSplitable,
+                  maxSplitBytes = maxSplitBytes,
+                  partitionValues = partition.values,
+                  metadata = file._2
+                )
+              } else {
+                Seq.empty
+              }
           }
       }
       .sortBy(_.length)(implicitly[Ordering[Long]].reverse)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/InputPartitionsUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/InputPartitionsUtil.scala
@@ -17,13 +17,15 @@
 package org.apache.gluten.utils
 
 import org.apache.gluten.sql.shims.SparkShimLoader
-import org.apache.hadoop.fs.Path
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.{BucketingUtils, FilePartition, HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
+
+import org.apache.hadoop.fs.Path
 
 case class InputPartitionsUtil(
     relation: HadoopFsRelation,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR ports the changes from [SPARK-32985][SQL] to decouple bucket scan and bucket filter pruning into the Apache Gluten project.

(Fixes: \#8877)

## How was this patch tested?

Manual tests.

```sql
SELECT * FROM bucket_table WHERE bucket_column = 2243296260;
```

Before:
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/df297af5-ddd0-4882-a2ea-949f17baf8e4" />


After:
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/373ead9d-5fac-45c8-9de3-8088a8ae5259" />


