### PR TITLE
[CORE] Fix missing build information

### DIFF
--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -137,9 +137,6 @@
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
       </resource>
-      <resource>
-        <directory>${project.build.directory}/generated-resources</directory>
-      </resource>
     </resources>
     <plugins>
       <!-- compile proto buffer files using copied protoc binary -->

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -137,6 +137,9 @@
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
       </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-resources</directory>
+      </resource>
     </resources>
     <plugins>
       <!-- compile proto buffer files using copied protoc binary -->

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -218,7 +218,12 @@
                     <exclude>NOTICE.txt</exclude>
                   </excludes>
                 </filter>
-
+                <filter>
+                  <artifact>org.apache.gluten:gluten-core</artifact>
+                  <excludes>
+                    <exclude>gluten-build-info.properties</exclude>
+                  </excludes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -116,6 +116,14 @@
   </profiles>
 
   <build>
+    <resources>
+      <resource>
+        <directory>../gluten-core/target/generated-resources/</directory>
+        <includes>
+          <include>gluten-build-info.properties</include>
+        </includes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -208,6 +216,12 @@
                     <exclude>META-INF/NOTICE.txt</exclude>
                     <exclude>LICENSE.txt</exclude>
                     <exclude>NOTICE.txt</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.apache.gluten:gluten-core</artifact>
+                  <excludes>
+                    <exclude>gluten-build-info.properties</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -218,12 +218,7 @@
                     <exclude>NOTICE.txt</exclude>
                   </excludes>
                 </filter>
-                <filter>
-                  <artifact>org.apache.gluten:gluten-core</artifact>
-                  <excludes>
-                    <exclude>gluten-build-info.properties</exclude>
-                  </excludes>
-                </filter>
+
               </filters>
             </configuration>
           </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix issue reported here: https://github.com/apache/incubator-gluten/issues/10102#issuecomment-3095015236.
The build information related to backend is missing, such as GCC version,  backend branch/revision/revision time, etc. In the log and web UI, `"<unknown>"` is displayed for these items. 

The build information is added in two places during the compile phase: `gluten-core/pom.xml` and `gluten-substrait/pom.xml`. And they both modify `gluten-build-info.properties` placed in gluten-core's resource path: `gluten-core/target/generated-resources/`.

When building gluten-core module, the generated resources will be copied into target/classes/ and then be packed into module jar. In the later build for gluten-substrait module, the backend related build info is just added in the property file under gluten-core's resource path. And at the final package phase for the project, the shade plugin just packs classes and resource files inside module jars, not considering a module's resource path, which means the later added build info is not actually covered by the property file packed into Gluten fat jar.

In this pr, gluten-core's resource file is included in package module, and a configuration is added for shade plugin to exclude the property file comes from gluten-core jar.

## How was this patch tested?

Verified by local test.

