### PR TITLE
[GLUTEN-9994][VL][FOLLOWUP] Use stringstream to construct velox memory usage stats log

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -296,8 +296,8 @@ MemoryUsageStats collectGlutenAllocatorMemoryUsageStats(
 
 void logMemoryUsageStats(MemoryUsageStats stats, const std::string& name, const std::string& logPrefix, std::stringstream& ss) {
   ss << logPrefix << "+- " << name
-          << " (used: " << velox::succinctBytes(stats.current())
-          << ", peak: " <<  velox::succinctBytes(stats.peak()) << ")\n";
+     << " (used: " << velox::succinctBytes(stats.current())
+     << ", peak: " <<  velox::succinctBytes(stats.peak()) << ")\n";
   if (stats.children_size() > 0) {
     for (auto it = stats.children().begin(); it != stats.children().end(); ++it) {
       logMemoryUsageStats(it->second, it->first, logPrefix + "   ", ss);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address https://github.com/apache/incubator-gluten/pull/10000#discussion_r2156567040

## How was this patch tested?

after this:
```
I20250624 19:40:35.823493 1133374 VeloxMemoryManager.cc:266] Shrink[root/root]: Trying to shrink 43201331 bytes of data...
I20250624 19:40:35.823499 1133374 VeloxMemoryManager.cc:267] Shrink[root/root]: Pool has reserved 1635399552/1663041536/1663041536/9223372036854775807 bytes.
I20250624 19:40:35.823580 1133374 VeloxMemoryManager.cc:273] Shrink[root/root]: Velox memory usage stats:
Shrink[root/root]: +- root/root (used: 1.52GB, peak: 1.59GB)
Shrink[root/root]:    +- task.Gluten_Stage_5_TID_9419_VTID_83 (used: 1.52GB, peak: 1.59GB)
Shrink[root/root]:       +- node.2 (used: 0B, peak: 0B)
Shrink[root/root]:          +- op.2.1.0.ValueStream (used: 0B, peak: 0B)
Shrink[root/root]:       +- node.6 (used: 24.00KB, peak: 1.00MB)
Shrink[root/root]:          +- op.6.0.0.FilterProject (used: 24.00KB, peak: 24.00KB)
Shrink[root/root]:       +- node.1 (used: 32.19MB, peak: 128.00MB)
Shrink[root/root]:          +- op.1.0.0.Aggregation (used: 32.19MB, peak: 98.69MB)
Shrink[root/root]:       +- node.3 (used: 1.49GB, peak: 1.56GB)
Shrink[root/root]:          +- op.3.0.0.HashProbe (used: 681.50KB, peak: 1.49MB)
Shrink[root/root]:          +- op.3.1.0.HashBuild (used: 1.49GB, peak: 1.55GB)
Shrink[root/root]:       +- node.7 (used: 0B, peak: 40.00MB)
Shrink[root/root]:          +- op.7.0.0.OrderBy (used: 0B, peak: 32.50MB)
Shrink[root/root]:       +- node.5 (used: 8.38KB, peak: 1.00MB)
Shrink[root/root]:          +- op.5.0.0.FilterProject (used: 8.38KB, peak: 40.75KB)
Shrink[root/root]:       +- node.8 (used: 0B, peak: 0B)
Shrink[root/root]:          +- op.8.0.0.FilterProject (used: 0B, peak: 0B)
Shrink[root/root]:       +- node.4 (used: 0B, peak: 0B)
Shrink[root/root]:          +- op.4.0.0.FilterProject (used: 0B, peak: 0B)
Shrink[root/root]:       +- node.0 (used: 0B, peak: 0B)
Shrink[root/root]:          +- op.0.0.0.ValueStream (used: 0B, peak: 0B)
Shrink[root/root]:    +- default_leaf (used: 0B, peak: 0B)
I20250624 19:40:35.823588 1133374 VeloxMemoryManager.cc:275] Shrink[root/root]: Shrinking...
I20250624 19:40:35.823594 1133374 VeloxMemoryManager.cc:280] Shrink[root/root]: 0 bytes released from shrinking.
```

