### PR TITLE
[VL] Sort by buffer size before hash shuffle evict partition buffers minSize

### DIFF
--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -1372,6 +1372,7 @@ arrow::Result<int64_t> VeloxHashShuffleWriter::evictPartitionBuffersMinSize(int6
     }
     pidToSize.emplace_back(pid, partitionBufferSize_[pid]);
   }
+  std::sort(pidToSize.begin(), pidToSize.end(), [&](const auto& a, const auto& b) { return a.second > b.second; });
   if (!pidToSize.empty()) {
     for (auto& item : pidToSize) {
       auto pid = item.first;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sort by buffer size before hash shuffle evict partition buffers minSize

## How was this patch tested?

minor improve

