### PR TITLE
[CORE] Remove unnecessary conf spark.gluten.sql.columnar.enableVanillaVectorizedReaders

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxRoughCostModelSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxRoughCostModelSuite.scala
@@ -43,7 +43,6 @@ class VeloxRoughCostModelSuite extends VeloxWholeStageTransformerSuite {
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(GlutenConfig.RAS_ENABLED.key, "true")
     .set(GlutenConfig.RAS_COST_MODEL.key, "rough")
-    .set(GlutenConfig.VANILLA_VECTORIZED_READERS_ENABLED.key, "false")
 
   test("fallback trivial project if its neighbor nodes fell back") {
     withSQLConf(GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key -> "false") {

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -207,25 +207,6 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     conf.set(
       COLUMNAR_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES.key,
       conservativeOffHeapPerTask.toString)
-
-    // Disable vanilla columnar readers, to prevent columnar-to-columnar conversions.
-    // FIXME: Do we still need this trick since
-    //  https://github.com/apache/incubator-gluten/pull/1931 was merged?
-    if (
-      !conf.getBoolean(
-        VANILLA_VECTORIZED_READERS_ENABLED.key,
-        VANILLA_VECTORIZED_READERS_ENABLED.defaultValue.get)
-    ) {
-      // FIXME Hongze 22/12/06
-      //  BatchScan.scala in shim was not always loaded by class loader.
-      //  The file should be removed and the "ClassCastException" issue caused by
-      //  spark.sql.<format>.enableVectorizedReader=true should be fixed in another way.
-      //  Before the issue is fixed we force the use of vanilla row reader by using
-      //  the following statement.
-      conf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, "false")
-      conf.set(SQLConf.ORC_VECTORIZED_READER_ENABLED.key, "false")
-      conf.set(SQLConf.CACHE_VECTORIZED_READER_ENABLED.key, "false")
-    }
   }
 }
 

--- a/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -809,13 +809,6 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
-  val VANILLA_VECTORIZED_READERS_ENABLED =
-    buildStaticConf("spark.gluten.sql.columnar.enableVanillaVectorizedReaders")
-      .internal()
-      .doc("Enable or disable vanilla vectorized scan.")
-      .booleanConf
-      .createWithDefault(true)
-
   val COLUMNAR_HASHAGG_ENABLED =
     buildConf("spark.gluten.sql.columnar.hashagg")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Users can configure Spark's own columnar read configuration, and we do not need to introduce additional gluten configuration to control it. (Especially when the configuration defaults to true)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)



(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

