### PR TITLE
[GLUTEN-9860][VL] Fix nightly upload action

### DIFF
--- a/.github/workflows/velox_nightly.yml
+++ b/.github/workflows/velox_nightly.yml
@@ -108,7 +108,7 @@ jobs:
           path: package/target/gluten-velox-bundle-*.jar
           retention-days: 7
       - name: rsync to apache nightly
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         with:
           switches: -avzr
           path: package/target/gluten-velox-bundle-*.jar
@@ -157,7 +157,7 @@ jobs:
           path: package/target/gluten-velox-bundle-*.jar
           retention-days: 7
       - name: rsync to apache nightly
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         with:
           switches: -avzr
           path: package/target/gluten-velox-bundle-*.jar
@@ -298,7 +298,7 @@ jobs:
           name: nightly-gluten-velox-bundle-package-jdk8-arm64-${{ steps.date.outputs.date }}
           path: package/
       - name: rsync to apache nightly
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         with:
           switches: -avzr
           path: package/gluten-velox-bundle-*.jar
@@ -321,7 +321,7 @@ jobs:
           name: nightly-gluten-velox-bundle-package-jdk17-arm64-${{ steps.date.outputs.date }}
           path: package/
       - name: rsync to apache nightly
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         with:
           switches: -avzr
           path: package/gluten-velox-bundle-*.jar


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch updated the apache nightly sync action. The action with version tag we used are banned 
```
burnett01/rsync-deployments@5.2 is not allowed to be used in apache/incubator-gluten
```
https://github.com/apache/incubator-gluten/actions/runs/16764175107

## How was this patch tested?
pass GHA

