### PR TITLE
[GLUEN-10107][INFRA]Deprecate isUseUniffleShuffleManager from glutenConfig

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -462,15 +462,11 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
           clazz.getConstructor(classOf[SQLMetric], classOf[SQLMetric], classOf[SQLMetric])
         constructor.newInstance(readBatchNumRows, numOutputRows, dataSize).asInstanceOf[Serializer]
       case _ =>
-        if (GlutenConfig.get.isUseUniffleShuffleManager) {
-          throw new UnsupportedOperationException("temporarily uniffle not support ch ")
-        } else {
-          new CHColumnarBatchSerializer(
-            readBatchNumRows,
-            numOutputRows,
-            dataSize,
-            deserializationTime)
-        }
+        new CHColumnarBatchSerializer(
+          readBatchNumRows,
+          numOutputRows,
+          dataSize,
+          deserializationTime)
     }
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -160,7 +160,7 @@ class GlutenConfig(conf: SQLConf) extends GlutenCoreConfig(conf) {
       .contains("celeborn")
 
   // Whether to use UniffleShuffleManager.
-  // TODO: Deprecate the API: https://github.com/apache/incubator-gluten/issues/10107.
+  @deprecated
   def isUseUniffleShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")


### PR DESCRIPTION

## What changes are proposed in this pull request?
The `isUseUniffleShuffleManager` configuration was originally introduced in PR #3767. However, subsequent refactoring efforts have relocated the Uniffle-related shuffle manager implementation to the `backends-velox` module. This configuration is now obsolete and should be removed. Additionally, we can eliminate the corresponding validation checks in the ClickHouse backends since the `UniffleShuffleManager` class will no longer be present in the classpath of CH-backends.

## How was this patch tested?

Existing tests.