### PR TITLE
[GLUTEN-10521][VL] Fall back `to_json` function for uppercase struct field name

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -821,9 +821,9 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       !SQLConf.get.caseSensitiveAnalysis &&
       ExpressionUtils.hasUppercaseFieldsStruct(child.dataType)
     ) {
-      throw new GlutenNotSupportException(
-        "'to_json' with 'spark.sql.caseSensitive = false' and has struct type which contains" +
-          " uppercase field name is not supported in Velox")
+      GlutenExceptionUtil.throwsNotFullySupported(
+        ExpressionNames.TO_JSON,
+        ToJsonRestrictions.NOT_SUPPORT_UPPERCASE_STRUCT)
     }
     ToJsonTransformer(substraitExprName, child, expr)
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -818,10 +818,12 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
         ToJsonRestrictions.NOT_SUPPORT_WITH_OPTIONS)
     }
     if (
-      !SQLConf.get.caseSensitiveAnalysis && ExpressionUtils.hasUppercaseFieldsStruct(child.dataType)
+      !SQLConf.get.caseSensitiveAnalysis &&
+      ExpressionUtils.hasUppercaseFieldsStruct(child.dataType)
     ) {
-      throw new GlutenNotSupportException("'to_json' with 'spark.sql.caseSensitive = false'" +
-        " and has struct type which contains uppercase field name is not supported in Velox")
+      throw new GlutenNotSupportException(
+        "'to_json' with 'spark.sql.caseSensitive = false' and has struct type which contains" +
+          " uppercase field name is not supported in Velox")
     }
     ToJsonTransformer(substraitExprName, child, expr)
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -819,7 +819,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
     }
     if (
       !SQLConf.get.caseSensitiveAnalysis &&
-      ExpressionUtils.hasUppercaseFieldsStruct(child.dataType)
+      ExpressionUtils.hasUppercaseStructFieldName(child.dataType)
     ) {
       GlutenExceptionUtil.throwsNotFullySupported(
         ExpressionNames.TO_JSON,

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -817,6 +817,12 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
         ExpressionNames.TO_JSON,
         ToJsonRestrictions.NOT_SUPPORT_WITH_OPTIONS)
     }
