### PR TITLE
[VL] Fix missing path `package/**` from the Velox backend PR CI path trigger

### DIFF
--- a/.github/workflows/velox_backend_arm.yml
+++ b/.github/workflows/velox_backend_arm.yml
@@ -32,6 +32,7 @@ on:
       - 'gluten-hudi/**'
       - 'gluten-paimon/**'
       - 'gluten-ut/**'
+      - 'package/**'
       - 'shims/**'
       - 'tools/gluten-it/**'
       - 'ep/build-velox/**'

--- a/.github/workflows/velox_backend_enhanced_features.yml
+++ b/.github/workflows/velox_backend_enhanced_features.yml
@@ -31,6 +31,7 @@ on:
       - 'gluten-iceberg/**'
       - 'gluten-hudi/**'
       - 'gluten-ut/**'
+      - 'package/**'
       - 'shims/**'
       - 'tools/gluten-it/**'
       - 'ep/build-velox/**'

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -32,6 +32,7 @@ on:
       - 'gluten-hudi/**'
       - 'gluten-paimon/**'
       - 'gluten-ut/**'
+      - 'package/**'
       - 'shims/**'
       - 'tools/gluten-it/**'
       - 'ep/build-velox/**'


### PR DESCRIPTION
Changes to `package/**` should trigger Velox backend CI since the packaging process is heavily relied on by the CI process. The patch fixes the issue.
