### PR TITLE
[GLUTEN-9849][VL] Avoid VeloxBloomFilterMightContain being applied to FileSourceScan partition filters

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/expression/VeloxBloomFilterMightContain.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/expression/VeloxBloomFilterMightContain.scala
@@ -32,6 +32,9 @@ import org.apache.spark.task.TaskResources
  * Velox's bloom-filter implementation uses different algorithms internally comparing to vanilla
  * Spark so produces different intermediate aggregate data. Thus we use different filter function /
  * agg function types for Velox's version to distinguish from vanilla Spark's implementation.
+ *
+ * FIXME: Remove GlutenTaskOnlyExpression after the VeloxBloomFilter expr is made compatible with
+ * spark. See: https://github.com/apache/incubator-gluten/pull/9850#issuecomment-3007448538
  */
 case class VeloxBloomFilterMightContain(
     bloomFilterExpression: Expression,

--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenExpression.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenExpression.scala
@@ -14,22 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql
+package org.apache.gluten.execution
 
-import org.apache.spark.sql.internal.SQLConf
+/**
+ * GlutenExpression is a marker trait for expressions that are specific to Gluten execution. It can
+ * be used to identify expressions that should only be evaluated in the context of a Spark task.
+ */
+trait GlutenExpression {
 
-class GlutenInjectRuntimeFilterSuite extends InjectRuntimeFilterSuite with GlutenSQLTestsBaseTrait {
+  def onlyInSparkTask(): Boolean = false
 
-  test("velox bloom filter applied to partition filter") {
-    withSQLConf(
-      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
-      SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000"
-    ) {
-      assertRewroteWithBloomFilter(
-        "select * from bf5part join bf2 on " +
-          "bf5part.f5 = bf2.c2 where bf2.a2 = 67")
-    }
-  }
+}
+
+trait GlutenTaskOnlyExpression extends GlutenExpression {
+
+  override def onlyInSparkTask(): Boolean = true
 
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
@@ -25,11 +25,17 @@ object ScanTransformerFactory {
 
   def createFileSourceScanTransformer(
       scanExec: FileSourceScanExec): FileSourceScanExecTransformerBase = {
+    // Partition filters will be evaluated in driver side, so we can remove
+    // GlutenTaskOnlyExpressions
+    val partitionFilters = scanExec.partitionFilters.filter {
+      case _: GlutenTaskOnlyExpression => false
+      case _ => true
+    }
     FileSourceScanExecTransformer(
       scanExec.relation,
       scanExec.output,
       scanExec.requiredSchema,
-      scanExec.partitionFilters,
+      partitionFilters,
       scanExec.optionalBucketSet,
       scanExec.optionalNumCoalescedBuckets,
       scanExec.dataFilters,

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -901,6 +901,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
   enableSuite[GlutenInjectRuntimeFilterSuite]
     // FIXME: yan
     .includeCH("Merge runtime bloom filters")
+    .excludeGlutenTest("GLUTEN-9849: bloom filter applied to partition filter")
   enableSuite[GlutenInnerJoinSuiteForceShjOff]
     .excludeCH(
       "inner join, one match per row using ShuffledHashJoin (build=left) (whole-stage-codegen off)")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenInjectRuntimeFilterSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenInjectRuntimeFilterSuite.scala
@@ -20,19 +20,12 @@ import org.apache.spark.sql.internal.SQLConf
 
 class GlutenInjectRuntimeFilterSuite extends InjectRuntimeFilterSuite with GlutenSQLTestsBaseTrait {
 
-  test("bloom filter applied to partition filter") {
+  testGluten("GLUTEN-9849: bloom filter applied to partition filter") {
     withSQLConf(
       SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
       SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
-      "spark.gluten.sql.native.bloomFilter" -> "false",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000"
     ) {
-      val query = "select * from bf5part join bf2 on bf5part.f5 = bf2.c2 where bf2.a2 = 67"
-      val df = sql(query)
-      df.collect()
-      val plan = df.queryExecution.executedPlan.toString()
-      logWarning(s"GlutenInjectRuntimeFilterSuite Plan:")
-      plan.split("\n").foreach(logWarning(_))
       assertRewroteWithBloomFilter(
         "select * from bf5part join bf2 on " +
           "bf5part.f5 = bf2.c2 where bf2.a2 = 67")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenInjectRuntimeFilterSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenInjectRuntimeFilterSuite.scala
@@ -24,12 +24,15 @@ class GlutenInjectRuntimeFilterSuite extends InjectRuntimeFilterSuite with Glute
     withSQLConf(
       SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
       SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
+      "spark.gluten.sql.native.bloomFilter" -> "false",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000"
     ) {
       val query = "select * from bf5part join bf2 on bf5part.f5 = bf2.c2 where bf2.a2 = 67"
       val df = sql(query)
       df.collect()
-      logWarning(s"GlutenInjectRuntimeFilterSuite Plan:\n${df.queryExecution.executedPlan}\n")
+      val plan = df.queryExecution.executedPlan.toString()
+      logWarning(s"GlutenInjectRuntimeFilterSuite Plan:")
+      plan.split("\n").foreach(logWarning(_))
       assertRewroteWithBloomFilter(
         "select * from bf5part join bf2 on " +
           "bf5part.f5 = bf2.c2 where bf2.a2 = 67")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenInjectRuntimeFilterSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenInjectRuntimeFilterSuite.scala
@@ -20,12 +20,16 @@ import org.apache.spark.sql.internal.SQLConf
 
 class GlutenInjectRuntimeFilterSuite extends InjectRuntimeFilterSuite with GlutenSQLTestsBaseTrait {
 
-  test("velox bloom filter applied to partition filter") {
+  test("bloom filter applied to partition filter") {
     withSQLConf(
       SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
       SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000"
     ) {
+      val query = "select * from bf5part join bf2 on bf5part.f5 = bf2.c2 where bf2.a2 = 67"
+      val df = sql(query)
+      df.collect()
+      logWarning(s"GlutenInjectRuntimeFilterSuite Plan:\n${df.queryExecution.executedPlan}\n")
       assertRewroteWithBloomFilter(
         "select * from bf5part join bf2 on " +
           "bf5part.f5 = bf2.c2 where bf2.a2 = 67")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude VeloxBloomFilterMightContain from FileSourceScan parition filters

Fixes: #9849

## How was this patch tested?

added unit test

