### PR TITLE
[VL] Fix VLA error when compiling with apple clang

### DIFF
--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -106,8 +106,8 @@ VectorPtr createFlatVector<TypeKind::HUGEINT>(
       int64_t offsetAndSize = *reinterpret_cast<int64_t*>(memoryAddress + offsets[pos] + fieldOffset);
       int32_t length = static_cast<int32_t>(offsetAndSize);
       int32_t wordoffset = static_cast<int32_t>(offsetAndSize >> 32);
-      uint8_t bytesValue[length];
-      memcpy(bytesValue, memoryAddress + offsets[pos] + wordoffset, length);
+      std::vector<uint8_t> bytesValue(length);
+      memcpy(bytesValue.data(), memoryAddress + offsets[pos] + wordoffset, length);
       uint8_t bytesValue2[16]{};
       GLUTEN_CHECK(length <= 16, "array out of bounds exception");
       for (int k = length - 1; k >= 0; k--) {


### PR DESCRIPTION
Variable length array is not part of the c++ standard. We should avoid using it in the code.

```
/Users/rong/workspace/github/apache/gluten/cpp/core/jni/JniCommon.h:39:15: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
   39 |   char buffer[clen + 1];
      |               ^~~~~~~~
/Users/rong/workspace/github/apache/gluten/cpp/core/jni/JniCommon.h:39:15: note: read of non-const variable 'clen' is not allowed in a constant expression
/Users/rong/workspace/github/apache/gluten/cpp/core/jni/JniCommon.h:36:17: note: declared here
   36 |   int32_t jlen, clen;
      |                 ^
1 error generated.
```

```
/Users/rong/workspace/github/apache/gluten/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc:109:26: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  109 |       uint8_t bytesValue[length];
      |                          ^~~~~~
/Users/rong/workspace/github/apache/gluten/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc:109:26: note: read of non-const variable 'length' is not allowed in a constant expression
/Users/rong/workspace/github/apache/gluten/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc:107:15: note: declared here
  107 |       int32_t length = static_cast<int32_t>(offsetAndSize);
      |               ^
1 error generated.
```