### PR TITLE
[GLUTEN-10163][VL] Optimize S3 network parameters

### DIFF
--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -74,7 +74,8 @@ std::shared_ptr<facebook::velox::config::ConfigBase> getHiveConfig(
       {S3Config::Keys::kMaxAttempts, std::make_pair("retry.limit", std::nullopt)},
       {S3Config::Keys::kRetryMode, std::make_pair("retry.mode", "legacy")},
       {S3Config::Keys::kMaxConnections, std::make_pair("connection.maximum", "15")},
-      {S3Config::Keys::kConnectTimeout, std::make_pair("connection.timeout", "200s")},
+      {S3Config::Keys::kSocketTimeout, std::make_pair("connection.timeout", "200s")},
+      {S3Config::Keys::kConnectTimeout, std::make_pair("connection.establish.timeout", "30s")},
       {S3Config::Keys::kUseInstanceCredentials, std::make_pair("instance.credentials", "false")},
       {S3Config::Keys::kIamRole, std::make_pair("iam.role", std::nullopt)},
       {S3Config::Keys::kIamRoleSessionName, std::make_pair("iam.role.session.name", "gluten-session")},
@@ -130,6 +131,7 @@ std::shared_ptr<facebook::velox::config::ConfigBase> getHiveConfig(
   setConfigIfPresent(S3Config::Keys::kSSLEnabled);
   setConfigIfPresent(S3Config::Keys::kPathStyleAccess);
   setConfigIfPresent(S3Config::Keys::kMaxConnections);
+  setConfigIfPresent(S3Config::Keys::kSocketTimeout);
   setConfigIfPresent(S3Config::Keys::kConnectTimeout);
   setConfigIfPresent(S3Config::Keys::kEndpointRegion);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?


The `fs.s3a.connection.timeout` is the timeout for socket problems on a TCP channel, rather than establish the TCP/TLS connection, and the  `fs.s3a.connection.establish.timeout` is the timeout to establish the TCP/TLS connection，so we should change them.

we can see the 
 https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/performance.html

https://github.com/aws/aws-sdk-cpp/blob/36382c786f9e5497a9233781002ddc58d0243f99/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h#L191-L203

            /**
             * Socket read timeouts for HTTP clients on Windows. Default 3000 ms. This should be more than adequate for most services. However, if you are transferring large amounts of data
             * or are worried about higher latencies, you should set to something that makes more sense for your use case.
             * For Curl, it's the low speed time, which contains the time in number milliseconds that transfer speed should be below "lowSpeedLimit" for the library to consider it too slow and abort.
             * Note that for Curl this config is converted to seconds by rounding down to the nearest whole second except when the value is greater than 0 and less than 1000. In this case it is set to one second. When it's 0, low speed limit check will be disabled.
             * Note that for Windows when this config is 0, the behavior is not specified by Windows.
             */
            long requestTimeoutMs = 0;
            /**
             * Socket connect timeout. Default 1000 ms. Unless you are very far away from your the data center you are talking to, 1000ms is more than sufficient.
             */
            long connectTimeoutMs = 1000;
            /**

The velox side :
https://github.com/facebookincubator/velox/blob/main/velox/connectors/hive/storage_adapters/s3fs/S3Config.h#L196-L205



(Fixes: \#10163)

## How was this patch tested?

No need.

