### PR TITLE
[VL] Support Velox's preferred_output_batch_bytes config

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/config/VeloxConfig.scala
@@ -80,6 +80,8 @@ class VeloxConfig(conf: SQLConf) extends GlutenConfig(conf) {
 
   def enableEnhancedFeatures(): Boolean = ConfigJniWrapper.isEnhancedFeaturesEnabled &&
     getConf(ENABLE_ENHANCED_FEATURES)
+
+  def veloxPreferredBatchBytes: Long = getConf(COLUMNAR_VELOX_PREFERRED_BATCH_BYTES)
 }
 
 object VeloxConfig {
@@ -702,4 +704,10 @@ object VeloxConfig {
       .doc("Enable some features including iceberg native write and other features.")
       .booleanConf
       .createWithDefault(true)
+
+  val COLUMNAR_VELOX_PREFERRED_BATCH_BYTES =
+    buildConf("spark.gluten.sql.columnar.backend.velox.preferredBatchBytes")
+      .internal()
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("10MB")
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/datasource/ArrowCSVFileFormat.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/datasource/ArrowCSVFileFormat.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.datasource
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
+import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.exception.SchemaMismatchException
 import org.apache.gluten.execution.RowToVeloxColumnarExec
 import org.apache.gluten.iterator.Iterators
@@ -312,7 +313,8 @@ object ArrowCSVFileFormat {
     val veloxBatch = RowToVeloxColumnarExec.toColumnarBatchIterator(
       it,
       schema,
-      batchSize
+      batchSize,
+      VeloxConfig.get.veloxPreferredBatchBytes
     )
     veloxBatch
       .map(v => ColumnarBatches.load(ArrowBufferAllocators.contextInstance(), v))

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -18,7 +18,7 @@ package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.ColumnarBatches
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.{GlutenConfig, VeloxConfig}
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
 import org.apache.gluten.runtime.Runtimes
@@ -49,6 +49,7 @@ case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBas
     val numOutputBatches = longMetric("numOutputBatches")
     val convertTime = longMetric("convertTime")
     val numRows = GlutenConfig.get.maxBatchSize
+    val numBytes = VeloxConfig.get.veloxPreferredBatchBytes
     // This avoids calling `schema` in the RDD closure, so that we don't need to include the entire
     // plan (this) in the closure.
     val localSchema = schema
@@ -60,7 +61,8 @@ case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBas
           numInputRows,
           numOutputBatches,
           convertTime,
-          numRows)
+          numRows,
+          numBytes)
     }
   }
 
@@ -69,6 +71,7 @@ case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBas
     val numOutputBatches = longMetric("numOutputBatches")
     val convertTime = longMetric("convertTime")
     val numRows = GlutenConfig.get.maxBatchSize
+    val numBytes = VeloxConfig.get.veloxPreferredBatchBytes
     val mode = BroadcastUtils.getBroadcastMode(outputPartitioning)
     val relation = child.executeBroadcast()
     BroadcastUtils.sparkToVeloxUnsafe(
@@ -83,7 +86,9 @@ case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBas
           numInputRows,
           numOutputBatches,
           convertTime,
-          numRows))
+          numRows,
+          numBytes)
+    )
   }
 
   // For spark 3.2.
