### PR TITLE
[GLUTEN-9691][VL]Fix driver core dump when broadcast too large when UnsafeColumnarBuildSideRelation enabled

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeBytesBufferArray.scala
@@ -57,7 +57,7 @@ case class UnsafeBytesBufferArray(arraySize: Int, bytesBufferLengths: Array[Int]
   private val bytesBufferOffset = if (bytesBufferLengths.isEmpty) {
     new Array(0)
   } else {
-    bytesBufferLengths.init.scanLeft(0)(_ + _)
+    bytesBufferLengths.init.scanLeft(0L)(_ + _)
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: #9691)

The type of `bytesBufferOffset`  in UnsafeBytesBufferArray.scala is Array[Int], while when `bytesBufferLengths ` are all large number, will cause the element in `bytesBufferOffset`  overflowed the Int.max_value, and finally lead to jvm coredump in other operation like 
``` scala 
Platform.copyMemory(
      bytesBuffer,
      Platform.BYTE_ARRAY_OFFSET,
      longArray.getBaseObject,
      longArray.getBaseOffset + bytesBufferOffset(index),
      bytesBufferLengths(index))
```


## How was this patch tested?

Manually test in our production environment



