### PR TITLE
[VL] Clarify the code objective of VeloxDataSourceJniWrapper#splitBlockByPartitionAndBucket

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -117,10 +117,8 @@ class VeloxRowSplitter extends GlutenRowSplitter {
     val runtime =
       Runtimes.contextInstance(BackendsApiManager.getBackendName, "VeloxPartitionWriter")
     val datasourceJniWrapper = VeloxDataSourceJniWrapper.create(runtime)
-    val originalColumns: Array[Int] = Array.range(0, batch.numCols())
-    val dataColIndice = originalColumns.filterNot(partitionColIndice.contains(_))
     new VeloxBlockStripes(
       datasourceJniWrapper
-        .splitBlockByPartitionAndBucket(handler, dataColIndice, hasBucket))
+        .splitBlockByPartitionAndBucket(handler, partitionColIndice, hasBucket))
   }
 }


### PR DESCRIPTION
Related to #3076

Currently `VeloxDataSourceJniWrapper#splitBlockByPartitionAndBucket` doesn't do exactly what it's intended to do. It actually takes an array of data columns then directly select them out from the input columnar batch.

The patch fixes the code a bit by moving the partition keys -> data keys conversion down from Java code to native code so less confusing will be made by the code.

Note dynamic partition write is still not supported in v1 write. The patch just does code cleanup.