### PR TITLE
[CORE][VL] Fix fallback for spark literal unsafe map data as input

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -511,6 +511,15 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("Test map_from_arrays function optimized by Spark constant folding") {
+    withSQLConf(("spark.sql.optimizer.excludedRules", NullPropagation.ruleName)) {
+      runQueryAndCompare("""SELECT map_from_arrays(sequence(1, 5),sequence(1, 5)), l_orderkey
+                           | from lineitem limit 100""".stripMargin) {
+        checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+    }
+  }
+
   test("raise_error, assert_true") {
     runQueryAndCompare("""SELECT assert_true(l_orderkey >= 1), l_orderkey
                          | from lineitem limit 100""".stripMargin) {

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -511,10 +511,10 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  test("Test map_from_arrays function optimized by Spark constant folding") {
-    withSQLConf(("spark.sql.optimizer.excludedRules", NullPropagation.ruleName)) {
+  test("map_from_arrays optimized by Spark constant folding") {
+    withSQLConf(("spark.sql.optimizer.excludedRules", "")) {
       runQueryAndCompare("""SELECT map_from_arrays(sequence(1, 5),sequence(1, 5)), l_orderkey
-                           | from lineitem limit 100""".stripMargin) {
+                           | from lineitem limit 10""".stripMargin) {
         checkGlutenOperatorMatch[ProjectExecTransformer]
       }
     }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ExpressionBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ExpressionBuilder.java
@@ -23,9 +23,7 @@ import org.apache.gluten.substrait.type.*;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.Expression;
-import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
-import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.*;
 
@@ -207,19 +205,6 @@ public class ExpressionBuilder {
 
   public static LiteralNode makeLiteral(Object obj, DataType dataType, Boolean nullable) {
     TypeNode typeNode = ConverterUtils.getTypeNode(dataType, nullable);
-    if (obj instanceof UnsafeArrayData) {
-      UnsafeArrayData oldObj = (UnsafeArrayData) obj;
-      int numElements = oldObj.numElements();
-      Object[] elements = new Object[numElements];
-      DataType elementType = ((ArrayType) dataType).elementType();
-
-      for (int i = 0; i < numElements; i++) {
-        elements[i] = oldObj.get(i, elementType);
-      }
-
-      GenericArrayData newObj = new GenericArrayData(elements);
-      return makeListLiteral(newObj, typeNode);
-    }
     return makeLiteral(obj, typeNode);
   }
 

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/BinaryTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/BinaryTypeNode.java
@@ -40,4 +40,9 @@ public class BinaryTypeNode implements TypeNode, Serializable {
     builder.setBinary(binaryBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/BooleanTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/BooleanTypeNode.java
@@ -40,4 +40,9 @@ public class BooleanTypeNode implements TypeNode, Serializable {
     builder.setBool(booleanBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/DateTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/DateTypeNode.java
@@ -39,4 +39,9 @@ public class DateTypeNode implements TypeNode, Serializable {
     builder.setDate(dateBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/DecimalTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/DecimalTypeNode.java
@@ -46,4 +46,9 @@ public class DecimalTypeNode implements TypeNode, Serializable {
     builder.setDecimal(decimalBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FP32TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FP32TypeNode.java
@@ -40,4 +40,9 @@ public class FP32TypeNode implements TypeNode, Serializable {
     builder.setFp32(doubleBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FP64TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FP64TypeNode.java
@@ -40,4 +40,9 @@ public class FP64TypeNode implements TypeNode, Serializable {
     builder.setFp64(doubleBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FixedBinaryTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FixedBinaryTypeNode.java
@@ -43,4 +43,9 @@ public class FixedBinaryTypeNode implements TypeNode, Serializable {
     builder.setFixedBinary(fixedBinaryBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FixedCharTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/FixedCharTypeNode.java
@@ -43,4 +43,9 @@ public class FixedCharTypeNode implements TypeNode, Serializable {
     builder.setFixedChar(fixedCharBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I16TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I16TypeNode.java
@@ -40,4 +40,9 @@ public class I16TypeNode implements TypeNode, Serializable {
     builder.setI16(i16Builder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I32TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I32TypeNode.java
@@ -40,4 +40,9 @@ public class I32TypeNode implements TypeNode, Serializable {
     builder.setI32(i32Builder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I64TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I64TypeNode.java
@@ -40,4 +40,9 @@ public class I64TypeNode implements TypeNode, Serializable {
     builder.setI64(i64Builder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I8TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/I8TypeNode.java
@@ -40,4 +40,9 @@ public class I8TypeNode implements TypeNode, Serializable {
     builder.setI8(i8Builder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/IntervalYearTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/IntervalYearTypeNode.java
@@ -40,4 +40,9 @@ public class IntervalYearTypeNode implements TypeNode, Serializable {
     builder.setIntervalYear(intervalYearBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/ListNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/ListNode.java
@@ -45,4 +45,9 @@ public class ListNode implements TypeNode, Serializable {
     builder.setList(listBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/MapNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/MapNode.java
@@ -61,4 +61,9 @@ public class MapNode implements TypeNode, Serializable {
     builder.setMap(mapBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/NothingNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/NothingNode.java
@@ -30,4 +30,9 @@ public class NothingNode implements TypeNode, Serializable {
     builder.setNothing(nothingBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/NothingNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/NothingNode.java
@@ -33,6 +33,6 @@ public class NothingNode implements TypeNode, Serializable {
 
   @Override
   public Boolean nullable() {
-    throw new UnsupportedOperationException();
+    return true;
   }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/StringTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/StringTypeNode.java
@@ -40,4 +40,9 @@ public class StringTypeNode implements TypeNode, Serializable {
     builder.setString(stringBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/StructNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/StructNode.java
@@ -57,4 +57,9 @@ public class StructNode implements TypeNode, Serializable {
     builder.setStruct(structBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TimestampTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TimestampTypeNode.java
@@ -40,4 +40,9 @@ public class TimestampTypeNode implements TypeNode, Serializable {
     builder.setTimestamp(timestampBuilder.build());
     return builder.build();
   }
+
+  @Override
+  public Boolean nullable() {
+    return nullable;
+  }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TypeNode.java
@@ -20,4 +20,6 @@ import io.substrait.proto.Type;
 
 public interface TypeNode {
   Type toProtobuf();
+
+  Boolean nullable();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix fallback sql
```
SELECT map_from_arrays(sequence(1, 5),sequence(1, 5)), string_column from t
```

```
java.lang.UnsupportedOperationException: Not supported on UnsafeArrayData.
	at org.apache.spark.sql.catalyst.expressions.UnsafeArrayData.array(UnsafeArrayData.java:103)
	at org.apache.gluten.substrait.expression.MapLiteralNode.updateLiteralBuilder(MapLiteralNode.java:34)
	at org.apache.gluten.substrait.expression.MapLiteralNode.updateLiteralBuilder(MapLiteralNode.java:27)
	at org.apache.gluten.substrait.expression.LiteralNodeWithValue.getLiteral(LiteralNodeWithValue.java:39)
	at org.apache.gluten.substrait.expression.LiteralNode.toProtobuf(LiteralNode.java:41)
	at org.apache.gluten.substrait.rel.ProjectRelNode.toProtobuf(ProjectRelNode.java:72)
	at org.apache.gluten.substrait.plan.PlanNode.toProtobuf(PlanNode.java:74)
```


In this PR:
- use `Object get(int ordinal, DataType dataType);` to obtain the value instead of `ArrayData.array()`, so that for UnsafeArrayData or Unsafe map(two UnsafeArrayData), it can internally automatically parse out safe value
- Add `parseFromTypeNode` in `ConverterUtils` to parse TypeNode to Spark DataType
- In order to obtain TypeNode's nullable, add `nullable()` in interface TypeNode
