### PR TITLE
[MINOR] Use `static constexpr` to follow C++ style

### DIFF
--- a/cpp/core/utils/ObjectStore.h
+++ b/cpp/core/utils/ObjectStore.h
@@ -32,7 +32,7 @@ namespace gluten {
 // for the object in the store.
 using StoreHandle = int32_t;
 using ObjectHandle = int64_t;
-constexpr static ObjectHandle kInvalidObjectHandle = -1;
+static constexpr ObjectHandle kInvalidObjectHandle = -1;
 
 template <typename T>
 struct SafeSizeOf {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to make code follows the modern C++ style.

## How was this patch tested?

unit tests, integration tests, manual tests

