### PR TITLE
[VL] Fix weekly build validation

### DIFF
--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -71,7 +71,7 @@ jobs:
           ls -l /usr/bin/mvn
           
           git clone -b main --depth=1 https://github.com/apache/incubator-gluten.git && cd incubator-gluten/
-          ./dev/package.sh
+          ./dev/package.sh --spark_version=3.5
           
 
   build-on-centos:
@@ -117,7 +117,7 @@ jobs:
           export MAVEN_HOME=/usr/lib/maven && \
           export PATH=${PATH}:${MAVEN_HOME}/bin
 
-          cd $GITHUB_WORKSPACE/ && ./dev/package.sh
+          cd $GITHUB_WORKSPACE/ && ./dev/package.sh --spark_version=3.5
 
   build-on-ubuntu:
     strategy:
@@ -153,7 +153,7 @@ jobs:
           fi
           sudo apt-get install -y openjdk-8-jdk python3-pip cmake
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-          cd $GITHUB_WORKSPACE/ && ./dev/package.sh
+          cd $GITHUB_WORKSPACE/ && ./dev/package.sh --spark_version=3.5
 
   build-on-openeuler:
     strategy:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Spark-4.0 has been added to the Gluten build script, but it requires Java 17. Currently, the weekly build environment only has Java 8 installed. Since Spark builds are well validated through per-PR checks, this PR only keeps the Spark-3.5 build, which I think is sufficient.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
