### PR TITLE
[MINOR][CORE] Simplify fillWithTransitions for InsertTransitions

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
@@ -35,13 +35,10 @@ case class InsertTransitions(convReq: ConventionReq) extends Rule[SparkPlan] {
   }
 
   private def fillWithTransitions(plan: SparkPlan): SparkPlan = plan.transformUp {
-    case p => applyForNode(p)
+    case node if node.children.nonEmpty => applyForNode(node)
   }
 
   private def applyForNode(node: SparkPlan): SparkPlan = {
-    if (node.children.isEmpty) {
-      return node
-    }
     val convReqs = convFunc.conventionReqOf(node)
     val newChildren = node.children.zip(convReqs).map {
       case (child, convReq) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to simplify `fillWithTransitions` for `InsertTransitions`.

## How was this patch tested?

unit tests, integration tests and manual tests