@@ -96,7 +101,8 @@ object RowToVeloxColumnarExec {
   def toColumnarBatchIterator(
       it: Iterator[InternalRow],
       schema: StructType,
-      columnBatchSize: Int): Iterator[ColumnarBatch] = {
+      columnBatchSize: Int,
+      columnBatchBytes: Long): Iterator[ColumnarBatch] = {
     val numInputRows = new SQLMetric("numInputRows")
     val numOutputBatches = new SQLMetric("numOutputBatches")
     val convertTime = new SQLMetric("convertTime")
@@ -106,7 +112,8 @@ object RowToVeloxColumnarExec {
       numInputRows,
       numOutputBatches,
       convertTime,
-      columnBatchSize)
+      columnBatchSize,
+      columnBatchBytes)
   }
 
   def toColumnarBatchIterator(
@@ -115,7 +122,8 @@ object RowToVeloxColumnarExec {
       numInputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       convertTime: SQLMetric,
-      columnBatchSize: Int): Iterator[ColumnarBatch] = {
+      columnBatchSize: Int,
+      columnBatchBytes: Long): Iterator[ColumnarBatch] = {
     if (it.isEmpty) {
       return Iterator.empty
     }
@@ -165,7 +173,7 @@ object RowToVeloxColumnarExec {
         val rowLength = new ListBuffer[Long]()
         var rowCount = 0
         var offset = 0L
-        while (rowCount < columnBatchSize && !finished) {
+        while (rowCount < columnBatchSize && offset < columnBatchBytes && !finished) {
           if (!it.hasNext) {
             finished = true
           } else {
@@ -180,14 +188,26 @@ object RowToVeloxColumnarExec {
               // maybe we should optimize to list ArrayBuf to native to avoid buf close and allocate
               // 31760L origins from BaseVariableWidthVector.lastValueAllocationSizeInBytes
               // experimental value
-              val estimatedBufSize = Math.max(
-                Math.min(sizeInBytes.toDouble * columnBatchSize * 1.2, 31760L * columnBatchSize),
-                sizeInBytes.toDouble * 10)
+              val estimatedBufSize = Math.min(
+                Math.max(
+                  Math.min(sizeInBytes.toDouble * columnBatchSize * 1.2, 31760L * columnBatchSize),
+                  sizeInBytes.toDouble * 10),
+                // Limit the size of the buffer to columnBatchBytes or the size of the first row,
+                // whichever is greater so we always have enough space for the first row.
+                Math.max(columnBatchBytes, sizeInBytes)
+              )
               arrowBuf = arrowAllocator.buffer(estimatedBufSize.toLong)
             }
 
             if ((offset + sizeInBytes) > arrowBuf.capacity()) {
-              val tmpBuf = arrowAllocator.buffer((offset + sizeInBytes) * 2)
+              val bufSize = if (offset + sizeInBytes > columnBatchBytes) {
+                // If adding the current row causes the batch size to exceed columnBatchBytes add
+                // just enough space to add the current row.
+                offset + sizeInBytes
+              } else {
+                Math.min((offset + sizeInBytes * 2), columnBatchBytes)
+              }
+              val tmpBuf = arrowAllocator.buffer(bufSize)
               tmpBuf.setBytes(0, arrowBuf, 0, offset)
               arrowBuf.close()
               arrowBuf = tmpBuf

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.{ColumnarBatches, VeloxColumnarBatches}
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.config.{GlutenConfig, VeloxConfig}
 import org.apache.gluten.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
@@ -125,7 +125,12 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with Logging {
 
     val numRows = conf.columnBatchSize
     val rddColumnarBatch = input.mapPartitions {
-      it => RowToVeloxColumnarExec.toColumnarBatchIterator(it, localSchema, numRows)
+      it =>
+        RowToVeloxColumnarExec.toColumnarBatchIterator(
+          it,
+          localSchema,
+          numRows,
+          VeloxConfig.get.veloxPreferredBatchBytes)
     }
     convertColumnarBatchToCachedBatch(rddColumnarBatch, schema, storageLevel, conf)
   }

--- a/backends-velox/src/test/java/org/apache/gluten/columnarbatch/ColumnarBatchTest.java
+++ b/backends-velox/src/test/java/org/apache/gluten/columnarbatch/ColumnarBatchTest.java
@@ -229,7 +229,8 @@ public class ColumnarBatchTest extends VeloxBackendTestBase {
               RowToVeloxColumnarExec.toColumnarBatchIterator(
                       JavaConverters.<InternalRow>asScalaIterator(batch.rowIterator()),
                       structType,
-                      numRows)
+                      numRows,
+                      Integer.MAX_VALUE)
                   .next();
           Assert.assertEquals("[true,15]\n[false,14]", ColumnarBatches.toString(veloxBatch, 0, 2));
           Assert.assertEquals(

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -486,6 +486,8 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
       std::to_string(veloxCfg_->get<uint32_t>(kSparkBatchSize, 4096));
   configs[velox::core::QueryConfig::kMaxOutputBatchRows] =
       std::to_string(veloxCfg_->get<uint32_t>(kSparkBatchSize, 4096));
+  configs[velox::core::QueryConfig::kPreferredOutputBatchBytes] =
+      std::to_string(veloxCfg_->get<uint64_t>(kVeloxPreferredBatchBytes, 10L << 20));
   try {
     configs[velox::core::QueryConfig::kSparkAnsiEnabled] = veloxCfg_->get<std::string>(kAnsiEnabled, "false");
     configs[velox::core::QueryConfig::kSessionTimezone] = veloxCfg_->get<std::string>(kSessionTimezone, "");

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -177,4 +177,7 @@ const std::string kCudfMemoryResourceDefault =
 const std::string kCudfMemoryPercent = "spark.gluten.sql.columnar.backend.velox.cudf.memoryPercent";
 const int32_t kCudfMemoryPercentDefault = 50;
 
+/// Preferred size of batches in bytes to be returned by operators.
+const std::string kVeloxPreferredBatchBytes = "spark.gluten.sql.columnar.backend.velox.preferredBatchBytes";
+
 } // namespace gluten

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -485,7 +485,8 @@ object GlutenConfig {
     "spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace",
     "spark.gluten.sql.columnar.backend.velox.memoryUseHugePages",
     "spark.gluten.sql.columnar.backend.velox.cachePrefetchMinPct",
-    "spark.gluten.sql.columnar.backend.velox.memoryPoolCapacityTransferAcrossTasks"
+    "spark.gluten.sql.columnar.backend.velox.memoryPoolCapacityTransferAcrossTasks",
+    "spark.gluten.sql.columnar.backend.velox.preferredBatchBytes"
   )
 
   /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Velox supports a config preferred_output_batch_bytes which is a soft/best effort limit on the number of bytes consumed in
a batch output by an Operator. It is used alongside max_output_batch_rows and in place of preferred_output_batch_rows, and applies when the number of bytes in rows can be estimated and that estimate exceeds preferred_output_batch_bytes before max_output_batch_rows is reached. This can help the system to adapt to very wide rows without OOM'ing.

In addition to plumbing this config through Spark to Velox, I also modified RowToVeloxColumnarExec to respect preferred_output_batch_bytes. Here I limit the Arrow buffer it allocates to hold preferred_output_batch_bytes + whatever overflow is needed to hold the last row that causes us to exceed the limit (again it's a soft limit).

We are currently using the default in Velox so users shouldn't see any change in behavior there unless they choose to set the config. Users may see smaller batches coming from RowToVeloxColumnarExec if the rows are currently exceeding the limit as we were previously not imposing the limit there.

## How was this patch tested?

Verified locally, we were seeing OOMs coming from RowToVeloxColumnarExec due to very wide rows.

Added a unit test to check that preferred_output_batch_bytes is respected in RowToVeloxColumnarExec.