### PR TITLE
[VL] Gluten-it: Fix inverted expected vs actual in result mismatch er…

### DIFF
--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/QueriesCompare.scala
@@ -165,8 +165,8 @@ object QueriesCompare {
       }
       TestUtils
         .compareAnswers(
-          expected.asSuccess().runResult.rows,
           actual.asSuccess().runResult.rows,
+          expected.asSuccess().runResult.rows,
           sort = true)
     }
 


### PR DESCRIPTION
When calling Spark test API `SparkUtils.compareAnswers`, the expected result should be passed by 2nd parameter, not the 1st one.