### PR TITLE
[GLUTEN-10112][VL] Fix deadLock caused by objectStore when native writer throws oom exception

### DIFF
--- a/cpp/core/utils/ObjectStore.cc
+++ b/cpp/core/utils/ObjectStore.cc
@@ -53,10 +53,13 @@ gluten::ObjectStore::~ObjectStore() {
                  " destroy it automatically but it's recommended to manually close"
                  " the object through the Java closing API after use,"
                  " to minimize peak memory pressure of the application.";
+      // transfer ownership of the object to the temporary vector
+      objects.push_back(store_.lookup(handle));
       store_.erase(handle);
     }
     stores().erase(storeId_);
   }
+  // destructing objects outside the lock to avoid deadlock
   for (auto& obj : objects) {
     if (obj) {
       obj.reset();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix dead lock founded in #10112

(Fixes: \#10112)

### Problem description 
The task thread on the Executor is blocked by a single runnable task thread. The runnable task thread continues to run in nativeSpill without exiting.
![Image](https://github.com/user-attachments/assets/9e435af7-de84-4ea1-89af-71efa5e17304)

### Cause Analysis

1. Observing the runnable task thread stack, it was found that the task is already in the resource release phase, and theoretically should not trigger spill operations again.

2. Checking the log of the runnable task and observing the task's operation logs, it was found that during the native write phase, insufficient OOM (Out Of Memory) triggered the task's failure cleanup action.

3. Why does the nativeSpill operation get triggered again during the resource release phase? 

 Additional logs were added to record the native stack of the last reserveMemory operation

![image](https://github.com/user-attachments/assets/a5d580fa-680d-4680-98e4-0e820faab829)

4. Why does triggering the nativeSpill method again during the RuntimeJniWrapper resource release phase lead to a stuck (deadlock) issue?

The core reason is that all operations on the ObjectStore data structure are protected by a mutual exclusion lock.

First, looking at the destructor method, a lock is acquired at the start of the method. When destructing VeloxParquetDatasource, the acquireMemory operation is triggered, which further triggers the spill operation.

![image](https://github.com/user-attachments/assets/c8c9ed87-9c3e-4e0b-bec4-e85bb0101402)


nativeSpill method:

![image](https://github.com/user-attachments/assets/3584f546-15ed-44c9-8b38-b44cf0e16f30)


The NativeSpill method then performs a retrieve iterator operation in the objectStore. The retrieve operation waits for the lock acquired by the `~ObjectStore` destructor, leading to a deadlock and the task not exiting.

![image](https://github.com/user-attachments/assets/3b5d8099-7a4a-408f-8dce-ba2f16b21844)



### how this modification would work?
Understanding the root cause, the fix approach is relatively straightforward, with several options:

Avoid acquiring additional memory during the destruction of VeloxParquetDatasource.
Change the locks for ObjectStore operations to reentrant locks.
Do not acquire locks when releasing objects held by ObjectStore.

After comprehensive evaluation, method 3 was chosen for the fix to minimize the impact of modifications on overall stability.



## How was this patch tested?
Tested in our production environment


