### PR TITLE
[GLUTEN-9496][VL] Enable concat function with array datatype for spark

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ScalarFunctionsValidateSuite.scala
@@ -1172,6 +1172,23 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("test concat with array") {
+    withTempPath {
+      path =>
+        Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
+          .toDF("value")
+          .write
+          .parquet(path.getCanonicalPath)
+
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("array_tbl")
+
+        runQueryAndCompare("select concat(value, array(1)) from array_tbl;") {
+          checkGlutenOperatorMatch[ProjectExecTransformer]
+        }
+
+    }
+  }
+
   test("test array transform") {
     withTable("t") {
       sql("create table t (arr ARRAY<INT>) using parquet")

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -211,8 +211,7 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
   }
   if (name == "concat") {
     for (const auto& type : types) {
-      if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos ||
-          type.find("list") != std::string::npos) {
+      if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos) {
         LOG_VALIDATION_MSG(type + " is not supported in concat.");
         return false;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to enable concat function with array datatype for spark.

(Fixes: \#9496)

## How was this patch tested?

New unit test.

