### PR TITLE
[VL] Manually register velox conf on executor start

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -20,6 +20,7 @@ import org.apache.gluten.backendsapi.ListenerApi
 import org.apache.gluten.columnarbatch.ArrowBatches.{ArrowJavaBatch, ArrowNativeBatch}
 import org.apache.gluten.columnarbatch.VeloxBatch
 import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.config.VeloxConfig._
 import org.apache.gluten.execution.datasource.GlutenFormatFactory
 import org.apache.gluten.expression.UDFMappings
@@ -210,15 +211,9 @@ class VeloxListenerApi extends ListenerApi with Logging {
     }
 
     // Initial native backend with configurations.
-    var parsed = GlutenConfigUtil.parseConfig(conf.getAll.toMap)
-
-    // Workaround for https://github.com/apache/incubator-gluten/issues/7837
-    if (isDriver && !inLocalMode(conf)) {
-      parsed += (COLUMNAR_VELOX_CACHE_ENABLED.key -> "false")
-    }
     NativeBackendInitializer
       .forBackend(VeloxBackend.BACKEND_NAME)
-      .initialize(newGlobalOffHeapMemoryListener(), parsed)
+      .initialize(newGlobalOffHeapMemoryListener(), parseConf(conf, isDriver))
 
     // Inject backend-specific implementations to override spark classes.
     GlutenFormatFactory.register(new VeloxParquetWriterInjects)
@@ -273,5 +268,19 @@ object VeloxListenerApi {
         recorder.current()
       }
     }
+  }
+
+  def parseConf(conf: SparkConf, isDriver: Boolean): Map[String, String] = {
+    // Ensure velox conf registered.
+    VeloxConfig.get
+
+    var parsed: Map[String, String] = GlutenConfigUtil.parseConfig(conf.getAll.toMap)
+
+    // Workaround for https://github.com/apache/incubator-gluten/issues/7837
+    if (isDriver && !inLocalMode(conf)) {
+      parsed += (COLUMNAR_VELOX_CACHE_ENABLED.key -> "false")
+    }
+
+    parsed
   }
 }

--- a/backends-velox/src/test/java/org/apache/gluten/backendsapi/VeloxListenerApiTest.java
+++ b/backends-velox/src/test/java/org/apache/gluten/backendsapi/VeloxListenerApiTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.backendsapi;
+
+import org.apache.gluten.backendsapi.velox.VeloxListenerApi;
+
+import org.apache.spark.SparkConf;
+import org.junit.Test;
+
+import scala.collection.immutable.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class VeloxListenerApiTest {
+
+  @Test
+  public void testParseByteConfig() {
+    SparkConf conf = new SparkConf();
+    // Use conf string to prevent VeloxConfig object initialization.
+    conf.set("spark.gluten.sql.columnar.backend.velox.filePreloadThreshold", "50MB");
+
+    Map<String, String> parsed = VeloxListenerApi.parseConf(conf, false);
+    assertEquals(
+        "52428800",
+        parsed.get("spark.gluten.sql.columnar.backend.velox.filePreloadThreshold").get());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

At present, velox conf has never been used on executor start, resulting in the conf inside `VeloxConfig` not being registered.

For example, if we set `spark.gluten.sql.columnar.backend.velox.filePreloadThreshold=50MB`

Then on the executor side, the following error will be reported

```
Caused by: org.apache.gluten.exception.GlutenException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Operator::getOutput failed for [operator: TableScan, plan node ID: 0]: Non-whitespace character found after end of conversion: "MB"
Retriable: False
Function: operator()
File: /velox/velox/exec/Driver.cpp
Line: 616
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
```




## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

