### PR TITLE
[VL] Support of offset + limit in TakeOrderedAndProjectExecTransformer

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -915,13 +915,23 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
   override def maybeCollapseTakeOrderedAndProject(plan: SparkPlan): SparkPlan = {
     // This to-top-n optimization assumes exchange operators were already placed in input plan.
     plan.transformUp {
-      case p @ LimitExecTransformer(SortExecTransformer(sortOrder, _, child, _), 0, count) =>
+      case p @ LimitExecTransformer(SortExecTransformer(sortOrder, _, child, _), offset, count) =>
+        val n = offset + count
         val global = child.outputPartitioning.satisfies(AllTuples)
-        val topN = TopNTransformer(count, sortOrder, global, child)
-        if (topN.doValidate().ok()) {
-          topN
-        } else {
+        val topN = TopNTransformer(n, sortOrder, global, child)
+        if (!topN.doValidate().ok()) {
           p
+        } else {
+          if (offset == 0) {
+            topN
+          } else {
+            val limit = LimitExecTransformer(topN, offset, count)
+            if (!limit.doValidate().ok()) {
+              p
+            } else {
+              limit
+            }
+          }
         }
       case other => other
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -2158,4 +2158,15 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
         }
       })
   }
+
+  test("Offload offset + limit") {
+    runQueryAndCompare(
+      "select l_shipdate from lineitem order by l_shipdate desc limit 10 offset 10") {
+      df =>
+        val numVanillaOffsetLimitOperators = df.queryExecution.executedPlan.collect {
+          case t: TakeOrderedAndProjectExec => t
+        }.size
+        assert(numVanillaOffsetLimitOperators == 0)
+    }
+  }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -2159,7 +2159,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
       })
   }
 
-  test("Offload offset + limit") {
+  testWithMinSparkVersion("Offload offset + limit", "3.4") {
     runQueryAndCompare(
       "select l_shipdate from lineitem order by l_shipdate desc limit 10 offset 10") {
       df =>


### PR DESCRIPTION
1. Support offloading Spark SQL clause `LIMIT ... OFFSET ...`
2. Nit fixes in `TakeOrderedAndProjectExecTransformer`