### PR TITLE
[GLUTEN-8663][VL] Fix column directory structure for partitioned writes

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1426,6 +1426,40 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
   }
 
+  test("partitioned write column order") {
+    // Temporary code for partition write
+    // TODO: Replace with test using the parquet test data
+    val data = Seq(
+      ("b1", 1, "a1"),
+      ("b2", 2, "a2"),
+      ("b1", 3, "a1"),
+      ("b2", 4, "a2")
+    )
+
+    val schema = StructType(
+      Seq(
+        StructField("b", StringType, nullable = false),
+        StructField("c", IntegerType, nullable = false),
+        StructField("a", StringType, nullable = false)
+      ))
+
+    val rdd = spark.sparkContext.parallelize(data).map { case (b, c, a) => Row(b, c, a) }
+
+    val my_df = spark.createDataFrame(rdd, schema)
+
+    withTempDir {
+      tempDir =>
+        val tempDirPath = tempDir.getPath
+        my_df.write
+          .format("parquet")
+          .partitionBy("a", "b")
+          .mode("overwrite")
+          .save(tempDirPath)
+
+        print(tempDir.getPath)
+    }
+  }
+
   test("timestamp cast fallback") {
     withTempPath {
       path =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a preproject operator for file writes in the case where columns are being partitioned. The preproject node reorders the columns to first have the partitioned columns, followed by the unpartitioned columns.

Fixes: #8663 

## How was this patch tested?

A test will be added (this is a WIP, after I can verify that the use case from the issue works then I will add a test using the existing data that is already loaded as part of the test suite). 
