### PR TITLE
[VL] Extend gluten-it to support more data source types

### DIFF
--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/BaseMixin.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/BaseMixin.java
@@ -68,10 +68,28 @@ public class BaseMixin {
   private boolean errorOnMemLeak;
 
   @CommandLine.Option(
+      names = {"--data-source"},
+      description = "Datasource used to generate data and to create tables",
+      defaultValue = "parquet")
+  private String dataSource;
+
+  @CommandLine.Option(
       names = {"--data-dir"},
       description = "Location for storing data used by tests",
       defaultValue = "/tmp")
   private String dataDir;
+
+  @CommandLine.Option(
+      names = {"-s", "--scale"},
+      description = "The scale factor of sample TPC-H dataset",
+      defaultValue = "0.1")
+  private double dataScale;
+
+  @CommandLine.Option(
+      names = {"--gen-partitioned-data"},
+      description = "Generate data with partitions",
+      defaultValue = "false")
+  private boolean genPartitionedData;
 
   @CommandLine.Option(
       names = {"--enable-ui"},
@@ -185,7 +203,10 @@ public class BaseMixin {
                 extraSparkConfScala,
                 level,
                 errorOnMemLeak,
+                dataSource,
                 dataDir,
+                dataScale,
+                genPartitionedData,
                 enableUi,
                 enableHsUi,
                 hsUiPort,
@@ -208,7 +229,10 @@ public class BaseMixin {
                 extraSparkConfScala,
                 level,
                 errorOnMemLeak,
+                dataSource,
                 dataDir,
+                dataScale,
+                genPartitionedData,
                 enableUi,
                 enableHsUi,
                 hsUiPort,
@@ -231,7 +255,10 @@ public class BaseMixin {
                 extraSparkConfScala,
                 level,
                 errorOnMemLeak,
+                dataSource,
                 dataDir,
+                dataScale,
+                genPartitionedData,
                 enableUi,
                 enableHsUi,
                 hsUiPort,

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/DataGenMixin.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/DataGenMixin.java
@@ -28,18 +28,6 @@ public class DataGenMixin {
       defaultValue = "always")
   private String dataGenStrategy;
 
-  @CommandLine.Option(
-      names = {"-s", "--scale"},
-      description = "The scale factor of sample TPC-H dataset",
-      defaultValue = "0.1")
-  private double scale;
-
-  @CommandLine.Option(
-      names = {"--gen-partitioned-data"},
-      description = "Generate data with partitions",
-      defaultValue = "false")
-  private boolean genPartitionedData;
-
   public Action[] makeActions() {
     final DataGenOnly.Strategy strategy;
     switch (dataGenStrategy) {
@@ -55,16 +43,6 @@ public class DataGenMixin {
       default:
         throw new IllegalArgumentException("Unexpected data-gen strategy: " + dataGenStrategy);
     }
-    return new Action[] {
-      new org.apache.gluten.integration.action.DataGenOnly(strategy, scale, genPartitionedData)
-    };
-  }
-
-  public double getScale() {
-    return scale;
-  }
-
-  public boolean genPartitionedData() {
-    return genPartitionedData;
+    return new Action[] {new org.apache.gluten.integration.action.DataGenOnly(strategy)};
   }
 }

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
@@ -175,8 +175,6 @@ public class Parameterized implements Callable<Integer> {
 
     org.apache.gluten.integration.action.Parameterized parameterized =
         new org.apache.gluten.integration.action.Parameterized(
-            dataGenMixin.getScale(),
-            dataGenMixin.genPartitionedData(),
             queriesMixin.queries(),
             queriesMixin.explain(),
             queriesMixin.iterations(),

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Queries.java
@@ -61,8 +61,6 @@ public class Queries implements Callable<Integer> {
     }
     org.apache.gluten.integration.action.Queries queries =
         new org.apache.gluten.integration.action.Queries(
-            dataGenMixin.getScale(),
-            dataGenMixin.genPartitionedData(),
             queriesMixin.queries(),
             queriesMixin.explain(),
             queriesMixin.iterations(),

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/QueriesCompare.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/QueriesCompare.java
@@ -39,8 +39,6 @@ public class QueriesCompare implements Callable<Integer> {
   public Integer call() throws Exception {
     org.apache.gluten.integration.action.QueriesCompare queriesCompare =
         new org.apache.gluten.integration.action.QueriesCompare(
-            dataGenMixin.getScale(),
-            dataGenMixin.genPartitionedData(),
             queriesMixin.queries(),
             queriesMixin.explain(),
             queriesMixin.iterations(),

--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/SparkShell.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/SparkShell.java
@@ -36,8 +36,7 @@ public class SparkShell implements Callable<Integer> {
   @Override
   public Integer call() throws Exception {
     org.apache.gluten.integration.action.SparkShell sparkShell =
-        new org.apache.gluten.integration.action.SparkShell(
-            dataGenMixin.getScale(), dataGenMixin.genPartitionedData());
+        new org.apache.gluten.integration.action.SparkShell();
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), sparkShell));
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/QueryRunner.scala
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 
 import java.io.File
 
-class QueryRunner(val queryResourceFolder: String, val dataPath: String) {
+class QueryRunner(val queryResourceFolder: String, val source: String, val dataPath: String) {
   import QueryRunner._
 
   Preconditions.checkState(
@@ -34,7 +34,7 @@ class QueryRunner(val queryResourceFolder: String, val dataPath: String) {
     Array(): _*)
 
   def createTables(creator: TableCreator, spark: SparkSession): Unit = {
-    creator.create(spark, dataPath)
+    creator.create(spark, source, dataPath)
   }
 
   def runQuery(

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Suite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/Suite.scala
@@ -173,9 +173,15 @@ abstract class Suite(
 
   protected def historyWritePath(): String
 
-  private[integration] def dataWritePath(scale: Double, genPartitionedData: Boolean): String
+  private[integration] def createDataGen(): DataGen
 
-  private[integration] def createDataGen(scale: Double, genPartitionedData: Boolean): DataGen
+  private[integration] def dataSource(): String
+
+  private[integration] def dataWritePath(): String
+
+  private[integration] def dataScale(): Double
+
+  private[integration] def genPartitionedData(): Boolean
 
   private[integration] def queryResource(): String
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/TableCreator.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/TableCreator.scala
@@ -53,14 +53,9 @@ object TableCreator {
           } else {
             spark.catalog.createTable(tableName, file.getAbsolutePath, source)
             createdTableNames += tableName
-            try {
+            if (spark.catalog.listColumns(tableName).collect().exists(_.isPartition)) {
               spark.catalog.recoverPartitions(tableName)
               recoveredPartitionTableNames += tableName
-            } catch {
-              case ae: AnalysisException if !ae.errorClass.contains("NOT_A_PARTITIONED_TABLE") =>
-                throw ae
-              case _ =>
-              // Swallows the `NOT_A_PARTITIONED_TABLE` exception.
             }
           }
         })

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/TableCreator.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/TableCreator.scala
@@ -23,7 +23,7 @@ import java.io.File
 import scala.collection.mutable
 
 trait TableCreator {
-  def create(spark: SparkSession, dataPath: String): Unit
+  def create(spark: SparkSession, source: String, dataPath: String): Unit
 }
 
 object TableCreator {
@@ -32,7 +32,7 @@ object TableCreator {
   }
 
   private object DiscoverSchema extends TableCreator {
-    override def create(spark: SparkSession, dataPath: String): Unit = {
+    override def create(spark: SparkSession, source: String, dataPath: String): Unit = {
       val files = new File(dataPath).listFiles()
       val tableNames = files.map(_.getName)
       val existedTableNames = mutable.ArrayBuffer[String]()
@@ -51,7 +51,7 @@ object TableCreator {
           if (spark.catalog.tableExists(tableName)) {
             existedTableNames += tableName
           } else {
-            spark.catalog.createTable(tableName, file.getAbsolutePath, "parquet")
+            spark.catalog.createTable(tableName, file.getAbsolutePath, source)
             createdTableNames += tableName
             try {
               spark.catalog.recoverPartitions(tableName)

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/DataGenOnly.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/DataGenOnly.scala
@@ -20,14 +20,13 @@ import org.apache.gluten.integration.Suite
 
 import java.io.File
 
-case class DataGenOnly(strategy: DataGenOnly.Strategy, scale: Double, genPartitionedData: Boolean)
-  extends Action {
+case class DataGenOnly(strategy: DataGenOnly.Strategy) extends Action {
   override def execute(suite: Suite): Boolean = {
     strategy match {
       case DataGenOnly.Skip =>
       // Do nothing
       case DataGenOnly.Once =>
-        val dataPath = suite.dataWritePath(scale, genPartitionedData)
+        val dataPath = suite.dataWritePath()
         val alreadyExists = new File(dataPath).exists()
         if (alreadyExists) {
           println(s"Data already exists at $dataPath, skipping generating it.")
@@ -42,7 +41,7 @@ case class DataGenOnly(strategy: DataGenOnly.Strategy, scale: Double, genPartiti
 
   private def gen(suite: Suite): Unit = {
     suite.sessionSwitcher.useSession("baseline", "Data Gen")
-    val dataGen = suite.createDataGen(scale, genPartitionedData)
+    val dataGen = suite.createDataGen()
     dataGen.gen()
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -31,8 +31,6 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import scala.collection.mutable
 
 class Parameterized(
-    scale: Double,
-    genPartitionedData: Boolean,
     queries: QuerySelector,
     explain: Boolean,
     iterations: Int,
@@ -110,7 +108,7 @@ class Parameterized(
 
   override def execute(suite: Suite): Boolean = {
     val runner: QueryRunner =
-      new QueryRunner(suite.queryResource(), suite.dataWritePath(scale, genPartitionedData))
+      new QueryRunner(suite.queryResource(), suite.dataSource(), suite.dataWritePath())
 
     val sessionSwitcher = suite.sessionSwitcher
     val testConf = suite.getTestConf()

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Queries.scala
@@ -26,8 +26,6 @@ import org.apache.gluten.integration.stat.RamStat
 import org.apache.spark.sql.SparkSession
 
 case class Queries(
-    scale: Double,
-    genPartitionedData: Boolean,
     queries: QuerySelector,
     explain: Boolean,
     iterations: Int,
@@ -41,7 +39,7 @@ case class Queries(
   override def execute(suite: Suite): Boolean = {
     val runQueryIds = queries.select(suite)
     val runner: QueryRunner =
-      new QueryRunner(suite.queryResource(), suite.dataWritePath(scale, genPartitionedData))
+      new QueryRunner(suite.queryResource(), suite.dataSource(), suite.dataWritePath())
     val sessionSwitcher = suite.sessionSwitcher
     sessionSwitcher.useSession("test", "Run Queries")
     runner.createTables(suite.tableCreator(), sessionSwitcher.spark())

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
@@ -26,8 +26,6 @@ import org.apache.gluten.integration.stat.RamStat
 import org.apache.spark.sql.{SparkSession, TestUtils}
 
 case class QueriesCompare(
-    scale: Double,
-    genPartitionedData: Boolean,
     queries: QuerySelector,
     explain: Boolean,
     iterations: Int,
@@ -37,7 +35,7 @@ case class QueriesCompare(
 
   override def execute(suite: Suite): Boolean = {
     val runner: QueryRunner =
-      new QueryRunner(suite.queryResource(), suite.dataWritePath(scale, genPartitionedData))
+      new QueryRunner(suite.queryResource(), suite.dataSource(), suite.dataWritePath())
     val runQueryIds = queries.select(suite)
     val sessionSwitcher = suite.sessionSwitcher
 

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/SparkShell.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/SparkShell.scala
@@ -20,11 +20,11 @@ import org.apache.gluten.integration.{QueryRunner, Suite}
 
 import org.apache.spark.repl.Main
 
-case class SparkShell(scale: Double, genPartitionedData: Boolean) extends Action {
+case class SparkShell() extends Action {
   override def execute(suite: Suite): Boolean = {
     suite.sessionSwitcher.useSession("test", "Spark CLI")
     val runner: QueryRunner =
-      new QueryRunner(suite.queryResource(), suite.dataWritePath(scale, genPartitionedData))
+      new QueryRunner(suite.queryResource(), suite.dataSource(), suite.dataWritePath())
     runner.createTables(suite.tableCreator(), suite.sessionSwitcher.spark())
     Main.sparkSession = suite.sessionSwitcher.spark()
     Main.sparkContext = suite.sessionSwitcher.spark().sparkContext

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchTableCreator.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/clickbench/ClickBenchTableCreator.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.types.StructType
 import java.io.File
 
 object ClickBenchTableCreator extends TableCreator {
-  private val SPARK_DATA_FILE_NAME = "hits-spark.parquet"
   private val TABLE_NAME = "hits"
   private val SCHEMA: StructType = StructType.fromDDL("""
                                                         |watchid bigint,
@@ -134,14 +133,14 @@ object ClickBenchTableCreator extends TableCreator {
                                                         |clid int
                                                         |""".stripMargin)
 
-  override def create(spark: SparkSession, dataPath: String): Unit = {
+  override def create(spark: SparkSession, source: String, dataPath: String): Unit = {
     if (spark.catalog.tableExists(TABLE_NAME)) {
       println("Table exists: " + TABLE_NAME)
       return
     }
     println("Creating catalog table: " + TABLE_NAME)
     val file = new File(dataPath + File.separator + ClickBenchDataGen.FILE_NAME)
-    spark.catalog.createTable(TABLE_NAME, "parquet", SCHEMA, Map("path" -> file.getAbsolutePath))
+    spark.catalog.createTable(TABLE_NAME, source, SCHEMA, Map("path" -> file.getAbsolutePath))
     try {
       spark.catalog.recoverPartitions(TABLE_NAME)
     } catch {

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsDataGen.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsDataGen.scala
@@ -31,6 +31,7 @@ class TpcdsDataGen(
     val spark: SparkSession,
     scale: Double,
     partitions: Int,
+    source: String,
     dir: String,
     typeModifiers: List[TypeModifier] = List(),
     val genPartitionedData: Boolean)
@@ -120,9 +121,10 @@ class TpcdsDataGen(
       }(ShimUtils.getExpressionEncoder(stringSchema))
       .select(columns: _*)
       .write
-      .mode(SaveMode.Overwrite)
+      .format(source)
       .partitionBy(partitionBy.toArray: _*)
-      .parquet(tablePath)
+      .mode(SaveMode.Overwrite)
+      .save(dir + File.separator + tableName)
   }
 
   override def gen(): Unit = {

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/ds/TpcdsSuite.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.integration.ds
 import org.apache.gluten.integration.{DataGen, Suite, TableCreator}
 import org.apache.gluten.integration.action.Action
 import org.apache.gluten.integration.ds.TpcdsSuite.{ALL_QUERY_IDS, HISTORY_WRITE_PATH, TPCDS_WRITE_RELATIVE_PATH}
+import org.apache.gluten.integration.h.TpchSuite.checkDataGenArgs
 import org.apache.gluten.integration.metrics.MetricMapper
 
 import org.apache.spark.SparkConf
@@ -35,7 +36,10 @@ class TpcdsSuite(
     val extraSparkConf: Map[String, String],
     val logLevel: Level,
     val errorOnMemLeak: Boolean,
+    val dataSource: String,
     val dataDir: String,
+    val dataScale: Double,
+    val genPartitionedData: Boolean,
     val enableUi: Boolean,
     val enableHsUi: Boolean,
     val hsUiPort: Int,
@@ -67,24 +71,33 @@ class TpcdsSuite(
     baselineMetricMapper,
     testMetricMapper
   ) {
+  import TpcdsSuite._
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH
 
-  override private[integration] def dataWritePath(
-      scale: Double,
-      genPartitionedData: Boolean): String =
-    new File(dataDir).toPath.resolve(TPCDS_WRITE_RELATIVE_PATH + s"-$scale").toFile.getAbsolutePath
+  override private[integration] def dataWritePath(): String = {
+    val partitionedFlag = if (genPartitionedData) {
+      "partitioned"
+    } else {
+      "non_partitioned"
+    }
+    new File(dataDir).toPath
+      .resolve(s"$TPCDS_WRITE_RELATIVE_PATH-$dataScale-$dataSource-$partitionedFlag")
+      .toFile
+      .getAbsolutePath
+  }
 
-  override private[integration] def createDataGen(
-      scale: Double,
-      genPartitionedData: Boolean): DataGen =
+  override private[integration] def createDataGen(): DataGen = {
+    checkDataGenArgs(dataSource, dataScale, genPartitionedData)
     new TpcdsDataGen(
       sessionSwitcher.spark(),
-      scale,
+      dataScale,
       shufflePartitions,
-      dataWritePath(scale, genPartitionedData),
+      dataSource,
+      dataWritePath(),
       typeModifiers(),
       genPartitionedData)
+  }
 
   override private[integration] def queryResource(): String = {
     "/tpcds-queries"
@@ -205,4 +218,13 @@ object TpcdsSuite {
     "q99"
   )
   private val HISTORY_WRITE_PATH = "/tmp/tpcds-history"
+
+  private def checkDataGenArgs(
+      dataSource: String,
+      scale: Double,
+      genPartitionedData: Boolean): Unit = {
+    require(
+      Set("parquet").contains(dataSource),
+      s"Data source type $dataSource is not supported by TPC-DS suite")
+  }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/h/TpchDataGen.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/h/TpchDataGen.scala
@@ -32,26 +32,27 @@ class TpchDataGen(
     val spark: SparkSession,
     scale: Double,
     partitions: Int,
-    path: String,
+    source: String,
+    dir: String,
     typeModifiers: List[TypeModifier] = List())
   extends Serializable
   with DataGen {
 
   override def gen(): Unit = {
-    generate(path, "lineitem", lineItemSchema, partitions, lineItemGenerator, lineItemParser)
-    generate(path, "customer", customerSchema, partitions, customerGenerator, customerParser)
-    generate(path, "orders", orderSchema, partitions, orderGenerator, orderParser)
+    generate(dir, "lineitem", lineItemSchema, partitions, lineItemGenerator, lineItemParser)
+    generate(dir, "customer", customerSchema, partitions, customerGenerator, customerParser)
+    generate(dir, "orders", orderSchema, partitions, orderGenerator, orderParser)
     generate(
-      path,
+      dir,
       "partsupp",
       partSupplierSchema,
       partitions,
       partSupplierGenerator,
       partSupplierParser)
-    generate(path, "supplier", supplierSchema, partitions, supplierGenerator, supplierParser)
-    generate(path, "nation", nationSchema, nationGenerator, nationParser)
-    generate(path, "part", partSchema, partitions, partGenerator, partParser)
-    generate(path, "region", regionSchema, regionGenerator, regionParser)
+    generate(dir, "supplier", supplierSchema, partitions, supplierGenerator, supplierParser)
+    generate(dir, "nation", nationSchema, nationGenerator, nationParser)
+    generate(dir, "part", partSchema, partitions, partGenerator, partParser)
+    generate(dir, "region", regionSchema, regionGenerator, regionParser)
   }
 
   // lineitem
@@ -336,7 +337,8 @@ class TpchDataGen(
           rows
       }(ShimUtils.getExpressionEncoder(modifiedSchema))
       .write
+      .format(source)
       .mode(SaveMode.Overwrite)
-      .parquet(dir + File.separator + tableName)
+      .save(dir + File.separator + tableName)
   }
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/h/TpchSuite.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/h/TpchSuite.scala
@@ -35,7 +35,10 @@ class TpchSuite(
     val extraSparkConf: Map[String, String],
     val logLevel: Level,
     val errorOnMemLeak: Boolean,
+    val dataSource: String,
     val dataDir: String,
+    val dataScale: Double,
+    val genPartitionedData: Boolean,
     val enableUi: Boolean,
     val enableHsUi: Boolean,
     val hsUiPort: Int,
@@ -67,23 +70,26 @@ class TpchSuite(
     baselineMetricMapper,
     testMetricMapper
   ) {
+  import TpchSuite._
 
   override protected def historyWritePath(): String = HISTORY_WRITE_PATH
 
-  override private[integration] def dataWritePath(
-      scale: Double,
-      genPartitionedData: Boolean): String =
-    new File(dataDir).toPath.resolve(TPCH_WRITE_RELATIVE_PATH + s"-$scale").toFile.getAbsolutePath
+  override private[integration] def dataWritePath(): String =
+    new File(dataDir).toPath
+      .resolve(s"$TPCH_WRITE_RELATIVE_PATH-$dataScale-$dataSource")
+      .toFile
+      .getAbsolutePath
 
-  override private[integration] def createDataGen(
-      scale: Double,
-      genPartitionedData: Boolean): DataGen =
+  override private[integration] def createDataGen(): DataGen = {
+    checkDataGenArgs(dataSource, dataScale, genPartitionedData)
     new TpchDataGen(
       sessionSwitcher.spark(),
-      scale,
+      dataScale,
       shufflePartitions,
-      dataWritePath(scale, genPartitionedData),
+      dataSource,
+      dataWritePath(),
       typeModifiers())
+  }
 
   override private[integration] def queryResource(): String = {
     "/tpch-queries"
@@ -122,4 +128,14 @@ object TpchSuite {
     "q21",
     "q22")
   private val HISTORY_WRITE_PATH = "/tmp/tpch-history"
+
+  private def checkDataGenArgs(
+      dataSource: String,
+      scale: Double,
+      genPartitionedData: Boolean): Unit = {
+    require(
+      Set("parquet").contains(dataSource),
+      s"Data source type $dataSource is not supported by TPC-H suite")
+    require(!genPartitionedData, "TPC-H suite doesn't support generating partitioned data")
+  }
 }


### PR DESCRIPTION
Add a new option`--data-source`:

```bash
      --data-source=<dataSource>
                             Datasource used to generate data and to create
                               tables
                               Default: parquet
```

Default value is `parquet`. And in this PR only `parquet` is supported. Error will be thrown otherwise.

The data generated will be in folder whose name has indicator of the data source type:

```
root@hongze-zhang-VMware20-1:/tmp# ls /tmp/tpcds-generated-1.0-parquet-partitioned
call_center   catalog_returns  customer          customer_demographics  household_demographics  inventory  promotion  ship_mode  store_returns  time_dim   web_page     web_sales
catalog_page  catalog_sales    customer_address  date_dim               income_band             item       reason     store      store_sales    warehouse  web_returns  web_site
```

The feature would help with the support of lake formats and other formats in gluten-it, in later PRs. For example, we should ideally have `--data-source=delta`, `--data-source=delta`, `--data-source=orc`, etc. supported eventually. 