### PR TITLE
[GLUTEN-10605][VL] Rewrite unbounded window to an equivalent aggregate join

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -65,6 +65,7 @@ object VeloxRuleApi {
     injector.injectOptimizerRule(CollapseGetJsonObjectExpressionRule.apply)
     injector.injectOptimizerRule(RewriteCastFromArray.apply)
     injector.injectPostHocResolutionRule(ArrowConvertorRule.apply)
+    injector.injectOptimizerRule(RewriteUnboundedWindow.apply)
   }
 
   /**

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -695,7 +695,7 @@ object VeloxConfig {
       .doc("When true, rewrite unbounded window to an equivalent aggregate join operation" +
         " to avoid OOM.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val ENABLE_ENHANCED_FEATURES =
     buildConf("spark.gluten.sql.enable.enhancedFeatures")

--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -76,6 +76,8 @@ class VeloxConfig(conf: SQLConf) extends GlutenConfig(conf) {
   def enableRewriteCastArrayToString: Boolean =
     getConf(ENABLE_REWRITE_CAST_ARRAY_TO_STRING)
 
+  def enableRewriteUnboundedWindow: Boolean = getConf(ENABLE_REWRITE_UNBOUNDED_WINDOW)
+
   def enableEnhancedFeatures(): Boolean = ConfigJniWrapper.isEnhancedFeaturesEnabled &&
     getConf(ENABLE_ENHANCED_FEATURES)
 }
@@ -684,6 +686,14 @@ object VeloxConfig {
       .internal()
       .doc("When true, rewrite `cast(array as String)` to" +
         " `concat('[', array_join(array, ', ', null), ']')` to allow offloading to Velox.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val ENABLE_REWRITE_UNBOUNDED_WINDOW =
+    buildConf("spark.gluten.sql.rewrite.unboundedWindow")
+      .internal()
+      .doc("When true, rewrite unbounded window to an equivalent aggregate join operation" +
+        " to avoid OOM.")
       .booleanConf
       .createWithDefault(true)
 

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/RewriteUnboundedWindow.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/RewriteUnboundedWindow.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.gluten.config.VeloxConfig
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, EqualNullSafe, NamedExpression, SpecifiedWindowFrame, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.plans.Inner
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.WINDOW
+
+/**
+ * For unbounded window, velox needs to load the entire partition's data into memory for
+ * calculation, which can easily cause OOM when the partition is too large. This rule rewrites
+ * unbounded window to an equivalent aggregate join operation to avoid OOM.
+ *
+ * Input query:
+ * {{{
+ *    SELECT *, SUM(c0) OVER (PARTITION BY c1) AS sum FROM t
+ * }}}
+ *
+ * Rewritten query:
+ * {{{
+ *    SELECT t.*, t1.sum FROM t LEFT JOIN (SELECT c1, SUM(c0) AS sum FROM t GROUP BY c1) t1
+ *     ON t.c1 <=> t1.c1
+ * }}}
+ */
+case class RewriteUnboundedWindow(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!VeloxConfig.get.enableRewriteUnboundedWindow) {
+      return plan
+    }
+    plan.transformUpWithPruning(_.containsPattern(WINDOW)) {
+      case w @ Window(windowExprs, partitionSpec, orderSpec, child)
+          if orderSpec.isEmpty && isUnboundedWindow(windowExprs) =>
+        val partitionAliases = partitionSpec.zipWithIndex.map {
+          case (expr, idx) => Alias(expr, s"part_$idx")()
+        }
+        val aggregateExprs = partitionAliases ++ windowExprs.map {
+          case alias @ Alias(WindowExpression(agg: AggregateExpression, _), _) =>
+            alias.copy(child = agg)(
+              alias.exprId,
+              alias.qualifier,
+              alias.explicitMetadata,
+              alias.nonInheritableMetadataKeys)
+        }
+        val aggregate = Aggregate(partitionSpec, aggregateExprs, child)
+        val joinCondition = partitionSpec
+          .zip(partitionAliases)
+          .map(exprs => EqualNullSafe(exprs._1, exprs._2.toAttribute))
+          .reduceOption(And)
+        val join = Join(child, aggregate, Inner, joinCondition, JoinHint(None, None))
+        Project(w.output, join)
+    }
+  }
+
+  private def isUnboundedWindow(windowExpressions: Seq[NamedExpression]): Boolean = {
+    windowExpressions.forall {
+      case Alias(WindowExpression(_: AggregateExpression, windowSpec), _) =>
+        windowSpec.frameSpecification match {
+          case f: SpecifiedWindowFrame => f.isUnbounded
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

For unbounded window, velox needs to load the entire partition's data into memory for calculation, which can easily cause OOM when the partition is too large. This rule rewrites unbounded window to an equivalent aggregate join operation to avoid OOM.
Input query:
```
SELECT *, SUM(c0) OVER (PARTITION BY c1) AS sum FROM t
```
Rewritten query:
```
SELECT t.*, t1.sum FROM t LEFT JOIN (SELECT c1, SUM(c0) AS sum FROM t GROUP BY c1) t1  ON t. c1 <=> t1.c1
```

## How was this patch tested?

UT
