### PR TITLE
[GLUTEN-10491][VL] Simplify the extractStructNeeded for HashAggregateExecTransformer

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -97,9 +97,7 @@ abstract class HashAggregateExecTransformer(
    *   extracting needed or not.
    */
   private def extractStructNeeded(): Boolean = aggregateExpressions.exists {
-    case AggregateExpression(aggFunc, Partial, _, _, _) =>
-      aggFunc.aggBufferAttributes.size > 1
-    case AggregateExpression(aggFunc, PartialMerge, _, _, _) =>
+    case AggregateExpression(aggFunc, Partial | PartialMerge, _, _, _) =>
       aggFunc.aggBufferAttributes.size > 1
     case _ => false
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -96,18 +96,12 @@ abstract class HashAggregateExecTransformer(
    * @return
    *   extracting needed or not.
    */
-  private def extractStructNeeded(): Boolean = {
-    aggregateExpressions.exists {
-      expr =>
-        expr.aggregateFunction match {
-          case aggFunc if aggFunc.aggBufferAttributes.size > 1 =>
-            expr.mode match {
-              case Partial | PartialMerge => true
-              case _ => false
-            }
-          case _ => false
-        }
-    }
+  private def extractStructNeeded(): Boolean = aggregateExpressions.exists {
+    case AggregateExpression(aggFunc, Partial, _, _, _) =>
+      aggFunc.aggBufferAttributes.size > 1
+    case AggregateExpression(aggFunc, PartialMerge, _, _, _) =>
+      aggFunc.aggBufferAttributes.size > 1
+    case _ => false
   }
 
   /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR proposes to simplify the `extractStructNeeded` for `HashAggregateExecTransformer`.
Fixes #10491

## How was this patch tested?

GA tests.
