### PR TITLE
[VL] Fix incorrect NestedLoopJoin metrics

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxMetricsApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxMetricsApi.scala
@@ -569,15 +569,63 @@ class VeloxMetricsApi extends MetricsApi with Logging {
   override def genNestedLoopJoinTransformerMetrics(
       sparkContext: SparkContext): Map[String, SQLMetric] =
     Map(
-      "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-      "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
-      "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-      "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "time of NestedLoopJoin"),
-      "cpuCount" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-      "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
-      "numMemoryAllocations" -> SQLMetrics.createMetric(
+      "nestedLoopJoinBuildInputRows" -> SQLMetrics.createMetric(
         sparkContext,
-        "number of memory allocations")
+        "number of nested loop join build input rows"),
+      "nestedLoopJoinBuildOutputRows" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join build output rows"),
+      "nestedLoopJoinBuildOutputVectors" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join build output vectors"),
+      "nestedLoopJoinBuildOutputBytes" -> SQLMetrics.createSizeMetric(
+        sparkContext,
+        "number of nested loop join build output bytes"),
+      "nestedLoopJoinBuildCpuCount" -> SQLMetrics.createMetric(
+        sparkContext,
+        "nested loop join build cpu wall time count"),
+      "nestedLoopJoinBuildWallNanos" -> SQLMetrics.createNanoTimingMetric(
+        sparkContext,
+        "time of nested loop join build"),
+      "nestedLoopJoinBuildPeakMemoryBytes" -> SQLMetrics.createSizeMetric(
+        sparkContext,
+        "nested loop join build peak memory bytes"),
+      "nestedLoopJoinBuildNumMemoryAllocations" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join build memory allocations"),
+      "nestedLoopJoinProbeInputRows" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join probe input rows"),
+      "nestedLoopJoinProbeOutputRows" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join probe output rows"),
+      "nestedLoopJoinProbeOutputVectors" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join probe output vectors"),
+      "nestedLoopJoinProbeOutputBytes" -> SQLMetrics.createSizeMetric(
+        sparkContext,
+        "number of nested loop join probe output bytes"),
+      "nestedLoopJoinProbeCpuCount" -> SQLMetrics.createMetric(
+        sparkContext,
+        "nested loop join probe cpu wall time count"),
+      "nestedLoopJoinProbeWallNanos" -> SQLMetrics.createNanoTimingMetric(
+        sparkContext,
+        "time of nested loop join probe"),
+      "nestedLoopJoinProbePeakMemoryBytes" -> SQLMetrics.createSizeMetric(
+        sparkContext,
+        "nested loop join probe peak memory bytes"),
+      "nestedLoopJoinProbeNumMemoryAllocations" -> SQLMetrics.createMetric(
+        sparkContext,
+        "number of nested loop join probe memory allocations"),
+      "postProjectionCpuCount" -> SQLMetrics.createMetric(
+        sparkContext,
+        "postProject cpu wall time count"),
+      "postProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
+        sparkContext,
+        "time of postProjection"),
+      "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+      "numOutputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
+      "numOutputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes")
     )
 
   override def genNestedLoopJoinTransformerMetricsUpdater(

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/MetricsUtil.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/MetricsUtil.scala
@@ -238,6 +238,16 @@ object MetricsUtil extends Logging {
           operatorMetrics,
           metrics.getSingleMetrics,
           joinParamsMap.get(operatorIdx))
+      case nestedLoopJoinUpdater: NestedLoopJoinMetricsUpdater =>
+        // NestedLoopJoin outputs two suites of metrics respectively for nested loop join build and
+        // nested loop join probe.
+        // Therefore, fetch one more suite of metrics here.
+        operatorMetrics.add(metrics.getOperatorMetrics(curMetricsIdx))
+        curMetricsIdx -= 1
+        nestedLoopJoinUpdater.updateJoinMetrics(
+          operatorMetrics,
+          metrics.getSingleMetrics,
+          joinParamsMap.get(operatorIdx))
       case smj: SortMergeJoinMetricsUpdater =>
         smj.updateJoinMetrics(
           operatorMetrics,

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/NestedLoopJoinMetricsUpdater.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/NestedLoopJoinMetricsUpdater.scala
@@ -16,20 +16,58 @@
  */
 package org.apache.gluten.metrics
 
+import org.apache.gluten.substrait.JoinParams
+
 import org.apache.spark.sql.execution.metric.SQLMetric
 
-class NestedLoopJoinMetricsUpdater(val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+import java.util
 
-  override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
-    if (opMetrics != null) {
-      val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
-      metrics("numOutputRows") += operatorMetrics.outputRows
-      metrics("outputVectors") += operatorMetrics.outputVectors
-      metrics("outputBytes") += operatorMetrics.outputBytes
-      metrics("cpuCount") += operatorMetrics.cpuCount
-      metrics("wallNanos") += operatorMetrics.wallNanos
-      metrics("peakMemoryBytes") += operatorMetrics.peakMemoryBytes
-      metrics("numMemoryAllocations") += operatorMetrics.numMemoryAllocations
-    }
+class NestedLoopJoinMetricsUpdater(override val metrics: Map[String, SQLMetric])
+  extends JoinMetricsUpdaterBase(metrics) {
+
+  val nestedLoopJoinBuildInputRows: SQLMetric = metrics("nestedLoopJoinBuildInputRows")
+  val nestedLoopJoinBuildOutputRows: SQLMetric = metrics("nestedLoopJoinBuildOutputRows")
+  val nestedLoopJoinBuildOutputVectors: SQLMetric = metrics("nestedLoopJoinBuildOutputVectors")
+  val nestedLoopJoinBuildOutputBytes: SQLMetric = metrics("nestedLoopJoinBuildOutputBytes")
+  val nestedLoopJoinBuildCpuCount: SQLMetric = metrics("nestedLoopJoinBuildCpuCount")
+  val nestedLoopJoinBuildWallNanos: SQLMetric = metrics("nestedLoopJoinBuildWallNanos")
+  val nestedLoopJoinBuildPeakMemoryBytes: SQLMetric = metrics("nestedLoopJoinBuildPeakMemoryBytes")
+  val nestedLoopJoinBuildNumMemoryAllocations: SQLMetric = metrics(
+    "nestedLoopJoinBuildNumMemoryAllocations")
+
+  val nestedLoopJoinProbeInputRows: SQLMetric = metrics("nestedLoopJoinProbeInputRows")
+  val nestedLoopJoinProbeOutputRows: SQLMetric = metrics("nestedLoopJoinProbeOutputRows")
+  val nestedLoopJoinProbeOutputVectors: SQLMetric = metrics("nestedLoopJoinProbeOutputVectors")
+  val nestedLoopJoinProbeOutputBytes: SQLMetric = metrics("nestedLoopJoinProbeOutputBytes")
+  val nestedLoopJoinProbeCpuCount: SQLMetric = metrics("nestedLoopJoinProbeCpuCount")
+  val nestedLoopJoinProbeWallNanos: SQLMetric = metrics("nestedLoopJoinProbeWallNanos")
+  val nestedLoopJoinProbePeakMemoryBytes: SQLMetric = metrics("nestedLoopJoinProbePeakMemoryBytes")
+  val nestedLoopJoinProbeNumMemoryAllocations: SQLMetric = metrics(
+    "nestedLoopJoinProbeNumMemoryAllocations")
+
+  override protected def updateJoinMetricsInternal(
+      joinMetrics: util.ArrayList[OperatorMetrics],
+      joinParams: JoinParams): Unit = {
+    // nestedLoopJoinProbe
+    val nestedLoopJoinProbeMetrics = joinMetrics.get(0)
+    nestedLoopJoinProbeInputRows += nestedLoopJoinProbeMetrics.inputRows
+    nestedLoopJoinProbeOutputRows += nestedLoopJoinProbeMetrics.outputRows
+    nestedLoopJoinProbeOutputVectors += nestedLoopJoinProbeMetrics.outputVectors
+    nestedLoopJoinProbeOutputBytes += nestedLoopJoinProbeMetrics.outputBytes
+    nestedLoopJoinProbeCpuCount += nestedLoopJoinProbeMetrics.cpuCount
+    nestedLoopJoinProbeWallNanos += nestedLoopJoinProbeMetrics.wallNanos
+    nestedLoopJoinProbePeakMemoryBytes += nestedLoopJoinProbeMetrics.peakMemoryBytes
+    nestedLoopJoinProbeNumMemoryAllocations += nestedLoopJoinProbeMetrics.numMemoryAllocations
+
+    // nestedLoopJoinBuild
+    val nestedLoopJoinBuildMetrics = joinMetrics.get(1)
+    nestedLoopJoinBuildInputRows += nestedLoopJoinBuildMetrics.inputRows
+    nestedLoopJoinBuildOutputRows += nestedLoopJoinBuildMetrics.outputRows
+    nestedLoopJoinBuildOutputVectors += nestedLoopJoinBuildMetrics.outputVectors
+    nestedLoopJoinBuildOutputBytes += nestedLoopJoinBuildMetrics.outputBytes
+    nestedLoopJoinBuildCpuCount += nestedLoopJoinBuildMetrics.cpuCount
+    nestedLoopJoinBuildWallNanos += nestedLoopJoinBuildMetrics.wallNanos
+    nestedLoopJoinBuildPeakMemoryBytes += nestedLoopJoinBuildMetrics.peakMemoryBytes
+    nestedLoopJoinBuildNumMemoryAllocations += nestedLoopJoinBuildMetrics.numMemoryAllocations
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses incorrect NestedLoopJoin metrics described in \#10149 and introduces metrics for nested loop join probe side, build side and post projection in NestedLoopJoin.

(Fixes: \#10149)

## How was this patch tested?

UT

NestedLoopJoin metrics before this change:
<img width="543" height="662" alt="Screenshot 2025-07-11 at 16 11 32" src="https://github.com/user-attachments/assets/38221016-d7bc-460d-b6e5-111c250dd526" />

NestedLoopJoin metrics after this change:
<img width="543" height="885" alt="Screenshot 2025-07-11 at 16 10 09" src="https://github.com/user-attachments/assets/939c91de-2be5-46b5-a005-a72b69d88500" />

