### PR TITLE
[FLINK] Add `java-17` profile for Flink build and update project version in flink doc

### DIFF
--- a/gluten-flink/docs/Flink.md
+++ b/gluten-flink/docs/Flink.md
@@ -98,8 +98,8 @@ export FLINK_HOME=
 cd $FLINK_HOME
 mkdir -p gluten_lib
 ln -s $VELOX4J_HOME/target/velox4j-0.1.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar
-ln -s $GLUTEN_FLINK_HOME/runtime/target/gluten-flink-runtime-1.5.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-runtime-1.5.0.jar
-ln -s $GLUTEN_FLINK_HOME/loader/target/gluten-flink-loader-1.5.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-loader-1.5.0.jar
+ln -s $GLUTEN_FLINK_HOME/runtime/target/gluten-flink-runtime-1.6.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar
+ln -s $GLUTEN_FLINK_HOME/loader/target/gluten-flink-loader-1.6.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar
 ```
 
 And make them loaded before flink libraries.
@@ -110,7 +110,7 @@ Gluten classes need to be loaded first in Flink,
 you can modify the constructFlinkClassPath function in `$FLINK_HOME/bin/config.sh` like this: 
 
 ```
-GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.5.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.5.0.jar:"
+GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar:"
 echo "$GLUTEN_JAR""$FLINK_CLASSPATH""$FLINK_DIST"
 ```
 

--- a/gluten-flink/docs/Gluten-Flink-troubleshooting.md
+++ b/gluten-flink/docs/Gluten-Flink-troubleshooting.md
@@ -10,6 +10,6 @@ Gluten classes need to be loaded first in Flink,
 you can modify the constructFlinkClassPath function in `$FLINK_HOME/bin/config.sh` like this:
 
 ```
-GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.5.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.5.0.jar:"
+GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar:"
 echo "$GLUTEN_JAR""$FLINK_CLASSPATH""$FLINK_DIST"
 ```

--- a/gluten-flink/pom.xml
+++ b/gluten-flink/pom.xml
@@ -59,6 +59,20 @@
     </spotless.license.header>
   </properties>
 
+    <profiles>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+            </properties>
+        </profile>
+    </profiles>
+
+
   <build>
     <plugins>
       <plugin>

--- a/gluten-flink/pom.xml
+++ b/gluten-flink/pom.xml
@@ -34,8 +34,8 @@
     <flink.version>1.19.2</flink.version>
     <velox4j.version>0.1.0-SNAPSHOT</velox4j.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <spotless.version>2.27.2</spotless.version>
     <spotless.scalafmt.version>3.8.3</spotless.scalafmt.version>
     <spotless.delimiter>package</spotless.delimiter>


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/apache/incubator-gluten/pull/10515 has made a great effort to decouple flink from parent gluten.

This PR adds a profile named java-17 to set both `maven.compiler.source/target` to 17 (defaults to 11) if users want to build the code with Java 17. 

This PR update compiler version and update  build jar version to match the master pom version change.
## How was this patch tested?

NA
