### PR TITLE
[MINOR] Improve moveToWorkDir for JniLibLoader

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
+++ b/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
@@ -106,11 +106,11 @@ public class JniLibLoader {
 
   private File moveToWorkDir(String workDir, String libraryToLoad) throws IOException {
     // final File temp = File.createTempFile(workDir, libraryToLoad);
-    final Path libPath = Paths.get(workDir + "/" + libraryToLoad);
+    final Path libPath = Paths.get(workDir, libraryToLoad);
     if (Files.exists(libPath)) {
       Files.delete(libPath);
     }
-    final File temp = new File(workDir + "/" + libraryToLoad);
+    final File temp = libPath.toFile();
     if (!temp.getParentFile().exists()) {
       temp.getParentFile().mkdirs();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to improve `moveToWorkDir` for `JniLibLoader` by avoiding string concatenation.

## How was this patch tested?

unit tests, integration tests, manual tests

