### PR TITLE
[GLUTEN-10192][VL] Fix sort shuffle read segfault in some cases

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -97,6 +97,8 @@ class VeloxSortShuffleReaderDeserializer final : public ColumnarBatchIterator {
 
   void readNextRow();
 
+  void reallocateRowBuffer();
+
   std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<arrow::util::Codec> codec_;
   facebook::velox::RowTypePtr rowType_;

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -43,6 +43,7 @@ struct ShuffleTestParams {
   int32_t diskWriteBufferSize{0};
   bool useRadixSort{false};
   bool enableDictionary{false};
+  int64_t deserializerBufferSize{0};
 
   std::string toString() const {
     std::ostringstream out;
@@ -52,7 +53,8 @@ struct ShuffleTestParams {
         << ", compressionThreshold = " << compressionThreshold << ", mergeBufferSize = " << mergeBufferSize
         << ", compressionBufferSize = " << diskWriteBufferSize
         << ", useRadixSort = " << (useRadixSort ? "true" : "false")
-        << ", enableDictionary = " << (enableDictionary ? "true" : "false");
+        << ", enableDictionary = " << (enableDictionary ? "true" : "false")
+        << ", deserializerBufferSize = " << deserializerBufferSize;
     return out.str();
   }
 };
@@ -106,12 +108,15 @@ std::vector<ShuffleTestParams> getTestParams() {
     for (const auto partitionWriterType : {PartitionWriterType::kLocal, PartitionWriterType::kRss}) {
       for (const auto diskWriteBufferSize : {4, 56, 32 * 1024}) {
         for (const bool useRadixSort : {true, false}) {
-          params.push_back(ShuffleTestParams{
-              .shuffleWriterType = ShuffleWriterType::kSortShuffle,
-              .partitionWriterType = partitionWriterType,
-              .compressionType = compression,
-              .diskWriteBufferSize = diskWriteBufferSize,
-              .useRadixSort = useRadixSort});
+          for (const int64_t deserializerBufferSize : {1L, kDefaultDeserializerBufferSize}) {
+            params.push_back(ShuffleTestParams{
+                .shuffleWriterType = ShuffleWriterType::kSortShuffle,
+                .partitionWriterType = partitionWriterType,
+                .compressionType = compression,
+                .diskWriteBufferSize = diskWriteBufferSize,
+                .useRadixSort = useRadixSort,
+                .deserializerBufferSize = deserializerBufferSize});
+          }
         }
       }
     }
@@ -297,7 +302,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
         rowType,
         kDefaultBatchSize,
         kDefaultReadBufferSize,
-        kDefaultDeserializerBufferSize,
+        GetParam().deserializerBufferSize,
         getDefaultMemoryManager()->defaultArrowMemoryPool(),
         pool_,
         GetParam().shuffleWriterType);

--- a/cpp/velox/tests/VeloxShuffleWriterTestBase.h
+++ b/cpp/velox/tests/VeloxShuffleWriterTestBase.h
@@ -92,8 +92,8 @@ class VeloxShuffleWriterTestBase : public facebook::velox::test::VectorTestBase 
              std::nullopt}),
         makeNullableFlatVector<float>(
             {-0.1234567,
-             std::nullopt,
              0.1234567,
+             std::nullopt,
              std::nullopt,
              -0.142857,
              std::nullopt,
@@ -104,9 +104,18 @@ class VeloxShuffleWriterTestBase : public facebook::velox::test::VectorTestBase 
         makeNullableFlatVector<bool>(
             {std::nullopt, true, false, std::nullopt, true, true, false, true, std::nullopt, std::nullopt}),
         makeFlatVector<facebook::velox::StringView>(
-            {"alice0", "bob1", "alice2", "bob3", "Alice4", "Bob5", "AlicE6", "boB7", "ALICE8", "BOB9"}),
+            {"a",
+             "bobbobbobooooooooooooooooooooooooooooob1",
+             "alice2",
+             "bob3",
+             "Alice4",
+             "Bob5",
+             "AlicE6",
+             "boB7",
+             "ALICE8",
+             "BOB9"}),
         makeNullableFlatVector<facebook::velox::StringView>(
-            {"alice_0",
+            {std::nullopt,
              "bob_1",
              std::nullopt,
              std::nullopt,


### PR DESCRIPTION
Segfault occurs when reading a row that exceed current rowBuffer size

https://github.com/apache/incubator-gluten/pull/10193/files#diff-c1147845fed4ad34faf580505712b04befdd3df0361297f93cb660069bedb7bdR646-R648