### PR TITLE
[GLUTEN-9960] Remove hardcoded path to cmake-format

### DIFF
--- a/.github/workflows/ch_code_style.yml
+++ b/.github/workflows/ch_code_style.yml
@@ -53,6 +53,7 @@ jobs:
           apt update -y
           apt install git python3-pip -y
           pip3 install --user cmake-format
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - uses: actions/checkout@v4
       - name: Check CMake format
         run: |
@@ -60,7 +61,7 @@ jobs:
           cd $GITHUB_WORKSPACE/
           fileList=$(find ./cpp ./cpp-ch -name CMakeLists.txt -o -name *.cmake)
           for file in $fileList; do
-              /github/home/.local/bin/cmake-format --first-comment-is-literal True --in-place $file
+              cmake-format --first-comment-is-literal True --in-place $file
           done
           if [ -n "$(git status --porcelain)" ]; then
              echo "Please use cmake-format to format cmake files or apply the below patch."


### PR DESCRIPTION
## What changes were proposed in this pull request?

`cmake-format` is used from a hardcoded path within Github action `ch_code_style.yml` like this:
```
/github/home/.local/bin/cmake-format ...
```

Fixes: #9906 

## How was this patch tested?
It was tested locally:
```
 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
[CH Backend Code style checks/CH CMake Format Check]   ✅  Success - Main Install tools [27.824740074s]
[CH Backend Code style checks/CH CMake Format Check]   ⚙  ::add-path:: /root/.local/bin
[CH Backend Code style checks/CH CMake Format Check] ⭐ Run Main actions/checkout@v4
[CH Backend Code style checks/CH CMake Format Check]   🐳  docker cp src=/localdisk/ashahba/source_code/incubator-gluten/. dst=/localdisk/ashahba/source_code/incubator-gluten
[CH Backend Code style checks/CH CMake Format Check]   ✅  Success - Main actions/checkout@v4 [1.438931312s]
[CH Backend Code style checks/CH CMake Format Check] ⭐ Run Main Check CMake format
[CH Backend Code style checks/CH CMake Format Check]   🐳  docker exec cmd=[sh -e /var/run/act/workflow/2.sh] user= workdir=
| No CMake format issue.
[CH Backend Code style checks/CH CMake Format Check]   ✅  Success - Main Check CMake format [4.938387058s]
[CH Backend Code style checks/CH CMake Format Check] ⭐ Run Complete job
[CH Backend Code style checks/CH CMake Format Check] Cleaning up container for job CH CMake Format Check
[CH Backend Code style checks/CH CMake Format Check]   ✅  Success - Complete job
[CH Backend Code style checks/CH CMake Format Check] 🏁  Job succeeded
```

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
N/A

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
N/A
