### PR TITLE
[GLUTEN-9502][VL] Remove useless datatype check for concat function

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -209,14 +209,6 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
   if (name == "extract") {
     return validateExtractExpr(params);
   }
-  if (name == "concat") {
-    for (const auto& type : types) {
-      if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos) {
-        LOG_VALIDATION_MSG(type + " is not supported in concat.");
-        return false;
-      }
-    }
-  }
 
   // Validate regex functions.
   if (kRegexFunctions.find(name) != kRegexFunctions.end()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to remove unused datatype check code from concat function, as this function only supports string / binary / array type in apache spark[1].  

[1] https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L2195

  

(Fixes: \#9502)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

