### PR TITLE
[GLUTEN-9631][CH] Fix: `AggregateDescription.parameters` is not set in `AggregateGroupLimitRelParser`

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHBackend.scala
@@ -166,6 +166,10 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   val GLUTEN_ELIMINATE_DEDUPLICATE_AGGREGATE_WITH_ANY_JOIN: String =
     CHConfig.prefixOf("eliminate_deduplicate_aggregate_with_any_join")
 
+  // If the partition keys are high cardinality, the aggregation method is slower.
+  val GLUTEN_ENABLE_WINDOW_GROUP_LIMIT_TO_AGGREGATE: String =
+    CHConfig.prefixOf("runtime_settings.enable_window_group_limit_to_aggregate")
+
   def affinityMode: String = {
     SparkEnv.get.conf
       .get(
@@ -393,14 +397,6 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
   def enablePreProjectionForJoinConditions(): Boolean = {
     SparkEnv.get.conf.getBoolean(
       CHConfig.runtimeConfig("enable_pre_projection_for_join_conditions"),
-      defaultValue = true
-    )
-  }
-
-  // If the partition keys are high cardinality, the aggregation method is slower.
-  def enableConvertWindowGroupLimitToAggregate(): Boolean = {
-    SparkEnv.get.conf.getBoolean(
-      CHConfig.runtimeConfig("enable_window_group_limit_to_aggregate"),
       defaultValue = true
     )
   }

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ConvertWindowToAggregate.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ConvertWindowToAggregate.scala
@@ -36,7 +36,11 @@ case class ConverRowNumbertWindowToAggregateRule(spark: SparkSession)
   with Logging {
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!CHBackendSettings.enableConvertWindowGroupLimitToAggregate) {
+    if (
+      !spark.conf
+        .get(CHBackendSettings.GLUTEN_ENABLE_WINDOW_GROUP_LIMIT_TO_AGGREGATE, "true")
+        .toBoolean
+    ) {
       return plan
     }
     plan.transformUp {

--- a/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
@@ -331,7 +331,7 @@ DB::AggregateDescription AggregateGroupLimitRelParser::buildAggregateDescription
     DB::AggregateDescription agg_desc;
     agg_desc.column_name = aggregate_tuple_column_name;
     agg_desc.argument_names = {aggregate_tuple_column_name};
-    DB::Array parameters;
+    auto & parameters = agg_desc.parameters;
     parameters.push_back(static_cast<UInt32>(limit));
     auto sort_directions = buildSQLLikeSortDescription(input_header, win_rel_def->sorts());
     parameters.push_back(sort_directions);


### PR DESCRIPTION
AggregateDescription.parameters is not set in AggregateGroupLimitRelParser. It will cause the deserialization of intermediate aggregate data to fail.


## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #9631 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

manual tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

