### PR TITLE
[CORE] Test trait `WithQueryPlanListener` for ensuring on fallback query plan nodes conveniently

### DIFF
--- a/gluten-substrait/src/test/scala/org/apache/gluten/test/FallbackUtil.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/test/FallbackUtil.scala
@@ -67,9 +67,13 @@ object FallbackUtil extends Logging with AdaptiveSparkPlanHelper {
   }
 
   def hasFallback(plan: SparkPlan): Boolean = {
-    val fallbackOperator = collectWithSubqueries(plan) { case plan => plan }.filterNot(
-      plan => plan.isInstanceOf[GlutenPlan] || skip(plan))
+    val fallbackOperator =
+      collectWithSubqueries(plan) { case plan => plan }.filter(plan => nodeHasFallback(plan))
     fallbackOperator.foreach(operator => log.info(s"gluten fallback operator:{$operator}"))
     fallbackOperator.nonEmpty
+  }
+
+  def nodeHasFallback(plan: SparkPlan): Boolean = {
+    !plan.isInstanceOf[GlutenPlan] && !skip(plan)
   }
 }

--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.gluten.test.FallbackUtil.collectWithSubqueries
+
+import org.apache.spark.sql.WithQueryPlanListener.ListenerImpl
+import org.apache.spark.sql.execution.{QueryExecution, SparkPlan, SparkPlanTest}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.util.QueryExecutionListener
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+// format: off
+/**
+ * A trait that registers listeners to collect all the executed query plans during running a single
+ * test case.
+ *
+ * The collected query plans can be used to verify the correctness of the query execution plan.
+ */
+// format: on
+trait WithQueryPlanListener extends SharedSparkSession with AnyFunSuiteLike {
+
+  assert(
+    !this.isInstanceOf[SparkPlanTest],
+    "WithQueryPlanListener should not be mixed in with SparkPlanTest as it doesn't intercept " +
+      "`checkAnswer` calls")
+
+  protected val planListeners: WithQueryPlanListener.QueryPlanListeners =
+    new WithQueryPlanListener.QueryPlanListeners()
+
+  override def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    super.test(testName, testTags: _*)({
+      testFun
+      listeners().foreach(_.invokeAll())
+    })(pos)
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    spark.sessionState.listenerManager.register(new ListenerImpl(planListeners.collect()))
+  }
+
+  override def afterEach(): Unit = {
+    listeners().foreach(listener => spark.sessionState.listenerManager.unregister(listener))
+    super.afterEach()
+  }
+
+  private def listeners() = {
+    spark.sessionState.listenerManager
+      .listListeners()
+      .filter(_.isInstanceOf[ListenerImpl])
+      .map(_.asInstanceOf[ListenerImpl])
+      .toSeq
+  }
+}
+
+object WithQueryPlanListener {
+  // A listener that collects all the executed query plans during running a single test case.
+  private class ListenerImpl(val listeners: Seq[QueryPlanListener])
+    extends QueryExecutionListener
+    with AdaptiveSparkPlanHelper {
+    private val plans = mutable.ArrayBuffer[SparkPlan]()
+
+    override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+      val plan = qe.executedPlan
+      plans += plan
+    }
+
+    override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {}
+
+    def invokeAll(): Unit = {
+      while (plans.nonEmpty) {
+        val popped = plans.toSeq
+        plans.clear()
+        popped.foreach(plan => listeners.foreach(listener => listener.apply(plan)))
+      }
+    }
+  }
+
+  class QueryPlanListeners private[WithQueryPlanListener] {
+    private val builder = mutable.ArrayBuffer[QueryPlanListener]()
+
+    private[WithQueryPlanListener] def collect(): Seq[QueryPlanListener] = {
+      builder.toSeq
+    }
+
+    def onPlanExecuted(listener: QueryPlanListener): QueryPlanListeners = {
+      builder += listener
+      this
+    }
+
+    def assertNoNodeExists(
+        prediction: SparkPlan => Boolean): QueryPlanListeners = {
+      builder += {
+        planRoot =>
+          val allNodes = collectWithSubqueries(planRoot)(p => p)
+          allNodes.foreach {
+            node =>
+              assert(
+                !prediction(node),
+                s"Found a node ${node.nodeName} in the query plan that fails the assertion: " +
+                  s"${planRoot.toString}")
+          }
+      }
+      this
+    }
+
+    def assertNoInstanceOf[T: ClassTag]: QueryPlanListeners = {
+      val clazz = implicitly[ClassTag[T]].runtimeClass
+      assertNoNodeExists(n => clazz.isAssignableFrom(n.getClass))
+    }
+  }
+
+  type QueryPlanListener = SparkPlan => Unit
+}

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQuerySuite.scala
@@ -28,7 +28,7 @@ class GlutenSQLQuerySuite
   import testImplicits._
 
   // Assert no fallbacks on the trivial supported operators
-  // This is an experimental feature API, so we only check for sort
+  // This is an experimental API, so we only check for sort
   // fallback at the moment.
   planListeners.assertNoInstanceOf[SortExec]
 

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQuerySuite.scala
@@ -17,11 +17,20 @@
 package org.apache.spark.sql
 
 import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.internal.SQLConf
 
-class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
+class GlutenSQLQuerySuite
+  extends SQLQuerySuite
+  with GlutenSQLTestsTrait
+  with WithQueryPlanListener {
   import testImplicits._
+
+  // Assert no fallbacks on the trivial supported operators
+  // This is an experimental feature API, so we only check for sort
+  // fallback at the moment.
+  planListeners.assertNoInstanceOf[SortExec]
 
   testGluten("SPARK-28156: self-join should not miss cached view") {
     withTable("table1") {


### PR DESCRIPTION
When overwriting a Spark test class in Gluten, add the trait `WithQueryPlanListener` to the class inheritance tree, then call APIs on `planListeners` in the class body to do assertions on all executed query plans during the test execution. E.g.:

```scala
class Gluten...Suite extends ...Suite with ... with WithQueryPlanListener {
  planListeners.assertNoInstanceOf[SortExec]
}
```

In the above code, all the test cases ran from the suite will be ensured not having the fallen back `SortExec` nodes in the query plan. Exceptions will be thrown otherwise.