### PR TITLE
[GLUTEN-9666][VL] Extend transition planner to support multiple row types

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/columnarbatch/CHBatch.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/columnarbatch/CHBatch.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.execution.{CHColumnarToRowExec, RowToCHNativeColumna
  */
 object CHBatch extends Convention.BatchType {
   override protected def registerTransitions(): Unit = {
-    fromRow(RowToCHNativeColumnarExec.apply)
-    toRow(CHColumnarToRowExec.apply)
+    fromRow(Convention.RowType.VanillaRow, RowToCHNativeColumnarExec.apply)
+    toRow(Convention.RowType.VanillaRow, CHColumnarToRowExec.apply)
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/columnarbatch/VeloxBatch.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/columnarbatch/VeloxBatch.scala
@@ -21,8 +21,8 @@ import org.apache.gluten.extension.columnar.transition.{Convention, Transition}
 
 object VeloxBatch extends Convention.BatchType {
   override protected def registerTransitions(): Unit = {
-    fromRow(RowToVeloxColumnarExec.apply)
-    toRow(VeloxColumnarToRowExec.apply)
+    fromRow(Convention.RowType.VanillaRow, RowToVeloxColumnarExec.apply)
+    toRow(Convention.RowType.VanillaRow, VeloxColumnarToRowExec.apply)
     fromBatch(ArrowBatches.ArrowNativeBatch, ArrowColumnarToVeloxColumnarExec.apply)
     toBatch(ArrowBatches.ArrowNativeBatch, Transition.empty)
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/enumerated/planner/VeloxRasSuite.scala
@@ -71,7 +71,7 @@ class VeloxRasSuite extends SharedSparkSession {
         RowUnary(
           RowUnary(ColumnarUnary(RowUnary(RowUnary(ColumnarUnary(RowLeaf(TRIVIAL_SCHEMA))))))))
     val planner =
-      newRas().newPlanner(in, PropertySet(List(Conv.req(ConventionReq.row))))
+      newRas().newPlanner(in, PropertySet(List(Conv.req(ConventionReq.vanillaRow))))
     val out = planner.plan()
     assert(
       out == ColumnarToRowExec(
@@ -99,7 +99,7 @@ class VeloxRasSuite extends SharedSparkSession {
           RowUnary(ColumnarUnary(RowUnary(RowUnary(ColumnarUnary(RowLeaf(TRIVIAL_SCHEMA))))))))
     val planner =
       newRas(List(ConvertRowUnaryToColumnar))
-        .newPlanner(in, PropertySet(List(Conv.req(ConventionReq.row))))
+        .newPlanner(in, PropertySet(List(Conv.req(ConventionReq.vanillaRow))))
     val out = planner.plan()
     assert(out == ColumnarToRowExec(ColumnarUnary(ColumnarUnary(ColumnarUnary(ColumnarUnary(
       ColumnarUnary(ColumnarUnary(ColumnarUnary(RowToColumnarExec(RowLeaf(TRIVIAL_SCHEMA)))))))))))

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
@@ -38,15 +38,18 @@ class VeloxTransitionSuite extends SharedSparkSession {
   }
 
   test("Vanilla C2R - requires row input") {
-    val in = RowUnary(BatchLeaf(VanillaBatch))
+    val in = RowUnary(Convention.RowType.VanillaRow, BatchLeaf(VanillaBatch))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
-    assert(out == RowUnary(ColumnarToRowExec(BatchLeaf(VanillaBatch))))
+    assert(
+      out == RowUnary(Convention.RowType.VanillaRow, ColumnarToRowExec(BatchLeaf(VanillaBatch))))
   }
 
   test("Vanilla R2C - requires vanilla input") {
-    val in = BatchUnary(VanillaBatch, RowLeaf())
+    val in = BatchUnary(VanillaBatch, RowLeaf(Convention.RowType.VanillaRow))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
-    assert(out == ColumnarToRowExec(BatchUnary(VanillaBatch, RowToColumnarExec(RowLeaf()))))
+    assert(
+      out == ColumnarToRowExec(
+        BatchUnary(VanillaBatch, RowToColumnarExec(RowLeaf(Convention.RowType.VanillaRow)))))
   }
 
   test("ArrowNative C2R - outputs row") {
@@ -56,17 +59,22 @@ class VeloxTransitionSuite extends SharedSparkSession {
   }
 
   test("ArrowNative C2R - requires row input") {
-    val in = RowUnary(BatchLeaf(ArrowNativeBatch))
+    val in = RowUnary(Convention.RowType.VanillaRow, BatchLeaf(ArrowNativeBatch))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
-    assert(out == RowUnary(ColumnarToRowExec(LoadArrowDataExec(BatchLeaf(ArrowNativeBatch)))))
+    assert(
+      out == RowUnary(
+        Convention.RowType.VanillaRow,
+        ColumnarToRowExec(LoadArrowDataExec(BatchLeaf(ArrowNativeBatch)))))
   }
 
   test("ArrowNative R2C - requires Arrow input") {
-    val in = BatchUnary(ArrowNativeBatch, RowLeaf())
+    val in = BatchUnary(ArrowNativeBatch, RowLeaf(Convention.RowType.VanillaRow))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
     assert(
       out == ColumnarToRowExec(
-        LoadArrowDataExec(BatchUnary(ArrowNativeBatch, RowToVeloxColumnarExec(RowLeaf())))))
+        LoadArrowDataExec(BatchUnary(
+          ArrowNativeBatch,
+          RowToVeloxColumnarExec(RowLeaf(Convention.RowType.VanillaRow))))))
   }
 
   test("ArrowNative-to-Velox C2C") {
@@ -113,17 +121,20 @@ class VeloxTransitionSuite extends SharedSparkSession {
   }
 
   test("ArrowJava C2R - requires row input") {
-    val in = RowUnary(BatchLeaf(ArrowJavaBatch))
+    val in = RowUnary(Convention.RowType.VanillaRow, BatchLeaf(ArrowJavaBatch))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
-    assert(out == RowUnary(ColumnarToRowExec(BatchLeaf(ArrowJavaBatch))))
+    assert(
+      out == RowUnary(Convention.RowType.VanillaRow, ColumnarToRowExec(BatchLeaf(ArrowJavaBatch))))
   }
 
   test("ArrowJava R2C - requires Arrow input") {
-    val in = BatchUnary(ArrowJavaBatch, RowLeaf())
+    val in = BatchUnary(ArrowJavaBatch, RowLeaf(Convention.RowType.VanillaRow))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
     assert(
       out == ColumnarToRowExec(
-        BatchUnary(ArrowJavaBatch, LoadArrowDataExec(RowToVeloxColumnarExec(RowLeaf())))))
+        BatchUnary(
+          ArrowJavaBatch,
+          LoadArrowDataExec(RowToVeloxColumnarExec(RowLeaf(Convention.RowType.VanillaRow))))))
   }
 
   test("ArrowJava-to-Velox C2C") {
@@ -167,21 +178,24 @@ class VeloxTransitionSuite extends SharedSparkSession {
   }
 
   test("Velox C2R - requires row input") {
-    val in = RowUnary(BatchLeaf(VeloxBatch))
+    val in = RowUnary(Convention.RowType.VanillaRow, BatchLeaf(VeloxBatch))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
-    assert(out == RowUnary(VeloxColumnarToRowExec(BatchLeaf(VeloxBatch))))
+    assert(
+      out == RowUnary(Convention.RowType.VanillaRow, VeloxColumnarToRowExec(BatchLeaf(VeloxBatch))))
   }
 
   test("Velox R2C - outputs Velox") {
-    val in = RowLeaf()
+    val in = RowLeaf(Convention.RowType.VanillaRow)
     val out = BackendTransitions.insert(in, outputsColumnar = true)
-    assert(out == RowToVeloxColumnarExec(RowLeaf()))
+    assert(out == RowToVeloxColumnarExec(RowLeaf(Convention.RowType.VanillaRow)))
   }
 
   test("Velox R2C - requires Velox input") {
-    val in = BatchUnary(VeloxBatch, RowLeaf())
+    val in = BatchUnary(VeloxBatch, RowLeaf(Convention.RowType.VanillaRow))
     val out = BackendTransitions.insert(in, outputsColumnar = false)
-    assert(out == VeloxColumnarToRowExec(BatchUnary(VeloxBatch, RowToVeloxColumnarExec(RowLeaf()))))
+    assert(
+      out == VeloxColumnarToRowExec(
+        BatchUnary(VeloxBatch, RowToVeloxColumnarExec(RowLeaf(Convention.RowType.VanillaRow)))))
   }
 
   test("Vanilla-to-Velox C2C") {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenColumnarRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenColumnarRule.scala
@@ -99,6 +99,7 @@ case class GlutenColumnarRule(
     }
     val vanillaPlan = Transitions.insert(originalPlan, outputsColumnar)
     val applier = applierBuilder.apply(session)
-    applier.apply(vanillaPlan, outputsColumnar)
+    val out = applier.apply(vanillaPlan, outputsColumnar)
+    out
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
@@ -66,7 +66,7 @@ object GlutenPlanModel {
 
     override val batchType: Convention.BatchType = {
       val out = req.req.requiredBatchType match {
-        case ConventionReq.BatchType.Any => Convention.BatchType.VanillaBatch
+        case ConventionReq.BatchType.Any => Convention.BatchType.None
         case ConventionReq.BatchType.Is(b) => b
       }
       out

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
@@ -66,7 +66,7 @@ object GlutenPlanModel {
 
     override val batchType: Convention.BatchType = {
       val out = req.req.requiredBatchType match {
-        case ConventionReq.BatchType.Any => Convention.BatchType.None
+        case ConventionReq.BatchType.Any => Convention.BatchType.VanillaBatch
         case ConventionReq.BatchType.Is(b) => b
       }
       out
@@ -78,7 +78,7 @@ object GlutenPlanModel {
 
     override val rowType0: Convention.RowType = {
       val out = req.req.requiredRowType match {
-        case ConventionReq.RowType.Any => Convention.RowType.None
+        case ConventionReq.RowType.Any => Convention.RowType.VanillaRow
         case ConventionReq.RowType.Is(r) => r
       }
       out

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/plan/GlutenPlanModel.scala
@@ -66,7 +66,7 @@ object GlutenPlanModel {
 
     override val batchType: Convention.BatchType = {
       val out = req.req.requiredBatchType match {
-        case ConventionReq.BatchType.Any => Convention.BatchType.None
+        case ConventionReq.BatchType.Any => Convention.BatchType.VanillaBatch
         case ConventionReq.BatchType.Is(b) => b
       }
       out

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -84,43 +84,22 @@ object Convention {
     Impl(rowType, batchType)
   }
 
-  sealed trait RowType extends TransitionGraph.Vertex with Serializable {
-    import RowType._
-
-    final protected[this] def register0(): Unit = BatchType.synchronized {
-      assert(all.add(this))
-    }
-  }
-
-  object RowType {
-    private val all: mutable.Set[RowType] = mutable.Set()
-    def values(): Set[RowType] = all.toSet
-
-    // None indicates that the plan doesn't support row-based processing.
-    final case object None extends RowType
-    final case object VanillaRow extends RowType
-  }
-
-  trait BatchType extends TransitionGraph.Vertex with Serializable {
-    import BatchType._
-
-    final protected[this] def register0(): Unit = BatchType.synchronized {
-      assert(all.add(this))
-      registerTransitions()
-    }
+  trait RowOrBatchType extends TransitionGraph.Vertex {
 
     /**
-     * User batch type could override this method to define transitions from/to this batch type by
-     * calling the subsequent protected APIs.
+     * User row / batch type could override this method to define transitions from/to this batch
+     * type by calling the subsequent protected APIs.
      */
     protected[this] def registerTransitions(): Unit
 
-    final protected[this] def fromRow(transition: Transition): Unit = {
-      Transition.factory.update(graph => graph.addEdge(RowType.VanillaRow, this, transition))
+    final protected[this] def fromRow(from: RowType, transition: Transition): Unit = {
+      assert(from != this)
+      Transition.factory.update(graph => graph.addEdge(from, this, transition))
     }
 
-    final protected[this] def toRow(transition: Transition): Unit = {
-      Transition.factory.update(graph => graph.addEdge(this, RowType.VanillaRow, transition))
+    final protected[this] def toRow(to: RowType, transition: Transition): Unit = {
+      assert(to != this)
+      Transition.factory.update(graph => graph.addEdge(this, to, transition))
     }
 
     final protected[this] def fromBatch(from: BatchType, transition: Transition): Unit = {
@@ -134,6 +113,37 @@ object Convention {
     }
   }
 
+  trait RowType extends RowOrBatchType with Serializable {
+    import RowType._
+
+    final protected[this] def register0(): Unit = BatchType.synchronized {
+      assert(all.add(this))
+      registerTransitions()
+    }
+  }
+
+  object RowType {
+    private val all: mutable.Set[RowType] = mutable.Set()
+    def values(): Set[RowType] = all.toSet
+
+    // None indicates that the plan doesn't support row-based processing.
+    final case object None extends RowType {
+      override protected[this] def registerTransitions(): Unit = {}
+    }
+    final case object VanillaRow extends RowType {
+      override protected[this] def registerTransitions(): Unit = {}
+    }
+  }
+
+  trait BatchType extends RowOrBatchType with Serializable {
+    import BatchType._
+
+    final protected[this] def register0(): Unit = BatchType.synchronized {
+      assert(all.add(this))
+      registerTransitions()
+    }
+  }
+
   object BatchType {
     private val all: mutable.Set[BatchType] = mutable.Set()
     def values(): Set[BatchType] = all.toSet
@@ -143,8 +153,8 @@ object Convention {
     }
     final case object VanillaBatch extends BatchType {
       override protected[this] def registerTransitions(): Unit = {
-        fromRow(RowToColumnarExec.apply)
-        toRow(ColumnarToRowExec.apply)
+        fromRow(RowType.VanillaRow, RowToColumnarExec.apply)
+        toRow(RowType.VanillaRow, ColumnarToRowExec.apply)
       }
     }
   }
@@ -170,7 +180,7 @@ object Convention {
         if (supportsColumnar) {
           Convention.RowType.None
         } else {
-          Convention.RowType.VanillaRow
+          rowType0()
         }
       } else {
         rowType0()

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Convention.scala
@@ -180,6 +180,7 @@ object Convention {
         if (supportsColumnar) {
           Convention.RowType.None
         } else {
+          assert(rowType0() != Convention.RowType.None)
           rowType0()
         }
       } else {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionReq.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/ConventionReq.scala
@@ -52,7 +52,7 @@ object ConventionReq {
   ) extends ConventionReq
 
   val any: ConventionReq = of(RowType.Any, BatchType.Any)
-  val row: ConventionReq = ofRow(RowType.Is(Convention.RowType.VanillaRow))
+  val vanillaRow: ConventionReq = ofRow(RowType.Is(Convention.RowType.VanillaRow))
   val vanillaBatch: ConventionReq = ofBatch(BatchType.Is(Convention.BatchType.VanillaBatch))
 
   def get(plan: SparkPlan): Seq[ConventionReq] = ConventionFunc.create().conventionReqOf(plan)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transition.scala
@@ -127,8 +127,8 @@ object Transition {
                 // We have only one single built-in row type.
                 Transition.empty
               case _ =>
-                throw new UnsupportedOperationException(
-                  "Row-to-row transition is not yet supported")
+                // Find row-to-row transition.
+                graph().transitionOfOption(from.rowType, toRowType).getOrElse(orElse)
             }
           case (ConventionReq.RowType.Any, ConventionReq.BatchType.Is(toBatchType)) =>
             from.batchType match {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
@@ -66,7 +66,7 @@ object InsertTransitions {
     val conventionReq = if (outputsColumnar) {
       ConventionReq.ofBatch(ConventionReq.BatchType.Is(batchType))
     } else {
-      ConventionReq.row
+      ConventionReq.vanillaRow
     }
     InsertTransitions(conventionReq)
   }
@@ -90,7 +90,7 @@ object Transitions {
   }
 
   def toRowPlan(plan: SparkPlan): SparkPlan = {
-    enforceReq(plan, ConventionReq.row)
+    enforceReq(plan, ConventionReq.vanillaRow)
   }
 
   def toBatchPlan(plan: SparkPlan, toBatchType: Convention.BatchType): SparkPlan = {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
@@ -27,6 +27,10 @@ import org.apache.spark.sql.execution.debug.DebugExec
 import org.apache.spark.util.SparkVersionUtil
 
 package object transition {
+  private val gteSpark33: Boolean = {
+    SparkVersionUtil.compareMajorMinorVersion(SparkVersionUtil.majorMinorVersion(), (3, 3)) >= 0
+  }
+
   type TransitionGraph = FloydWarshallGraph[TransitionGraph.Vertex, Transition]
   // These 5 plan operators (as of Spark 3.5) are operators that have the
   // same convention with their children.
@@ -34,10 +38,7 @@ package object transition {
   // Extend this list in shim layer once Spark has more.
   def canPropagateConvention(plan: SparkPlan): Boolean = plan match {
     case p: DebugExec => true
-    case p: UnionExec
-        if SparkVersionUtil.compareMajorMinorVersion(
-          SparkVersionUtil.majorMinorVersion(),
-          (3, 3)) >= 0 =>
+    case p: UnionExec if gteSpark33 =>
       true
     case p: AQEShuffleReadExec => true
     case p: InputAdapter => true

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
 import org.apache.spark.sql.execution.debug.DebugExec
+import org.apache.spark.util.SparkVersionUtil
 
 package object transition {
   type TransitionGraph = FloydWarshallGraph[TransitionGraph.Vertex, Transition]
@@ -33,7 +34,11 @@ package object transition {
   // Extend this list in shim layer once Spark has more.
   def canPropagateConvention(plan: SparkPlan): Boolean = plan match {
     case p: DebugExec => true
-    case p: UnionExec => true
+    case p: UnionExec
+        if SparkVersionUtil.compareMajorMinorVersion(
+          SparkVersionUtil.majorMinorVersion(),
+          (3, 3)) >= 0 =>
+      true
     case p: AQEShuffleReadExec => true
     case p: InputAdapter => true
     case p: WholeStageCodegenExec => true

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/RowToColumnarExecBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/RowToColumnarExecBase.scala
@@ -50,7 +50,7 @@ abstract class RowToColumnarExecBase(child: SparkPlan)
   override def rowType0(): Convention.RowType = Convention.RowType.None
 
   override def requiredChildConvention(): Seq[ConventionReq] = {
-    Seq(ConventionReq.row)
+    Seq(ConventionReq.vanillaRow)
   }
 
   final override def doExecute(): RDD[InternalRow] = {

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/MiscColumnarRulesSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/MiscColumnarRulesSuite.scala
@@ -27,7 +27,10 @@ class MiscColumnarRulesSuite extends SharedSparkSession with WithDummyBackend {
 
   test("Fix ColumnarToRowRemovalGuard not able to be copied") {
     val dummyPlan =
-      BatchToRow(Convention.BatchType.VanillaBatch, spark.range(1).queryExecution.sparkPlan)
+      BatchToRow(
+        Convention.BatchType.VanillaBatch,
+        Convention.RowType.VanillaRow,
+        spark.range(1).queryExecution.sparkPlan)
     val cloned =
       PreventBatchTypeMismatchInTableCache(isCalledByTableCachePlaning = true, Set.empty)
         .apply(dummyPlan)

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuite.scala
@@ -38,89 +38,142 @@ class TransitionSuite extends SharedSparkSession with WithDummyBackend {
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     Convention.ensureSparkRowAndBatchTypesRegistered()
-    TypeA.ensureRegistered()
-    TypeB.ensureRegistered()
-    TypeC.ensureRegistered()
-    TypeD.ensureRegistered()
+    RowTypeA.ensureRegistered()
+    BatchTypeA.ensureRegistered()
+    BatchTypeB.ensureRegistered()
+    BatchTypeC.ensureRegistered()
+    BatchTypeD.ensureRegistered()
+    RowTypeB.ensureRegistered()
   }
 
   test("Trivial C2R") {
-    val in = BatchLeaf(TypeA)
-    val out = Transitions.insert(in, outputsColumnar = false)
-    assert(out == BatchToRow(TypeA, BatchLeaf(TypeA)))
+    val in = BatchLeaf(BatchTypeA)
+    val out = insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
+    assert(out == BatchToRow(BatchTypeA, RowTypeA, BatchLeaf(BatchTypeA)))
   }
 
   test("Insert C2R") {
-    val in = RowUnary(BatchLeaf(TypeA))
-    val out = Transitions.insert(in, outputsColumnar = false)
-    assert(out == RowUnary(BatchToRow(TypeA, BatchLeaf(TypeA))))
+    val in = RowUnary(RowTypeA, BatchLeaf(BatchTypeA))
+    val out = insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
+    assert(out == RowUnary(RowTypeA, BatchToRow(BatchTypeA, RowTypeA, BatchLeaf(BatchTypeA))))
   }
 
   test("Insert R2C") {
-    val in = BatchUnary(TypeA, RowLeaf())
-    val out = Transitions.insert(in, outputsColumnar = false)
-    assert(out == BatchToRow(TypeA, BatchUnary(TypeA, RowToBatch(TypeA, RowLeaf()))))
+    val in = BatchUnary(BatchTypeA, RowLeaf(RowTypeA))
+    val out = insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
+    assert(
+      out == BatchToRow(
+        BatchTypeA,
+        RowTypeA,
+        BatchUnary(BatchTypeA, RowToBatch(RowTypeA, BatchTypeA, RowLeaf(RowTypeA)))))
   }
 
   test("Insert C2R2C") {
-    val in = BatchUnary(TypeA, BatchLeaf(TypeB))
-    val out = Transitions.insert(in, outputsColumnar = false)
+    val in = BatchUnary(BatchTypeA, BatchLeaf(BatchTypeB))
+    val out = insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
     assert(
       out == BatchToRow(
-        TypeA,
-        BatchUnary(TypeA, RowToBatch(TypeA, BatchToRow(TypeB, BatchLeaf(TypeB))))))
+        BatchTypeA,
+        RowTypeA,
+        BatchUnary(
+          BatchTypeA,
+          RowToBatch(
+            RowTypeA,
+            BatchTypeA,
+            BatchToRow(BatchTypeB, RowTypeA, BatchLeaf(BatchTypeB))))))
   }
 
   test("Insert C2C") {
-    val in = BatchUnary(TypeA, BatchLeaf(TypeC))
-    val out = Transitions.insert(in, outputsColumnar = false)
+    val in = BatchUnary(BatchTypeA, BatchLeaf(BatchTypeC))
+    val out = insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
     assert(
       out == BatchToRow(
-        TypeA,
-        BatchUnary(TypeA, BatchToBatch(from = TypeC, to = TypeA, BatchLeaf(TypeC)))))
+        BatchTypeA,
+        RowTypeA,
+        BatchUnary(
+          BatchTypeA,
+          BatchToBatch(from = BatchTypeC, to = BatchTypeA, BatchLeaf(BatchTypeC)))))
+  }
+
+  test("Insert R2C2R") {
+    val in = RowUnary(RowTypeB, RowLeaf(RowTypeA))
+    val out = insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
+    assert(
+      out == BatchToRow(
+        BatchTypeB,
+        RowTypeA,
+        RowToBatch(
+          RowTypeB,
+          BatchTypeB,
+          RowUnary(
+            RowTypeB,
+            BatchToRow(BatchTypeA, RowTypeB, RowToBatch(RowTypeA, BatchTypeA, RowLeaf(RowTypeA)))))
+      ))
   }
 
   test("No transitions found") {
-    val in = BatchUnary(TypeA, BatchLeaf(TypeD))
+    val in = BatchUnary(BatchTypeA, BatchLeaf(BatchTypeD))
     assertThrows[GlutenException] {
-      Transitions.insert(in, outputsColumnar = false)
+      insertTransitions(in, ConventionReq.ofRow(ConventionReq.RowType.Is(RowTypeA)))
     }
   }
 }
 
 object TransitionSuite extends TransitionSuiteBase {
-  object TypeA extends Convention.BatchType {
-    override protected[this] def registerTransitions(): Unit = {
-      fromRow(RowToBatch(this, _))
-      toRow(BatchToRow(this, _))
-    }
+  private def insertTransitions(plan: SparkPlan, req: ConventionReq): SparkPlan = {
+    InsertTransitions(req).apply(plan)
   }
 
-  object TypeB extends Convention.BatchType {
-    override protected[this] def registerTransitions(): Unit = {
-      fromRow(RowToBatch(this, _))
-      toRow(BatchToRow(this, _))
-    }
-  }
-
-  object TypeC extends Convention.BatchType {
-    override protected[this] def registerTransitions(): Unit = {
-      fromRow(RowToBatch(this, _))
-      toRow(BatchToRow(this, _))
-      fromBatch(TypeA, BatchToBatch(TypeA, this, _))
-      toBatch(TypeA, BatchToBatch(this, TypeA, _))
-    }
-  }
-
-  object TypeD extends Convention.BatchType {
+  object RowTypeA extends Convention.RowType {
     override protected[this] def registerTransitions(): Unit = {}
   }
 
-  case class RowToBatch(toBatchType: Convention.BatchType, override val child: SparkPlan)
+  object BatchTypeA extends Convention.BatchType {
+    override protected[this] def registerTransitions(): Unit = {
+      fromRow(RowTypeA, RowToBatch(RowTypeA, this, _))
+      toRow(RowTypeA, BatchToRow(this, RowTypeA, _))
+    }
+  }
+
+  object BatchTypeB extends Convention.BatchType {
+    override protected[this] def registerTransitions(): Unit = {
+      fromRow(RowTypeA, RowToBatch(RowTypeA, this, _))
+      toRow(RowTypeA, BatchToRow(this, RowTypeA, _))
+    }
+  }
+
+  object BatchTypeC extends Convention.BatchType {
+    override protected[this] def registerTransitions(): Unit = {
+      fromRow(RowTypeA, RowToBatch(RowTypeA, this, _))
+      toRow(RowTypeA, BatchToRow(this, RowTypeA, _))
+      fromBatch(BatchTypeA, BatchToBatch(BatchTypeA, this, _))
+      toBatch(BatchTypeA, BatchToBatch(this, BatchTypeA, _))
+    }
+  }
+
+  object BatchTypeD extends Convention.BatchType {
+    override protected[this] def registerTransitions(): Unit = {}
+  }
+
+  object RowTypeB extends Convention.RowType {
+    override protected[this] def registerTransitions(): Unit = {
+      fromBatch(BatchTypeA, BatchToRow(BatchTypeA, this, _))
+      toBatch(BatchTypeB, RowToBatch(this, BatchTypeB, _))
+    }
+  }
+
+  case class RowToBatch(
+      fromRowType: Convention.RowType,
+      toBatchType: Convention.BatchType,
+      override val child: SparkPlan)
     extends RowToColumnarTransition
     with GlutenPlan {
     override def batchType(): Convention.BatchType = toBatchType
     override def rowType0(): Convention.RowType = Convention.RowType.None
+    override def requiredChildConvention(): Seq[ConventionReq] = {
+      List(ConventionReq.ofRow(ConventionReq.RowType.Is(fromRowType)))
+    }
+
     override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
       copy(child = newChild)
     override protected def doExecute(): RDD[InternalRow] =
@@ -128,8 +181,18 @@ object TransitionSuite extends TransitionSuiteBase {
     override def output: Seq[Attribute] = child.output
   }
 
-  case class BatchToRow(fromBatchType: Convention.BatchType, override val child: SparkPlan)
-    extends ColumnarToRowTransition {
+  case class BatchToRow(
+      fromBatchType: Convention.BatchType,
+      toRowType: Convention.RowType,
+      override val child: SparkPlan)
+    extends ColumnarToRowTransition
+    with GlutenPlan {
+    override def batchType(): Convention.BatchType = Convention.BatchType.None
+    override def rowType0(): Convention.RowType = toRowType
+    override def requiredChildConvention(): Seq[ConventionReq] = {
+      List(ConventionReq.ofBatch(ConventionReq.BatchType.Is(fromBatchType)))
+    }
+
     override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
       copy(child = newChild)
     override protected def doExecute(): RDD[InternalRow] =

--- a/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuiteBase.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionSuiteBase.scala
@@ -64,13 +64,21 @@ trait TransitionSuiteBase {
     override def output: Seq[Attribute] = left.output ++ right.output
   }
 
-  case class RowLeaf() extends LeafExecNode {
+  case class RowLeaf(override val rowType0: Convention.RowType)
+    extends LeafExecNode
+    with GlutenPlan {
+    override def batchType(): Convention.BatchType = Convention.BatchType.None
+
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
 
     override def output: Seq[Attribute] = List.empty
   }
 
-  case class RowUnary(override val child: SparkPlan) extends UnaryExecNode {
+  case class RowUnary(override val rowType0: Convention.RowType, override val child: SparkPlan)
+    extends UnaryExecNode
+    with GlutenPlan {
+    override def batchType(): Convention.BatchType = Convention.BatchType.None
+
     override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
       copy(child = newChild)
 
@@ -79,8 +87,14 @@ trait TransitionSuiteBase {
     override def output: Seq[Attribute] = child.output
   }
 
-  case class RowBinary(override val left: SparkPlan, override val right: SparkPlan)
-    extends BinaryExecNode {
+  case class RowBinary(
+      override val rowType0: Convention.RowType,
+      override val left: SparkPlan,
+      override val right: SparkPlan)
+    extends BinaryExecNode
+    with GlutenPlan {
+    override def batchType(): Convention.BatchType = Convention.BatchType.None
+
     override protected def withNewChildrenInternal(
         newLeft: SparkPlan,
         newRight: SparkPlan): SparkPlan = copy(left = newLeft, right = newRight)


### PR DESCRIPTION
In preparation for https://github.com/apache/incubator-gluten/issues/9666, the PR extends the transition planner to support alternative row types than `VanillaRow`, so in the future we could make the query planner automatically add transitions between columnar batch types to `FakeRow`s.