### PR TITLE
[GLUTEN-9860] followup: Fix rsync remote path

### DIFF
--- a/.github/workflows/nightly_sync.yml
+++ b/.github/workflows/nightly_sync.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           switches: -avzr
           path: docs/*
-          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/gluten/docs
+          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/gluten/docs/
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
           remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

this patch adds the trailing '/' for the remote path. 
example from opendal: 
https://github.com/apache/opendal/blob/main/.github/workflows/docs.yml#L715

## How was this patch tested?

pass GHA
