### PR TITLE
[GLUTEN-9967][VL] Log error stacktrace on velox memory pool grow capacity

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -24,6 +24,7 @@
 
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/MemoryPool.h"
+#include "velox/common/process/StackTrace.h"
 #include "velox/exec/MemoryReclaimer.h"
 
 #include "config/VeloxConfig.h"
@@ -171,6 +172,8 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
     try {
       listener_->allocationChanged(neededBytes);
     } catch (const std::exception&) {
+       VLOG(2) << "ListenableArbitrator growCapacityInternal failed, stacktrace: "
+               << velox::process::StackTrace().toString();
       // if allocationChanged failed, we need to free the reclaimed bytes
       listener_->allocationChanged(-reclaimedFreeBytes);
       std::rethrow_exception(std::current_exception());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log error stacktrace on velox memory pool grow capacity

Fixes: #9967

## How was this patch tested?

output like:

```
I20250613 15:34:28.744055 3270498 VeloxMemoryManager.cc:149] Allocation changed error, stacktrace: # 0  _ZN8facebook5velox7process10StackTraceC1Ei
# 1  _ZN6gluten20ListenableArbitrator18growCapacityLockedEPN8facebook5velox6memory10MemoryPoolEm
# 2  _ZN6gluten20ListenableArbitrator12growCapacityEPN8facebook5velox6memory10MemoryPoolERKSt6vectorISt10shared_ptrIS4_ESaIS8_EEm
# 3  _ZN8facebook5velox6memory13MemoryManager8growPoolEPNS1_10MemoryPoolEm
# 4  _ZN8facebook5velox6memory14MemoryPoolImpl30incrementReservationThreadSafeEPNS1_10MemoryPoolEm
# 5  _ZN8facebook5velox6memory14MemoryPoolImpl30incrementReservationThreadSafeEPNS1_10MemoryPoolEm
# 6  _ZN8facebook5velox6memory14MemoryPoolImpl30incrementReservationThreadSafeEPNS1_10MemoryPoolEm
# 7  _ZN8facebook5velox6memory14MemoryPoolImpl30incrementReservationThreadSafeEPNS1_10MemoryPoolEm
# 8  _ZN8facebook5velox6memory14MemoryPoolImpl17reserveThreadSafeEmb
# 9  _ZN8facebook5velox6memory14MemoryPoolImpl7reserveEmb
# 10 _ZN8facebook5velox6memory14MemoryPoolImpl8allocateEl
# 11 _ZN8facebook5velox13AlignedBuffer8allocateIcEEN5boost13intrusive_ptrINS0_6BufferEEEmPNS0_6memory10MemoryPoolERKSt8optionalIT_E
# 12 _ZN8facebook5velox4exec16SpillInputStreamC2EOSt10unique_ptrINS0_8ReadFileESt14default_deleteIS4_EEmPNS0_6memory10MemoryPoolEPN5folly12SynchronizedINS0_6common10SpillStatsENSC_15SharedMutexImplILb0EvSt6atomicNSC_24SharedMutexPolicyDefaultEEEEE
# 13 _ZN8facebook5velox4exec13SpillReadFileC2EjRKSsmmRKSt10shared_ptrIKNS0_7RowTypeEEjRKSt6vectorINS0_12CompareFlagsESaISC_EENS0_6common15CompressionKindEPNS0_6memory10MemoryPoolEPN5folly12SynchronizedINSH_10SpillStatsENSM_15SharedMutexImplILb0EvSt6atomicNSM_24SharedMutexPolicyDefaultEEEEE
# 14 _ZN8facebook5velox4exec13SpillReadFile6createERKNS1_13SpillFileInfoEmPNS0_6memory10MemoryPoolEPN5folly12SynchronizedINS0_6common10SpillStatsENS9_15SharedMutexImplILb0EvSt6atomicNS9_24SharedMutexPolicyDefaultEEEEE
# 15 _ZN8facebook5velox4exec14SpillPartition19createOrderedReaderEmPNS0_6memory10MemoryPoolEPN5folly12SynchronizedINS0_6common10SpillStatsENS6_15SharedMutexImplILb0EvSt6atomicNS6_24SharedMutexPolicyDefaultEEEEE
# 16 _ZN8facebook5velox4exec10SortBuffer22prepareOutputWithSpillEv
# 17 _ZN8facebook5velox4exec10SortBuffer13prepareOutputEj
# 18 _ZN8facebook5velox4exec10SortBuffer9getOutputEj
# 19 _ZN8facebook5velox4exec7OrderBy9getOutputEv
# 20 _ZN8facebook5velox4exec6Driver11runInternalERSt10shared_ptrIS2_ERS3_INS1_13BlockingStateEERS3_INS0_9RowVectorEE
# 21 _ZN8facebook5velox4exec6Driver4nextEPN5folly10SemiFutureINS3_4UnitEEE
# 22 _ZN8facebook5velox4exec4Task4nextEPN5folly10SemiFutureINS3_4UnitEEE
# 23 _ZN6gluten24WholeStageResultIterator4nextEv
# 24 Java_org_apache_gluten_vectorized_ColumnarBatchOutIterator_nativeHasNext
# 25 0x00007f6ba2168628
```

