### PR TITLE
[VL] Remove unused-function warning

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -296,23 +296,6 @@ std::shared_ptr<VeloxColumnarBatch> makeColumnarBatch(
   return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
 }
 
-std::shared_ptr<VeloxColumnarBatch> makeColumnarBatch(
-    RowTypePtr type,
-    std::unique_ptr<InMemoryPayload> payload,
-    memory::MemoryPool* pool,
-    int64_t& deserializeTime) {
-  ScopedTimer timer(&deserializeTime);
-  std::vector<BufferPtr> veloxBuffers;
-  auto numBuffers = payload->numBuffers();
-  veloxBuffers.reserve(numBuffers);
-  for (size_t i = 0; i < numBuffers; ++i) {
-    GLUTEN_ASSIGN_OR_THROW(auto buffer, payload->readBufferAt(i));
-    veloxBuffers.push_back(convertToVeloxBuffer(std::move(buffer)));
-  }
-  auto rowVector = deserialize(type, payload->numRows(), veloxBuffers, {}, {}, pool);
-  return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
-}
-
 arrow::Result<BufferPtr>
 readDictionaryBuffer(arrow::io::InputStream* in, facebook::velox::memory::MemoryPool* pool, arrow::util::Codec* codec) {
   size_t bufferSize;


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix the warning:

```c++
warning: ‘std::shared_ptr<gluten::VeloxColumnarBatch> gluten::{anonymous}::makeColumnarBatch(facebook::velox::RowTypePtr, std::unique_ptr<gluten::InMemoryPayload>, facebook::velox::memory::MemoryPool*, int64_t&)’ defined but not used [-Wunused-function]
  299 | std::shared_ptr<VeloxColumnarBatch> makeColumnarBatch(
      |                                     ^~~~~~~~~~~~~~~~~
```

## How was this patch tested?
Manually test