### PR TITLE
[GLUTEN-10033][FLINK] Fix memory leak caused by unclosed RowVector in `GlutenSourceFunction`

### DIFF
--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
@@ -111,9 +111,7 @@ public class GlutenSourceFunction extends RichParallelSourceFunction<RowData> {
             sourceContext.collect(row);
           }
         } finally {
-          if (outRv != null) {
-            outRv.close();
-          }
+          outRv.close();
         }
       } else if (state == UpIterator.State.BLOCKED) {
         LOG.debug("Get empty row");

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
@@ -102,16 +102,13 @@ public class GlutenSourceFunction extends RichParallelSourceFunction<RowData> {
       UpIterator.State state = task.advance();
       if (state == UpIterator.State.AVAILABLE) {
         final StatefulElement element = task.statefulGet();
-        final RowVector outRv = element.asRecord().getRowVector();
-        try {
+        try (final RowVector outRv = element.asRecord().getRowVector()) {
           List<RowData> rows =
               FlinkRowToVLVectorConvertor.toRowData(
                   outRv, allocator, outputTypes.values().iterator().next());
           for (RowData row : rows) {
             sourceContext.collect(row);
           }
-        } finally {
-          outRv.close();
         }
       } else if (state == UpIterator.State.BLOCKED) {
         LOG.debug("Get empty row");


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#10033)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

