### PR TITLE
[CORE] Fix FallbackByNativeValidation attempts to offload a whole tree than a single node

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.expression.ExpressionUtils
 import org.apache.gluten.extension.columnar.FallbackTags
-import org.apache.gluten.extension.columnar.heuristic.LegacyOffload
 import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.sql.shims.SparkShimLoader
 
@@ -232,7 +231,6 @@ object Validators {
   private class FallbackByNativeValidation(offloadRules: Seq[OffloadSingleNode])
     extends Validator
     with Logging {
-    private val offloadAttempt: LegacyOffload = LegacyOffload(offloadRules)
     override def validate(plan: SparkPlan): Validator.OutCome = {
       val offloadedNode = offloadAttempt.apply(plan)
       val out = offloadedNode match {
@@ -243,6 +241,14 @@ object Validators {
           pass()
       }
       out
+    }
+
+    private val offloadAttempt: SparkPlan => SparkPlan = {
+      node =>
+        offloadRules.foldLeft(node) {
+          case (node, rule) =>
+            rule.offload(node)
+        }
     }
   }
 


### PR DESCRIPTION
As title. FallbackByNativeValidation is supposed to handle a single node. We currently pass a tree to the offload attempt which overkills the goal. It's functioning but may impact the performance.

The patch fixes the issue.