### PR TITLE
[GLUTEN] Move Range to PostTransform to avoid unnecessary R2C transitions

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -103,6 +103,7 @@ object VeloxRuleApi {
     injector.injectPostTransform(c => HashAggregateIgnoreNullKeysRule.apply(c.session))
     injector.injectPostTransform(_ => CollectLimitTransformerRule())
     injector.injectPostTransform(_ => CollectTailTransformerRule())
+    injector.injectPostTransform(_ => ColumnarRangeTransformerRule())
     injector.injectPostTransform(c => InsertTransitions.create(c.outputsColumnar, VeloxBatch))
 
     // Gluten columnar: Fallback policies.
@@ -193,6 +194,7 @@ object VeloxRuleApi {
     injector.injectPostTransform(c => HashAggregateIgnoreNullKeysRule.apply(c.session))
     injector.injectPostTransform(_ => CollectLimitTransformerRule())
     injector.injectPostTransform(_ => CollectTailTransformerRule())
+    injector.injectPostTransform(_ => ColumnarRangeTransformerRule())
     injector.injectPostTransform(c => InsertTransitions.create(c.outputsColumnar, VeloxBatch))
     injector.injectPostTransform(c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
     SparkShimLoader.getSparkShims

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/ColumnarRangeTransformerRule.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/ColumnarRangeTransformerRule.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar
+
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.config.GlutenConfig
+
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{RangeExec, SparkPlan}
+
+case class ColumnarRangeTransformerRule() extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!GlutenConfig.get.enableColumnarRange) {
+      return plan
+    }
+
+    val transformed = plan.transformUp {
+      case exec: RangeExec if exec.supportsColumnar =>
+        BackendsApiManager.getSparkPlanExecApiInstance
+          .genColumnarRangeExec(
+            exec.start,
+            exec.end,
+            exec.step,
+            exec.numSlices,
+            exec.numElements,
+            exec.output,
+            exec.children)
+    }
+
+    transformed
+  }
+}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -322,17 +322,6 @@ object OffloadOthers {
               child,
               plan.evalType)
           }
-        case plan: RangeExec =>
-          logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-          BackendsApiManager.getSparkPlanExecApiInstance.genColumnarRangeExec(
-            plan.start,
-            plan.end,
-            plan.step,
-            plan.numSlices,
-            plan.numElements,
-            plan.output,
-            plan.children
-          )
         case plan: SampleExec =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
           val child = plan.child


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - Prevent unwanted R2C transitions for Columnar Range.
 - Moved to post transform rule similar to columnar tail/collect.
## How was this patch tested?
 - Existing Unit tests.

