### PR TITLE
[MINOR] Rename ConfigProvider to GlutenConfigProvider

### DIFF
--- a/shims/common/src/main/scala/org/apache/gluten/config/ConfigEntry.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/config/ConfigEntry.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.config
 
 import org.apache.gluten.config.BackendType.BackendType
 
-import org.apache.spark.sql.internal.ConfigProvider
+import org.apache.spark.sql.internal.GlutenConfigProvider
 
 /**
  * An entry contains all meta information for a configuration.
@@ -61,8 +61,8 @@ trait ConfigEntry[T] {
   /** How to convert a value to a string that the user can use it as a valid string value. */
   def stringConverter: T => String
 
-  /** Read the configuration from the given ConfigProvider. */
-  def readFrom(conf: ConfigProvider): T
+  /** Read the configuration from the given GlutenConfigProvider. */
+  def readFrom(conf: GlutenConfigProvider): T
 
   /** The default value of the configuration. */
   def defaultValue: Option[T]
@@ -70,7 +70,7 @@ trait ConfigEntry[T] {
   /** The string representation of the default value. */
   def defaultValueString: String
 
-  final protected def readString(provider: ConfigProvider): Option[String] = {
+  final protected def readString(provider: GlutenConfigProvider): Option[String] = {
     alternatives.foldLeft(provider.get(key))((res, nextKey) => res.orElse(provider.get(nextKey)))
   }
 
@@ -108,7 +108,8 @@ private[gluten] class OptionalConfigEntry[T](
 
   override def stringConverter: Option[T] => String = v => v.map(_stringConverter).orNull
 
-  override def readFrom(conf: ConfigProvider): Option[T] = readString(conf).map(_valueConverter)
+  override def readFrom(conf: GlutenConfigProvider): Option[T] =
+    readString(conf).map(_valueConverter)
 
   override def defaultValue: Option[Option[T]] = None
 
@@ -142,7 +143,7 @@ private[gluten] class ConfigEntryWithDefault[T](
 
   override def stringConverter: T => String = _stringConverter
 
-  override def readFrom(conf: ConfigProvider): T = {
+  override def readFrom(conf: GlutenConfigProvider): T = {
     readString(conf).map(valueConverter).getOrElse(_defaultVal)
   }
 
@@ -178,7 +179,7 @@ private[gluten] class ConfigEntryWithDefaultString[T](
 
   override def stringConverter: T => String = _stringConverter
 
-  override def readFrom(conf: ConfigProvider): T = {
+  override def readFrom(conf: GlutenConfigProvider): T = {
     val value = readString(conf).getOrElse(_defaultVal)
     valueConverter(value)
   }
@@ -213,7 +214,7 @@ private[gluten] class ConfigEntryFallback[T](
 
   override def stringConverter: T => String = fallback.stringConverter
 
-  override def readFrom(conf: ConfigProvider): T = {
+  override def readFrom(conf: GlutenConfigProvider): T = {
     readString(conf).map(valueConverter).getOrElse(fallback.readFrom(conf))
   }
 

--- a/shims/common/src/main/scala/org/apache/spark/sql/internal/ConfigProvider.scala
+++ b/shims/common/src/main/scala/org/apache/spark/sql/internal/ConfigProvider.scala
@@ -17,14 +17,14 @@
 package org.apache.spark.sql.internal
 
 /** A source of configuration values. */
-trait ConfigProvider {
+trait GlutenConfigProvider {
   def get(key: String): Option[String]
 }
 
-class SQLConfProvider(conf: SQLConf) extends ConfigProvider {
+class SQLConfProvider(conf: SQLConf) extends GlutenConfigProvider {
   override def get(key: String): Option[String] = Option(conf.settings.get(key))
 }
 
-class MapProvider(conf: Map[String, String]) extends ConfigProvider {
+class MapProvider(conf: Map[String, String]) extends GlutenConfigProvider {
   override def get(key: String): Option[String] = conf.get(key)
 }

--- a/shims/common/src/main/scala/org/apache/spark/sql/internal/GlutenConfigUtil.scala
+++ b/shims/common/src/main/scala/org/apache/spark/sql/internal/GlutenConfigUtil.scala
@@ -21,7 +21,10 @@ import org.apache.gluten.config._
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
 
 object GlutenConfigUtil {
-  private def getConfString(configProvider: ConfigProvider, key: String, value: String): String = {
+  private def getConfString(
+      configProvider: GlutenConfigProvider,
+      key: String,
+      value: String): String = {
     Option(ConfigEntry.findEntry(key))
       .map {
         _.readFrom(configProvider) match {


### PR DESCRIPTION
## What changes were proposed in this pull request?

To avoid class conflict issue if add gluten jar as a dependency of the Spark project. For example:
```xml
    <dependency>
      <groupId>org.apache.gluten</groupId>
      <artifactId>gluten-velox-bundle</artifactId>
      <version>1.5.0-SNAPSHOT</version>
      <scope>system</scope>
      <systemPath>/Users/yumwang/Downloads/gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.5.0-SNAPSHOT.jar</systemPath>
    </dependency>
```
Error message:
```
/Users/yumwang/spark/sql/core/src/main/scala/org/apache/spark/sql/internal/VariableSubstitution.scala:38:24
overloaded method constructor ConfigReader with alternatives:
  (conf: java.util.Map[String,String])org.apache.spark.internal.config.ConfigReader <and>
  (conf: org.apache.spark.internal.config.ConfigProvider)org.apache.spark.internal.config.ConfigReader
 cannot be applied to (org.apache.spark.sql.internal.ConfigProvider)
  private val reader = new ConfigReader(provider)
```

## How was this patch tested?

Manual tests.

