### PR TITLE
Revert "Add RichSparkConf to simplify the interoperations with gluten config entries (#9876)

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoader.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoader.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.jni.JniLibLoader
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.internal.SparkConfigUtil._
 
 import scala.sys.process._
 
@@ -31,7 +30,9 @@ trait SharedLibraryLoader {
 
 object SharedLibraryLoader {
   def load(conf: SparkConf, jni: JniLibLoader): Unit = {
-    val shouldLoad = conf.get(GlutenConfig.GLUTEN_LOAD_LIB_FROM_JAR)
+    val shouldLoad = conf.getBoolean(
+      GlutenConfig.GLUTEN_LOAD_LIB_FROM_JAR.key,
+      GlutenConfig.GLUTEN_LOAD_LIB_FROM_JAR.defaultValue.get)
     if (!shouldLoad) {
       return
     }
@@ -53,9 +54,9 @@ object SharedLibraryLoader {
   }
 
   private def find(conf: SparkConf): SharedLibraryLoader = {
-    val systemName = conf.get(GlutenConfig.GLUTEN_LOAD_LIB_OS)
+    val systemName = conf.getOption(GlutenConfig.GLUTEN_LOAD_LIB_OS.key)
     val loader = if (systemName.isDefined) {
-      val systemVersion = conf.get(GlutenConfig.GLUTEN_LOAD_LIB_OS_VERSION)
+      val systemVersion = conf.getOption(GlutenConfig.GLUTEN_LOAD_LIB_OS_VERSION.key)
       if (systemVersion.isEmpty) {
         throw new GlutenException(
           s"${GlutenConfig.GLUTEN_LOAD_LIB_OS_VERSION.key} must be specified when specifies the " +

--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -33,8 +33,7 @@ import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.softaffinity.SoftAffinityListener
 import org.apache.spark.sql.execution.adaptive.GlutenCostEvaluator
 import org.apache.spark.sql.execution.ui.{GlutenSQLAppStatusListener, GlutenUIUtils}
-import org.apache.spark.sql.internal.SparkConfigUtil._
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SparkConfigUtil, SQLConf}
 import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
 import org.apache.spark.task.TaskResources
 import org.apache.spark.util.SparkResourceUtil
@@ -63,7 +62,11 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
 
     // Register Gluten listeners
     GlutenSQLAppStatusListener.register(sc)
-    if (conf.get(GLUTEN_SOFT_AFFINITY_ENABLED)) {
+    if (
+      conf.getBoolean(
+        GLUTEN_SOFT_AFFINITY_ENABLED.key,
+        GLUTEN_SOFT_AFFINITY_ENABLED.defaultValue.get)
+    ) {
       SoftAffinityListener.register(sc)
     }
 
@@ -134,13 +137,19 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
   }
 
   private def checkOffHeapSettings(conf: SparkConf): Unit = {
-    if (conf.get(DYNAMIC_OFFHEAP_SIZING_ENABLED)) {
+    if (
+      conf.getBoolean(
+        DYNAMIC_OFFHEAP_SIZING_ENABLED.key,
+        DYNAMIC_OFFHEAP_SIZING_ENABLED.defaultValue.get)
+    ) {
       // When dynamic off-heap sizing is enabled, off-heap mode is not strictly required to be
       // enabled. Skip the check.
       return
     }
 
-    if (conf.get(COLUMNAR_MEMORY_UNTRACKED)) {
+    if (
+      conf.getBoolean(COLUMNAR_MEMORY_UNTRACKED.key, COLUMNAR_MEMORY_UNTRACKED.defaultValue.get)
+    ) {
       // When untracked memory mode is enabled, off-heap mode is not strictly required to be
       // enabled. Skip the check.
       return
@@ -160,19 +169,22 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
 
   private def setPredefinedConfigs(conf: SparkConf): Unit = {
     // Spark SQL extensions
-    val extensionSeq = conf.get(SPARK_SESSION_EXTENSIONS).getOrElse(Seq.empty)
+    val extensionSeq =
+      SparkConfigUtil.getEntryValue(conf, SPARK_SESSION_EXTENSIONS).getOrElse(Seq.empty)
     if (!extensionSeq.toSet.contains(GlutenSessionExtensions.GLUTEN_SESSION_EXTENSION_NAME)) {
       conf.set(
-        SPARK_SESSION_EXTENSIONS,
-        Some(extensionSeq :+ GlutenSessionExtensions.GLUTEN_SESSION_EXTENSION_NAME))
+        SPARK_SESSION_EXTENSIONS.key,
+        (extensionSeq :+ GlutenSessionExtensions.GLUTEN_SESSION_EXTENSION_NAME).mkString(","))
     }
 
     // adaptive custom cost evaluator class
-    val enableGlutenCostEvaluator = conf.get(GlutenConfig.COST_EVALUATOR_ENABLED)
+    val enableGlutenCostEvaluator = conf.getBoolean(
+      GlutenConfig.COST_EVALUATOR_ENABLED.key,
+      GlutenConfig.COST_EVALUATOR_ENABLED.defaultValue.get)
     if (enableGlutenCostEvaluator) {
       conf.set(
-        SQLConf.ADAPTIVE_CUSTOM_COST_EVALUATOR_CLASS,
-        Some(classOf[GlutenCostEvaluator].getName))
+        SQLConf.ADAPTIVE_CUSTOM_COST_EVALUATOR_CLASS.key,
+        classOf[GlutenCostEvaluator].getName)
     }
 
     // check memory off-heap enabled and size.
@@ -182,33 +194,39 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
     val offHeapSize = conf.getSizeAsBytes(SPARK_OFFHEAP_SIZE_KEY)
 
     // Set off-heap size in bytes.
-    conf.set(COLUMNAR_OFFHEAP_SIZE_IN_BYTES, offHeapSize)
+    conf.set(COLUMNAR_OFFHEAP_SIZE_IN_BYTES.key, offHeapSize.toString)
 
     // Set off-heap size in bytes per task.
     val taskSlots = SparkResourceUtil.getTaskSlots(conf)
-    conf.set(NUM_TASK_SLOTS_PER_EXECUTOR, taskSlots)
+    conf.set(NUM_TASK_SLOTS_PER_EXECUTOR.key, taskSlots.toString)
     val offHeapPerTask = offHeapSize / taskSlots
-    conf.set(COLUMNAR_TASK_OFFHEAP_SIZE_IN_BYTES, offHeapPerTask)
+    conf.set(COLUMNAR_TASK_OFFHEAP_SIZE_IN_BYTES.key, offHeapPerTask.toString)
 
     // Pessimistic off-heap sizes, with the assumption that all non-borrowable storage memory
     // determined by spark.memory.storageFraction was used.
     val fraction = 1.0d - conf.getDouble("spark.memory.storageFraction", 0.5d)
     val conservativeOffHeapPerTask = (offHeapSize * fraction).toLong / taskSlots
-    conf.set(COLUMNAR_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES, conservativeOffHeapPerTask)
+    conf.set(
+      COLUMNAR_CONSERVATIVE_TASK_OFFHEAP_SIZE_IN_BYTES.key,
+      conservativeOffHeapPerTask.toString)
 
     // Disable vanilla columnar readers, to prevent columnar-to-columnar conversions.
     // FIXME: Do we still need this trick since
     //  https://github.com/apache/incubator-gluten/pull/1931 was merged?
-    if (!conf.get(VANILLA_VECTORIZED_READERS_ENABLED)) {
+    if (
+      !conf.getBoolean(
+        VANILLA_VECTORIZED_READERS_ENABLED.key,
+        VANILLA_VECTORIZED_READERS_ENABLED.defaultValue.get)
+    ) {
       // FIXME Hongze 22/12/06
       //  BatchScan.scala in shim was not always loaded by class loader.
       //  The file should be removed and the "ClassCastException" issue caused by
       //  spark.sql.<format>.enableVectorizedReader=true should be fixed in another way.
       //  Before the issue is fixed we force the use of vanilla row reader by using
       //  the following statement.
-      conf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED, false)
-      conf.set(SQLConf.ORC_VECTORIZED_READER_ENABLED, false)
-      conf.set(SQLConf.CACHE_VECTORIZED_READER_ENABLED, false)
+      conf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, "false")
+      conf.set(SQLConf.ORC_VECTORIZED_READER_ENABLED.key, "false")
+      conf.set(SQLConf.CACHE_VECTORIZED_READER_ENABLED.key, "false")
     }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/internal/SparkConfigUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/internal/SparkConfigUtil.scala
@@ -16,44 +16,11 @@
  */
 package org.apache.spark.sql.internal
 
-import org.apache.gluten.config.ConfigEntry
-
 import org.apache.spark.SparkConf
-import org.apache.spark.internal.config.{ConfigEntry => SparkConfigEntry}
+import org.apache.spark.internal.config.ConfigEntry
 
 object SparkConfigUtil {
-
-  implicit class RichSparkConf(val conf: SparkConf) {
-    def get[T](entry: SparkConfigEntry[T]): T = {
-      SparkConfigUtil.get(conf, entry)
-    }
-
-    def get[T](entry: ConfigEntry[T]): T = {
-      SparkConfigUtil.get(conf, entry)
-    }
-
-    def set[T](entry: SparkConfigEntry[T], value: T): SparkConf = {
-      SparkConfigUtil.set(conf, entry, value)
-    }
-
-    def set[T](entry: ConfigEntry[T], value: T): SparkConf = {
-      SparkConfigUtil.set(conf, entry, value)
-    }
-  }
-
-  def get[T](conf: SparkConf, entry: SparkConfigEntry[T]): T = {
+  def getEntryValue[T](conf: SparkConf, entry: ConfigEntry[T]): T = {
     conf.get(entry)
-  }
-
-  def get[T](conf: SparkConf, entry: ConfigEntry[T]): T = {
-    entry.valueConverter(conf.get(entry.key, entry.defaultValueString))
-  }
-
-  def set[T](conf: SparkConf, entry: SparkConfigEntry[T], value: T): SparkConf = {
-    conf.set(entry, value)
-  }
-
-  def set[T](conf: SparkConf, entry: ConfigEntry[T], value: T): SparkConf = {
-    conf.set(entry.key, entry.stringConverter(value))
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/UDFMappings.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/UDFMappings.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.config.GlutenConfig
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.internal.SparkConfigUtil._
 
 import org.apache.commons.lang3.StringUtils
 
@@ -59,19 +58,19 @@ object UDFMappings extends Logging {
   }
 
   def loadFromSparkConf(conf: SparkConf): Unit = {
-    val strHiveUDFs = conf.get(GlutenConfig.GLUTEN_SUPPORTED_HIVE_UDFS)
+    val strHiveUDFs = conf.get(GlutenConfig.GLUTEN_SUPPORTED_HIVE_UDFS.key, "")
     if (!StringUtils.isBlank(strHiveUDFs)) {
       parseStringToMap(strHiveUDFs, hiveUDFMap)
       logDebug(s"loaded hive udf mappings:${hiveUDFMap.toString}")
     }
 
-    val strPythonUDFs = conf.get(GlutenConfig.GLUTEN_SUPPORTED_PYTHON_UDFS)
+    val strPythonUDFs = conf.get(GlutenConfig.GLUTEN_SUPPORTED_PYTHON_UDFS.key, "")
     if (!StringUtils.isBlank(strPythonUDFs)) {
       parseStringToMap(strPythonUDFs, pythonUDFMap)
       logDebug(s"loaded python udf mappings:${pythonUDFMap.toString}")
     }
 
-    val strScalaUDFs = conf.get(GlutenConfig.GLUTEN_SUPPORTED_SCALA_UDFS)
+    val strScalaUDFs = conf.get(GlutenConfig.GLUTEN_SUPPORTED_SCALA_UDFS.key, "")
     if (!StringUtils.isBlank(strScalaUDFs)) {
       parseStringToMap(strScalaUDFs, scalaUDFMap)
       logDebug(s"loaded scala udf mappings:${scalaUDFMap.toString}")


### PR DESCRIPTION
#9876 causes [CH UT failed](https://opencicd.kyligence.com/blue/organizations/jenkins/gluten%2Fgluten-ci/detail/gluten-ci/16353/pipeline).


```
[2025-06-07T02:42:07.376Z] [ERROR] org.apache.gluten.execution.iceberg.TestPositionDeletesTableGluten -- Time elapsed: 8.793 s <<< ERROR!
[2025-06-07T02:42:07.376Z] java.lang.NumberFormatException: For input string: "2147483648b"
[2025-06-07T02:42:07.376Z] 	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
[2025-06-07T02:42:07.376Z] 	at java.base/java.lang.Long.parseLong(Long.java:711)
[2025-06-07T02:42:07.376Z] 	at java.base/java.lang.Long.parseLong(Long.java:836)
[2025-06-07T02:42:07.376Z] 	at scala.collection.StringOps$.toLong$extension(StringOps.scala:928)
[2025-06-07T02:42:07.376Z] 	at org.apache.gluten.backendsapi.clickhouse.CHTransformerApi.postProcessNativeConfig(CHTransformerApi.scala:101)
[2025-06-07T02:42:07.376Z] 	at org.apache.gluten.vectorized.CHNativeExpressionEvaluator.initNative(CHNativeExpressionEvaluator.java:41)
```

It ugdate `SparkConfigUtil.set`  to use  `entry.stringConverter` which add `b` to  `byteConf`

```scala
  def set[T](conf: SparkConf, entry: ConfigEntry[T], value: T): SparkConf = {
    conf.set(entry.key, entry.stringConverter(value))
  }
```

But we still use **conf.get(conf.key)** in `getNativeBackendConf` which cause failure.