### PR TITLE
[GLUTEN-9779][VL] Remove redundant GetTimestamp

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -71,6 +71,7 @@ object VeloxRuleApi {
     injector.injectPreTransform(_ => RewriteSubqueryBroadcast())
     injector.injectPreTransform(c => BloomFilterMightContainJointRewriteRule.apply(c.session))
     injector.injectPreTransform(c => ArrowScanReplaceRule.apply(c.session))
+    injector.injectPreTransform(_ => EliminateRedundantGetTimestamp)
 
     // Legacy: The legacy transform rule.
     val offloads = Seq(OffloadOthers(), OffloadExchange(), OffloadJoin()).map(_.toStrcitRule())
@@ -133,6 +134,7 @@ object VeloxRuleApi {
     injector.injectPreTransform(_ => RewriteSubqueryBroadcast())
     injector.injectPreTransform(c => BloomFilterMightContainJointRewriteRule.apply(c.session))
     injector.injectPreTransform(c => ArrowScanReplaceRule.apply(c.session))
+    injector.injectPreTransform(_ => EliminateRedundantGetTimestamp)
 
     // Gluten RAS: The RAS rule.
     val validatorBuilder: GlutenConfig => Validator = conf => Validators.newValidator(conf)

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -277,6 +277,28 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("Test to_date function") {
+    val query =
+      """
+        |select to_date(a, 'yyyy-MM') from
+        | values (TIMESTAMP'2025-01-02 00:00:00') as tab(a)
+        |""".stripMargin
+    runQueryAndCompare(query) {
+      checkGlutenOperatorMatch[ProjectExecTransformer]
+    }
+  }
+
+  test("Test to_timestamp function") {
+    val query =
+      """
+        |select to_timestamp(a, 'yyyy-MM') from
+        | values (TIMESTAMP'2025-01-02 00:00:00') as tab(a)
+        |""".stripMargin
+    runQueryAndCompare(query) {
+      checkGlutenOperatorMatch[ProjectExecTransformer]
+    }
+  }
+
   test("Test to_utc_timestamp function") {
     withTempPath {
       path =>

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EliminateRedundantGetTimestamp.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EliminateRedundantGetTimestamp.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar
+
+import org.apache.spark.sql.catalyst.expressions.GetTimestamp
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.TimestampType
+
+/**
+ * When there is a format parameter, to_date and to_timestamp will be replaced by GetTimestamp. If
+ * the left of GetTimestamp is TimestampType, then GetTimestamp is redundant. Velox does not support
+ * GetTimestamp(Timestamp, format). In this case, it needs to be removed.
+ */
+object EliminateRedundantGetTimestamp extends Rule[SparkPlan] {
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    plan.transformExpressions {
+      case getTimestamp: GetTimestamp
+          if getTimestamp.left.dataType == TimestampType &&
+            getTimestamp.dataType == TimestampType =>
+        getTimestamp.left
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove redundant GetTimestamp to support to_date(Timestamp, format) and to_timestamp(Timestamp, format).

(Fixes: \#9779)

## How was this patch tested?

Unit test.

