### PR TITLE
[GLUTEN-9468][VL] Follow up: Remove parquet-arrow cpp build

### DIFF
--- a/dev/build_arrow.sh
+++ b/dev/build_arrow.sh
@@ -37,6 +37,7 @@ function build_arrow_cpp() {
  pushd $ARROW_PREFIX/cpp
 
  cmake_install \
+       -DARROW_PARQUET=OFF \
        -DARROW_FILESYSTEM=ON \
        -DARROW_PROTOBUF_USE_SHARED=OFF \
        -DARROW_DEPENDENCY_USE_SHARED=OFF \

--- a/dev/build_arrow.sh
+++ b/dev/build_arrow.sh
@@ -37,7 +37,6 @@ function build_arrow_cpp() {
  pushd $ARROW_PREFIX/cpp
 
  cmake_install \
-       -DARROW_PARQUET=ON \
        -DARROW_FILESYSTEM=ON \
        -DARROW_PROTOBUF_USE_SHARED=OFF \
        -DARROW_DEPENDENCY_USE_SHARED=OFF \


### PR DESCRIPTION
#9483 has removed the dependency on arrow parquet.