### PR TITLE
[GLUTEN-10457][VL] Iceberg supports copy on write

### DIFF
--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/execution/OffloadIcebergWrite.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/execution/OffloadIcebergWrite.scala
@@ -24,7 +24,7 @@ import org.apache.gluten.extension.columnar.validator.Validators
 import org.apache.gluten.extension.injector.Injector
 
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.datasources.v2.AppendDataExec
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExec, ReplaceDataExec}
 
 case class OffloadIcebergWrite() extends OffloadSingleNode {
   override def offload(plan: SparkPlan): SparkPlan = plan match {
@@ -34,25 +34,33 @@ case class OffloadIcebergWrite() extends OffloadSingleNode {
   }
 }
 
+case class OffloadIcebergDelete() extends OffloadSingleNode {
+  override def offload(plan: SparkPlan): SparkPlan = plan match {
+    case r: ReplaceDataExec =>
+      VeloxIcebergReplaceDataExec(r)
+    case other => other
+  }
+}
+
 object OffloadIcebergWrite {
   def inject(injector: Injector): Unit = {
     // Inject legacy rule.
     injector.gluten.legacy.injectTransform {
       c =>
-        val offload = Seq(OffloadIcebergWrite())
+        val offload = Seq(OffloadIcebergWrite(), OffloadIcebergDelete())
         HeuristicTransform.Simple(
           Validators.newValidator(new GlutenConfig(c.sqlConf), offload),
           offload
         )
     }
 
-    // Inject RAS rule.
-    injector.gluten.ras.injectRasRule {
-      c =>
-        RasOffload.Rule(
-          RasOffload.from[AppendDataExec](OffloadIcebergWrite()),
-          Validators.newValidator(new GlutenConfig(c.sqlConf)),
-          Nil)
-    }
+    val offloads: Seq[RasOffload] = Seq(
+      RasOffload.from[AppendDataExec](OffloadIcebergWrite()),
+      RasOffload.from[ReplaceDataExec](OffloadIcebergDelete())
+    )
+    offloads.foreach(
+      offload =>
+        injector.gluten.ras.injectRasRule(
+          c => RasOffload.Rule(offload, Validators.newValidator(new GlutenConfig(c.sqlConf)), Nil)))
   }
 }

--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/execution/VeloxIcebergReplaceDataExec.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/execution/VeloxIcebergReplaceDataExec.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.connector.write.{ColumnarBatchDataWriterFactory, IcebergDataWriteFactory}
+
+import org.apache.spark.sql.connector.write.Write
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2._
+import org.apache.spark.sql.types.StructType
+
+import org.apache.iceberg.spark.source.IcebergWriteUtil
+
+case class VeloxIcebergReplaceDataExec(query: SparkPlan, refreshCache: () => Unit, write: Write)
+  extends IcebergAppendDataExec {
+
+  override protected def withNewChildInternal(newChild: SparkPlan): IcebergAppendDataExec =
+    copy(query = newChild)
+
+  override def createFactory(schema: StructType): ColumnarBatchDataWriterFactory =
+    IcebergDataWriteFactory(
+      schema,
+      getFileFormat(IcebergWriteUtil.getFileFormat(write)),
+      IcebergWriteUtil.getDirectory(write),
+      getCodec,
+      getPartitionSpec)
+}
+
+object VeloxIcebergReplaceDataExec {
+  def apply(original: ReplaceDataExec): VeloxIcebergReplaceDataExec = {
+    VeloxIcebergReplaceDataExec(
+      original.query,
+      original.refreshCache,
+      original.write
+    )
+  }
+}


### PR DESCRIPTION
The only implementation difference with AppendDataExec is the BatchWrite commit function, but it is called by the interface, so we only apply the rule is enough.