### PR TITLE
[DOC][FLINK] Update flink build command to skip gpg and spotless check

### DIFF
--- a/gluten-flink/docs/Flink.md
+++ b/gluten-flink/docs/Flink.md
@@ -49,7 +49,7 @@ As some features have not been committed to upstream, you have to use the follow
 git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
 cd velox4j
 git reset --hard a5e3e9d7f11440f8c4eafeff88ae6945186d02c1
-mvn clean install
+mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
 ```
 **Get gluten**
 


### PR DESCRIPTION

## What changes are proposed in this pull request?

Since https://github.com/apache/incubator-gluten/pull/10205/files has provide a runnable command to build velox4j, but it's broken after recent code commit. This PR re-update the build command.

## How was this patch tested?

NA
