### PR TITLE
[GLUTEN-9769][CELEBORN][1.4]  Use the correct shuffle time metrics for celeborn columnar shuffle (#9770)

### DIFF
--- a/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -34,7 +34,6 @@ import org.apache.spark.util.SparkResourceUtil
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 import org.apache.gluten.config.GlutenConfig
-import org.apache.gluten.config.ReservedKeys
 
 import java.io.IOException
 

--- a/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
+++ b/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriter.scala
@@ -27,6 +27,7 @@ import org.apache.spark.internal.config.{SHUFFLE_SORT_INIT_BUFFER_SIZE, SHUFFLE_
 import org.apache.spark.memory.SparkMemoryUtil
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SparkResourceUtil
 
@@ -51,8 +52,6 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
     celebornConf,
     client,
     writeMetrics) {
-  private val isSort = !ReservedKeys.GLUTEN_HASH_SHUFFLE_WRITER.equals(shuffleWriterType)
-
   private val runtime =
     Runtimes.contextInstance(BackendsApiManager.getBackendName, "CelebornShuffleWriter")
 
@@ -61,9 +60,15 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
   private var splitResult: GlutenSplitResult = _
 
   private def availableOffHeapPerTask(): Long = {
-    val perTask =
-      SparkMemoryUtil.getCurrentAvailableOffHeapMemory / SparkResourceUtil.getTaskSlots(conf)
-    perTask
+    SparkMemoryUtil.getCurrentAvailableOffHeapMemory / SparkResourceUtil.getTaskSlots(conf)
+  }
+
+  private val nativeMetrics: SQLMetric = {
+    if (dep.isSort) {
+      dep.metrics("sortTime")
+    } else {
+      dep.metrics("splitTime")
+    }
   }
 
   @throws[IOException]
@@ -99,11 +104,6 @@ class VeloxCelebornColumnarShuffleWriter[K, V](
     splitResult = jniWrapper.stop(nativeShuffleWriter)
 
     dep.metrics("shuffleWallTime").add(System.nanoTime() - startTime)
-    val nativeMetrics = if (isSort) {
-      dep.metrics("sortTime")
-    } else {
-      dep.metrics("splitTime")
-    }
     nativeMetrics
       .add(
         dep.metrics("shuffleWallTime").value - splitResult.getTotalPushTime -

--- a/backends-velox/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -38,12 +38,12 @@ class ColumnarShuffleWriter[K, V](
     shuffleBlockResolver: IndexShuffleBlockResolver,
     handle: BaseShuffleHandle[K, V, V],
     mapId: Long,
-    writeMetrics: ShuffleWriteMetricsReporter,
-    isSort: Boolean)
+    writeMetrics: ShuffleWriteMetricsReporter)
   extends ShuffleWriter[K, V]
   with Logging {
 
   private val dep = handle.dependency.asInstanceOf[ColumnarShuffleDependency[K, V, V]]
+  protected val isSort: Boolean = dep.isSort
 
   private val conf = SparkEnv.get.conf
 

--- a/backends-velox/src/main/scala/org/apache/spark/shuffle/utils/ShuffleUtil.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/shuffle/utils/ShuffleUtil.scala
@@ -27,7 +27,6 @@ object ShuffleUtil {
         parameters.shuffleBlockResolver,
         parameters.columnarShuffleHandle,
         parameters.mapId,
-        parameters.metrics,
-        parameters.isSort))
+        parameters.metrics))
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/spark/shuffle/GlutenShuffleWriterWrapper.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/shuffle/GlutenShuffleWriterWrapper.scala
@@ -26,8 +26,7 @@ case class GenShuffleWriterParameters[K, V](
     shuffleBlockResolver: IndexShuffleBlockResolver,
     columnarShuffleHandle: ColumnarShuffleHandle[K, V],
     mapId: Long,
-    metrics: ShuffleWriteMetricsReporter,
-    isSort: Boolean = false)
+    metrics: ShuffleWriteMetricsReporter)
 
 object GlutenShuffleWriterWrapper {
 
@@ -36,16 +35,9 @@ object GlutenShuffleWriterWrapper {
       columnarShuffleHandle: ColumnarShuffleHandle[K, V],
       mapId: Long,
       metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
-    val isSort =
-      columnarShuffleHandle.dependency.asInstanceOf[ColumnarShuffleDependency[K, V, V]].isSort
     BackendsApiManager.getSparkPlanExecApiInstance
       .genColumnarShuffleWriter(
-        GenShuffleWriterParameters(
-          shuffleBlockResolver,
-          columnarShuffleHandle,
-          mapId,
-          metrics,
-          isSort))
+        GenShuffleWriterParameters(shuffleBlockResolver, columnarShuffleHandle, mapId, metrics))
       .shuffleWriter
   }
 }


### PR DESCRIPTION
Backport #9770 to branch-1.4

## What changes were proposed in this pull request?

Bug fix for velox + celeborn + columnar shuffle.

gluten changes the shuffle writer type of celeborn in https://github.com/apache/incubator-gluten/blob/main/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala#L555-L557

As a result, we cannot determine whether the shuffle writer in VeloxCelebornColumnarShuffleWriter is sort or not,  can only  use the passed in shuffle time metric .

(Fixes: \#9769)

## How was this patch tested?

manual tests

