### PR TITLE
Fix UnsupportedOperationException when converting EmptyHashedRelation

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/BroadcastUtils.scala
@@ -28,7 +28,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, BroadcastPartitioning, IdentityBroadcastMode, Partitioning}
-import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashedRelation, HashedRelationBroadcastMode, LongHashedRelation}
+import org.apache.spark.sql.execution.joins.{BuildSideRelation, EmptyHashedRelation, HashedRelation, HashedRelationBroadcastMode, LongHashedRelation}
 import org.apache.spark.sql.execution.unsafe.UnsafeColumnarBuildSideRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -203,6 +203,7 @@ object BroadcastUtils {
         relation.keys().map(k => relation.getValue(k))
       case relation: LongHashedRelation if !relation.keyIsUnique =>
         relation.keys().flatMap(k => relation.get(k))
+      case EmptyHashedRelation => Iterator.empty
       case other => other.valuesWithKeyIndex().map(_.getValue)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the below UnsupportedOperationException when calling `valuesWithKeyIndex` of `EmptyHashedRelation` class

```java
java.sql.SQLException: org.apache.kyuubi.KyuubiSQLException: org.apache.kyuubi.KyuubiSQLException: Error operating ExecuteStatement: java.lang.UnsupportedOperationException
	at org.apache.spark.sql.execution.joins.HashedRelation.valuesWithKeyIndex(HashedRelation.scala:93)
	at org.apache.spark.sql.execution.joins.HashedRelation.valuesWithKeyIndex$(HashedRelation.scala:92)
	at org.apache.spark.sql.execution.joins.EmptyHashedRelation$.valuesWithKeyIndex(HashedRelation.scala:1088)
	at org.apache.spark.sql.execution.BroadcastUtils$.reconstructRows(BroadcastUtils.scala:199)
	at org.apache.spark.sql.execution.BroadcastUtils$.$anonfun$sparkToVeloxUnsafe$1(BroadcastUtils.scala:103)
	at org.apache.spark.task.TaskResources$.runUnsafe(TaskResources.scala:99)
	at org.apache.spark.sql.execution.BroadcastUtils$.sparkToVeloxUnsafe(BroadcastUtils.scala:102)
	at org.apache.gluten.execution.RowToVeloxColumnarExec.doExecuteBroadcast(RowToVeloxColumnarExec.scala:79)
```

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

