### PR TITLE
[MINOR] Correct the comments for primaryBatchType

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -94,7 +94,6 @@ object VeloxBackendSettings extends BackendSettingsApi {
   val GLUTEN_VELOX_INTERNAL_UDF_LIB_PATHS = VeloxBackend.CONF_PREFIX + ".internal.udfLibraryPaths"
   val GLUTEN_VELOX_UDF_ALLOW_TYPE_CONVERSION = VeloxBackend.CONF_PREFIX + ".udfAllowTypeConversion"
 
-  /** The columnar-batch type this backend is by default using. */
   override def primaryBatchType: Convention.BatchType = VeloxBatchType
 
   override def validateScanExec(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.conf.Configuration
 
 trait BackendSettingsApi {
 
-  /** The columnar-batch type this backend is by default using. */
+  /** The default columnar-batch type of this backend. */
   def primaryBatchType: Convention.BatchType
 
   def validateScanExec(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to correct the comments for `primaryBatchType`.
There are two fixed issues.

1. The original comments have syntax error.
2. We only need obtain the comments at the parent class if the subclass hasn't any special description.

## How was this patch tested?

N/A.