+    if (
+      !SQLConf.get.caseSensitiveAnalysis && ExpressionUtils.hasUppercaseFieldsStruct(child.dataType)
+    ) {
+      throw new GlutenNotSupportException("'to_json' with 'spark.sql.caseSensitive = false'" +
+        " and has struct type which contains uppercase field name is not supported in Velox")
+    }
     ToJsonTransformer(substraitExprName, child, expr)
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionRestrictions.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionRestrictions.scala
@@ -65,8 +65,8 @@ object ToJsonRestrictions extends ExpressionRestrictions {
     s"${ExpressionNames.TO_JSON} with options is not supported in Velox"
 
   val NOT_SUPPORT_UPPERCASE_STRUCT: String =
-    s"${ExpressionNames.TO_JSON} with 'spark.sql.caseSensitive = false' and has struct type" +
-      s" which contains uppercase field name is not supported in Velox"
+    s"When 'spark.sql.caseSensitive = false', ${ExpressionNames.TO_JSON} produces unexpected" +
+      s" result for struct field with uppercase name"
 
   override val functionName: String = ExpressionNames.TO_JSON
 

--- a/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionRestrictions.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionRestrictions.scala
@@ -64,9 +64,14 @@ object ToJsonRestrictions extends ExpressionRestrictions {
   val NOT_SUPPORT_WITH_OPTIONS: String =
     s"${ExpressionNames.TO_JSON} with options is not supported in Velox"
 
+  val NOT_SUPPORT_UPPERCASE_STRUCT: String =
+    s"${ExpressionNames.TO_JSON} with 'spark.sql.caseSensitive = false' and has struct type" +
+      s" which contains uppercase field name is not supported in Velox"
+
   override val functionName: String = ExpressionNames.TO_JSON
 
-  override val restrictionMessages: Array[String] = Array(NOT_SUPPORT_WITH_OPTIONS)
+  override val restrictionMessages: Array[String] =
+    Array(NOT_SUPPORT_WITH_OPTIONS, NOT_SUPPORT_UPPERCASE_STRUCT)
 }
 
 object Unbase64Restrictions extends ExpressionRestrictions {

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
@@ -380,10 +380,14 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
 
   test("to_json function") {
     withTable("t") {
-      spark.sql("create table t (a int, b string, c array<int>, d map<int, string>) using parquet")
-      spark.sql("""insert into t values (1, 'str', array(1,2,3), map(1, 'v')),
-                  |(2, 'str2', array(), map(1, 'v1', 2, 'v2')),
-                  |(3, '', array(1), map())
+      spark.sql(
+        """
+          |create table t (a int, b string, c array<int>, d map<int, string>, e struct<aA: int>)
+          |using parquet
+          |""".stripMargin)
+      spark.sql("""insert into t values (1, 'str', array(1,2,3), map(1, 'v'), struct(1)),
+                  |(2, 'str2', array(), map(1, 'v1', 2, 'v2'), struct(2)),
+                  |(3, '', array(1), map(), struct(null))
                   |""".stripMargin)
 
       runQueryAndCompare("select to_json(named_struct('a', a, 'b', b, 'c', c, 'd', d)) from t") {
@@ -396,6 +400,14 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
 
       runQueryAndCompare("select to_json(d) from t") {
         checkGlutenOperatorMatch[ProjectExecTransformer]
+      }
+
+      runQueryAndCompare("select to_json(e) from t") {
+        checkSparkOperatorMatch[ProjectExec]
+      }
+
+      runQueryAndCompare("select to_json(Array(named_struct('aA', a))) from t") {
+        checkSparkOperatorMatch[ProjectExec]
       }
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
@@ -20,8 +20,6 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, LeafExpression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 
-import java.util.Locale
-
 object ExpressionUtils {
 
   private def getExpressionTreeDepth(expr: Expression): Integer = {
@@ -44,13 +42,12 @@ object ExpressionUtils {
     hasComplexExpressions(plan.expressions, threshold)
   }
 
-  def hasUppercaseFieldsStruct(dataType: DataType): Boolean = {
+  def hasUppercaseStructFieldName(dataType: DataType): Boolean = {
     dataType match {
-      case StructType(fields) =>
-        fields.exists(field => field.name.toLowerCase(Locale.ROOT) != field.name)
-      case ArrayType(elementType, _) => hasUppercaseFieldsStruct(elementType)
+      case StructType(fields) => fields.exists(_.name.exists(_.isUpper))
+      case ArrayType(elementType, _) => hasUppercaseStructFieldName(elementType)
       case MapType(keyType, valueType, _) =>
-        hasUppercaseFieldsStruct(keyType) || hasUppercaseFieldsStruct(valueType)
+        hasUppercaseStructFieldName(keyType) || hasUppercaseStructFieldName(valueType)
       case _ => false
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, LeafExpression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 
+import java.util.Locale
+
 object ExpressionUtils {
 
   private def getExpressionTreeDepth(expr: Expression): Integer = {
@@ -44,7 +46,8 @@ object ExpressionUtils {
 
   def hasUppercaseFieldsStruct(dataType: DataType): Boolean = {
     dataType match {
-      case StructType(fields) => fields.exists(field => field.name.toLowerCase != field.name)
+      case StructType(fields) =>
+        fields.exists(field => field.name.toLowerCase(Locale.ROOT) != field.name)
       case ArrayType(elementType, _) => hasUppercaseFieldsStruct(elementType)
       case MapType(keyType, valueType, _) =>
         hasUppercaseFieldsStruct(keyType) || hasUppercaseFieldsStruct(valueType)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
@@ -18,6 +18,7 @@ package org.apache.gluten.expression
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, LeafExpression}
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 
 object ExpressionUtils {
 
@@ -39,5 +40,15 @@ object ExpressionUtils {
 
   def hasComplexExpressions(plan: SparkPlan, threshold: Int): Boolean = {
     hasComplexExpressions(plan.expressions, threshold)
+  }
+
+  def hasUppercaseFieldsStruct(dataType: DataType): Boolean = {
+    dataType match {
+      case StructType(fields) => fields.exists(field => field.name.toLowerCase != field.name)
+      case ArrayType(elementType, _) => hasUppercaseFieldsStruct(elementType)
+      case MapType(keyType, valueType, _) =>
+        hasUppercaseFieldsStruct(keyType) || hasUppercaseFieldsStruct(valueType)
+      case _ => false
+    }
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, gluten uses spark.sql.caseSensitive to determine whether to convert struct field names to lowercase and pass the converted field names to velox. This results in all struct field names becoming lowercase when spark.sql.caseSensitive is false. I haven't found a suitable solution to this problem for the current design, so let's fall back first.

## How was this patch tested?

unit test.
