### PR TITLE
[GLUTEN-6269][VL][UNIFFLE] Remove incBytesWritten in VeloxUniffleColumnarShuffleWriter

### DIFF
--- a/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -226,7 +226,8 @@ public class VeloxUniffleColumnarShuffleWriter<K, V> extends RssShuffleWriter<K,
                 - splitResult.getTotalWriteTime()
                 - splitResult.getTotalCompressTime());
 
-    shuffleWriteMetrics.incBytesWritten(splitResult.getTotalBytesWritten());
+    // bytesWritten is calculated in uniffle side: WriteBufferManager.createShuffleBlock
+    // shuffleWriteMetrics.incBytesWritten(splitResult.getTotalBytesWritten());
     shuffleWriteMetrics.incWriteTime(
         splitResult.getTotalWriteTime() + splitResult.getTotalPushTime());
     // partitionLengths is calculate in uniffle side


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reopen #6270, remove incBytesWritten in VeloxUniffleColumnarShuffleWriter to avoid double counting of shuffle bytesWritten

Fixes: #6269

## How was this patch tested?

Before this change:
![image](https://github.com/user-attachments/assets/89cd8f93-cea6-438b-9324-4fe7f99e4b4b)


