### PR TITLE
[CORE] Add more logs for Spiller

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/NativePlanEvaluator.java
@@ -25,12 +25,15 @@ import org.apache.gluten.utils.DebugUtil;
 import org.apache.gluten.validate.NativePlanValidationInfo;
 
 import org.apache.spark.TaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class NativePlanEvaluator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NativePlanEvaluator.class);
   private static final AtomicInteger id = new AtomicInteger(0);
 
   private final Runtime runtime;
@@ -86,7 +89,13 @@ public class NativePlanEvaluator {
                 if (!Spillers.PHASE_SET_SPILL_ONLY.contains(phase)) {
                   return 0L;
                 }
-                return out.spill(size);
+                long spilled = out.spill(size);
+                LOGGER.info(
+                    "NativePlanEvaluator-{}: Spilled {} / {} bytes of data.",
+                    id.get(),
+                    spilled,
+                    size);
+                return spilled;
               }
             });
     return out;

--- a/gluten-arrow/src/main/scala/org/apache/gluten/memory/NativeMemoryManager.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/memory/NativeMemoryManager.scala
@@ -61,7 +61,9 @@ object NativeMemoryManager {
           // Only respond for shrinking.
           return 0L
         }
-        NativeMemoryManagerJniWrapper.shrink(handle, size)
+        val shrunk = NativeMemoryManagerJniWrapper.shrink(handle, size)
+        LOGGER.info(s"NativeMemoryManager: Shrunk $shrunk / $size bytes of data.")
+        shrunk
       }
     })
     mutableStats += "single" -> new MemoryUsageStatsBuilder {

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
@@ -90,7 +90,7 @@ public final class MemoryTargets {
           LOGGER.info("Request for spilling on consumer {}...", consumer.name());
           // Note: Spill from root node so other consumers also get spilled.
           long spilled = TreeMemoryTargets.spillTree(root, Long.MAX_VALUE);
-          LOGGER.info("Consumer {} spilled {} bytes.", consumer.name(), spilled);
+          LOGGER.info("Consumer {} gets {} bytes from spilling.", consumer.name(), spilled);
         });
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we only include spilling trigger logs in `ColumnarShuffleWriter`. We need to add logs in more Spillers so that when a spill is triggered, it is clear which Spiller executed the spill and how much memory was spilled. This will help with troubleshooting spill-related issues.

## How was this patch tested?

N/A

