### PR TITLE
[VL] Following #9802, fix the plan listener not working for Scala 2.12

### DIFF
--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
@@ -92,7 +92,7 @@ object WithQueryPlanListener {
 
     def invokeAll(): Unit = {
       while (plans.nonEmpty) {
-        val plansCopy = Seq[SparkPlan](plans: _*)
+        val plansCopy = Seq[SparkPlan](plans.toSeq: _*)
         plans.clear()
         plansCopy.foreach(plan => listeners.foreach(listener => listener.apply(plan)))
       }

--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
@@ -92,9 +92,9 @@ object WithQueryPlanListener {
 
     def invokeAll(): Unit = {
       while (plans.nonEmpty) {
-        val popped = plans.toSeq
+        val plansCopy = Seq[SparkPlan](plans: _*)
         plans.clear()
-        popped.foreach(plan => listeners.foreach(listener => listener.apply(plan)))
+        plansCopy.foreach(plan => listeners.foreach(listener => listener.apply(plan)))
       }
     }
   }


### PR DESCRIPTION
Following: #9802 

Scala 2.12 doesn't copy a mutable seq when #toSeq is called so the listeners will not be invoked.

The patch quickly fixes the issue.