### PR TITLE
[MINOR] Avoid using the fields of StructType

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
@@ -71,9 +71,9 @@ class VeloxValidatorApi extends ValidatorApi {
       case map: MapType =>
         doSchemaValidate(map.keyType).orElse(doSchemaValidate(map.valueType))
       case struct: StructType =>
-        struct.fields.foreach {
-          f =>
-            val reason = doSchemaValidate(f.dataType)
+        struct.foreach {
+          field =>
+            val reason = doSchemaValidate(field.dataType)
             if (reason.isDefined) {
               return reason
             }

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -217,9 +217,9 @@ case class IcebergScanTransformer(
     }
     (icebergType, currentType, sparkType) match {
       case (iceberg: Types.StructType, currentType: Types.StructType, sparkStruct: StructType) =>
-        sparkStruct.fields.forall {
-          f =>
-            val currentField = new Schema(currentType.fields()).findField(f.name)
+        sparkStruct.forall {
+          sparkField =>
+            val currentField = new Schema(currentType.fields()).findField(sparkField.name)
             // Find not exists column
             if (currentField == null) {
               false
@@ -230,8 +230,8 @@ case class IcebergScanTransformer(
                 true
               } else {
                 // Maybe rename column
-                field.name() == f.name &&
-                typesMatch(field.`type`(), currentField.`type`(), f.dataType)
+                field.name() == sparkField.name &&
+                typesMatch(field.`type`(), currentField.`type`(), sparkField.dataType)
               }
             }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to avoid using the fields of `StructType`.

`StructType` implements the `Seq[StructField]`. Please see the declaration show below.

```
case class StructType(fields: Array[StructField]) extends DataType with Seq[StructField] {
  // ignore code
}
```

## How was this patch tested?

unit tests, integration tests, manual tests

