### PR TITLE
[GLUTEN-10544] Remove unnecessary method separateScanRDD

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -446,10 +446,11 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
 
       /**
        * the whole stage contains NO [[LeafTransformSupport]]. this the default case for:
-       *   1. SCAN with clickhouse backend (check ColumnarCollapseTransformStages#separateScanRDD())
-       *      2. test case where query plan is constructed from simple dataframes (e.g.
-       *      GlutenDataFrameAggregateSuite) in these cases, separate RDDs takes care of SCAN as a
-       *      result, genFinalStageIterator rather than genFirstStageIterator will be invoked
+       *   1. SCAN with clickhouse backend (check
+       *      BackendsApiManager.getSettings.excludeScanExecFromCollapsedStage()) 2. test case where
+       *      query plan is constructed from simple dataframes (e.g. GlutenDataFrameAggregateSuite)
+       *      in these cases, separate RDDs takes care of SCAN as a result, genFinalStageIterator
+       *      rather than genFirstStageIterator will be invoked
        */
       new WholeStageZippedPartitionsRDD(
         sparkContext,

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -132,9 +132,6 @@ case class ColumnarCollapseTransformStages(
     transformStageCounter: AtomicInteger = ColumnarCollapseTransformStages.transformStageCounter)
   extends Rule[SparkPlan] {
 
-  def separateScanRDD: Boolean =
-    BackendsApiManager.getSettings.excludeScanExecFromCollapsedStage()
-
   def apply(plan: SparkPlan): SparkPlan = {
     insertWholeStageTransformer(plan)
   }
@@ -144,7 +141,8 @@ case class ColumnarCollapseTransformStages(
    * WholeStageTransformer.
    */
   private def isSeparateBaseScanExecTransformer(plan: SparkPlan): Boolean = plan match {
-    case _: BasicScanExecTransformer if separateScanRDD => true
+    case _: BasicScanExecTransformer =>
+      BackendsApiManager.getSettings.excludeScanExecFromCollapsedStage()
     case _ => false
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR proposes to remove unnecessary method `separateScanRDD`.
Fixes #10544

## How was this patch tested?

GA tests.