### PR TITLE
[GLUTEN-8852][VL] Fix compilation issues in existing tests for Spark 4.0.0

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
@@ -17,10 +17,8 @@
 package org.apache.gluten.execution
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.Column
-import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
 import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, NullPropagation}
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types.StringType
 
 class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
@@ -35,10 +33,11 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    val nullColumn = lit(null).cast(StringType).alias(NULL_STR_COL)
     createTPCHNotNullTables()
     spark
       .table("lineitem")
-      .select(col("*"), new Column(Alias(Literal(null, StringType), NULL_STR_COL)()))
+      .select(col("*"), nullColumn)
       .createOrReplaceTempView(LINEITEM_TABLE)
   }
 

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.benchmark
 
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.Table
+import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.Arm
 
 import org.apache.spark.benchmark.Benchmark
@@ -71,14 +72,14 @@ object VeloxRasBenchmark extends SqlBasedBenchmark {
   }
 
   private def createLegacySession(): SparkSession = {
-    SparkSession.cleanupAnyExistingSession()
+    SparkShimLoader.getSparkShims.cleanupAnyExistingSession()
     sessionBuilder()
       .config(GlutenConfig.RAS_ENABLED.key, false)
       .getOrCreate()
   }
 
   private def createRasSession(): SparkSession = {
-    SparkSession.cleanupAnyExistingSession()
+    SparkShimLoader.getSparkShims.cleanupAnyExistingSession()
     sessionBuilder()
       .config(GlutenConfig.RAS_ENABLED.key, true)
       .getOrCreate()

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/joins/GlutenExistenceJoinSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/joins/GlutenExistenceJoinSuite.scala
@@ -17,8 +17,9 @@
 package org.apache.spark.sql.execution.joins
 
 import org.apache.gluten.execution.{VeloxBroadcastNestedLoopJoinExecTransformer, VeloxWholeStageTransformerSuite}
+import org.apache.gluten.sql.shims.SparkShimLoader
 
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.ExistenceJoin
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -54,8 +55,8 @@ class GlutenExistenceJoinSuite extends VeloxWholeStageTransformerSuite with SQLT
       new StructType().add("id", IntegerType).add("val", StringType)
     )
 
-    val leftPlan = left.logicalPlan
-    val rightPlan = right.logicalPlan
+    val leftPlan = SparkShimLoader.getSparkShims.getLogicalPlanFromDataFrame(left)
+    val rightPlan = SparkShimLoader.getSparkShims.getLogicalPlanFromDataFrame(right)
 
     val existsAttr = AttributeReference("exists", BooleanType, nullable = false)()
 
@@ -74,7 +75,7 @@ class GlutenExistenceJoinSuite extends VeloxWholeStageTransformerSuite with SQLT
       child = existenceJoin
     )
 
-    val df = Dataset.ofRows(spark, project)
+    val df = SparkShimLoader.getSparkShims.dataSetOfRows(spark, project)
 
     assert(existenceJoin.joinType == ExistenceJoin(existsAttr))
     assert(existenceJoin.condition.contains(joinCondition))

--- a/pom.xml
+++ b/pom.xml
@@ -486,6 +486,25 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>scala-test-compile-first</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <excludes>
+                    <exclude>**/GlutenHiveUDFSuite.scala</exclude>
+                    <exclude>**/VeloxParquetWriteForHiveSuite.scala</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -24,7 +24,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.csv.CSVOptions
@@ -318,4 +318,13 @@ trait SparkShims {
   def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean = false
 
   def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType
+
+  /** For test use only */
+  def cleanupAnyExistingSession(): Unit
+
+  /** For test use only */
+  def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan
+
+  /** For test use only */
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame
 }

