### PR TITLE
[Core] Port SPARK-34541 to ColumnarShuffleManager

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/spark/shuffle/sort/ColumnarShuffleManager.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/shuffle/sort/ColumnarShuffleManager.scala
@@ -78,7 +78,7 @@ class ColumnarShuffleManager(conf: SparkConf) extends ShuffleManager with Loggin
     val mapTaskIds =
       taskIdMapsForShuffle.computeIfAbsent(handle.shuffleId, _ => new OpenHashSet[Long](16))
     mapTaskIds.synchronized {
-      mapTaskIds.add(context.taskAttemptId())
+      mapTaskIds.add(mapId)
     }
     val env = SparkEnv.get
     handle match {


### PR DESCRIPTION
port the fix in https://github.com/apache/spark/commit/f340857757034ac955862b34e60322ca5ee81758