### PR TITLE
[CORE] Minor: Fix gluten-it decimal as double decimal match

### DIFF
--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Constants.scala
@@ -167,6 +167,7 @@ object Constants {
       override def modValue(from: Any): Any = {
         from match {
           case v: java.math.BigDecimal => v.doubleValue()
+          case v: scala.math.BigDecimal => v.doubleValue()
         }
       }
     }


### PR DESCRIPTION
Fix
```
04:59:10.749 [task-result-getter-2] WARN  org.apache.spark.scheduler.TaskSetManager - Lost task 9.0 in stage 0.0 (TID 9) (43689e113b67 executor driver): scala.MatchError: 37 (of class scala.math.BigDecimal)
	at org.apache.gluten.integration.Constants$$anon$5.modValue(Constants.scala:168)
	at org.apache.gluten.integration.h.TpchDataGen.$anonfun$generate$4(TpchDataGen.scala:318)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at scala.collection.TraversableLike.map(TraversableLike.scala:286)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at org.apache.gluten.integration.h.TpchDataGen.$anonfun$generate$3(TpchDataGen.scala:315)
	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage2.processNex
```
