### PR TITLE
[GLUTEN-10377][CH] Move specialized delta internal column mapping to CH backend

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.execution.utils.{CHExecUtil, PushDownUtil}
 import org.apache.spark.sql.execution.window._
 import org.apache.spark.sql.types.{DecimalType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SparkVersionUtil
 
 import org.apache.commons.lang3.ClassUtils
 
@@ -999,4 +1000,10 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
 
   override def genColumnarToCarrierRow(plan: SparkPlan): SparkPlan =
     CHColumnarToCarrierRowExec.enforce(plan)
+
+  override def isRowIndexMetadataColumn(columnName: String): Boolean = {
+    SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(
+      columnName) || (SparkVersionUtil.gteSpark35 && columnName.equalsIgnoreCase(
+      "__delta_internal_is_row_deleted"))
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkVersionUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkVersionUtil.scala
@@ -19,9 +19,11 @@ package org.apache.spark.util
 object SparkVersionUtil {
   val lteSpark32: Boolean = compareMajorMinorVersion((3, 2)) <= 0
   private val comparedWithSpark33 = compareMajorMinorVersion((3, 3))
+  private val comparedWithSpark35 = compareMajorMinorVersion((3, 5))
   val eqSpark33: Boolean = comparedWithSpark33 == 0
   val lteSpark33: Boolean = lteSpark32 || eqSpark33
   val gteSpark33: Boolean = comparedWithSpark33 >= 0
+  val gteSpark35: Boolean = comparedWithSpark35 >= 0
 
   // Returns X. X < 0 if one < other, x == 0 if one == other, x > 0 if one > other.
   def compareMajorMinorVersion(other: (Int, Int)): Int = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -637,7 +637,7 @@ trait SparkPlanExecApi {
       val pushedFilters =
         dataFilters ++ FilterHandler.getRemainingFilters(dataFilters, extraFilters)
       pushedFilters.filterNot(_.references.exists {
-        attr => SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)
+        attr => BackendsApiManager.getSparkPlanExecApiInstance.isRowIndexMetadataColumn(attr.name)
       })
     }
     sparkExecNode match {
@@ -761,5 +761,9 @@ trait SparkPlanExecApi {
       right: ExpressionTransformer,
       original: Expression): ExpressionTransformer = {
     throw new GlutenNotSupportException("timestampdiff is not supported")
+  }
+
+  def isRowIndexMetadataColumn(columnName: String): Boolean = {
+    SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(columnName)
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -19,7 +19,6 @@ package org.apache.gluten.execution
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.expression.{ConverterUtils, ExpressionConverter}
-import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.`type`.ColumnTypeNode
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.extensions.ExtensionBuilder
@@ -125,7 +124,9 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
       attr =>
         if (getPartitionSchema.exists(_.name.equals(attr.name))) {
           new ColumnTypeNode(NamedStruct.ColumnType.PARTITION_COL)
-        } else if (SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)) {
+        } else if (
+          BackendsApiManager.getSparkPlanExecApiInstance.isRowIndexMetadataColumn(attr.name)
+        ) {
           new ColumnTypeNode(NamedStruct.ColumnType.ROWINDEX_COL)
         } else if (attr.isMetadataCol) {
           new ColumnTypeNode(NamedStruct.ColumnType.METADATA_COL)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -37,8 +37,6 @@ import org.apache.spark.util.collection.BitSet
 
 import org.apache.commons.lang3.StringUtils
 
-import scala.collection.JavaConverters._
-
 case class FileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
     override val output: Seq[Attribute],

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -109,6 +109,10 @@ abstract class FileSourceScanExecTransformerBase(
         output)
   }
 
+  protected def dataFiltersInScan: Seq[Expression] = dataFilters.filterNot(_.references.exists {
+    attr => BackendsApiManager.getSparkPlanExecApiInstance.isRowIndexMetadataColumn(attr.name)
+  })
+
   override def getMetadataColumns(): Seq[AttributeReference] = metadataColumns
 
   override def outputAttributes(): Seq[Attribute] = output

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -400,8 +400,7 @@ class Spark35Shims extends SparkShims {
   }
 
   def isRowIndexMetadataColumn(name: String): Boolean =
-    name == ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME ||
-      name.equalsIgnoreCase("__delta_internal_is_row_deleted")
+    name == ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME
 
   def findRowIndexColumnIndexInSchema(sparkSchema: StructType): Int = {
     sparkSchema.fields.zipWithIndex.find {

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
+import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
@@ -58,7 +59,9 @@ abstract class FileSourceScanExecShim(
 
   protected lazy val driverMetricsAlias = driverMetrics
 
-  protected def dataFiltersInScan: Seq[Expression]
+  def dataFiltersInScan: Seq[Expression] = {
+    throw new UnsupportedOperationException("Not implemented")
+  }
 
   def hasUnsupportedColumns: Boolean = {
     // TODO, fallback if user define same name column due to we can't right now

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
@@ -59,9 +58,7 @@ abstract class FileSourceScanExecShim(
 
   protected lazy val driverMetricsAlias = driverMetrics
 
-  def dataFiltersInScan: Seq[Expression] = dataFilters.filterNot(_.references.exists {
-    attr => SparkShimLoader.getSparkShims.isRowIndexMetadataColumn(attr.name)
-  })
+  protected def dataFiltersInScan: Seq[Expression]
 
   def hasUnsupportedColumns: Boolean = {
     // TODO, fallback if user define same name column due to we can't right now


### PR DESCRIPTION
In preparation for supporting deletion vector in Velox backend, move the specialized column mapping `__delta_internal_is_row_deleted` -> `row_index` from common place to CH backend.