--- a/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/org/apache/gluten/sql/shims/spark32/Spark32Shims.scala
@@ -24,7 +24,7 @@ import org.apache.gluten.utils.ExceptionUtils
 import org.apache.spark.{ShuffleUtils, SparkContext}
 import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession, SparkSqlUtils}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -313,6 +313,18 @@ class Spark32Shims extends SparkShims {
 
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecision.widerDecimalType(d1, d2)
+  }
+
+  override def cleanupAnyExistingSession(): Unit = {
+    SparkSqlUtils.cleanupAnyExistingSession()
+  }
+
+  override def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    SparkSqlUtils.getLogicalPlanFromDataFrame(df)
+  }
+
+  override def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    SparkSqlUtils.dataSetOfRows(spark, logicalPlan)
   }
 
 }

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object SparkSqlUtils {
+  def cleanupAnyExistingSession(): Unit = {
+    SparkSession.cleanupAnyExistingSession()
+  }
+  def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    df.logicalPlan
+  }
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, logicalPlan)
+  }
+}

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -25,7 +25,7 @@ import org.apache.gluten.utils.ExceptionUtils
 import org.apache.spark._
 import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession, SparkSqlUtils}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -407,6 +407,18 @@ class Spark33Shims extends SparkShims {
 
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecision.widerDecimalType(d1, d2)
+  }
+
+  override def cleanupAnyExistingSession(): Unit = {
+    SparkSqlUtils.cleanupAnyExistingSession()
+  }
+
+  override def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    SparkSqlUtils.getLogicalPlanFromDataFrame(df)
+  }
+
+  override def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    SparkSqlUtils.dataSetOfRows(spark, logicalPlan)
   }
 
 }

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object SparkSqlUtils {
+  def cleanupAnyExistingSession(): Unit = {
+    SparkSession.cleanupAnyExistingSession()
+  }
+  def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    df.logicalPlan
+  }
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, logicalPlan)
+  }
+}

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession, SparkSqlUtils}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -645,6 +645,18 @@ class Spark34Shims extends SparkShims {
 
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecision.widerDecimalType(d1, d2)
+  }
+
+  override def cleanupAnyExistingSession(): Unit = {
+    SparkSqlUtils.cleanupAnyExistingSession()
+  }
+
+  override def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    SparkSqlUtils.getLogicalPlanFromDataFrame(df)
+  }
+
+  override def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    SparkSqlUtils.dataSetOfRows(spark, logicalPlan)
   }
 
 }

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object SparkSqlUtils {
+  def cleanupAnyExistingSession(): Unit = {
+    SparkSession.cleanupAnyExistingSession()
+  }
+  def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    df.logicalPlan
+  }
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, logicalPlan)
+  }
+}

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession, SparkSqlUtils}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -705,6 +705,18 @@ class Spark35Shims extends SparkShims {
 
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecision.widerDecimalType(d1, d2)
+  }
+
+  override def cleanupAnyExistingSession(): Unit = {
+    SparkSqlUtils.cleanupAnyExistingSession()
+  }
+
+  override def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    SparkSqlUtils.getLogicalPlanFromDataFrame(df)
+  }
+
+  override def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    SparkSqlUtils.dataSetOfRows(spark, logicalPlan)
   }
 
 }

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object SparkSqlUtils {
+  def cleanupAnyExistingSession(): Unit = {
+    SparkSession.cleanupAnyExistingSession()
+  }
+  def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    df.logicalPlan
+  }
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, logicalPlan)
+  }
+}

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession, SparkSqlUtils}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -696,4 +696,15 @@ class Spark40Shims extends SparkShims {
     DecimalPrecisionTypeCoercion.widerDecimalType(d1, d2)
   }
 
+  override def cleanupAnyExistingSession(): Unit = {
+    SparkSqlUtils.cleanupAnyExistingSession()
+  }
+
+  override def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    SparkSqlUtils.getLogicalPlanFromDataFrame(df)
+  }
+
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    SparkSqlUtils.dataSetOfRows(spark, logicalPlan)
+  }
 }

--- a/shims/spark40/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/shims/spark40/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object SparkSqlUtils {
+  def cleanupAnyExistingSession(): Unit = {
+    classic.SparkSession.cleanupAnyExistingSession()
+  }
+  def getLogicalPlanFromDataFrame(df: DataFrame): LogicalPlan = {
+    df.asInstanceOf[classic.Dataset[Row]].logicalPlan
+  }
+  def dataSetOfRows(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    classic.Dataset.ofRows(spark.asInstanceOf[classic.SparkSession], logicalPlan)
+  }
+}


### PR DESCRIPTION

## What changes are proposed in this pull request?
https://github.com/apache/incubator-gluten/pull/9768 has support spark 400, but when build it, require 
```
rm -f backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala \
     backends-velox/src/test/scala/org/apache/spark/sql/execution/GlutenHiveUDFSuite.scala \
     backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteForHiveSuite.scala \
     backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/VeloxRasBenchmark.scala \
    backends-velox/src/test/scala/org/apache/spark/sql/execution/joins/GlutenExistenceJoinSuite.scala 

mvn clean package -Pbackends-velox -Pspark-4.0 -Pscala-2.13 -DskipTests
```
This PR aims to avoid manual remove such file by add shim to support VeloxStringFunctionsSuite/VeloxRasBenchmark/GlutenExistenceJoinSuite and add profile to avoid compile GlutenHiveUDFSuite and VeloxParquetWriteForHiveSuite.

## How was this patch tested?

`mvn clean package -Pbackends-velox -Pspark-4.0 -Pscala-2.13 -DskipTests` in my own box.
