### PR TITLE
[GLUTEN-10577][CELEBORN] Refactor `CelebornShuffleManager` to load factory in a better way

### DIFF
--- a/backends-clickhouse/src-celeborn/main/scala/org/apache/spark/shuffle/CHCelebornColumnarBatchSerializerFactory.scala
+++ b/backends-clickhouse/src-celeborn/main/scala/org/apache/spark/shuffle/CHCelebornColumnarBatchSerializerFactory.scala
@@ -16,11 +16,9 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.spark.shuffle.gluten.celeborn.CelebornColumnarBatchSerializerFactory
 
 class CHCelebornColumnarBatchSerializerFactory extends CelebornColumnarBatchSerializerFactory {
-  override def backendName(): String = BackendsApiManager.getBackendName
 
   override def columnarBatchSerializerClass(): String =
     "org.apache.spark.shuffle.CHCelebornColumnarBatchSerializer"

--- a/backends-clickhouse/src-celeborn/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriterFactory.scala
+++ b/backends-clickhouse/src-celeborn/main/scala/org/apache/spark/shuffle/CHCelebornColumnarShuffleWriterFactory.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.BackendsApiManager
-
 import org.apache.spark.TaskContext
 import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
 import org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
@@ -26,7 +24,6 @@ import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 
 class CHCelebornColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
-  override def backendName(): String = BackendsApiManager.getBackendName
 
   override def createShuffleWriterInstance[K, V](
       shuffleId: Int,

--- a/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializerFactory.scala
+++ b/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializerFactory.scala
@@ -16,12 +16,9 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.velox.VeloxBackend
-
 import org.apache.spark.shuffle.gluten.celeborn.CelebornColumnarBatchSerializerFactory
 
 class VeloxCelebornColumnarBatchSerializerFactory extends CelebornColumnarBatchSerializerFactory {
-  override def backendName(): String = VeloxBackend.BACKEND_NAME
 
   override def columnarBatchSerializerClass(): String =
     "org.apache.spark.shuffle.CelebornColumnarBatchSerializer"

--- a/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriterFactory.scala
+++ b/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarShuffleWriterFactory.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.shuffle
 
-import org.apache.gluten.backendsapi.velox.VeloxBackend
-
 import org.apache.spark.TaskContext
 import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
 import org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleWriterFactory
@@ -26,7 +24,6 @@ import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 
 class VeloxCelebornColumnarShuffleWriterFactory extends CelebornShuffleWriterFactory {
-  override def backendName(): String = VeloxBackend.BACKEND_NAME
 
   override def createShuffleWriterInstance[K, V](
       shuffleId: Int,

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornColumnarBatchSerializerFactory.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornColumnarBatchSerializerFactory.java
@@ -17,7 +17,6 @@
 package org.apache.spark.shuffle.gluten.celeborn;
 
 public interface CelebornColumnarBatchSerializerFactory {
-  String backendName();
 
   String columnarBatchSerializerClass();
 }

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -70,7 +70,7 @@ public class CelebornShuffleManager
     writerFactory = shuffleWriterFactoryIterator.next();
     Preconditions.checkState(
         !shuffleWriterFactoryIterator.hasNext(),
-        "Multiple factory found for Celeborn shuffle writer");
+        "Multiple factories found for Celeborn shuffle writer");
 
     final Iterator<CelebornColumnarBatchSerializerFactory> serializerFactoryIterator =
         ServiceLoader.load(CelebornColumnarBatchSerializerFactory.class).iterator();
@@ -81,7 +81,7 @@ public class CelebornShuffleManager
     columnarBatchSerializerFactory = serializerFactoryIterator.next();
     Preconditions.checkState(
         !serializerFactoryIterator.hasNext(),
-        "Multiple factory found for Celeborn columnar batch serializer");
+        "Multiple factories found for Celeborn columnar batch serializer");
   }
 
   private final SparkConf conf;

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -16,14 +16,12 @@
  */
 package org.apache.spark.shuffle.gluten.celeborn;
 
-import org.apache.gluten.backendsapi.BackendsApiManager;
 import org.apache.gluten.config.GlutenConfig;
 import org.apache.gluten.exception.GlutenException;
 import org.apache.gluten.shuffle.NeedCustomColumnarBatchSerializer;
 import org.apache.gluten.shuffle.SupportsColumnarShuffle;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
 import org.apache.celeborn.client.LifecycleManager;
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
@@ -36,11 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 public class CelebornShuffleManager
     implements ShuffleManager, SupportsColumnarShuffle, NeedCustomColumnarBatchSerializer {
@@ -67,35 +63,25 @@ public class CelebornShuffleManager
   private static final CelebornColumnarBatchSerializerFactory columnarBatchSerializerFactory;
 
   static {
-    final String backendName = BackendsApiManager.getBackendName();
-    final ServiceLoader<CelebornShuffleWriterFactory> loader =
-        ServiceLoader.load(CelebornShuffleWriterFactory.class);
-    final List<CelebornShuffleWriterFactory> factoryList =
-        Arrays.stream(Iterators.toArray(loader.iterator(), CelebornShuffleWriterFactory.class))
-            .collect(Collectors.toList());
+    final Iterator<CelebornShuffleWriterFactory> shuffleWriterFactoryIterator =
+        ServiceLoader.load(CelebornShuffleWriterFactory.class).iterator();
     Preconditions.checkState(
-        !factoryList.isEmpty(),
-        "No Celeborn shuffle writer factory found for backend " + backendName);
+        shuffleWriterFactoryIterator.hasNext(), "No Celeborn shuffle writer factory found");
+    writerFactory = shuffleWriterFactoryIterator.next();
     Preconditions.checkState(
-        factoryList.size() == 1,
-        "Multiple factory found for Celeborn shuffle writer for backend " + backendName);
-    writerFactory = factoryList.get(0);
+        !shuffleWriterFactoryIterator.hasNext(),
+        "Multiple factory found for Celeborn shuffle writer");
 
-    final ServiceLoader<CelebornColumnarBatchSerializerFactory> serializerLoader =
-        ServiceLoader.load(CelebornColumnarBatchSerializerFactory.class);
-    final List<CelebornColumnarBatchSerializerFactory> serializerFactoryList =
-        Arrays.stream(
-                Iterators.toArray(
-                    serializerLoader.iterator(), CelebornColumnarBatchSerializerFactory.class))
-            .collect(Collectors.toList());
+    final Iterator<CelebornColumnarBatchSerializerFactory> serializerFactoryIterator =
+        ServiceLoader.load(CelebornColumnarBatchSerializerFactory.class).iterator();
 
     Preconditions.checkState(
-        !serializerFactoryList.isEmpty(),
-        "No factory found for Celeborn columnar batch serializer for backend " + backendName);
+        serializerFactoryIterator.hasNext(),
+        "No factory found for Celeborn columnar batch serializer");
+    columnarBatchSerializerFactory = serializerFactoryIterator.next();
     Preconditions.checkState(
-        serializerFactoryList.size() == 1,
-        "Multiple factory found for Celeborn columnar batch serializer for backend " + backendName);
-    columnarBatchSerializerFactory = serializerFactoryList.get(0);
+        !serializerFactoryIterator.hasNext(),
+        "Multiple factory found for Celeborn columnar batch serializer");
   }
 
   private final SparkConf conf;

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -72,7 +72,6 @@ public class CelebornShuffleManager
         ServiceLoader.load(CelebornShuffleWriterFactory.class);
     final List<CelebornShuffleWriterFactory> factoryList =
         Arrays.stream(Iterators.toArray(loader.iterator(), CelebornShuffleWriterFactory.class))
-            .filter(f -> f.backendName().equalsIgnoreCase(backendName))
             .collect(Collectors.toList());
     Preconditions.checkState(
         !factoryList.isEmpty(),
@@ -88,7 +87,6 @@ public class CelebornShuffleManager
         Arrays.stream(
                 Iterators.toArray(
                     serializerLoader.iterator(), CelebornColumnarBatchSerializerFactory.class))
-            .filter(f -> f.backendName().equalsIgnoreCase(backendName))
             .collect(Collectors.toList());
 
     Preconditions.checkState(

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleWriterFactory.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleWriterFactory.java
@@ -24,7 +24,6 @@ import org.apache.spark.shuffle.ShuffleWriter;
 import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle;
 
 public interface CelebornShuffleWriterFactory {
-  String backendName();
 
   <K, V> ShuffleWriter<K, V> createShuffleWriterInstance(
       int shuffleId,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Refactor CelebornShuffleManager use list instead of map to load the factory as described in #10577 .

## How was this patch tested?

Existing tests.
