### PR TITLE
[CORE] Build: Enforce -P scala-2.13 / -P java-17 for Spark 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,6 +448,46 @@
           <scope>provided</scope>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java-17</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireActiveProfile>
+                      <!-- Spark 4.0 requires Java 17+ -->
+                      <profiles>java-17</profiles>
+                      <message>"-P spark-4.0" requires JDK 17 </message>
+                    </requireActiveProfile>
+                  </rules>
+                </configuration>
+              </execution>
+              <execution>
+                <id>enforce-scala-213</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireActiveProfile>
+                      <!-- Spark 4.0 requires Scala 2.13 -->
+                      <profiles>scala-2.13</profiles>
+                      <message>"-P spark-4.0" requires Scala 2.13</message>
+                    </requireActiveProfile>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>hadoop-2.7.4</id>


### PR DESCRIPTION
When Maven profile `-P scala-2.13` / `-P java-17` are not set with `-P spark-4.0`, reports the following build error:

```
[ERROR] Rule 0: org.apache.maven.enforcer.rules.RequireActiveProfile failed with message:
[ERROR] "-P spark-4.0" requires Scala 2.13
[ERROR] Profile "scala-2.13" is not activated.
```

or 

```
[ERROR] Rule 0: org.apache.maven.enforcer.rules.RequireActiveProfile failed with message:
[ERROR] "-P spark-4.0" requires Scala 2.13
[ERROR] Profile "scala-2.13" is not activated.
```