### PR TITLE
[GLUTEN-10741][CH] Invalid results: sort keys contains partition keys when get windows' topK

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -3012,6 +3012,17 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         compareResult = true,
         checkWindowGroupLimit
       )
+
+      compareResultsAgainstVanillaSpark(
+        """
+          |select * from(
+          |select a, b, c, row_number() over (partition by a order by b, c, a) as r
+          |from test_win_top)
+          |where r <= 1
+          |""".stripMargin,
+        compareResult = true,
+        checkWindowGroupLimit
+      )
       spark.sql("drop table if exists test_win_top")
     }
 

--- a/cpp-ch/local-engine/Common/GlutenConfig.h
+++ b/cpp-ch/local-engine/Common/GlutenConfig.h
@@ -164,8 +164,8 @@ struct WindowConfig
 public:
     inline static const String WINDOW_AGGREGATE_TOPK_SAMPLE_ROWS = "window.aggregate_topk_sample_rows";
     inline static const String WINDOW_AGGREGATE_TOPK_HIGH_CARDINALITY_THRESHOLD = "window.aggregate_topk_high_cardinality_threshold";
-    size_t aggregate_topk_sample_rows = 5000;
-    double aggregate_topk_high_cardinality_threshold = 0.6;
+    size_t aggregate_topk_sample_rows = 50000;
+    double aggregate_topk_high_cardinality_threshold = 0.4;
     static WindowConfig loadFromContext(const DB::ContextPtr & context);
 };
 

--- a/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.h
@@ -66,14 +66,17 @@ private:
     String aggregate_function_name;
     size_t limit = 0;
     DB::SharedHeader input_header;
-    // DB::Block output_header;
+    // Field indexes at the input header which are used as partition keys
+    std::vector<size_t> partition_fields;
+    // Field indexes at the input header which are used as sort keys
+    std::vector<size_t> sort_fields;
     DB::Names aggregate_grouping_keys;
     String aggregate_tuple_column_name;
 
     String getAggregateFunctionName(const String & window_function_name);
 
+    void collectPartitionAndSortFields();
     void prePrejectionForAggregateArguments(DB::QueryPlan & plan);
-
     void addGroupLmitAggregationStep(DB::QueryPlan & plan);
     String parseSortDirections(const google::protobuf::RepeatedPtrField<substrait::SortField> & sort_fields);
     DB::AggregateDescription buildAggregateDescription(DB::QueryPlan & plan);

--- a/cpp-ch/local-engine/Parser/RelParsers/SortParsingUtils.h
+++ b/cpp-ch/local-engine/Parser/RelParsers/SortParsingUtils.h
@@ -28,6 +28,6 @@ DB::SortDescription
 parseSortFields(const DB::Block & header, const google::protobuf::RepeatedPtrField<substrait::Expression> & expressions);
 DB::SortDescription parseSortFields(const DB::Block & header, const google::protobuf::RepeatedPtrField<substrait::SortField> & sort_fields);
 
-std::string
-buildSQLLikeSortDescription(const DB::Block & header, const google::protobuf::RepeatedPtrField<substrait::SortField> & sort_fields);
+
+std::string buildSQLLikeSortDescription(const DB::SortDescription & sort_description);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Fix #10741. When the sort keys contains a partition keys, the `GroupLimit` operator may generate incorrect data due to improper aggregation key generation.

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

test by UTs
