### PR TITLE
[VL] Gluten-it: Enrich test report with --sql-metrics=execution-time

### DIFF
--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Suite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Suite.scala
@@ -163,11 +163,11 @@ abstract class Suite(
     testMetricMapper
   }
 
-  protected def historyWritePath(): String
-
-  protected[integration] def typeModifiers(): List[TypeModifier] = {
+  private[integration] def typeModifiers(): List[TypeModifier] = {
     if (decimalAsDouble) List(TYPE_MODIFIER_DECIMAL_AS_DOUBLE) else List()
   }
+
+  protected def historyWritePath(): String
 
   private[integration] def dataWritePath(scale: Double, genPartitionedData: Boolean): String
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/metrics/PlanMetric.scala
@@ -50,7 +50,10 @@ case class PlanMetric(
 
 object PlanMetric {
   def newReporter(`type`: String): Reporter = `type` match {
-    case "execution-time" => new SelfTimeReporter(10)
+    case "execution-time" => new ChainedReporter(Seq(
+      new NodeTimeReporter(10),
+      new StepTimeReporter(30)
+    ))
     case other => throw new IllegalArgumentException(s"Metric reporter type $other not defined")
   }
 
@@ -58,7 +61,19 @@ object PlanMetric {
     def toString(metrics: Seq[PlanMetric]): String
   }
 
-  class SelfTimeReporter(topN: Int) extends Reporter {
+  private class ChainedReporter(reporter: Seq[Reporter]) extends Reporter {
+    override def toString(metrics: Seq[PlanMetric]): String = {
+      val sb = new StringBuilder()
+      reporter.foreach{
+        r =>
+          sb.append(r.toString(metrics))
+          sb.append(System.lineSeparator())
+      }
+      sb.toString()
+    }
+  }
+
+  private class StepTimeReporter(topN: Int) extends Reporter {
     private def toNanoTime(m: SQLMetric): Long = m.metricType match {
       case "nsTiming" => m.value
       case "timing" => m.value * 1000000
@@ -69,7 +84,7 @@ object PlanMetric {
       val selfTimes = metrics
         .filter(_.containsTags[MetricTag.IsSelfTime])
       val sorted = selfTimes.sortBy(m => toNanoTime(m.metric))(Ordering.Long.reverse)
-      sb.append(s"Top $topN plan nodes that took longest time to execute: ")
+      sb.append(s"Top $topN computation steps that took longest time to execute: ")
       sb.append(System.lineSeparator())
       sb.append(System.lineSeparator())
       val tr: TableRender[Seq[String]] =
@@ -77,7 +92,7 @@ object PlanMetric {
           Leaf("Query"),
           Leaf("Node ID"),
           Leaf("Node Name"),
-          Leaf("Execution Time (ns)"))
+          Leaf("Step Time (ns)"))
       for (i <- 0 until (topN.min(sorted.size))) {
         val m = sorted(i)
         val f = new File(m.queryPath).toPath.getFileName.toString
@@ -93,5 +108,65 @@ object PlanMetric {
       sb.append(out.toString(Charset.defaultCharset))
       sb.toString()
     }
+  }
+
+  private class NodeTimeReporter(topN: Int) extends Reporter {
+    import NodeTimeReporter._
+    private def toNanoTime(m: SQLMetric): Long = m.metricType match {
+      case "nsTiming" => m.value
+      case "timing" => m.value * 1000000
+    }
+
+    override def toString(metrics: Seq[PlanMetric]): String = {
+      val sb = new StringBuilder()
+      val selfTimes = metrics
+          .filter(_.containsTags[MetricTag.IsSelfTime])
+      val rows: Seq[TableRow] = selfTimes
+          .groupBy(m => m.plan.id)
+          .toSeq
+          .map {
+            perPlanId =>
+              assert(perPlanId._2.map(_.plan.id).distinct.count(_ => true) == 1)
+              assert(perPlanId._2.map(_.queryPath).distinct.count(_ => true) == 1)
+              val head = perPlanId._2.head
+              TableRow(
+                head.queryPath,
+                head.plan,
+                perPlanId._2.map(m => toNanoTime(m.metric)).sum,
+                perPlanId._2.map(m => (m.key, m.metric)))
+          }
+      val sorted = rows.sortBy(m => m.selfTimeNs)(Ordering.Long.reverse)
+      sb.append(s"Top $topN plan nodes that took longest time to execute: ")
+      sb.append(System.lineSeparator())
+      sb.append(System.lineSeparator())
+      val tr: TableRender[Seq[String]] =
+        TableRender.create(
+          Leaf("Query"),
+          Leaf("Node ID"),
+          Leaf("Node Name"),
+          Leaf("Node Time (ns)"))
+      for (i <- 0 until (topN.min(sorted.size))) {
+        val row = sorted(i)
+        val f = new File(row.queryPath).toPath.getFileName.toString
+        tr.appendRow(
+          Seq(
+            f,
+            row.plan.id.toString,
+            row.plan.nodeName,
+            s"${row.selfTimeNs}"))
+      }
+      val out = new ByteArrayOutputStream()
+      tr.print(out)
+      sb.append(out.toString(Charset.defaultCharset))
+      sb.toString()
+    }
+  }
+
+  private object NodeTimeReporter {
+    private case class TableRow(
+        queryPath: String,
+        plan: SparkPlan,
+        selfTimeNs: Long,
+        metrics: Seq[(String, SQLMetric)])
   }
 }


### PR DESCRIPTION
Add more information to the test report when `--sql-metrics=execution-time` is specified.

Before:

```
Top 10 plan nodes that took longest time to execute: 

| Query  | Node ID |                       Node Name                        |            Execution Time (ns)            |
|--------|---------|--------------------------------------------------------|-------------------------------------------|
|  q1.sql|      864|                   FlushableHashAggregateExecTransformer|            [time of aggregation] 184268837|
|  q1.sql|      859|                                  ProjectExecTransformer|                [time of project] 141018941|
|  q1.sql|      794|  ScanTransformer parquet spark_catalog.default.lineitem|                    [time of scan] 12198000|
|  q1.sql|      870|                                      VeloxResizeBatches|  [time to append / split batches] 10000000|
|  q1.sql|      871|                                        ColumnarExchange|                [shuffle wall time] 8930861|
|  q1.sql|      871|                                        ColumnarExchange|                    [time to split] 8915168|
|  q1.sql|     1009|                     RegularHashAggregateExecTransformer|               [time of aggregation] 897235|
|  q1.sql|     1012|                                        ColumnarExchange|                 [shuffle wall time] 639323|
|  q1.sql|     1012|                                        ColumnarExchange|                     [time to split] 637339|
|  q1.sql|      871|                                        ColumnarExchange|               [time to deserialize] 612300|


Test report: 

Summary: 1 out of 1 queries passed. 

| Query ID | Was Passed | Row Count | Plan Time (Millis) | Query Time (Millis) |
|----------|------------|-----------|--------------------|---------------------|
|        q1|        true|          4|                 300|                 1025|
|        q1|        true|          4|                 300|                 1025|

No failed queries. 
```

After:

```
Top 10 plan nodes that took longest time to execute: 

| Query  | Node ID |                       Node Name                        | Node Time (ns) |
|--------|---------|--------------------------------------------------------|----------------|
|  q1.sql|      755|                   FlushableHashAggregateExecTransformer|       185334095|
|  q1.sql|      750|                                  ProjectExecTransformer|       142123707|
|  q1.sql|      762|                                        ColumnarExchange|        20997903|
|  q1.sql|      685|  ScanTransformer parquet spark_catalog.default.lineitem|        11391000|
|  q1.sql|      761|                                      VeloxResizeBatches|        10000000|
|  q1.sql|      903|                                        ColumnarExchange|         1557093|
|  q1.sql|      900|                     RegularHashAggregateExecTransformer|         1283039|
|  q1.sql|      902|                                      VeloxResizeBatches|         1000000|
|  q1.sql|      981|                                     SortExecTransformer|          354799|
|  q1.sql|      756|                                  ProjectExecTransformer|          199577|

Top 30 computation steps that took longest time to execute: 

| Query  | Node ID |                       Node Name                        |              Step Time (ns)               |
|--------|---------|--------------------------------------------------------|-------------------------------------------|
|  q1.sql|      755|                   FlushableHashAggregateExecTransformer|            [time of aggregation] 185334095|
|  q1.sql|      750|                                  ProjectExecTransformer|                [time of project] 142123707|
|  q1.sql|      685|  ScanTransformer parquet spark_catalog.default.lineitem|                    [time of scan] 11391000|
|  q1.sql|      762|                                        ColumnarExchange|               [shuffle wall time] 10162137|
|  q1.sql|      762|                                        ColumnarExchange|                   [time to split] 10135455|
|  q1.sql|      761|                                      VeloxResizeBatches|  [time to append / split batches] 10000000|
|  q1.sql|      900|                     RegularHashAggregateExecTransformer|              [time of aggregation] 1114532|
|  q1.sql|      902|                                      VeloxResizeBatches|   [time to append / split batches] 1000000|
|  q1.sql|      762|                                        ColumnarExchange|               [time to deserialize] 700311|
|  q1.sql|      903|                                        ColumnarExchange|                 [shuffle wall time] 700139|
|  q1.sql|      903|                                        ColumnarExchange|                     [time to split] 698126|
|  q1.sql|      981|                                     SortExecTransformer|                      [time of sort] 354799|
|  q1.sql|      756|                                  ProjectExecTransformer|                   [time of project] 199577|
|  q1.sql|      900|                     RegularHashAggregateExecTransformer|           [time of rowConstruction] 168507|
|  q1.sql|      903|                                        ColumnarExchange|               [time to deserialize] 158828|
|  q1.sql|      983|                                      VeloxColumnarToRow|                        [time to convert] 0|
|  q1.sql|      903|                                        ColumnarExchange|                     [time to decompress] 0|
|  q1.sql|      903|                                        ColumnarExchange|                        [fetch wait time] 0|
|  q1.sql|      762|                                        ColumnarExchange|                     [time to decompress] 0|
|  q1.sql|      762|                                        ColumnarExchange|                        [fetch wait time] 0|
|  q1.sql|      755|                   FlushableHashAggregateExecTransformer|                [time of rowConstruction] 0|
|  q1.sql|      690|                                   FilterExecTransformer|                         [time of filter] 0|
|  q1.sql|      685|  ScanTransformer parquet spark_catalog.default.lineitem|         [dynamic partition pruning time] 0|
|  q1.sql|      685|  ScanTransformer parquet spark_catalog.default.lineitem|                  [remaining filter time] 0|



Test report: 

Summary: 1 out of 1 queries passed. 

| Query ID | Was Passed | Row Count | Plan Time (Millis) | Query Time (Millis) |
|----------|------------|-----------|--------------------|---------------------|
|        q1|        true|          4|                 332|                 1114|
|        q1|        true|          4|                 332|                 1114|

No failed queries. 
```