### PR TITLE
[VL] Support spark.sql.legacy.followThreeValuedLogicInArrayExists

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -82,7 +82,8 @@ const std::string kSparkMapKeyDedupPolicy = "spark.sql.mapKeyDedupPolicy";
 
 const std::string kSparkLegacyStatisticalAggregate = "spark.sql.legacy.statisticalAggregate";
 
-const std::string kSparkLegacyFollowThreeValuedLogicInArrayExists = "spark.sql.legacy.followThreeValuedLogicInArrayExists";
+const std::string kSparkLegacyFollowThreeValuedLogicInArrayExists =
+    "spark.sql.legacy.followThreeValuedLogicInArrayExists";
 
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength);

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -82,6 +82,8 @@ const std::string kSparkMapKeyDedupPolicy = "spark.sql.mapKeyDedupPolicy";
 
 const std::string kSparkLegacyStatisticalAggregate = "spark.sql.legacy.statisticalAggregate";
 
+const std::string kSparkLegacyFollowThreeValuedLogicInArrayExists = "spark.sql.legacy.followThreeValuedLogicInArrayExists";
+
 std::unordered_map<std::string, std::string>
 parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength);
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -584,7 +584,9 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
     setIfExists(kQueryTraceMaxBytes, velox::core::QueryConfig::kQueryTraceMaxBytes);
     setIfExists(kQueryTraceTaskRegExp, velox::core::QueryConfig::kQueryTraceTaskRegExp);
     setIfExists(kOpTraceDirectoryCreateConfig, velox::core::QueryConfig::kOpTraceDirectoryCreateConfig);
-    setIfExists(kSparkLegacyFollowThreeValuedLogicInArrayExists, velox::core::QueryConfig::kSparkLegacyFollowThreeValuedLogicInArrayExists);
+    setIfExists(
+        kSparkLegacyFollowThreeValuedLogicInArrayExists,
+        velox::core::QueryConfig::kSparkLegacyFollowThreeValuedLogicInArrayExists);
   } catch (const std::invalid_argument& err) {
     std::string errDetails = err.what();
     throw std::runtime_error("Invalid conf arg: " + errDetails);

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -584,6 +584,7 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
     setIfExists(kQueryTraceMaxBytes, velox::core::QueryConfig::kQueryTraceMaxBytes);
     setIfExists(kQueryTraceTaskRegExp, velox::core::QueryConfig::kQueryTraceTaskRegExp);
     setIfExists(kOpTraceDirectoryCreateConfig, velox::core::QueryConfig::kOpTraceDirectoryCreateConfig);
+    setIfExists(kSparkLegacyFollowThreeValuedLogicInArrayExists, velox::core::QueryConfig::kSparkLegacyFollowThreeValuedLogicInArrayExists);
   } catch (const std::invalid_argument& err) {
     std::string errDetails = err.what();
     throw std::runtime_error("Invalid conf arg: " + errDetails);

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2025_05_06
+VELOX_REPO=https://github.com/ccat3z/velox.git
+VELOX_BRANCH=fb/feature/legacy-binary-exists
 VELOX_HOME=""
 
 OS=`uname -s`

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenHigherOrderFunctionsSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenHigherOrderFunctionsSuite.scala
@@ -16,6 +16,95 @@
  */
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.{Column, DataFrame, GlutenTestsTrait, Row}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, IntegerType, StringType, StructField, StructType}
 
