### PR TITLE
[VL] Refactor IndexRange usage in serializeColumnarBatches

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -66,12 +66,8 @@ std::shared_ptr<arrow::Buffer> VeloxColumnarBatchSerializer::serializeColumnarBa
   auto serializer = serde_->createIterativeSerializer(rowType, numRows, arena.get(), &options_);
   for (auto& batch : batches) {
     auto rowVector = VeloxColumnarBatch::from(veloxPool_.get(), batch)->getRowVector();
-    numRows = rowVector->size();
-    std::vector<IndexRange> rows(numRows);
-    for (int i = 0; i < numRows; i++) {
-      rows[i] = IndexRange{i, 1};
-    }
-    serializer->append(rowVector, folly::Range(rows.data(), numRows));
+    const IndexRange allRows{0, rowVector->size()};
+    serializer->append(rowVector, folly::Range(&allRows, 1));
   }
 
   std::shared_ptr<arrow::Buffer> valueBuffer;


### PR DESCRIPTION
## What changes were proposed in this pull request?

There’s no need to create the IndexRange for every row.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

