### PR TITLE
[GLUTEN-10607][MINOR] Fix: Use  `setSafe` in DateWriter to avoid overflow

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
@@ -1930,7 +1930,7 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
 
     @Override
     final void setInt(int rowId, int value) {
-      writer.set(rowId, value);
+      writer.setSafe(rowId, value);
     }
 
     @Override


### PR DESCRIPTION
## What changes are proposed in this pull request?
If the Date type is nested within an Array, Map, or Struct, invoking `writeRow` may result in an exception due to DateWriter utilizing the unsafe set interface. The `set` interface does not reallocate the value buffer in cases of overflow. Consequently, this pull request changes to use the safer `setSafe` interface.