### PR TITLE
[VL] Fix missing tag after CollapseProjectExecTransformer rule

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/CollapseProjectExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/CollapseProjectExecTransformer.scala
@@ -42,10 +42,10 @@ object CollapseProjectExecTransformer extends Rule[SparkPlan] {
         val validationResult = collapsedProject.doValidate()
         if (validationResult.ok()) {
           logDebug(s"Collapse project $p1 and $p2.")
-          // copy tags from p2 first
-          collapsedProject.copyTagsFrom(p2)
-          // if p2 has no tags, copy p1's tags
+          // copy tags from p1 first
           collapsedProject.copyTagsFrom(p1)
+          // if p1 has no tags, copy p2's tags
+          collapsedProject.copyTagsFrom(p2)
           collapsedProject
         } else {
           logDebug(s"Failed to collapse project, due to ${validationResult.reason()}")

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/CollapseProjectExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/CollapseProjectExecTransformer.scala
@@ -42,6 +42,10 @@ object CollapseProjectExecTransformer extends Rule[SparkPlan] {
         val validationResult = collapsedProject.doValidate()
         if (validationResult.ok()) {
           logDebug(s"Collapse project $p1 and $p2.")
+          // copy tags from p2 first
+          collapsedProject.copyTagsFrom(p2)
+          // if p2 has no tags, copy p1's tags
+          collapsedProject.copyTagsFrom(p1)
           collapsedProject
         } else {
           logDebug(s"Failed to collapse project, due to ${validationResult.reason()}")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/GlutenCollapseProjectExecTransformerSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/GlutenCollapseProjectExecTransformerSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.extension
 
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.ProjectExecTransformer
+
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.SparkPlan

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/GlutenCollapseProjectExecTransformerSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/GlutenCollapseProjectExecTransformerSuite.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.extension
 
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.ProjectExecTransformer
-
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.SparkPlan
 
 class GlutenCollapseProjectExecTransformerSuite extends GlutenSQLTestsTrait {
 
@@ -112,6 +112,12 @@ class GlutenCollapseProjectExecTransformerSuite extends GlutenSQLTestsTrait {
                 case _ => false
               } == !collapsed
             )
+            if (collapsed) {
+              val projectPlan = getExecutedPlan(df).collect {
+                case plan: ProjectExecTransformer => plan
+              }.head
+              assert(projectPlan.getTagValue(SparkPlan.LOGICAL_PLAN_TAG).isDefined)
+            }
           }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Microsoft we have a set of internal tests that check logical links in final plans. Recently, when I was trying to turn on RAS by default, I saw an assertion failure due to missing logical link in a ProjectExecTransformer. After some investigation I found the problem:

`CollapseProjectExecTransformer` rule collapses two projects,

```
p1
| p2
```

into a single ProjectExecTransformer. Spark's `transformUpWithPruning` method would then [copy](https://github.com/apache/spark/blob/b84d3e6cca95470d3c26e76861b31308ec236e14/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala#L537-L543) the tags from `p1` to the new collapsed project.

However, if `p1` has no tags but `p2` has, then the collapsed project would lose those tags. This PR fixes this problem - and now the failed test passes.

The failure only happened under RAS but I think it's just a coincidence.


## How was this patch tested?

Added an assertion to `GlutenCollapseProjectExecTransformerSuite`. Unfortunately this added unit test doesn't reproduce the problem I mentioned as it would have passed even without the fix, but I think it's at least a safeguard to prove there's no regression.

Unfortunately I don't know how I can construct a unittest to reproduce the issue.

