### PR TITLE
[VL] Minor fix: simplify a few function tests' verbose names

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -43,7 +43,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
 
   import testImplicits._
 
-  test("Test date_add function") {
+  test("date_add") {
     withTempPath {
       path =>
         Seq(
@@ -66,7 +66,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test date_diff function") {
+  test("date_diff") {
     withTempPath {
       path =>
         Seq(
@@ -89,7 +89,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test date_format function") {
+  test("date_format") {
     withTempPath {
       path =>
         val t1 = Timestamp.valueOf("2024-08-22 10:10:10.010")
@@ -104,7 +104,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test date_part & extract & weekofyear function") {
+  test("date_part, extract, weekofyear") {
     withTempPath {
       path =>
         Seq(
@@ -127,7 +127,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test date_trunc function") {
+  test("date_trunc") {
     withTempPath {
       path =>
         Seq(
@@ -162,7 +162,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test from_utc_timestamp function") {
+  test("from_utc_timestamp") {
     withTempPath {
       path =>
         Seq(
@@ -183,7 +183,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test make_date function") {
+  test("make_date") {
     runQueryAndCompare(
       "select make_date(2025, 2, 7), make_date(2024, 11, null), make_date(2024, 11, 50)") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
@@ -233,7 +233,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test make_ym_interval function") {
+  test("make_ym_interval") {
     runQueryAndCompare("select make_ym_interval(1, 1)") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -265,7 +265,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test timestamp_micros function") {
+  test("timestamp_micros") {
     runQueryAndCompare("select timestamp_micros(l_orderkey) from lineitem") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -307,7 +307,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test to_utc_timestamp function") {
+  test("to_utc_timestamp") {
     withTempPath {
       path =>
         Seq(
@@ -328,7 +328,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test unix_date function") {
+  test("unix_date") {
     withTempPath {
       path =>
         Seq(
@@ -348,7 +348,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test unix_micros function") {
+  test("unix_micros") {
     withTempPath {
       path =>
         val t1 = Timestamp.valueOf("2015-07-22 10:00:00.012")
@@ -363,7 +363,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test unix_millis function") {
+  test("unix_millis") {
     withTempPath {
       path =>
         val t1 = Timestamp.valueOf("2015-07-22 10:00:00.012")
@@ -378,7 +378,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test unix_seconds function") {
+  test("unix_seconds") {
     withTempPath {
       path =>
         val t1 = Timestamp.valueOf("2024-08-22 10:10:10.010")

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -190,7 +190,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test make_timestamp function") {
+  test("make_timestamp") {
     withTempPath {
       path =>
         // w/o timezone.
@@ -271,7 +271,7 @@ abstract class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test timestamp_millis function") {
+  test("timestamp_millis") {
     runQueryAndCompare("select timestamp_millis(l_orderkey) from lineitem") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
@@ -348,7 +348,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("json_object_keys function") {
+  test("json_object_keys") {
     withTempPath {
       path =>
         Seq[(String)](

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
@@ -40,83 +40,83 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
   disableFallbackCheck
   import testImplicits._
 
-  test("Test abs function") {
+  test("abs") {
     val df = runQueryAndCompare("SELECT abs(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test acos function") {
+  test("acos") {
     runQueryAndCompare("SELECT acos(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test asin function") {
+  test("asin") {
     runQueryAndCompare("SELECT asin(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test atan function") {
+  test("atan") {
     runQueryAndCompare("SELECT atan(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  ignore("Test atan2 function datatab") {
+  ignore("atan2") {
     runQueryAndCompare("SELECT atan2(double_field1, 0) from datatab limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test bin function") {
+  test("bin function") {
     val df = runQueryAndCompare("SELECT bin(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test ceil function") {
+  test("ceil function") {
     val df = runQueryAndCompare("SELECT ceil(cast(l_orderkey as long)) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test ceiling function") {
+  test("ceiling function") {
     runQueryAndCompare("SELECT ceiling(cast(l_orderkey as long)) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test cos function") {
+  test("cos") {
     runQueryAndCompare("SELECT cos(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test cosh function") {
+  test("cosh") {
     runQueryAndCompare("SELECT cosh(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test degrees function") {
+  test("degrees function") {
     runQueryAndCompare("SELECT degrees(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test exp function") {
+  test("exp function") {
     val df = runQueryAndCompare("SELECT exp(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test factorial function") {
+  test("factorial function") {
     withTable("factorial_input") {
       sql("CREATE TABLE factorial_input(id INT) USING parquet")
       sql("""
@@ -156,14 +156,14 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test floor function") {
+  test("floor function") {
     val df = runQueryAndCompare("SELECT floor(cast(l_orderkey as long)) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test greatest function") {
+  test("greatest function") {
     runQueryAndCompare(
       "SELECT greatest(l_orderkey, l_orderkey)" +
         "from lineitem limit 1") {
@@ -187,13 +187,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test hex function") {
+  test("hex function") {
     runQueryAndCompare("SELECT hex(l_partkey), hex(l_shipmode) FROM lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test least function") {
+  test("least function") {
     runQueryAndCompare(
       "SELECT least(l_orderkey, l_orderkey)" +
         "from lineitem limit 1") {
@@ -217,39 +217,39 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test log function") {
+  test("log function") {
     runQueryAndCompare("SELECT log(10, l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test log10 function") {
+  test("log10 function") {
     runQueryAndCompare("SELECT log10(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test negative function") {
+  test("negative function") {
     runQueryAndCompare("select negative(l_orderkey) from lineitem") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test pmod function") {
+  test("pmod") {
     val df = runQueryAndCompare("SELECT pmod(cast(l_orderkey as int), 3) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test power function") {
+  test("power function") {
     val df = runQueryAndCompare("SELECT power(l_orderkey, 2) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test rand function") {
+  test("rand function") {
     runQueryAndCompare(
       """SELECT rand() from lineitem limit 100""".stripMargin,
       compareResult = false) {
@@ -257,7 +257,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test rint function") {
+  test("rint function") {
     withTempPath {
       path =>
         Seq(1.2, 1.5, 1.9).toDF("d").write.parquet(path.getCanonicalPath)
@@ -269,7 +269,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test round function") {
+  test("round function") {
     runQueryAndCompare(
       "SELECT round(cast(l_orderkey as int), 2)" +
         "from lineitem limit 1") {
@@ -288,13 +288,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     compareResultsAgainstVanillaSpark("select round(44, -1)", true, { _ => })
   }
 
-  test("Test shiftleft function") {
+  test("shiftleft function") {
     runQueryAndCompare("SELECT shiftleft(int_field1, 1) from datatab limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test try_add function") {
+  test("try_add function") {
     runQueryAndCompare(
       "select try_add(cast(l_orderkey as int), 1), try_add(cast(l_orderkey as int), 2147483647)" +
         " from lineitem") {
@@ -302,7 +302,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test try_divide function") {
+  test("try_divide function") {
     runQueryAndCompare(
       "select try_divide(cast(l_orderkey as int), 0) from lineitem",
       noFallBack = false) {
@@ -310,7 +310,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test try_multiply function", "3.3") {
+  testWithMinSparkVersion("try_multiply function", "3.3") {
     runQueryAndCompare(
       "select try_multiply(2147483647, cast(l_orderkey as int)), " +
         "try_multiply(-2147483648, cast(l_orderkey as int)) from lineitem") {
@@ -318,7 +318,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test try_subtract function", "3.3") {
+  testWithMinSparkVersion("try_subtract function", "3.3") {
     runQueryAndCompare(
       "select try_subtract(2147483647, cast(l_orderkey as int)), " +
         "try_subtract(-2147483648, cast(l_orderkey as int)) from lineitem") {
@@ -326,13 +326,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test unhex function") {
+  test("unhex function") {
     runQueryAndCompare("SELECT unhex(hex(l_shipmode)) FROM lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  testWithMinSparkVersion("Test width_bucket function", "3.4") {
+  testWithMinSparkVersion("width_bucket function", "3.4") {
     withTempPath {
       path =>
         Seq[(Integer, Integer, Integer, Integer)](
@@ -350,7 +350,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test sqrt function") {
+  test("sqrt function") {
     val df = runQueryAndCompare("SELECT sqrt(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
@@ -71,21 +71,21 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("bin function") {
+  test("bin") {
     val df = runQueryAndCompare("SELECT bin(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("ceil function") {
+  test("ceil") {
     val df = runQueryAndCompare("SELECT ceil(cast(l_orderkey as long)) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("ceiling function") {
+  test("ceiling") {
     runQueryAndCompare("SELECT ceiling(cast(l_orderkey as long)) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -103,20 +103,20 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("degrees function") {
+  test("degrees") {
     runQueryAndCompare("SELECT degrees(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("exp function") {
+  test("exp") {
     val df = runQueryAndCompare("SELECT exp(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("factorial function") {
+  test("factorial") {
     withTable("factorial_input") {
       sql("CREATE TABLE factorial_input(id INT) USING parquet")
       sql("""
@@ -156,14 +156,14 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("floor function") {
+  test("floor") {
     val df = runQueryAndCompare("SELECT floor(cast(l_orderkey as long)) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("greatest function") {
+  test("greatest") {
     runQueryAndCompare(
       "SELECT greatest(l_orderkey, l_orderkey)" +
         "from lineitem limit 1") {
@@ -187,13 +187,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("hex function") {
+  test("hex") {
     runQueryAndCompare("SELECT hex(l_partkey), hex(l_shipmode) FROM lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("least function") {
+  test("least") {
     runQueryAndCompare(
       "SELECT least(l_orderkey, l_orderkey)" +
         "from lineitem limit 1") {
@@ -217,19 +217,19 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("log function") {
+  test("log") {
     runQueryAndCompare("SELECT log(10, l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("log10 function") {
+  test("log10") {
     runQueryAndCompare("SELECT log10(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("negative function") {
+  test("negative") {
     runQueryAndCompare("select negative(l_orderkey) from lineitem") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -242,14 +242,14 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     checkLengthAndPlan(df, 1)
   }
 
-  test("power function") {
+  test("power") {
     val df = runQueryAndCompare("SELECT power(l_orderkey, 2) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("rand function") {
+  test("rand") {
     runQueryAndCompare(
       """SELECT rand() from lineitem limit 100""".stripMargin,
       compareResult = false) {
@@ -257,7 +257,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("rint function") {
+  test("rint") {
     withTempPath {
       path =>
         Seq(1.2, 1.5, 1.9).toDF("d").write.parquet(path.getCanonicalPath)
@@ -269,7 +269,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("round function") {
+  test("round") {
     runQueryAndCompare(
       "SELECT round(cast(l_orderkey as int), 2)" +
         "from lineitem limit 1") {
@@ -288,13 +288,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     compareResultsAgainstVanillaSpark("select round(44, -1)", true, { _ => })
   }
 
-  test("shiftleft function") {
+  test("shiftleft") {
     runQueryAndCompare("SELECT shiftleft(int_field1, 1) from datatab limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("try_add function") {
+  test("try_add") {
     runQueryAndCompare(
       "select try_add(cast(l_orderkey as int), 1), try_add(cast(l_orderkey as int), 2147483647)" +
         " from lineitem") {
@@ -302,7 +302,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("try_divide function") {
+  test("try_divide") {
     runQueryAndCompare(
       "select try_divide(cast(l_orderkey as int), 0) from lineitem",
       noFallBack = false) {
@@ -310,7 +310,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_multiply function", "3.3") {
+  testWithMinSparkVersion("try_multiply", "3.3") {
     runQueryAndCompare(
       "select try_multiply(2147483647, cast(l_orderkey as int)), " +
         "try_multiply(-2147483648, cast(l_orderkey as int)) from lineitem") {
@@ -318,7 +318,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_subtract function", "3.3") {
+  testWithMinSparkVersion("try_subtract", "3.3") {
     runQueryAndCompare(
       "select try_subtract(2147483647, cast(l_orderkey as int)), " +
         "try_subtract(-2147483648, cast(l_orderkey as int)) from lineitem") {
@@ -326,13 +326,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("unhex function") {
+  test("unhex") {
     runQueryAndCompare("SELECT unhex(hex(l_shipmode)) FROM lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  testWithMinSparkVersion("width_bucket function", "3.4") {
+  testWithMinSparkVersion("width_bucket", "3.4") {
     withTempPath {
       path =>
         Seq[(Integer, Integer, Integer, Integer)](
@@ -350,7 +350,7 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("sqrt function") {
+  test("sqrt") {
     val df = runQueryAndCompare("SELECT sqrt(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -43,17 +43,17 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
   import testImplicits._
 
   // Test "SELECT ..." without a from clause.
-  test("isnull function") {
+  test("isnull") {
     runQueryAndCompare("SELECT isnull(1)")(checkGlutenOperatorMatch[ProjectExecTransformer])
   }
 
-  test("Test bit_count function") {
+  test("bit_count") {
     runQueryAndCompare("SELECT bit_count(l_partkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test bit_get and getbit function") {
+  test("bit_get and getbit") {
     runQueryAndCompare("SELECT bit_get(l_partkey, 0) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -62,7 +62,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test array_append function - INT", "3.4") {
+  testWithMinSparkVersion("array_append - INT", "3.4") {
     withTempPath {
       path =>
         Seq[(Array[Int], Int)](
@@ -87,7 +87,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test array_append function - STRING", "3.4") {
+  testWithMinSparkVersion("array_append - STRING", "3.4") {
     withTempPath {
       path =>
         Seq[(Array[String], String)](
@@ -111,7 +111,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test array_prepend function", "3.5") {
+  testWithMinSparkVersion("array_prepend", "3.5") {
     withTempPath {
       path =>
         Seq[(Array[String], String)](
@@ -135,7 +135,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test array_compact function", "3.4") {
+  testWithMinSparkVersion("array_compact", "3.4") {
     withTempPath {
       path =>
         Seq[Array[String]](
@@ -174,20 +174,20 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("chr function") {
+  test("chr") {
     val df = runQueryAndCompare("SELECT chr(l_orderkey + 64) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     checkLengthAndPlan(df, 1)
   }
 
-  test("Test hash function") {
+  test("hash") {
     runQueryAndCompare("SELECT hash(l_orderkey) from lineitem limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test shiftright function") {
+  test("shiftright") {
     val df = runQueryAndCompare("SELECT shiftright(int_field1, 1) from datatab limit 1") {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -232,7 +232,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Support HOUR function") {
+  test("HOUR") {
     withTable("t1") {
       sql("create table t1 (c1 int, c2 timestamp) USING PARQUET")
       sql("INSERT INTO t1 VALUES(1, NOW())")
@@ -261,7 +261,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test map_entries function") {
+  test("map_entries") {
     withTempPath {
       path =>
         Seq(
@@ -281,7 +281,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test map_keys function") {
+  test("map_keys") {
     withTempPath {
       path =>
         Seq(
@@ -301,7 +301,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("test map_contains_key function", "3.3") {
+  testWithMinSparkVersion("map_contains_key", "3.3") {
     withTempPath {
       path =>
         Seq(
@@ -321,7 +321,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test map_values function") {
+  test("map_values") {
     withTempPath {
       path =>
         Seq(
@@ -392,7 +392,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test transform_keys function") {
+  test("transform_keys") {
     withTempPath {
       path =>
         Seq(
@@ -412,7 +412,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test transform_values function") {
+  test("transform_values") {
     withTempPath {
       path =>
         Seq(
@@ -452,7 +452,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test isnan function") {
+  test("isnan") {
     runQueryAndCompare(
       "SELECT isnan(l_orderkey), isnan(cast('NaN' as double)), isnan(0.0F/0.0F)" +
         " from lineitem limit 1") {
@@ -460,7 +460,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test conditional function") {
+  test("conditional") {
     Seq("nanvl", "nullif", "nvl").foreach {
       func =>
         runQueryAndCompare(s"""
@@ -477,7 +477,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test nvl2 function") {
+  test("nvl2") {
     Seq("null", "l_orderkey").foreach {
       expr =>
         runQueryAndCompare(s"""
@@ -495,14 +495,14 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
   }
 
   // FIXME: Ignored: https://github.com/apache/incubator-gluten/issues/7600.
-  ignore("Test monotonically_increasintestg_id function") {
+  ignore("monotonically_increasintestg_id") {
     runQueryAndCompare("""SELECT monotonically_increasing_id(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test sequence function optimized by Spark constant folding") {
+  test("sequence function optimized by Spark constant folding") {
     withSQLConf(("spark.sql.optimizer.excludedRules", NullPropagation.ruleName)) {
       runQueryAndCompare("""SELECT sequence(1, 5), l_orderkey
                            | from lineitem limit 100""".stripMargin) {
@@ -511,7 +511,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test raise_error, assert_true function") {
+  test("raise_error, assert_true") {
     runQueryAndCompare("""SELECT assert_true(l_orderkey >= 1), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
@@ -524,37 +524,37 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     assert(e.getMessage.contains("l_orderkey"))
   }
 
-  test("Test E function") {
-    runQueryAndCompare("""SELECT E() from lineitem limit 100""".stripMargin) {
+  test("EulerNumber") {
+    runQueryAndCompare("""SELECT E() from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     runQueryAndCompare("""SELECT E(), l_orderkey
-                         | from lineitem limit 100""".stripMargin) {
+                         | from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test Pi function") {
-    runQueryAndCompare("""SELECT Pi() from lineitem limit 100""".stripMargin) {
+  test("Pi") {
+    runQueryAndCompare("""SELECT Pi() from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     runQueryAndCompare("""SELECT Pi(), l_orderkey
-                         | from lineitem limit 100""".stripMargin) {
+                         | from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test version function") {
-    runQueryAndCompare("""SELECT version() from lineitem limit 100""".stripMargin) {
+  test("version function") {
+    runQueryAndCompare("""SELECT version() from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
     runQueryAndCompare("""SELECT version(), l_orderkey
-                         | from lineitem limit 100""".stripMargin) {
+                         | from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
   }
 
-  test("Test sum/count function") {
+  test("sum/count function") {
     withTempPath {
       path =>
         Seq[(Integer, Integer)](
@@ -572,7 +572,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test spark_partition_id function") {
+  test("spark_partition_id") {
     runQueryAndCompare("""SELECT spark_partition_id(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
@@ -583,7 +583,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test url_decode function", "3.4") {
+  testWithMinSparkVersion("url_decode", "3.4") {
     withTempPath {
       path =>
         Seq("https%3A%2F%2Fspark.apache.org")
@@ -597,7 +597,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test url_encode function", "3.4") {
+  testWithMinSparkVersion("url_encode", "3.4") {
     withTempPath {
       path =>
         Seq("https://spark.apache.org")
@@ -617,7 +617,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test uuid function") {
+  test("uuid function") {
     runQueryAndCompare("""SELECT uuid() from lineitem limit 100""".stripMargin, false) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -695,7 +695,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test array filter") {
+  test("filter function") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -715,7 +715,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test concat with array") {
+  test("concat function") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -732,7 +732,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test array transform") {
+  test("transform function") {
     withTable("t") {
       sql("create table t (arr ARRAY<INT>) using parquet")
       sql("insert into t values(array(1, 2, 3, null))")
@@ -742,7 +742,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test array forall") {
+  test("forall function") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -762,7 +762,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test array exists") {
+  test("exists function") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -800,7 +800,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test shuffle") {
+  test("shuffle") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -816,7 +816,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test flatten nested array") {
+  test("flatten nested array") {
     withTempPath {
       path =>
         Seq[Seq[Seq[Integer]]](
@@ -890,7 +890,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test substring_index") {
+  test("substring_index") {
     withTempView("substring_index_table") {
       withTempPath {
         path =>
@@ -951,7 +951,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test input_file_name function") {
+  test("input_file_name function") {
     runQueryAndCompare("""SELECT input_file_name(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
@@ -1024,7 +1024,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("test internal function: AtLeastNNonNulls") {
+  test("internal function: AtLeastNNonNulls") {
     // AtLeastNNonNulls is called by drop DataFrameNafunction
     withTempPath {
       path =>
@@ -1045,7 +1045,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("Test try_cast", "3.4") {
+  testWithMinSparkVersion("try_cast", "3.4") {
     withTempView("try_cast_table") {
       withTempPath {
         path =>
@@ -1064,7 +1064,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test cast") {
+  test("cast") {
     withTempView("cast_table") {
       withTempPath {
         path =>

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -544,7 +544,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("version function") {
+  test("version") {
     runQueryAndCompare("""SELECT version() from lineitem limit 10""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -554,7 +554,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("sum/count function") {
+  test("sum/count") {
     withTempPath {
       path =>
         Seq[(Integer, Integer)](
@@ -617,7 +617,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("uuid function") {
+  test("uuid") {
     runQueryAndCompare("""SELECT uuid() from lineitem limit 100""".stripMargin, false) {
       checkGlutenOperatorMatch[ProjectExecTransformer]
     }
@@ -695,7 +695,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("filter function") {
+  test("filter") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -715,7 +715,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("concat function") {
+  test("concat") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -732,7 +732,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("transform function") {
+  test("transform") {
     withTable("t") {
       sql("create table t (arr ARRAY<INT>) using parquet")
       sql("insert into t values(array(1, 2, 3, null))")
@@ -742,7 +742,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("forall function") {
+  test("forall") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -762,7 +762,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("exists function") {
+  test("exists") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -951,7 +951,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("input_file_name function") {
+  test("input_file_name") {
     runQueryAndCompare("""SELECT input_file_name(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
       checkGlutenOperatorMatch[ProjectExecTransformer]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up fix for this comment:
https://github.com/apache/incubator-gluten/pull/9782#discussion_r2113247329

Remove "Test" from test name if not very necessary. Keep "function" in test name only if it help avoid ambiguity.

