### PR TITLE
Disable OS setup in get_velox.sh via RUN_SETUP_SCRIPT

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -179,6 +179,10 @@ function concat_velox_param {
     if [[ -n $VELOX_HOME ]]; then
         VELOX_PARAMETER+="--velox_home=$VELOX_HOME "
     fi
+
+    if [[ -n $RUN_SETUP_SCRIPT ]]; then
+        VELOX_PARAMETER+="--run_setup_script=$RUN_SETUP_SCRIPT "
+    fi
 }
 
 if [ "$ENABLE_VCPKG" = "ON" ]; then

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -19,6 +19,7 @@ set -exu
 VELOX_REPO=https://github.com/oap-project/velox.git
 VELOX_BRANCH=2025_06_03
 VELOX_HOME=""
+RUN_SETUP_SCRIPT=ON
 
 OS=`uname -s`
 
@@ -34,6 +35,10 @@ for arg in "$@"; do
     ;;
   --velox_home=*)
     VELOX_HOME=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --run_setup_script=*)
+    RUN_SETUP_SCRIPT=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
   *)
@@ -234,13 +239,15 @@ function setup_linux {
   fi
 }
 
-if [ $OS == 'Linux' ]; then
-  setup_linux
-elif [ $OS == 'Darwin' ]; then
-  :
-else
-  echo "Unsupported kernel: $OS"
-  exit 1
+if [[ "$RUN_SETUP_SCRIPT" == "ON" ]]; then
+  if [ $OS == 'Linux' ]; then
+    setup_linux
+  elif [ $OS == 'Darwin' ]; then
+    :
+  else
+    echo "Unsupported kernel: $OS"
+    exit 1
+  fi
 fi
 
 apply_compilation_fixes $CURRENT_DIR $VELOX_SOURCE_DIR


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make RUN_SETUP_SCRIPT more respected
Make gluten buildable on OSes with manual setup on some non-builtin supported ones


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

