### PR TITLE
[GLUTEN-10392][VL] Fix filter fallback in scan-only execution

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -216,7 +216,8 @@ object Validators {
         case p if HiveTableScanExecTransformer.isHiveTableScan(p) => pass()
         case filter: FilterExec =>
           val childIsScan = filter.child.isInstanceOf[FileSourceScanExec] ||
-            filter.child.isInstanceOf[BatchScanExec]
+            filter.child.isInstanceOf[BatchScanExec] || filter.child
+              .isInstanceOf[BasicScanExecTransformer]
           if (childIsScan) {
             pass()
           } else {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Filter used to fallback when reading delta table in the scan-only execution. This PR fixes this issue.

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

UT verified.