### PR TITLE
[GLUTEN-10279][VL] Reset reserved counter when allocationChanged fails

### DIFF
--- a/cpp/core/memory/AllocationListener.h
+++ b/cpp/core/memory/AllocationListener.h
@@ -59,7 +59,12 @@ class BlockAllocationListener final : public AllocationListener {
     if (granted == 0) {
       return;
     }
-    delegated_->allocationChanged(granted);
+    try {
+      delegated_->allocationChanged(granted);
+    } catch (const std::exception&) {
+      reserve(-diff);
+      throw;
+    }
   }
 
   int64_t currentBytes() override {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should reset `blocksReserved_` when `allocationChanged` fails to avoid inaccurate memory allocation.

Fixes: #10279

## How was this patch tested?

After this fix, the failed job of #10279 is successfully executed
