### PR TITLE
[CORE] Enable wartremover check for Scala 2.13

### DIFF
--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -595,6 +595,7 @@ class DeltaLog private(
     // --- modified end
 
     val r = buildHadoopFsRelationWithFileIndex(snapshotToUse, fileIndex, bucketSpec = bucketSpec)
+    @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
     new HadoopFsRelation(
       r.location,
       r.partitionSchema,

--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -596,7 +596,7 @@ class DeltaLog private(
 
     val r = buildHadoopFsRelationWithFileIndex(snapshotToUse, fileIndex, bucketSpec = bucketSpec)
     @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
-    new HadoopFsRelation(
+    val relation = new HadoopFsRelation(
       r.location,
       r.partitionSchema,
       r.dataSchema,
@@ -616,6 +616,7 @@ class DeltaLog private(
           catalogTableOpt = catalogTableOpt).run(spark)
       }
     }
+    relation
   }
 
   def buildHadoopFsRelationWithFileIndex(snapshot: SnapshotDescriptor, fileIndex: TahoeFileIndex,

--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -95,6 +95,7 @@ class DeltaLog private(
   with ProvidesUniFormConverters
   with ReadChecksum {
 
+  import DeltaLog._
   import org.apache.spark.sql.delta.files.TahoeFileIndex
 
   /**
@@ -595,28 +596,14 @@ class DeltaLog private(
     // --- modified end
 
     val r = buildHadoopFsRelationWithFileIndex(snapshotToUse, fileIndex, bucketSpec = bucketSpec)
-    @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
-    val relation = new HadoopFsRelation(
+    new DeltaHadoopFsRelation(
       r.location,
       r.partitionSchema,
       r.dataSchema,
       r.bucketSpec,
       r.fileFormat,
       r.options
-    )(spark) with InsertableRelation {
-      def insert(data: DataFrame, overwrite: Boolean): Unit = {
-        val mode = if (overwrite) SaveMode.Overwrite else SaveMode.Append
-        WriteIntoDelta(
-          deltaLog = DeltaLog.this,
-          mode = mode,
-          new DeltaOptions(Map.empty[String, String], spark.sessionState.conf),
-          partitionColumns = Seq.empty,
-          configuration = Map.empty,
-          data = data,
-          catalogTableOpt = catalogTableOpt).run(spark)
-      }
-    }
-    relation
+    )(spark, catalogTableOpt, this)
   }
 
   def buildHadoopFsRelationWithFileIndex(snapshot: SnapshotDescriptor, fileIndex: TahoeFileIndex,
@@ -705,7 +692,39 @@ class DeltaLog private(
 }
 
 object DeltaLog extends DeltaLogging {
-
+  @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+  private class DeltaHadoopFsRelation(
+      location: FileIndex,
+      partitionSchema: StructType,
+      // The top-level columns in `dataSchema` should match the actual physical file schema, otherwise
+      // the ORC data source may not work with the by-ordinal mode.
+      dataSchema: StructType,
+      bucketSpec: Option[BucketSpec],
+      fileFormat: FileFormat,
+      options: Map[String, String])(
+      sparkSession: SparkSession,
+      catalogTableOpt:Option[CatalogTable],
+      deltaLog: DeltaLog)
+    extends HadoopFsRelation(
+      location,
+      partitionSchema,
+      dataSchema,
+      bucketSpec,
+      fileFormat,
+      options
+  )(sparkSession) with InsertableRelation {
+    def insert(data: DataFrame, overwrite: Boolean): Unit = {
+      val mode = if (overwrite) SaveMode.Overwrite else SaveMode.Append
+      WriteIntoDelta(
+        deltaLog = deltaLog,
+        mode = mode,
+        new DeltaOptions(Map.empty[String, String], sparkSession.sessionState.conf),
+        partitionColumns = Seq.empty,
+        configuration = Map.empty,
+        data = data,
+        catalogTableOpt = catalogTableOpt).run(sparkSession)
+    }
+  }
   /**
    * The key type of `DeltaLog` cache. It's a pair of the canonicalized table path and the file
    * system options (options starting with "fs." or "dfs." prefix) passed into

--- a/pom.xml
+++ b/pom.xml
@@ -190,12 +190,11 @@
               <groupId>net.alchim31.maven</groupId>
               <artifactId>scala-maven-plugin</artifactId>
               <configuration>
-                <!-- TODO: Fix the plugin scalawarts to support scala 2.13 in IDEA
                 <compilerPlugins>
                   <compilerPlugin>
                     <groupId>org.wartremover</groupId>
                     <artifactId>wartremover_${scala.binary.version}</artifactId>
-                    <version>3.1.6</version>
+                    <version>3.0.6</version>
                   </compilerPlugin>
                 </compilerPlugins>
                 <dependencies>
@@ -204,7 +203,7 @@
                     <artifactId>scalawarts_${scala.binary.version}</artifactId>
                     <version>0.1.2</version>
                   </dependency>
-                </dependencies> -->
+                </dependencies>
                 <recompileMode>${scala.recompile.mode}</recompileMode>
                 <args>
                   <arg>-unchecked</arg>
@@ -246,9 +245,7 @@
                   <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
                   <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
                   <arg>-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s</arg>
-                  <!--
                   <arg>-P:wartremover:traverser:io.github.zhztheplayer.scalawarts.InheritFromCaseClass</arg>
-                  -->
                 </args>
               </configuration>
               <executions>
@@ -1502,7 +1499,7 @@
               <compilerPlugin>
                 <groupId>org.wartremover</groupId>
                 <artifactId>wartremover_${scala.binary.version}</artifactId>
-                <version>3.1.6</version>
+                <version>3.0.6</version>
               </compilerPlugin>
             </compilerPlugins>
             <dependencies>


### PR DESCRIPTION
Downgrade the wartremover version to `3.0.6` which is the latest version that was built on Scala 2.13.8 to ensure the compatibility between wartremover and Gluten / Spark.

Previously we may face an error in Intellij IDEA so wartremover was disabled for 2.13. The error has gone with the downgraded wartremover version.