### PR TITLE
[GLUTEN-9660][CH]Fix incorrect columns order when deleting from the mergetree table with the delta dv

### DIFF
--- a/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/gluten/delta/GlutenDeltaParquetDeletionVectorSuite.scala
+++ b/backends-clickhouse/src-delta-32/test/scala/org/apache/spark/gluten/delta/GlutenDeltaParquetDeletionVectorSuite.scala
@@ -69,9 +69,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
 
   test("test parquet table delete with the delta DV") {
     spark.sql(s"""
-                 |set spark.gluten.enabled=false;
-                 |""".stripMargin)
-    spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_delta_parquet_delete_dv;
                  |""".stripMargin)
 
@@ -93,9 +90,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
                  | where l_orderkey = 3
                  |""".stripMargin)
 
-    spark.sql(s"""
-                 |set spark.gluten.enabled=true;
-                 |""".stripMargin)
     val df = spark.sql(s"""
                           | select sum(l_linenumber) from lineitem_delta_parquet_delete_dv
                           |""".stripMargin)
@@ -112,15 +106,9 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
     assert(addFiles.size === 6)
 
     spark.sql(s"""
-                 |set spark.gluten.enabled=false;
-                 |""".stripMargin)
-    spark.sql(s"""
                  | delete from lineitem_delta_parquet_delete_dv where mod(l_orderkey, 3) = 2
                  |""".stripMargin)
 
-    spark.sql(s"""
-                 |set spark.gluten.enabled=true;
-                 |""".stripMargin)
     val df3 = spark.sql(s"""
                            | select sum(l_linenumber) from lineitem_delta_parquet_delete_dv
                            |""".stripMargin)
@@ -130,9 +118,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
   }
 
   test("test parquet table delete + update with the delta DV") {
-    spark.sql(s"""
-                 |set spark.gluten.enabled=false;
-                 |""".stripMargin)
     spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_delta_parquet_update_dv;
                  |""".stripMargin)
@@ -155,9 +140,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
          | update lineitem_delta_parquet_update_dv set l_returnflag = 'AAA' where l_orderkey < 200
          |""".stripMargin)
 
-    spark.sql(s"""
-                 |set spark.gluten.enabled=true;
-                 |""".stripMargin)
     val df =
       spark.sql(s"""
                    | select sum(l_linenumber)
@@ -366,9 +348,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
   test("test parquet partition table delete with the delta DV") {
     withSQLConf(("spark.sql.sources.partitionOverwriteMode", "dynamic")) {
       spark.sql(s"""
-                   |set spark.gluten.enabled=false;
-                   |""".stripMargin)
-      spark.sql(s"""
                    |DROP TABLE IF EXISTS lineitem_delta_partition_parquet_delete_dv;
                    |""".stripMargin)
 
@@ -391,9 +370,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
                    | where mod(l_orderkey, 3) = 1
                    |""".stripMargin)
 
-      spark.sql(s"""
-                   |set spark.gluten.enabled=true;
-                   |""".stripMargin)
       val df =
         spark.sql(s"""
                      | select sum(l_linenumber) from lineitem_delta_partition_parquet_delete_dv
@@ -411,9 +387,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
 
   test("test parquet table upsert with the delta DV") {
     spark.sql(s"""
-                 |set spark.gluten.enabled=false;
-                 |""".stripMargin)
-    spark.sql(s"""
                  |DROP TABLE IF EXISTS lineitem_delta_parquet_upsert_dv;
                  |""".stripMargin)
 
@@ -430,9 +403,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
                  | select * from lineitem
                  |""".stripMargin)
 
-    spark.sql(s"""
-                 |set spark.gluten.enabled=true;
-                 |""".stripMargin)
     val df0 = spark.sql(s"""
                            | select sum(l_linenumber) from lineitem_delta_parquet_upsert_dv
                            |""".stripMargin)
@@ -443,9 +413,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
   }
 
   private def upsertSourceTableAndCheck(tableName: String) = {
-    spark.sql(s"""
-                 |set spark.gluten.enabled=false;
-                 |""".stripMargin)
     // Why selecting l_orderkey having count(*) =1 ?
     // Answer: to avoid "org.apache.spark.sql.delta.DeltaUnsupportedOperationException:
     // Cannot perform Merge as multiple source rows matched and attempted to modify the same
@@ -476,9 +443,6 @@ class GlutenDeltaParquetDeletionVectorSuite extends ParquetSuite {
           when not matched then insert *
           """.stripMargin)
 
-    spark.sql(s"""
-                 |set spark.gluten.enabled=true;
-                 |""".stripMargin)
     val df1 = spark.sql(s"""
                            | select sum(l_linenumber) from $tableName
                            |""".stripMargin)

--- a/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.cpp
@@ -202,6 +202,7 @@ void MergeTreeRelParser::recoverDeltaNameIfNeeded(
     DB::ActionsDAG actions_dag(header.getNamesAndTypesList());
     // Use 'Names' to make sure the orders of the output
     Names names;
+    names.reserve(output.getColumns().size());
     bool need_recover = false;
     for (const auto & column : output)
     {

--- a/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/MergeTreeRelParser.cpp
@@ -200,7 +200,8 @@ void MergeTreeRelParser::recoverDeltaNameIfNeeded(
 {
     const auto & header = plan.getCurrentHeader();
     DB::ActionsDAG actions_dag(header.getNamesAndTypesList());
-    NameSet names;
+    // Use 'Names' to make sure the orders of the output
+    Names names;
     bool need_recover = false;
     for (const auto & column : output)
     {
@@ -212,7 +213,7 @@ void MergeTreeRelParser::recoverDeltaNameIfNeeded(
             func(actions_dag, merge_tree_table, context);
         }
 
-        names.insert(column.name);
+        names.push_back(column.name);
     }
 
     if (!need_recover)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix incorrect columns order when deleting from the mergetree table with the delta dv： the error is below:
```
Cannot parse string 'R' as Int64: syntax error at begin of string. Note: there are toInt64OrZero and toInt64OrNull functions,
which returns zero/NULL instead of throwing exception.: while converting source column `tuple(file_path,l_returnflag)`
to destination column `tuple(file_path,l_returnflag)`: while executing
'FUNCTION _CAST(tuple(file_path,l_returnflag) :: 5, Tuple(file_path String, row_index Int64) :: 4)
-> tuple(file_path,l_returnflag) Tuple(file_path String, row_index Int64) : 1'
```

Close #9660.

(Fixes: #9660)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

