### PR TITLE
[GLUTEN-9571][VL] Respect parquet configs, parquet.page.size and parquet.compression.codec.zstd.level etc.

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetWriterInjects.scala
@@ -47,6 +47,13 @@ class VeloxParquetWriterInjects extends VeloxFormatWriterInjects {
     options
       .get(GlutenConfig.PARQUET_GZIP_WINDOW_SIZE)
       .foreach(sparkOptions.put(GlutenConfig.PARQUET_GZIP_WINDOW_SIZE, _))
+
+    Seq(
+      GlutenConfig.PARQUET_ZSTD_COMPRESSION_LEVEL,
+      GlutenConfig.PARQUET_DATAPAGE_SIZE,
+      GlutenConfig.PARQUET_ENABLE_DICTIONARY,
+      GlutenConfig.PARQUET_WRITER_VERSION
+    ).foreach(key => options.get(key).foreach(sparkOptions.put(key, _)))
     sparkOptions.asJava
   }
 

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -58,6 +58,14 @@ const std::string kParquetBlockRows = "parquet.block.rows";
 const std::string kParquetGzipWindowSize = "parquet.gzip.windowSize";
 const std::string kGzipWindowSize4k = "4096";
 
+const std::string kParquetZSTDCompressionLevel = "parquet.compression.codec.zstd.level";
+
+const std::string kParquetDataPageSize = "parquet.page.size";
+
+const std::string kParquetEnableDictionary = "parquet.enable.dictionary";
+
+const std::string kParquetWriterVersion = "parquet.writer.version";
+
 const std::string kParquetCompressionCodec = "spark.sql.parquet.compression.codec";
 
 const std::string kColumnarToRowMemoryThreshold = "spark.gluten.sql.columnarToRowMemoryThreshold";

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -171,3 +171,49 @@ nav_order: 15
 | spark.gluten.supported.scala.udfs                                                     || Supported scala udf names.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | spark.gluten.ui.enabled                                            | true              | Whether to enable the gluten web UI, If true, attach the gluten UI page to the Spark web UI.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
+## Parquet write configurations
+|                                                   | parquet-mr default                         | Spark default | Velox Default | Gluten Support |
+|---------------------------------------------------| ------------------------------------------ |---------------| ------------- |----------------|
+| -------------------Spark----------------          |                                            |               |               |                |
+| spark.sql.parquet.outputTimestampType             |                                            | int96         |               |                |
+| spark.sql.parquet.writeLegacyFormat               |                                            | false         |               |                |
+| -------------------Velox/Arrow----------------    |                                            |               |               |                |
+| write_batch_size                                  |                                            |               | 1024          | Y (batch size) |
+| rowgroup_length                                   |                                            |               | 1M            |                |
+| compression_level                                 |                                            |               | 0             |                |
+| page_index                                        |                                            |               | false         |                |
+| decimal_as_integer                                |                                            |               | false         |                |
+| statistics_enabled                                |                                            |               | false         |                |
+| -------------------parquet-mr----------------     |                                            |               |               |                |
+| parquet.summary.metadata.level                    | all                                        |               |               |                |
+| parquet.enable.summary-metadata                   | true                                       |               |               |                |
+| parquet.block.size                                | 128m                                       |               |               | Y              |
+| parquet.page.size                                 | 1m                                         |               | 1M            | Y              |
+| parquet.compression                               | uncompressed                               | snappy        | uncompressed  | Y              |
+| parquet.write.support.class                       | org.apache.parquet.hadoop.api.WriteSupport |               |               |                |
+| parquet.enable.dictionary                         | true                                       |               | true          | Y              |
+| parquet.dictionary.page.size                      | 1m                                         |               | 1m            |                |
+| parquet.validation                                | false                                      |               |               |                |
+| parquet.writer.version                            | PARQUET_1_0                                |               | PARQUET_2_6   | Y              |
+| parquet.memory.pool.ratio                         | 0.95                                       |               |               |                |
+| parquet.memory.min.chunk.size                     | 1m                                         |               |               |                |
+| parquet.writer.max-padding                        | 8m                                         |               |               |                |
+| parquet.page.size.row.check.min                   | 100                                        |               |               |                |
+| parquet.page.size.row.check.max                   | 10000                                      |               |               |                |
+| parquet.page.value.count.threshold                | Integer.MAX_VALUE / 2                      |               |               |                |
+| parquet.page.size.check.estimate                  | true                                       |               |               |                |
+| parquet.columnindex.truncate.length               | 64                                         |               |               |                |
+| parquet.statistics.truncate.length                | 2147483647                                 |               |               |                |
+| parquet.bloom.filter.enabled                      | false                                      |               |               |                |
+| parquet.bloom.filter.adaptive.enabled             | false                                      |               |               |                |
+| parquet.bloom.filter.candidates.number            | 5                                          |               |               |                |
+| parquet.bloom.filter.expected.ndv                 |                                            |               |               |                |
+| parquet.bloom.filter.fpp                          | 0.01                                       |               |               |                |
+| parquet.bloom.filter.max.bytes                    | 1m                                         |               |               |                |
+| parquet.decrypt.off-heap.buffer.enabled           | false                                      |               |               |                |
+| parquet.page.row.count.limit                      | 20000                                      |               |               |                |
+| parquet.page.write-checksum.enabled               | true                                       |               | false         |                |
+| parquet.crypto.factory.class                      | None                                       |               |               |                |
+| parquet.compression.codec.zstd.bufferPool.enabled | true                                       |               |               |                |
+| parquet.compression.codec.zstd.level              | 3                                          |               | 0             | Y              |
+| parquet.compression.codec.zstd.workers            | 0                                          |               |               |                |

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -367,6 +367,10 @@ object GlutenConfig {
   val PARQUET_BLOCK_SIZE: String = "parquet.block.size"
   val PARQUET_BLOCK_ROWS: String = "parquet.block.rows"
   val PARQUET_GZIP_WINDOW_SIZE: String = "parquet.gzip.windowSize"
+  val PARQUET_ZSTD_COMPRESSION_LEVEL: String = "parquet.compression.codec.zstd.level"
+  val PARQUET_DATAPAGE_SIZE: String = "parquet.page.size"
+  val PARQUET_ENABLE_DICTIONARY: String = "parquet.enable.dictionary"
+  val PARQUET_WRITER_VERSION: String = "parquet.writer.version"
   // Hadoop config
   val HADOOP_PREFIX = "spark.hadoop."
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Respect parquet writer configs
1. parquet.page.size
2. parquet.compression.codec.zstd.level
3. parquet.enable.dictionary
4. parquet.writer.version

(Fixes: \#9571)

## How was this patch tested?

manually