-class GlutenHigherOrderFunctionsSuite extends HigherOrderFunctionsSuite with GlutenTestsTrait {}
+class GlutenHigherOrderFunctionsSuite extends HigherOrderFunctionsSuite with GlutenTestsTrait {
+  import org.apache.spark.sql.catalyst.dsl.expressions._
+
+  // If LEGACY_ARRAY_EXISTS_FOLLOWS_THREE_VALUED_LOGIC is false, the schema of literal exists
+  // expression is not nullable. Even though the native engine output null, the actual result
+  // is false. As a result, the `Array Exists` unit test in parent suite cannot detect the issue.
+  testGluten("ArrayExists") {
+    def createDF[T](arr: Seq[T], dataType: DataType): DataFrame = {
+      _spark.createDataFrame(
+        _spark.sparkContext.parallelize(Seq(Row(arr))),
+        StructType(
+          StructField("arr", ArrayType(dataType, containsNull = true), nullable = true) :: Nil)
+      )
+    }
+
+    def checkExistsResult(df: DataFrame, f: Expression => Expression, expected: Any): Unit = {
+      val itemDataType = df.schema.head.dataType match {
+        case ArrayType(dt, _) => dt
+      }
+      val arrayFieldName = df.schema.head.name
+
+      val lv = NamedLambdaVariable("arg", itemDataType, nullable = true)
+      val filterLambda = LambdaFunction(f(lv), Seq(lv))
+
+      val resultDf =
+        df.select(Column(ArrayExists(UnresolvedAttribute(arrayFieldName), filterLambda)))
+      val result = resultDf.collect.head.get(0)
+
+      if (result != expected) {
+        fail(
+          s"Incorrect evaluation: $f, " +
+            s"actual: $result, " +
+            s"expected: $expected")
+      }
+    }
+
+    val ai0 = createDF(Seq(1, 2, 3), IntegerType)
+    val ai1 = createDF(Seq[Integer](1, null, 3), IntegerType)
+    val ain = createDF(null, IntegerType)
+
+    val isEven: Expression => Expression = x => x % 2 === 0
+    val isNullOrOdd: Expression => Expression = x => x.isNull || x % 2 === 1
+    val alwaysFalse: Expression => Expression = _ => Literal.FalseLiteral
+    val alwaysNull: Expression => Expression = _ => Literal(null, BooleanType)
+
+    for (followThreeValuedLogic <- Seq(false, true)) {
+      withSQLConf(
+        SQLConf.LEGACY_ARRAY_EXISTS_FOLLOWS_THREE_VALUED_LOGIC.key
+          -> followThreeValuedLogic.toString) {
+        checkExistsResult(ai0, isEven, true)
+        checkExistsResult(ai0, isNullOrOdd, true)
+        checkExistsResult(ai0, alwaysFalse, false)
+        checkExistsResult(ai0, alwaysNull, if (followThreeValuedLogic) null else false)
+        checkExistsResult(ai1, isEven, if (followThreeValuedLogic) null else false)
+        checkExistsResult(ai1, isNullOrOdd, true)
+        checkExistsResult(ai1, alwaysFalse, false)
+        checkExistsResult(ai1, alwaysNull, if (followThreeValuedLogic) null else false)
+        checkExistsResult(ain, isEven, null)
+        checkExistsResult(ain, isNullOrOdd, null)
+        checkExistsResult(ain, alwaysFalse, null)
+        checkExistsResult(ain, alwaysNull, null)
+      }
+    }
+
+    val as0 = createDF(Seq("a0", "b1", "a2", "c3"), StringType)
+    val as1 = createDF(Seq(null, "b", "c"), StringType)
+    val asn = createDF(null, StringType)
+
+    val startsWithA: Expression => Expression = x => x.startsWith("a")
+
+    for (followThreeValuedLogic <- Seq(false, true)) {
+      withSQLConf(
+        SQLConf.LEGACY_ARRAY_EXISTS_FOLLOWS_THREE_VALUED_LOGIC.key
+          -> followThreeValuedLogic.toString) {
+        checkExistsResult(as0, startsWithA, true)
+        checkExistsResult(as0, alwaysFalse, false)
+        checkExistsResult(as0, alwaysNull, if (followThreeValuedLogic) null else false)
+        checkExistsResult(as1, startsWithA, if (followThreeValuedLogic) null else false)
+        checkExistsResult(as1, alwaysFalse, false)
+        checkExistsResult(as1, alwaysNull, if (followThreeValuedLogic) null else false)
+        checkExistsResult(asn, startsWithA, null)
+        checkExistsResult(asn, alwaysFalse, null)
+        checkExistsResult(asn, alwaysNull, null)
+      }
+    }
+  }
+}

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -475,6 +475,7 @@ object GlutenConfig {
       SHUFFLE_WRITER_BUFFER_SIZE.key,
       SQLConf.LEGACY_SIZE_OF_NULL.key,
       SQLConf.LEGACY_STATISTICAL_AGGREGATE.key,
+      SQLConf.LEGACY_ARRAY_EXISTS_FOLLOWS_THREE_VALUED_LOGIC.key,
       "spark.io.compression.codec",
       "spark.sql.decimalOperations.allowPrecisionLoss",
       "spark.gluten.sql.columnar.backend.velox.bloomFilter.expectedNumItems",


### PR DESCRIPTION
## What changes were proposed in this pull request?

In spark, the behavior of array_exists (any_match in velox) can be changed by spark.sql.legacy.followThreeValuedLogicInArrayExists. For three-valued boolean logic, if the predicate returns any nulls and no true is obtained, then exists returns null instead of false. For example, exists(array(1, null, 3), x -> x % 2 == 0) is null. For binary-valued boolean logic, the result is false instead of null. This PR add a config kSparkLegacyFollowThreeValuedLogicInArrayExists to support this behavior.

## How was this patch tested?

Unit tests.
