### PR TITLE
[VL] Fix gen all config

### DIFF
--- a/dev/gen_all_config_docs.sh
+++ b/dev/gen_all_config_docs.sh
@@ -18,7 +18,7 @@
 
 GLUTEN_UPDATE="${GLUTEN_UPDATE:-1}" \
 mvn clean test \
-  -pl gluten-substrait -pl backends-velox -am \
+  -pl gluten-substrait -P backends-velox -am \
   -Dtest=none \
   -DfailIfNoTests=false \
   -DwildcardSuites=org.apache.gluten.config.AllGlutenConfiguration,org.apache.gluten.config.AllVeloxConfiguration


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
dev/gen_all_config_docs.sh
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[ERROR] [ERROR] Could not find the selected project in the reactor: :backends-velox @ 
[ERROR] Could not find the selected project in the reactor: :backends-velox -> [Help 1]
org.apache.maven.MavenExecutionException: Could not find the selected project in the reactor: :backends-velox
    at org.apache.maven.graph.DefaultGraphBuilder.trimSelectedProjects (DefaultGraphBuilder.java:148)
```

The backends-velox module is activated via Maven Profile.

## How was this patch tested?

Local test.

