### PR TITLE
[CORE][VL] Minor cleanups for pom.xml

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -337,11 +337,11 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -349,11 +349,13 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <!-- Fasterxml -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1696,6 +1696,82 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
+          <!--We use build-helper-maven-plugin rather than maven-resources-plugin-->
+          <!--to add base resources (generated-resources and other common extended resource folders).-->
+          <!--So submodules could easily add their own resources through maven-resources-plugin-->
+          <!--which is more compatible with Intellij IDEA (E.g., `targetPath` can be respected by-->
+          <!--IDEA with maven-resources-plugin while it is not working with build-helper-maven-plugin).-->
+          <executions>
+            <execution>
+              <id>add-common-sources</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${project.basedir}/src-spark${spark.plain.version}/main/java</source>
+                  <source>${project.basedir}/src-spark${spark.plain.version}/main/scala</source>
+                </sources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-common-resources</id>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>add-resource</goal>
+              </goals>
+              <configuration>
+                <resources>
+                  <resource>
+                    <directory>${project.basedir}/src-spark${spark.plain.version}/main/resources</directory>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-common-test-sources</id>
+              <phase>generate-test-sources</phase>
+              <goals>
+                <goal>add-test-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${project.basedir}/src-spark${spark.plain.version}/test/scala</source>
+                  <source>${project.basedir}/src-spark${spark.plain.version}/test/java</source>
+                </sources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-common-test-resources</id>
+              <phase>generate-test-resources</phase>
+              <goals>
+                <goal>add-test-resource</goal>
+              </goals>
+              <configuration>
+                <resources>
+                  <resource>
+                    <directory>${project.basedir}/src-spark${spark.plain.version}/test/resources</directory>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-generated-resources</id>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>add-resource</goal>
+              </goals>
+              <configuration>
+                <resources>
+                  <resource>
+                    <!-- Include the properties file to provide the build information. -->
+                    <directory>${project.build.directory}/generated-resources</directory>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
@@ -1754,100 +1830,12 @@
         <version>2.15.0</version>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <!--We use build-helper-maven-plugin rather than maven-resources-plugin-->
-        <!--to add base resources (generated-resources and other common extended resource folders).-->
-        <!--So submodules could easily add their own resources through maven-resources-plugin-->
-        <!--which is more compatible with Intellij IDEA (E.g., `targetPath` can be respected by-->
-        <!--IDEA with maven-resources-plugin while it is not working with build-helper-maven-plugin).-->
-        <executions>
-          <execution>
-          </execution>
-          <execution>
-            <id>add-generated-resources</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>add-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <!-- Include the properties file to provide the build information. -->
-                  <directory>${project.build.directory}/generated-resources</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-common-sources</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.basedir}/src-spark${spark.plain.version}/main/java</source>
-                <source>${project.basedir}/src-spark${spark.plain.version}/main/scala</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-common-resources</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>add-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/src-spark${spark.plain.version}/main/resources</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-common-test-sources</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.basedir}/src-spark${spark.plain.version}/test/scala</source>
-                <source>${project.basedir}/src-spark${spark.plain.version}/test/java</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-common-test-resources</id>
-            <phase>generate-test-resources</phase>
-            <goals>
-              <goal>add-test-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/src-spark${spark.plain.version}/test/resources</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
1. Unify configuration of `build-helper-maven-plugin` in the root `pom.xml` together.
2. Correct `<type>test-jar</type>` / `<scope>test</scope>` usages in `backends-velox/pom.xml`.