### PR TITLE
[GLUTEN-10701] Refactor SortRelNode by avoiding call addAll

### DIFF
--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/SortRelNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/SortRelNode.java
@@ -24,23 +24,22 @@ import io.substrait.proto.SortField;
 import io.substrait.proto.SortRel;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 
 public class SortRelNode implements RelNode, Serializable {
   private final RelNode input;
-  private final List<SortField> sorts = new ArrayList<>();
+  private final List<SortField> sorts;
   private final AdvancedExtensionNode extensionNode;
 
   public SortRelNode(RelNode input, List<SortField> sorts, AdvancedExtensionNode extensionNode) {
     this.input = input;
-    this.sorts.addAll(sorts);
+    this.sorts = sorts;
     this.extensionNode = extensionNode;
   }
 
   public SortRelNode(RelNode input, List<SortField> sorts) {
     this.input = input;
-    this.sorts.addAll(sorts);
+    this.sorts = sorts;
     this.extensionNode = null;
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR proposes to refactor `SortRelNode` by avoiding call `addAll`
Fixes #10701

## How was this patch tested?

GA tests.
