### PR TITLE
[GLUTEN-10671][VL] Ignore datetime-legacy.sql

### DIFF
--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -141,7 +141,8 @@ class GlutenSQLQueryTestSuite
     "ignored.sql", // Do NOT remove this one. It is here to test the ignore functionality.
     "explain-aqe.sql", // Explain is different in Gluten.
     "explain-cbo.sql", // Explain is different in Gluten.
-    "explain.sql" // Explain is different in Gluten.
+    "explain.sql", // Explain is different in Gluten.
+    "datetime-legacy.sql" // https://github.com/apache/incubator-gluten/issues/10671
   ) ++ otherIgnoreList ++
     BackendTestSettings.instance.getSQLQueryTestSettings.getIgnoredSQLQueryTests
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Temporarily ignore the "datetime-legacy.sql" due to the below exception. A follow-up PR will be filed to override the sql test file.

```
Expected "[java.lang.ArithmeticException long overflow]", but got "[org.apache.gluten.exception.GlutenException
Could not convert Timestamp(1230219000123123, 0) to microseconds]" Result did not match for query #121
select TIMESTAMP_SECONDS(1230219000123123) (GlutenSQLQueryTestSuite.scala:993)
```

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

UT verified.