### PR TITLE
[VL] Fix FallbackTags for Delta ops

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicTransform.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicTransform.scala
@@ -20,6 +20,7 @@ import org.apache.gluten.component.Component
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.caller.CallerInfo
 import org.apache.gluten.extension.columnar.ColumnarRuleApplier.ColumnarRuleCall
+import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.extension.columnar.rewrite.RewriteSingleNode
 import org.apache.gluten.extension.columnar.validator.Validator
@@ -83,6 +84,9 @@ object HeuristicTransform {
                   rule.offload(node)
                 case Validator.Failed(reason) =>
                   logDebug(s"Validation failed by reason: $reason on query plan: ${node.nodeName}")
+                  if (FallbackTags.maybeOffloadable(node)) {
+                    FallbackTags.add(node, reason)
+                  }
                   node
               }
           }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/enumerated/RasOffload.scala
@@ -89,6 +89,8 @@ object RasOffload {
           case Validator.Passed =>
           case Validator.Failed(reason) =>
             if (FallbackTags.maybeOffloadable(node)) {
+              // FIXME: This is a solution that is not completely verified for all cases, however
+              // it's no harm anyway so we temporarily apply this practice.
               FallbackTags.add(node, reason)
             }
             return List.empty
@@ -135,6 +137,8 @@ object RasOffload {
                   //  in RAS as the query plan we got here may be a copy so may not propagate tags
                   //  to original plan.
                   if (FallbackTags.maybeOffloadable(from)) {
+                    // FIXME: This is a solution that is not completely verified for all cases,
+                    // however it's no harm anyway so we temporarily apply this practice.
                     outComes.foreach(FallbackTags.add(from, _))
                   }
                   from
@@ -147,6 +151,8 @@ object RasOffload {
                 //  in RAS as the query plan we got here may be a copy so may not propagate tags
                 //  to original plan.
                 if (FallbackTags.maybeOffloadable(from)) {
+                  // FIXME: This is a solution that is not completely verified for all cases,
+                  // however it's no harm anyway so we temporarily apply this practice.
                   FallbackTags.add(from, reason)
                 }
                 from


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a Delta scan falls back, the reported reason is incorrect—please see below.
```
== Fallback Summary ==
(1) Scan parquet XX: Unsupported file format UnknownFormat.; Unsupported file format UnknownFormat.

```
## How was this patch tested?

UT.


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

