### PR TITLE
[GLUTEN-8851][VL] Supports deploy cudf in cluster

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -204,9 +204,17 @@ class VeloxListenerApi extends ListenerApi with Logging {
     if (StringUtils.isNotBlank(libPath)) { // Path based load. Ignore all other loadees.
       JniLibLoader.loadFromPath(libPath)
     } else {
+      if (
+        conf.getBoolean(
+          GlutenConfig.COLUMNAR_CUDF_ENABLED.key,
+          GlutenConfig.COLUMNAR_CUDF_ENABLED.defaultValue.get)
+      ) {
+        loader.load(s"$platformLibDir/${System.mapLibraryName("cudf")}")
+      }
       val baseLibName = conf.get(GlutenConfig.GLUTEN_LIB_NAME.key, "gluten")
       loader.load(s"$platformLibDir/${System.mapLibraryName(baseLibName)}")
       loader.load(s"$platformLibDir/${System.mapLibraryName(VeloxBackend.BACKEND_NAME)}")
+
     }
 
     // Initial native backend with configurations.

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -345,8 +345,10 @@ if(ENABLE_GPU)
     ${VELOX_BUILD_PATH}/velox/experimental/cudf/exec/libvelox_cudf_exec.a)
 
   target_link_libraries(velox PUBLIC facebook::velox::velox_cudf_exec)
+  file(COPY ${VELOX_BUILD_PATH}/_deps/cudf-build/libcudf.so
+    DESTINATION ${root_directory}/releases)
   target_link_libraries(velox
-                        PRIVATE ${VELOX_BUILD_PATH}/_deps/cudf-build/libcudf.so)
+                        PRIVATE ${root_directory}/releases/libcudf.so)
 endif()
 
 add_custom_command(

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -346,9 +346,8 @@ if(ENABLE_GPU)
 
   target_link_libraries(velox PUBLIC facebook::velox::velox_cudf_exec)
   file(COPY ${VELOX_BUILD_PATH}/_deps/cudf-build/libcudf.so
-    DESTINATION ${root_directory}/releases)
-  target_link_libraries(velox
-                        PRIVATE ${root_directory}/releases/libcudf.so)
+       DESTINATION ${root_directory}/releases)
+  target_link_libraries(velox PRIVATE ${root_directory}/releases/libcudf.so)
 endif()
 
 add_custom_command(


### PR DESCRIPTION
Before that, if we move the velox home directory, execution failed. And we also need to copy the cudf dependency library to `/lib64`, you can use `ldd ./release/_deps/cudf-build/libcudf.so` to show the dependency library.
```
[root@785a4f75d34b _build]# ldd ./release/_deps/cudf-build/libcudf.so 
	linux-vdso.so.1 (0x00007fff0412c000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f731e970000)
	libnvcomp.so.4 => not found
	libkvikio.so => not found
	libcudart.so.12 => /usr/local/cuda-12.8/lib64/libcudart.so.12 (0x00007f731e6ba000)
	librapids_logger.so => not found

./release/_deps/nvcomp_proprietary_binary-src/lib64/[libnvcomp.so](http://libnvcomp.so/)
./release/_deps/kvikio-build/[libkvikio.so](http://libkvikio.so/)
./release/_deps/rapids_logger-build/[librapids_logger.so](http://librapids_logger.so/)
```