### PR TITLE
[GLUTEN-9475][VL] Serialize ColumnarBatch one by one to reduce memory footprint when broadcasting

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -636,7 +636,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       .mapPartitions(itr => Iterator(BroadcastUtils.serializeStream(itr)))
       .filter(_.getNumRows != 0)
       .collect
-    val rawSize = serialized.flatMap(_.getSerialized.map(_.length)).sum
+    val rawSize = serialized.flatMap(_.getSerialized.map(_.length.toLong)).sum
     if (rawSize >= GlutenConfig.get.maxBroadcastTableSize) {
       throw new SparkException(
         "Cannot broadcast the table that is larger than " +

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
@@ -173,19 +173,19 @@ object BroadcastUtils {
       return ColumnarBatchSerializeResult.EMPTY
     }
     var rowNums = 0
-    val values = filtered.map(b => {
-      val handle = ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, b)
-      rowNums += b.numRows()
-      try {
-        ColumnarBatchSerializerJniWrapper
-          .create(
-            Runtimes
+    val values = filtered.map(
+      b => {
+        val handle = ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, b)
+        rowNums += b.numRows()
+        try {
+          ColumnarBatchSerializerJniWrapper
+            .create(Runtimes
               .contextInstance(BackendsApiManager.getBackendName, "BroadcastUtils#serializeStream"))
-          .serialize(handle)
-      } finally {
-        ColumnarBatches.release(b)
-      }
-    })
+            .serialize(handle)
+        } finally {
+          ColumnarBatches.release(b)
+        }
+      })
     new ColumnarBatchSerializeResult(rowNums, values)
   }
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -176,11 +176,11 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with Logging {
                     BackendsApiManager.getBackendName,
                     "ColumnarCachedBatchSerializer#serialize"))
                 .serialize(
-                  Array(ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, batch)))
+                  ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, batch))
             CachedColumnarBatch(
-              results.getNumRows.toInt,
-              results.getSerialized.length,
-              results.getSerialized)
+              batch.numRows(),
+              results.length,
+              results)
           }
         }
     }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -177,10 +177,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with Logging {
                     "ColumnarCachedBatchSerializer#serialize"))
                 .serialize(
                   ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, batch))
-            CachedColumnarBatch(
-              batch.numRows(),
-              results.length,
-              results)
+            CachedColumnarBatch(batch.numRows(), results.length, results)
           }
         }
     }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1106,8 +1106,7 @@ JNIEXPORT jobject JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchSeriali
 
   std::vector<std::shared_ptr<ColumnarBatch>> batches;
   auto batch = ObjectStore::retrieve<ColumnarBatch>(handle);
-  GLUTEN_DCHECK(
-      batch != nullptr, "Cannot find the ColumnarBatch with handle " + std::to_string(handle));
+  GLUTEN_DCHECK(batch != nullptr, "Cannot find the ColumnarBatch with handle " + std::to_string(handle));
   batches.emplace_back(batch);
 
   auto serializer = ctx->createColumnarBatchSerializer(nullptr);

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -53,9 +53,6 @@ jmethodID jniByteInputStreamClose;
 jclass splitResultClass;
 jmethodID splitResultConstructor;
 
-jclass columnarBatchSerializeResultClass;
-jmethodID columnarBatchSerializeResultConstructor;
-
 jclass metricsBuilderClass;
 jmethodID metricsBuilderConstructor;
 jclass nativeColumnarToRowInfoClass;
@@ -217,11 +214,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   splitResultClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/GlutenSplitResult;");
   splitResultConstructor = getMethodIdOrError(env, splitResultClass, "<init>", "(JJJJJJJJJJ[J[J)V");
 
-  columnarBatchSerializeResultClass =
-      createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/ColumnarBatchSerializeResult;");
-  columnarBatchSerializeResultConstructor =
-      getMethodIdOrError(env, columnarBatchSerializeResultClass, "<init>", "(J[B)V");
-
   metricsBuilderClass = createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/metrics/Metrics;");
 
   metricsBuilderConstructor = getMethodIdOrError(
@@ -249,7 +241,6 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   vm->GetEnv(reinterpret_cast<void**>(&env), jniVersion);
   env->DeleteGlobalRef(jniByteInputStreamClass);
   env->DeleteGlobalRef(splitResultClass);
-  env->DeleteGlobalRef(columnarBatchSerializeResultClass);
   env->DeleteGlobalRef(nativeColumnarToRowInfoClass);
   env->DeleteGlobalRef(byteArrayClass);
   env->DeleteGlobalRef(shuffleReaderMetricsClass);

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1097,7 +1097,7 @@ JNIEXPORT void JNICALL Java_org_apache_gluten_vectorized_ShuffleReaderJniWrapper
   JNI_METHOD_END()
 }
 
-JNIEXPORT jobject JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchSerializerJniWrapper_serialize( // NOLINT
+JNIEXPORT jbyteArray JNICALL Java_org_apache_gluten_vectorized_ColumnarBatchSerializerJniWrapper_serialize( // NOLINT
     JNIEnv* env,
     jobject wrapper,
     jlong handle) {

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializeResult.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializeResult.java
@@ -20,13 +20,13 @@ import java.io.Serializable;
 
 public class ColumnarBatchSerializeResult implements Serializable {
   public static final ColumnarBatchSerializeResult EMPTY =
-      new ColumnarBatchSerializeResult(0, new byte[0]);
+      new ColumnarBatchSerializeResult(0, new byte[0][0]);
 
   private long numRows;
 
-  private byte[] serialized;
+  private byte[][] serialized;
 
-  public ColumnarBatchSerializeResult(long numRows, byte[] serialized) {
+  public ColumnarBatchSerializeResult(long numRows, byte[][] serialized) {
     this.numRows = numRows;
     this.serialized = serialized;
   }
@@ -35,7 +35,7 @@ public class ColumnarBatchSerializeResult implements Serializable {
     return numRows;
   }
 
-  public byte[] getSerialized() {
+  public byte[][] getSerialized() {
     return serialized;
   }
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializerJniWrapper.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchSerializerJniWrapper.java
@@ -35,7 +35,7 @@ public class ColumnarBatchSerializerJniWrapper implements RuntimeAware {
     return runtime.getHandle();
   }
 
-  public native ColumnarBatchSerializeResult serialize(long[] handles);
+  public native byte[] serialize(long handle);
 
   // Return the native ColumnarBatchSerializer handle
   public native long init(long cSchema);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Serialize ColumnarBatch one by one when broadcasting

Fixes: #9475

## How was this patch tested?

After this fix, the original abnormal job will no longer have offheap OOM.

