### PR TITLE
[GLUTEN-9557][VL] Remove outdated test exclusion logic

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -23,9 +23,6 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.catalyst.optimizer.NullPropagation
 import org.apache.spark.sql.execution.ProjectExec
 
-import org.scalactic.source.Position
-import org.scalatest.Tag
-
 class ScalarFunctionsValidateSuiteRasOff extends ScalarFunctionsValidateSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
@@ -37,21 +34,6 @@ class ScalarFunctionsValidateSuiteRasOn extends ScalarFunctionsValidateSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.gluten.ras.enabled", "true")
-  }
-
-  // TODO: Fix the incompatibilities then remove this method. See GLUTEN-7600.
-  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
-      pos: Position): Unit = {
-    val exclusions = Set(
-      "isnull function",
-      "null input for array_size",
-      "Test make_ym_interval function"
-    )
-    if (exclusions.contains(testName)) {
-      super.ignore(testName, testTags: _*)(testFun)(pos)
-      return
-    }
-    super.test(testName, testTags: _*)(testFun)(pos)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

* The temporary logic to exclude specific tests (isnull function, null input for array_size, Test make_ym_interval function) has been removed as the underlying incompatibilities have been resolved (see https://github.com/apache/incubator-gluten/issues/7600).   
* These tests are now executed normally, improving test coverage and alignment with expected behavior.  

(Fixes: \#9557)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

