### PR TITLE
[GLUTEN-9335][VL] Support iceberg partition write

### DIFF
--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/connector/write/IcebergColumnarBatchDataWriter.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/connector/write/IcebergColumnarBatchDataWriter.scala
@@ -62,7 +62,6 @@ case class IcebergColumnarBatchDataWriter(
 
   private def parseDataFile(json: String, spec: PartitionSpec, sortOrder: SortOrder): DataFile = {
     val dataFile = mapper.readValue(json, classOf[DataFileJson])
-
     val builder = DataFiles
       .builder(spec)
       .withPath(dataFile.path)

--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/connector/write/IcebergDataWriteFactory.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/connector/write/IcebergDataWriteFactory.scala
@@ -56,7 +56,7 @@ case class IcebergDataWriteFactory(
     val fields = partitionSpec
       .fields()
       .stream()
-      .map[IcebergPartitionField](IcebergTransformUtil.convertPartitionField _)
+      .map[IcebergPartitionField](f => IcebergTransformUtil.convertPartitionField(f, partitionSpec))
       .collect(Collectors.toList[IcebergPartitionField])
     val specProto = IcebergPartitionSpec
       .newBuilder()

--- a/backends-velox/src-iceberg/main/scala/org/apache/iceberg/transforms/IcebergTransformUtil.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/iceberg/transforms/IcebergTransformUtil.scala
@@ -42,11 +42,13 @@ object IcebergTransformUtil {
   }
 
   private def convertTimestamps(timestamps: Timestamps): TransformType = {
-    timestamps match {
-      case Timestamps.MICROS_TO_HOUR => TransformType.HOUR
-      case Timestamps.MICROS_TO_DAY => TransformType.DAY
-      case Timestamps.MICROS_TO_MONTH => TransformType.MONTH
-      case Timestamps.MICROS_TO_YEAR => TransformType.YEAR
+    // We could not match the enum instance because Iceberg 1.5.0 enum is different, and we fall
+    // back TimestampNano data type
+    timestamps.toString match {
+      case "hour" => TransformType.HOUR
+      case "day" => TransformType.DAY
+      case "month" => TransformType.MONTH
+      case "year" => TransformType.YEAR
       case _ => throw new GlutenNotSupportException()
     }
   }

--- a/backends-velox/src-iceberg/main/scala/org/apache/iceberg/transforms/IcebergTransformUtil.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/iceberg/transforms/IcebergTransformUtil.scala
@@ -37,6 +37,7 @@ object IcebergTransformUtil {
       case b: Bucket[_] => builder.setTransform(TransformType.BUCKET).setParameter(b.numBuckets())
       case t: Truncate[_] => builder.setTransform(TransformType.TRUNCATE).setParameter(t.width)
       case t: Timestamps => builder.setTransform(convertTimestamps(t))
+      case d: Dates => builder.setTransform(convertDates(d))
     }
     builder.build()
   }
@@ -49,6 +50,17 @@ object IcebergTransformUtil {
       case "day" => TransformType.DAY
       case "month" => TransformType.MONTH
       case "year" => TransformType.YEAR
+      case _ => throw new GlutenNotSupportException()
+    }
+  }
+
+  private def convertDates(dates: Dates): TransformType = {
+    // We could not match the enum instance because Iceberg 1.5.0 enum is different, and we fall
+    // back TimestampNano data type
+    dates match {
+      case Dates.DAY => TransformType.DAY
+      case Dates.MONTH => TransformType.MONTH
+      case Dates.YEAR => TransformType.YEAR
       case _ => throw new GlutenNotSupportException()
     }
   }

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxTPCHIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxTPCHIcebergSuite.scala
@@ -93,6 +93,7 @@ class VeloxTPCHIcebergSuite extends VeloxTPCHSuite {
 }
 
 class VeloxPartitionedTableTPCHIcebergSuite extends VeloxTPCHIcebergSuite {
+
   override protected def createTPCHNotNullTables(): Unit = {
     TPCHTables.map {
       table =>
@@ -103,8 +104,11 @@ class VeloxPartitionedTableTPCHIcebergSuite extends VeloxTPCHIcebergSuite {
           .repartition(table.partitionColumns.map(col): _*)
           .sortWithinPartitions(table.partitionColumns.map(col): _*)
 
+        // Use ORC to disable native write in case of OOM, velox behavior likes FANOUT_ENABLED true
+        // The number of writers too much.
         tableDF.write
           .format("iceberg")
+          .option(SparkWriteOptions.WRITE_FORMAT, "orc")
           .partitionBy(table.partitionColumns: _*)
           .option(SparkWriteOptions.FANOUT_ENABLED, "false")
           .mode("overwrite")

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -128,7 +128,7 @@ class VeloxIcebergSuite extends IcebergSuite {
         df.queryExecution.executedPlan
           .asInstanceOf[CommandResultExec]
           .commandPhysicalPlan
-          .isInstanceOf[IcebergAppendDataExec])
+          .isInstanceOf[VeloxIcebergAppendDataExec])
       val selectDf = spark.sql("""
                                  |select * from iceberg_tb2;
                                  |""".stripMargin)
@@ -153,7 +153,7 @@ class VeloxIcebergSuite extends IcebergSuite {
         df.queryExecution.executedPlan
           .asInstanceOf[CommandResultExec]
           .commandPhysicalPlan
-          .isInstanceOf[IcebergAppendDataExec])
+          .isInstanceOf[VeloxIcebergAppendDataExec])
       val selectDf = spark.sql("""
                                  |select * from iceberg_tb2;
                                  |""".stripMargin)

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -46,8 +46,7 @@ class VeloxIcebergSuite extends IcebergSuite {
     }
   }
 
-  // TODO: support later
-  ignore("iceberg insert partition table identity transform") {
+  test("iceberg insert partition table identity transform") {
     withTable("iceberg_tb2") {
       spark.sql("""
                   |create table if not exists iceberg_tb2(a int, b int)
@@ -111,6 +110,57 @@ class VeloxIcebergSuite extends IcebergSuite {
                                  |""".stripMargin)
       val result = selectDf.collect()
       assert(result.length == 5)
+
+    }
+  }
+
+  test("iceberg insert partition table bucket transform") {
+    withTable("iceberg_tb2") {
+      spark.sql("""
+                  |create table if not exists iceberg_tb2(a int, b int)
+                  |using iceberg
+                  |partitioned by (bucket(16, a));
+                  |""".stripMargin)
+      val df = spark.sql("""
+                           |insert into table iceberg_tb2 values(1098, 189)
+                           |""".stripMargin)
+      assert(
+        df.queryExecution.executedPlan
+          .asInstanceOf[CommandResultExec]
+          .commandPhysicalPlan
+          .isInstanceOf[IcebergAppendDataExec])
+      val selectDf = spark.sql("""
+                                 |select * from iceberg_tb2;
+                                 |""".stripMargin)
+      val result = selectDf.collect()
+      assert(result.length == 1)
+      assert(result(0).get(0) == 1098)
+      assert(result(0).get(1) == 189)
+    }
+  }
+
+  test("iceberg insert partition table truncate transform") {
+    withTable("iceberg_tb2") {
+      spark.sql("""
+                  |create table if not exists iceberg_tb2(a int, b int)
+                  |using iceberg
+                  |partitioned by (truncate(16, a));
+                  |""".stripMargin)
+      val df = spark.sql("""
+                           |insert into table iceberg_tb2 values(1098, 189)
+                           |""".stripMargin)
+      assert(
+        df.queryExecution.executedPlan
+          .asInstanceOf[CommandResultExec]
+          .commandPhysicalPlan
+          .isInstanceOf[IcebergAppendDataExec])
+      val selectDf = spark.sql("""
+                                 |select * from iceberg_tb2;
+                                 |""".stripMargin)
+      val result = selectDf.collect()
+      assert(result.length == 1)
+      assert(result(0).get(0) == 1098)
+      assert(result(0).get(1) == 189)
     }
   }
 

--- a/backends-velox/src/main/resources/org/apache/gluten/proto/IcebergPartitionSpec.proto
+++ b/backends-velox/src/main/resources/org/apache/gluten/proto/IcebergPartitionSpec.proto
@@ -17,9 +17,10 @@ enum TransformType {
 }
 
 message IcebergPartitionField {
-  string name = 1;
-  TransformType transform = 2;
-  optional int32 parameter = 3;  // Optional parameter for transform config
+  int32 source_id = 1;
+  string name = 2;
+  TransformType transform = 3;
+  optional int32 parameter = 4;  // Optional parameter for transform config
 }
 
 message IcebergPartitionSpec {

--- a/cpp/velox/compute/iceberg/IcebergWriter.cc
+++ b/cpp/velox/compute/iceberg/IcebergWriter.cc
@@ -103,11 +103,12 @@ IcebergWriter::IcebergWriter(
     : rowType_(rowType), field_(convertToIcebergNestedField(field)), pool_(memoryPool), connectorPool_(connectorPool) {
   auto veloxCfg =
       std::make_shared<facebook::velox::config::ConfigBase>(std::unordered_map<std::string, std::string>(sparkConfs));
-  auto connectorSessionProperties_ = getHiveConfig(veloxCfg);
+  auto connectorSessionProperties_ = std::make_shared<facebook::velox::config::ConfigBase>(
+      std::unordered_map<std::string, std::string>(sparkConfs), true);
   connectorSessionProperties_->set(
       facebook::velox::connector::hive::HiveConfig::kMaxPartitionsPerWritersSession,
       std::to_string(veloxCfg->get<int32_t>(kMaxPartitions, 10000)));
-  connectorConfig_ = std::make_shared<facebook::velox::connector::hive::HiveConfig>(connectorSessionProperties_);
+  connectorConfig_ = std::make_shared<facebook::velox::connector::hive::HiveConfig>(getHiveConfig(veloxCfg));
   connectorQueryCtx_ = std::make_unique<connector::ConnectorQueryCtx>(
       pool_.get(),
       connectorPool_.get(),

--- a/cpp/velox/compute/iceberg/IcebergWriter.cc
+++ b/cpp/velox/compute/iceberg/IcebergWriter.cc
@@ -103,8 +103,8 @@ IcebergWriter::IcebergWriter(
     : rowType_(rowType), field_(convertToIcebergNestedField(field)), pool_(memoryPool), connectorPool_(connectorPool) {
   auto veloxCfg =
       std::make_shared<facebook::velox::config::ConfigBase>(std::unordered_map<std::string, std::string>(sparkConfs));
-  auto connectorSessionProperties_ = std::make_shared<facebook::velox::config::ConfigBase>(
-      std::unordered_map<std::string, std::string>(sparkConfs), true);
+  connectorSessionProperties_ = std::make_shared<facebook::velox::config::ConfigBase>(
+      std::unordered_map<std::string, std::string>(), true);
   connectorSessionProperties_->set(
       facebook::velox::connector::hive::HiveConfig::kMaxPartitionsPerWritersSession,
       std::to_string(veloxCfg->get<int32_t>(kMaxPartitions, 10000)));

--- a/cpp/velox/tests/iceberg/IcebergWriteTest.cc
+++ b/cpp/velox/tests/iceberg/IcebergWriteTest.cc
@@ -43,7 +43,8 @@ class VeloxIcebergWriteTest : public ::testing::Test, public test::VectorTestBas
 TEST_F(VeloxIcebergWriteTest, write) {
   auto vector = makeRowVector({makeFlatVector<int8_t>({1, 2}), makeFlatVector<int16_t>({1, 2})});
   auto tmpPath = tmpDir_->getPath();
-  auto partitionSpec = std::make_shared<const connector::hive::iceberg::IcebergPartitionSpec>(0, {});
+  std::vector<connector::hive::iceberg::IcebergPartitionSpec::Field> fields;
+  auto partitionSpec = std::make_shared<const connector::hive::iceberg::IcebergPartitionSpec>(0, fields);
 
   gluten::IcebergNestedField root;
   root.set_id(0);
@@ -57,7 +58,7 @@ TEST_F(VeloxIcebergWriteTest, write) {
       1,
       tmpPath + "/iceberg_write_test_table",
       common::CompressionKind::CompressionKind_ZSTD,
-      spec,
+      partitionSpec,
       root,
       std::unordered_map<std::string, std::string>(),
       pool_,

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -281,7 +281,7 @@ std::shared_ptr<facebook::velox::config::ConfigBase> getHiveConfig(
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kParquetUseColumnNames] = "true";
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kOrcUseColumnNames] = "true";
 
-  return std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfMap));
+  return std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfMap), true);
 }
 
 } // namespace gluten

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -281,7 +281,7 @@ std::shared_ptr<facebook::velox::config::ConfigBase> getHiveConfig(
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kParquetUseColumnNames] = "true";
   hiveConfMap[facebook::velox::connector::hive::HiveConfig::kOrcUseColumnNames] = "true";
 
-  return std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfMap), true);
+  return std::make_shared<facebook::velox::config::ConfigBase>(std::move(hiveConfMap));
 }
 
 } // namespace gluten

--- a/dev/ci-velox-buildstatic-centos-7-enhanced-features.sh
+++ b/dev/ci-velox-buildstatic-centos-7-enhanced-features.sh
@@ -19,5 +19,5 @@ set -e
 
 source /opt/rh/devtoolset-11/enable
 export NUM_THREADS=4
-./dev/builddeps-veloxbe.sh --enable_vcpkg=ON --build_arrow=OFF --build_tests=OFF --build_benchmarks=OFF \
+./dev/builddeps-veloxbe.sh --enable_vcpkg=ON --build_arrow=OFF --build_tests=ON --build_benchmarks=ON \
                            --build_examples=OFF --enable_s3=ON --enable_gcs=ON --enable_hdfs=ON --enable_abfs=ON --enable_enhanced_features=ON

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergWriteExec.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergWriteExec.scala
@@ -76,7 +76,10 @@ trait IcebergWriteExec extends ColumnarV2TableWriteExec {
         spec
           .fields()
           .stream()
-          .anyMatch(f => !validatePartitionType(spec.schema(), f) || !topIds.contains(f.sourceId()))
+          .anyMatch(
+            f =>
+              !validatePartitionType(spec.schema(), f) || !topIds
+                .contains(f.sourceId()) || f.transform().isVoid)
       ) {
         return ValidationResult.failed(
           "Not support write unsupported partition type, or is nested partition column")

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergWriteExec.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergWriteExec.scala
@@ -55,7 +55,7 @@ trait IcebergWriteExec extends ColumnarV2TableWriteExec {
 
   private def validatePartitionType(schema: Schema, field: PartitionField): Boolean = {
     val partitionType = schema.findType(field.sourceId())
-    val unSupportType = Seq(TypeID.DOUBLE, TypeID.FLOAT, TypeID.BINARY, TypeID.DECIMAL)
+    val unSupportType = Seq(TypeID.DOUBLE, TypeID.FLOAT, TypeID.DECIMAL)
     !unSupportType.contains(partitionType.typeId())
   }
 
@@ -71,22 +71,15 @@ trait IcebergWriteExec extends ColumnarV2TableWriteExec {
     }
     val spec = IcebergWriteUtil.getTable(write).spec()
     if (spec.isPartitioned) {
-      return ValidationResult.failed("Not support write partition table")
-    }
-    if (spec.isPartitioned) {
       val topIds = spec.schema().columns().asScala.map(c => c.fieldId())
       if (
         spec
           .fields()
           .stream()
-          .anyMatch(
-            f =>
-              !f.transform().isIdentity
-                || !validatePartitionType(spec.schema(), f) || !topIds.contains(f.sourceId()))
+          .anyMatch(f => !validatePartitionType(spec.schema(), f) || !topIds.contains(f.sourceId()))
       ) {
         return ValidationResult.failed(
-          "Not support write non identity partition table," +
-            "or contains unsupported partition type, or is nested partition column")
+          "Not support write unsupported partition type, or is nested partition column")
       }
     }
     if (IcebergWriteUtil.getTable(write).sortOrder().isSorted) {

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/IcebergWriteUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/IcebergWriteUtil.scala
@@ -16,18 +16,16 @@
  */
 package org.apache.iceberg.spark.source
 
-import org.apache.spark.sql.connector.write.{BatchWrite, Write, WriterCommitMessage}
+import org.apache.spark.sql.connector.write.{Write, WriterCommitMessage}
 
 import org.apache.iceberg._
+import org.apache.iceberg.spark.SparkWriteConf
 import org.apache.iceberg.spark.source.SparkWrite.TaskCommit
 import org.apache.iceberg.types.Type
 import org.apache.iceberg.types.Type.TypeID
 import org.apache.iceberg.types.Types.{ListType, MapType}
 
 object IcebergWriteUtil {
-  def isBatchAppend(write: BatchWrite): Boolean = {
-    write.getClass.getSimpleName.equals("BatchAppend")
-  }
 
   def isDataWrite(write: Write): Boolean = {
     write.isInstanceOf[SparkWrite]
@@ -60,30 +58,22 @@ object IcebergWriteUtil {
     field.get(write).asInstanceOf[java.util.Map[String, String]]
   }
 
+  def getWriteConf(write: Write): SparkWriteConf = {
+    val field = classOf[SparkWrite].getDeclaredField("writeConf")
+    field.setAccessible(true)
+    field.get(write).asInstanceOf[SparkWriteConf]
+  }
+
   def getTable(write: Write): Table = {
     val field = classOf[SparkWrite].getDeclaredField("table")
     field.setAccessible(true)
     field.get(write).asInstanceOf[Table]
   }
 
-  def getSparkWrite(write: BatchWrite): SparkWrite = {
-    // Access the enclosing SparkWrite instance from BatchAppend
-    val outerInstanceField = write.getClass.getDeclaredField("this$0")
-    outerInstanceField.setAccessible(true)
-    outerInstanceField.get(write).asInstanceOf[SparkWrite]
-  }
-
   def getFileFormat(write: Write): FileFormat = {
     val field = classOf[SparkWrite].getDeclaredField("format")
     field.setAccessible(true)
     field.get(write).asInstanceOf[FileFormat]
-  }
-
-  def getFileFormat(write: BatchWrite): FileFormat = {
-    val sparkWrite = getSparkWrite(write)
-    val field = classOf[SparkWrite].getDeclaredField("format")
-    field.setAccessible(true)
-    field.get(sparkWrite).asInstanceOf[FileFormat]
   }
 
   def getDirectory(write: Write): String = {
@@ -100,14 +90,7 @@ object IcebergWriteUtil {
   def getPartitionSpec(write: Write): PartitionSpec = {
     val field = classOf[SparkWrite].getDeclaredField("table")
     field.setAccessible(true)
-    getTable(write).spec()
-  }
-
-  def getDirectory(write: BatchWrite): String = {
-    val sparkWrite = getSparkWrite(write)
-    val field = classOf[SparkWrite].getDeclaredField("table")
-    field.setAccessible(true)
-    getTable(sparkWrite).locationProvider().newDataLocation("")
+    getTable(write).specs().get(getWriteConf(write).outputSpecId())
   }
 
   // Similar to the UnpartitionedDataWriter#commit


### PR DESCRIPTION
Add Protobuf struct IcebergPartitionField to transfer the iceberg id information, add IcebergPartitionSpec to transfer partition information.
Build with test and benchmark in CI and fix IcebergWriteTest build.
Set the file format to orc to bypass native parquet write for partitioned tpch iceberg suite, after https://github.com/facebookincubator/velox/pull/14670 which supports fanout false mode merged, we can relax the restriction.

Relevant PR: https://github.com/facebookincubator/velox/pull/13874