### PR TITLE
[GLUTEN-6887][VL] Daily Update Velox Version (2025_05_24)

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -21,7 +21,6 @@
 
 #include "memory/VeloxColumnarBatch.h"
 #include "utils/Exception.h"
-#include "velox/row/UnsafeRowDeserializers.h"
 #include "velox/row/UnsafeRowFast.h"
 
 using namespace facebook;

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -17,7 +17,6 @@
 
 #include "VeloxRowToColumnarConverter.h"
 #include "memory/VeloxColumnarBatch.h"
-#include "velox/row/UnsafeRowDeserializers.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/arrow/Bridge.h"
 

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -271,13 +271,13 @@ VeloxRowToColumnarConverter::convert(int64_t numRows, int64_t* rowLength, uint8_
   if (supporteType(asRowType(rowType_))) {
     return convertPrimitive(numRows, rowLength, memoryAddress);
   }
-  std::vector<std::optional<std::string_view>> data;
+  std::vector<char*> data;
   int64_t offset = 0;
   for (auto i = 0; i < numRows; i++) {
-    data.emplace_back(std::string_view(reinterpret_cast<const char*>(memoryAddress + offset), rowLength[i]));
+    data.emplace_back(reinterpret_cast<char*>(memoryAddress + offset));
     offset += rowLength[i];
   }
-  auto vp = row::UnsafeRowFast::deserialize(data, rowType_, pool_.get());
+  auto vp = row::UnsafeRowFast::deserialize(data, asRowType(rowType_), pool_.get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<RowVector>(vp));
 }
 

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -19,6 +19,7 @@
 #include "memory/VeloxColumnarBatch.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/arrow/Bridge.h"
+#include "velox/row/UnsafeRowFast.h"
 
 using namespace facebook::velox;
 namespace gluten {
@@ -276,7 +277,7 @@ VeloxRowToColumnarConverter::convert(int64_t numRows, int64_t* rowLength, uint8_
     data.emplace_back(std::string_view(reinterpret_cast<const char*>(memoryAddress + offset), rowLength[i]));
     offset += rowLength[i];
   }
-  auto vp = row::UnsafeRowDeserializer::deserialize(data, rowType_, pool_.get());
+  auto vp = row::UnsafeRowFast::deserialize(data, rowType_, pool_.get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<RowVector>(vp));
 }
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2025_05_23
+VELOX_BRANCH=2025_05_24
 VELOX_HOME=""
 
 OS=`uname -s`


### PR DESCRIPTION

```
db8a1df0c new: Added type validation for intermediate and output vectors (#13322)
b3955982b refactor: Setup scripts (#12321)
b8fd936c3 fix: Incorrect filter result when the range is outside of old type during schema evolution (#13459)
1aae6a028 feat: Add ColumnReaderOptions (#12840)
78578792e fix: Add alias substring for SubstrFunction (#13220)
8b2ff7195 refactor: Drop UnsafeRowDeserializer old API (#12817)
c6f4d283c fix(json): Bug with duplicate keys leading to incorrect writes (#13445)
bbf1f3410 feat: Create internal TableEvolutionFuzzer and add internal Nimble support during runs (#13441)
984d561b6 feat: Register Spark sqrt function (#13416)
d870492c0 refactor: Move the parquet reader and writer factory register into InsertTest (#13432)
845b7252a feat(functions): Support named rows as return type (#13423)
f2bc62ada feat: Add streaming aggregation test inside AggregationReplayerTest (#13426)
6c6ac4e83 feat: Add support for memory pool priority (#13386)

```