### PR TITLE
[GLUTEN-9392][VL] Support integral to boolean array casts

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -224,21 +224,25 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
 }
 
 bool isSupportedArrayCast(const TypePtr& fromType, const TypePtr& toType) {
-  static const std::unordered_set<TypeKind> kAllowedArrayElementKinds = {
-      TypeKind::DOUBLE,
-      TypeKind::BOOLEAN,
-      TypeKind::TIMESTAMP,
-  };
 
   // https://github.com/apache/incubator-gluten/issues/9392
   // is currently WIP to add support for other types.
   if (toType->isVarchar()) {
-    return kAllowedArrayElementKinds.count(fromType->kind()) > 0;
+    return fromType->kind() == TypeKind::DOUBLE ||
+           fromType->kind() == TypeKind::BOOLEAN ||
+           fromType->kind() == TypeKind::TIMESTAMP;
   }
 
   if (toType->isDouble()) {
     if (fromType->isInteger() || fromType->isBigint() || fromType->isSmallint() || fromType->isTinyint()) {
       return true;
+    }
+  }
+
+  if (toType->isBoolean()) {
+    if( fromType->isTinyint() || fromType->isSmallint() || fromType->isInteger() ||
+           fromType->isBigint() || fromType->isReal() || fromType->isDouble()) {
+        return true;
     }
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -224,13 +224,10 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
 }
 
 bool isSupportedArrayCast(const TypePtr& fromType, const TypePtr& toType) {
-
   // https://github.com/apache/incubator-gluten/issues/9392
   // is currently WIP to add support for other types.
   if (toType->isVarchar()) {
-    return fromType->kind() == TypeKind::DOUBLE ||
-           fromType->kind() == TypeKind::BOOLEAN ||
-           fromType->kind() == TypeKind::TIMESTAMP;
+    return fromType->isDouble() || fromType->isBoolean() || fromType->isTimestamp();
   }
 
   if (toType->isDouble()) {
@@ -240,9 +237,13 @@ bool isSupportedArrayCast(const TypePtr& fromType, const TypePtr& toType) {
   }
 
   if (toType->isBoolean()) {
-    if( fromType->isTinyint() || fromType->isSmallint() || fromType->isInteger() ||
-           fromType->isBigint() || fromType->isReal() || fromType->isDouble()) {
-        return true;
+    if (fromType->isDate() || fromType->isShortDecimal()) {
+      return false;
+    }
+
+    if (fromType->isTinyint() || fromType->isSmallint() || fromType->isInteger() || fromType->isBigint() ||
+        fromType->isReal() || fromType->isDouble()) {
+      return true;
     }
   }
 

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -101,7 +101,7 @@ function compile {
   # Maybe there is some set option in velox setup script. Run set command again.
   set -exu
 
-  CXX_FLAGS='-Wno-missing-field-initializers'
+  CXX_FLAGS='-Wno-missing-field-initializers -Wno-error=stringop-overflow'
   COMPILE_OPTION="-DCMAKE_CXX_FLAGS=\"$CXX_FLAGS\" -DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF -DVELOX_MONO_LIBRARY=ON -DVELOX_BUILD_RUNNER=OFF -DVELOX_SIMDJSON_SKIPUTF8VALIDATION=ON"
   if [ $BUILD_TEST_UTILS == "ON" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_BUILD_TEST_UTILS=ON"

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -101,7 +101,7 @@ function compile {
   # Maybe there is some set option in velox setup script. Run set command again.
   set -exu
 
-  CXX_FLAGS='-Wno-missing-field-initializers -Wno-error=stringop-overflow'
+  CXX_FLAGS='-Wno-missing-field-initializers'
   COMPILE_OPTION="-DCMAKE_CXX_FLAGS=\"$CXX_FLAGS\" -DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF -DVELOX_MONO_LIBRARY=ON -DVELOX_BUILD_RUNNER=OFF -DVELOX_SIMDJSON_SKIPUTF8VALIDATION=ON"
   if [ $BUILD_TEST_UTILS == "ON" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_BUILD_TEST_UTILS=ON"

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -164,6 +164,22 @@ class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
     checkEvaluation(cast(timestampArray, ArrayType(StringType)), Seq("2023-01-01 12:00:00", null))
   }
 
+  test("cast array of numeric types to array of boolean") {
+    val tinyintArray = Literal.create(Seq(0.toByte, 1.toByte, -1.toByte), ArrayType(ByteType))
+    val smallintArray = Literal.create(Seq(0.toShort, 2.toShort, -2.toShort), ArrayType(ShortType))
+    val intArray = Literal.create(Seq(0, 3, -3), ArrayType(IntegerType))
+    val bigintArray = Literal.create(Seq(0L, 100L, -100L), ArrayType(LongType))
+    val floatArray = Literal.create(Seq(0.0f, 1.5f, -2.3f), ArrayType(FloatType))
+    val doubleArray = Literal.create(Seq(0.0, 2.5, -3.7), ArrayType(DoubleType))
+
+    checkEvaluation(cast(tinyintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(smallintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(intArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(bigintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(floatArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(doubleArray, ArrayType(BooleanType)), Seq(false, true, true))
+  }
+
   testGluten("missing cases - from short") {
     DataTypeTestUtils.numericTypeWithoutDecimal.foreach {
       t =>

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -140,6 +140,22 @@ class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
     checkEvaluation(cast(timestampArray, ArrayType(StringType)), Seq("2023-01-01 12:00:00", null))
   }
 
+  test("cast array of numeric types to array of boolean") {
+    val tinyintArray = Literal.create(Seq(0.toByte, 1.toByte, -1.toByte), ArrayType(ByteType))
+    val smallintArray = Literal.create(Seq(0.toShort, 2.toShort, -2.toShort), ArrayType(ShortType))
+    val intArray = Literal.create(Seq(0, 3, -3), ArrayType(IntegerType))
+    val bigintArray = Literal.create(Seq(0L, 100L, -100L), ArrayType(LongType))
+    val floatArray = Literal.create(Seq(0.0f, 1.5f, -2.3f), ArrayType(FloatType))
+    val doubleArray = Literal.create(Seq(0.0, 2.5, -3.7), ArrayType(DoubleType))
+
+    checkEvaluation(cast(tinyintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(smallintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(intArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(bigintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(floatArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(doubleArray, ArrayType(BooleanType)), Seq(false, true, true))
+  }
+
   testGluten("missing cases - from boolean") {
     (DataTypeTestUtils.numericTypeWithoutDecimal + BooleanType).foreach {
       t =>

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -152,6 +152,22 @@ class GlutenCastSuite extends CastWithAnsiOffSuite with GlutenTestsTrait {
     checkEvaluation(cast(timestampArray, ArrayType(StringType)), Seq("2023-01-01 12:00:00", null))
   }
 
+  test("cast array of numeric types to array of boolean") {
+    val tinyintArray = Literal.create(Seq(0.toByte, 1.toByte, -1.toByte), ArrayType(ByteType))
+    val smallintArray = Literal.create(Seq(0.toShort, 2.toShort, -2.toShort), ArrayType(ShortType))
+    val intArray = Literal.create(Seq(0, 3, -3), ArrayType(IntegerType))
+    val bigintArray = Literal.create(Seq(0L, 100L, -100L), ArrayType(LongType))
+    val floatArray = Literal.create(Seq(0.0f, 1.5f, -2.3f), ArrayType(FloatType))
+    val doubleArray = Literal.create(Seq(0.0, 2.5, -3.7), ArrayType(DoubleType))
+
+    checkEvaluation(cast(tinyintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(smallintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(intArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(bigintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(floatArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(doubleArray, ArrayType(BooleanType)), Seq(false, true, true))
+  }
+
   testGluten("missing cases - from byte") {
     DataTypeTestUtils.numericTypeWithoutDecimal.foreach {
       t =>

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -141,6 +141,22 @@ class GlutenCastSuite extends CastWithAnsiOffSuite with GlutenTestsTrait {
     checkEvaluation(cast(timestampArray, ArrayType(StringType)), Seq("2023-01-01 12:00:00", null))
   }
 
+  test("cast array of numeric types to array of boolean") {
+    val tinyintArray = Literal.create(Seq(0.toByte, 1.toByte, -1.toByte), ArrayType(ByteType))
+    val smallintArray = Literal.create(Seq(0.toShort, 2.toShort, -2.toShort), ArrayType(ShortType))
+    val intArray = Literal.create(Seq(0, 3, -3), ArrayType(IntegerType))
+    val bigintArray = Literal.create(Seq(0L, 100L, -100L), ArrayType(LongType))
+    val floatArray = Literal.create(Seq(0.0f, 1.5f, -2.3f), ArrayType(FloatType))
+    val doubleArray = Literal.create(Seq(0.0, 2.5, -3.7), ArrayType(DoubleType))
+
+    checkEvaluation(cast(tinyintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(smallintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(intArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(bigintArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(floatArray, ArrayType(BooleanType)), Seq(false, true, true))
+    checkEvaluation(cast(doubleArray, ArrayType(BooleanType)), Seq(false, true, true))
+  }
+
   testGluten("missing cases - from boolean") {
     (DataTypeTestUtils.numericTypeWithoutDecimal ++ Set(BooleanType)).foreach {
       t =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - Add support for array integral to bool casts.
 - Enabled the same in validator for array types.
 - Minor refactor to the existing code for validations.

## How was this patch tested?
 - New unit tests added, relying on existing Spark UTs