### PR TITLE
[GLUTEN-9551][VL] Fix build failure due to libelf vcpkg unavailable files

### DIFF
--- a/dev/vcpkg/ports/libelf/portfile.cmake
+++ b/dev/vcpkg/ports/libelf/portfile.cmake
@@ -11,8 +11,13 @@ vcpkg_extract_source_archive(
 )
 
 # Update config.guess and config.sub
-file(DOWNLOAD "https://git.savannah.gnu.org/cgit/config.git/plain/config.guess" "${SOURCE_PATH}/config.guess")
-file(DOWNLOAD "https://git.savannah.gnu.org/cgit/config.git/plain/config.sub" "${SOURCE_PATH}/config.sub")
+file(DOWNLOAD "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
+     "${SOURCE_PATH}/config.guess"
+     STATUS status_guess)
+
+file(DOWNLOAD "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD"
+     "${SOURCE_PATH}/config.sub"
+     STATUS status_sub)
 
 vcpkg_configure_make(SOURCE_PATH ${SOURCE_PATH} AUTOCONFIG)
 vcpkg_install_make()


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - `https://git.savannah.gnu.org/cgit/config.git/plain/config.guess` is no longer available causing builds to fail with vcpkg.
 - Updated to gitweb interface which is correctly serving the files.

## How was this patch tested?
 - Build succeed / CI

```
 wget 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess'                      
--2025-05-08 02:22:32--  https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
Resolving git.savannah.gnu.org (git.savannah.gnu.org)... 209.51.188.168, 2001:470:142::168
Connecting to git.savannah.gnu.org (git.savannah.gnu.org)|209.51.188.168|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-05-08 02:22:33 ERROR 404: Not Found.



wget 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'  
--2025-05-08 02:22:23--  https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
Resolving git.savannah.gnu.org (git.savannah.gnu.org)... 209.51.188.168, 2001:470:142::168
Connecting to git.savannah.gnu.org (git.savannah.gnu.org)|209.51.188.168|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/plain]
Saving to: ‘index.html?p=config.git;a=blob_plain;f=config.guess;hb=HEAD’

index.html?p=config.git;a=blob_plain;f=con     [  <=>                                                                                    ]  49.55K   216KB/s    in 0.2s    

2025-05-08 02:22:25 (216 KB/s) - ‘index.html?p=config.git;a=blob_plain;f=config.guess;hb=HEAD’ saved [50743]
```


