### PR TITLE
[CORE] Refactor: Make `GlutenFormatWriterInjects#executeWriterWrappedSparkPlan` return the wrapped query plan rather than the executed RDD

### DIFF
--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v1/clickhouse/MergeTreeFileFormatWriter.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v1/clickhouse/MergeTreeFileFormatWriter.scala
@@ -204,13 +204,13 @@ object MergeTreeFileFormatWriter extends Logging {
       }
 
       val nativeFormat = sparkSession.sparkContext.getLocalProperty("nativeFormat")
-      (GlutenFormatFactory(nativeFormat).executeWriterWrappedSparkPlan(wrapped), None)
+      (GlutenFormatFactory(nativeFormat).getWriterWrappedSparkPlan(wrapped), None)
     }
 
     try {
-      val (rdd, concurrentOutputWriterSpec) = if (orderingMatched) {
+      val (finalPlan, concurrentOutputWriterSpec) = if (orderingMatched) {
         if (!nativeEnabled || (staticPartitionWriteOnly && nativeEnabled)) {
-          (empty2NullPlan.execute(), None)
+          (empty2NullPlan, None)
         } else {
           nativeWrap(empty2NullPlan)
         }
@@ -234,21 +234,23 @@ object MergeTreeFileFormatWriter extends Logging {
 
         if (concurrentWritersEnabled) {
           (
-            empty2NullPlan.execute(),
+            empty2NullPlan,
             Some(ConcurrentOutputWriterSpec(maxWriters, () => sortPlan.createSorter())))
         } else {
           if (staticPartitionWriteOnly && nativeEnabled) {
             // remove the sort operator for static partition write.
-            (empty2NullPlan.execute(), None)
+            (empty2NullPlan, None)
           } else {
             if (!nativeEnabled) {
-              (sortPlan.execute(), None)
+              (sortPlan, None)
             } else {
               nativeWrap(sortPlan)
             }
           }
         }
       }
+
+      val rdd = finalPlan.execute()
 
       // SPARK-23271 If we are attempting to write a zero partition rdd, create a dummy single
       // partition rdd to make sure we at least set up one write task to write the metadata.

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -115,7 +115,7 @@ class VeloxRowSplitter extends GlutenRowSplitter {
       reservePartitionColumns: Boolean = false): BlockStripes = {
     val handler = ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName, batch)
     val runtime =
-      Runtimes.contextInstance(BackendsApiManager.getBackendName, "VeloxPartitionWriter")
+      Runtimes.contextInstance(BackendsApiManager.getBackendName, "VeloxRowSplitter")
     val datasourceJniWrapper = VeloxDataSourceJniWrapper.create(runtime)
     val originalColumns: Array[Int] = Array.range(0, batch.numCols())
     val dataColIndice = originalColumns.filterNot(partitionColIndice.contains(_))

--- a/shims/common/src/main/scala/org/apache/gluten/execution/datasource/GlutenFormatWriterInjects.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/execution/datasource/GlutenFormatWriterInjects.scala
@@ -16,9 +16,7 @@
  */
 package org.apache.gluten.execution.datasource
 
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.{BlockStripes, OutputWriter}
@@ -40,7 +38,7 @@ trait GlutenFormatWriterInjects {
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType]
 
-  def executeWriterWrappedSparkPlan(plan: SparkPlan): RDD[InternalRow]
+  def getWriterWrappedSparkPlan(plan: SparkPlan): SparkPlan
 
   def nativeConf(
       options: Map[String, String],

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -258,13 +258,13 @@ object FileFormatWriter extends Logging {
       }
 
       val nativeFormat = sparkSession.sparkContext.getLocalProperty("nativeFormat")
-      (GlutenFormatFactory(nativeFormat).executeWriterWrappedSparkPlan(wrapped), None)
+      (GlutenFormatFactory(nativeFormat).getWriterWrappedSparkPlan(wrapped), None)
     }
 
     try {
-      val (rdd, concurrentOutputWriterSpec) = if (orderingMatched) {
+      val (finalPlan, concurrentOutputWriterSpec) = if (orderingMatched) {
         if (!nativeEnabled || (staticPartitionWriteOnly && nativeEnabled)) {
-          (empty2NullPlan.execute(), None)
+          (empty2NullPlan, None)
         } else {
           nativeWrap(empty2NullPlan)
         }
@@ -288,21 +288,23 @@ object FileFormatWriter extends Logging {
 
         if (concurrentWritersEnabled) {
           (
-            empty2NullPlan.execute(),
+            empty2NullPlan,
             Some(ConcurrentOutputWriterSpec(maxWriters, () => sortPlan.createSorter())))
         } else {
           if (staticPartitionWriteOnly && nativeEnabled) {
             // remove the sort operator for static partition write.
-            (empty2NullPlan.execute(), None)
+            (empty2NullPlan, None)
           } else {
             if (!nativeEnabled) {
-              (sortPlan.execute(), None)
+              (sortPlan, None)
             } else {
               nativeWrap(sortPlan)
             }
           }
         }
       }
+
+      val rdd = finalPlan.execute()
 
       // SPARK-23271 If we are attempting to write a zero partition rdd, create a dummy single
       // partition rdd to make sure we at least set up one write task to write the metadata.


### PR DESCRIPTION
API

```scala
def executeWriterWrappedSparkPlan(plan: SparkPlan): RDD[InternalRow]
```

is being changed to

```scala
def getWriterWrappedSparkPlan(plan: SparkPlan): SparkPlan
```

We don't have to execute the SparkPlan before it's returned to the file format writer. This change will make it easier to debug or operate on the wrapped query plan. The previous use of RDD more or less limited the flexibility of coding and troubleshooting.


Related to #2205, #2553