### PR TITLE
[GLUTEN-10403] Extract the common code from ObjectStore as a new method lookup

### DIFF
--- a/cpp/core/utils/ObjectStore.cc
+++ b/cpp/core/utils/ObjectStore.cc
@@ -36,6 +36,14 @@ gluten::ResourceMap<gluten::ObjectStore*>& gluten::ObjectStore::stores() {
   return stores;
 }
 
+// static
+std::pair<gluten::ObjectStore*, gluten::ResourceHandle> gluten::ObjectStore::lookup(gluten::ObjectHandle handle) {
+  ResourceHandle storeId = safeCast<ResourceHandle>(handle >> (sizeof(gluten::ResourceHandle) * 8));
+  ResourceHandle resourceId = safeCast<ResourceHandle>(handle & std::numeric_limits<ResourceHandle>::max());
+  auto store = stores().lookup(storeId);
+  return {store, resourceId};
+};
+
 gluten::ObjectStore::~ObjectStore() {
   for (;;) {
     if (aliveObjects_.empty()) {

--- a/cpp/core/utils/ObjectStore.h
+++ b/cpp/core/utils/ObjectStore.h
@@ -81,12 +81,7 @@ class ObjectStore {
  private:
   static ResourceMap<ObjectStore*>& stores();
 
-  static std::pair<ObjectStore*, ResourceHandle> lookup(ObjectHandle handle) {
-    ResourceHandle storeId = safeCast<ResourceHandle>(handle >> (sizeof(ResourceHandle) * 8));
-    ResourceHandle resourceId = safeCast<ResourceHandle>(handle & std::numeric_limits<ResourceHandle>::max());
-    auto store = stores().lookup(storeId);
-    return {store, resourceId};
-  };
+  static std::pair<ObjectStore*, ResourceHandle> lookup(ObjectHandle handle);
 
   struct ObjectDebugInfo {
     const std::string_view typeName;

--- a/cpp/core/utils/ObjectStore.h
+++ b/cpp/core/utils/ObjectStore.h
@@ -52,17 +52,13 @@ class ObjectStore {
   static std::unique_ptr<ObjectStore> create();
 
   static void release(ObjectHandle handle) {
-    ResourceHandle storeId = safeCast<ResourceHandle>(handle >> (sizeof(ResourceHandle) * 8));
-    ResourceHandle resourceId = safeCast<ResourceHandle>(handle & std::numeric_limits<ResourceHandle>::max());
-    auto store = stores().lookup(storeId);
+    auto [store, resourceId] = lookup(handle);
     store->releaseInternal(resourceId);
   }
 
   template <typename T>
   static std::shared_ptr<T> retrieve(ObjectHandle handle) {
-    ResourceHandle storeId = safeCast<ResourceHandle>(handle >> (sizeof(ResourceHandle) * 8));
-    ResourceHandle resourceId = safeCast<ResourceHandle>(handle & std::numeric_limits<ResourceHandle>::max());
-    auto store = stores().lookup(storeId);
+    auto [store, resourceId] = lookup(handle);
     return store->retrieveInternal<T>(resourceId);
   }
 
@@ -84,6 +80,13 @@ class ObjectStore {
 
  private:
   static ResourceMap<ObjectStore*>& stores();
+
+  static std::pair<ObjectStore*, ResourceHandle> lookup(ObjectHandle handle) {
+    ResourceHandle storeId = safeCast<ResourceHandle>(handle >> (sizeof(ResourceHandle) * 8));
+    ResourceHandle resourceId = safeCast<ResourceHandle>(handle & std::numeric_limits<ResourceHandle>::max());
+    auto store = stores().lookup(storeId);
+    return {store, resourceId};
+  };
 
   struct ObjectDebugInfo {
     const std::string_view typeName;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to extract the common code from `ObjectStore` as a new method `lookup`.

(Fixes: \#10403)

## How was this patch tested?

unit tests, integration tests, manual tests

