### PR TITLE
[GLUTEN-9823] Exclude jsr305 from Gluten shaded jar to reduce redundancy

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -192,6 +192,12 @@
               </relocations>
               <filters>
                 <filter>
+                  <artifact>com.google.code.findbugs:jsr305</artifact>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>META-INF/*.SF</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude `com.google.code.findbugs:jsr305` from Gluten shade package. This is because Spark jars already include this jar: `${SPARK_HOME}/jars/jsr305-3.0.0.jar`.

(Fixes: #9823)

## How was this patch tested?

Manual tests:
Before| After
-- | --
<img width="500" alt="image" src="https://github.com/user-attachments/assets/167caea1-6d63-46f8-8d7b-5142e2ab509b" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/76aa3e23-1cb1-42fd-be0e-117430fec967" />



