### PR TITLE
[VL] Fix precision loss with multiple decimal casts

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -128,9 +128,8 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       attributeSeq: Seq[Attribute],
       expressionsMap: Map[Class[_], String]): DecimalArithmeticExpressionTransformer = {
     val rescaleBinary = DecimalArithmeticUtil.rescaleLiteral(b)
-    val (left, right) = DecimalArithmeticUtil.rescaleCastForDecimal(
-      DecimalArithmeticUtil.removeCastForDecimal(rescaleBinary.left),
-      DecimalArithmeticUtil.removeCastForDecimal(rescaleBinary.right))
+    val (left, right) =
+      DecimalArithmeticUtil.rescaleCastForDecimal(rescaleBinary.left, rescaleBinary.right)
     val resultType = DecimalArithmeticUtil.getResultType(
       b,
       left.dataType.asInstanceOf[DecimalType],

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/DecimalArithmeticUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/DecimalArithmeticUtil.scala
@@ -166,7 +166,6 @@ object DecimalArithmeticUtil {
     }
 
     if (!isPromoteCast(left) && isPromoteCastIntegral(right)) {
-      // Have removed PromotePrecision(Cast(DecimalType)).
       // Decimal * cast int.
       doScale(left, right)
     } else if (!isPromoteCast(right) && isPromoteCastIntegral(left)) {
@@ -176,21 +175,6 @@ object DecimalArithmeticUtil {
     } else {
       (left, right)
     }
-  }
-
-  /**
-   * Remove the Cast when child is PromotePrecision and PromotePrecision is Cast(Decimal, Decimal)
-   *
-   * @param arithmeticExpr
-   *   BinaryArithmetic left or right
-   * @return
-   *   expression removed child PromotePrecision->Cast
-   */
-  def removeCastForDecimal(arithmeticExpr: Expression): Expression = arithmeticExpr match {
-    case PromotePrecision(_ @Cast(child, _: DecimalType, _, _))
-        if child.dataType.isInstanceOf[DecimalType] =>
-      child
-    case _ => arithmeticExpr
   }
 
   private def isPromoteCastIntegral(expr: Expression): Boolean = expr match {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the are multiple consecutive casts, the precision is not right in Spark3.2/Spark3.3

(Fixes: \#ISSUE-ID)

## How was this patch tested?

UT & Manually
