### PR TITLE
[GLUTEN-6609][CH] Remove unnecessary readFile override in GlutenDiskS3

### DIFF
--- a/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.cpp
+++ b/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.cpp
@@ -34,18 +34,6 @@ namespace local_engine
         return std::make_shared<CompactObjectStorageDiskTransaction>(*this, QueryContext::globalContext()->getSharedTempDataOnDisk());
     }
 
-    std::unique_ptr<DB::ReadBufferFromFileBase> GlutenDiskS3::readFile(
-        const String & path,
-        const ReadSettings & settings,
-        std::optional<size_t> read_hint,
-        std::optional<size_t> file_size) const
-    {
-        ReadSettings copy_settings = settings;
-        // Threadpool read is not supported for s3 compact version currently
-        copy_settings.remote_fs_method = RemoteFSReadMethod::read;
-        return DiskObjectStorage::readFile(path, copy_settings, read_hint, file_size);
-    }
-
     DiskObjectStoragePtr GlutenDiskS3::createDiskObjectStorage()
     {
         const auto config_prefix = "storage_configuration.disks." + name;

--- a/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.h
+++ b/cpp-ch/local-engine/Disks/ObjectStorages/GlutenDiskS3.h
@@ -40,10 +40,6 @@ public:
 
     DB::DiskTransactionPtr createTransaction() override;
 
-    std::unique_ptr<DB::ReadBufferFromFileBase>
-    readFile(const String & path, const DB::ReadSettings & settings, std::optional<size_t> read_hint, std::optional<size_t> file_size)
-        const override;
-
     DB::DiskObjectStoragePtr createDiskObjectStorage() override;
 
 private:


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: #6609)

Removed the custom implementation of the `readFile` method from the `GlutenDiskS3` class as it's no longer required for the S3 compact version.  

Previously, this override forced the `remote_fs_method` to use `RemoteFSReadMethod::read` since threadpool reading wasn't supported for the S3 compact version. Now, we can simply rely on the parent `DiskObjectStorage` implementation.

This change simplifies the codebase and reduces maintenance overhead without affecting functionality

## How was this patch tested?

use existed uts