### PR TITLE
[DOC] Fix VeloxStageResourceAdj config table style

### DIFF
--- a/docs/get-started/VeloxStageResourceAdj.md
+++ b/docs/get-started/VeloxStageResourceAdj.md
@@ -32,6 +32,7 @@ Add the following configurations to your Spark application:
 | spark.gluten.auto.adjustStageResource.enabled                     | Experimental: If enabled, gluten will try to set the stage resource according to stage execution plan. NOTE: Only works when aqe is enabled at the same time. | false   |
 | spark.gluten.auto.adjustStageResources.heap.ratio                 | Experimental: Increase executor heap memory when match adjust stage resource rule.                                                                            | 2.0d    |
 | spark.gluten.auto.adjustStageResources.fallenNode.ratio.threshold | Experimental: Increase executor heap memory when stage contains fallen node count exceeds the total node count ratio.                                         | 0.5d    |
+
 #### **1. Enable Auto-Adjustment**
 ```properties  
 spark.gluten.auto.AdjustStageResource.enabled=true  


### PR DESCRIPTION
## What changes were proposed in this pull request?

The configuration section of https://apache.github.io/incubator-gluten/get-started/VeloxStageResourceAdj.html  is not rendered properly, I guess it's because the lack of empty line after markdown table code.
Try to fix this.
<img width="981" alt="image" src="https://github.com/user-attachments/assets/33ec7df2-3d24-4fa3-937d-c139cc831158" />

