### PR TITLE
[GLUTEN-9952][VL] Python Security updates June 2025

### DIFF
--- a/tools/workload/benchmark_velox/analysis/requirements.txt
+++ b/tools/workload/benchmark_velox/analysis/requirements.txt
@@ -57,7 +57,7 @@ jsonschema-specifications==2023.12.1
 jupyter_client==7.4.9
 jupyter_contrib_core==0.4.2
 jupyter_contrib_nbextensions==0.7.0
-jupyter_core==5.7.2
+jupyter_core==5.8.1
 jupyter-events==0.10.0
 jupyter-highlight-selected-word==0.2.0
 jupyter-nbextensions-configurator==0.6.3
@@ -127,7 +127,7 @@ pytz==2022.1
 PyYAML==6.0.2
 pyzmq==24.0.1
 referencing==0.35.1
-requests==2.32.3
+requests==2.32.4
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rfc3987==1.3.8


### PR DESCRIPTION
## The following file was updated to ensure the desired versions are installed:
tools/workload/benchmark_velox/analysis/requirements.txt b/tools/workload/benchmark_velox/analysis/requirements.txt 

(Fixes: #9952)

## How was this patch tested?
Mostly just creating a fresh virtualenv for 3 different Python versions (3.10, 3.11, 3.12) and making sure that pip can install this requirements file without any issues and using no cached versions.