### PR TITLE
[VL] Minor fix, rename dictionarygess to footerestimate

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -476,17 +476,19 @@ object VeloxConfig {
       .booleanConf
       .createWithDefault(false)
 
-  val DIRECTORY_SIZE_GUESS =
-    buildStaticConf("spark.gluten.sql.columnar.backend.velox.directorySizeGuess")
+  val FOOTER_ESTIMATED_SIZE =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.footerEstimatedSize")
       .internal()
-      .doc("Set the directory size guess for velox file scan")
+      .doc("Set the footer estimated size for velox file scan, " +
+        "refer to Velox's footer-estimated-size")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32KB")
 
   val FILE_PRELOAD_THRESHOLD =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.filePreloadThreshold")
       .internal()
-      .doc("Set the file preload threshold for velox file scan")
+      .doc("Set the file preload threshold for velox file scan, " +
+        "refer to Velox's file-preload-threshold")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1MB")
 

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -131,7 +131,7 @@ const std::string kVeloxFileHandleCacheEnabled = "spark.gluten.sql.columnar.back
 const bool kVeloxFileHandleCacheEnabledDefault = false;
 
 /* configs for file read in velox*/
-const std::string kDirectorySizeGuess = "spark.gluten.sql.columnar.backend.velox.directorySizeGuess";
+const std::string footerEstimatedSize = "spark.gluten.sql.columnar.backend.velox.footerEstimatedSize";
 const std::string kFilePreloadThreshold = "spark.gluten.sql.columnar.backend.velox.filePreloadThreshold";
 const std::string kPrefetchRowGroups = "spark.gluten.sql.columnar.backend.velox.prefetchRowGroups";
 const std::string kLoadQuantum = "spark.gluten.sql.columnar.backend.velox.loadQuantum";

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -227,7 +227,7 @@ std::shared_ptr<facebook::velox::config::ConfigBase> getHiveConfig(
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kLoadQuantum] =
       conf->get<std::string>(kLoadQuantum, "268435456"); // 256M
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kFooterEstimatedSize] =
-      conf->get<std::string>(kDirectorySizeGuess, "32768"); // 32K
+      conf->get<std::string>(kFooterEstimatedSize, "32768"); // 32K
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kFilePreloadThreshold] =
       conf->get<std::string>(kFilePreloadThreshold, "1048576"); // 1M
 


### PR DESCRIPTION
To align with Velox's name. Added Deprecated infomation to avoid break current use case.