### PR TITLE
[MINOR] Override `outputPartitioning` in `GenerateExecTransformerBase`

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/GenerateExecTransformerBase.scala
@@ -26,6 +26,7 @@ import org.apache.gluten.substrait.extensions.{AdvancedExtensionNode, ExtensionB
 import org.apache.gluten.substrait.rel.RelNode
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
 
 import scala.collection.JavaConverters._
@@ -61,6 +62,8 @@ abstract class GenerateExecTransformerBase(
   }
 
   override def output: Seq[Attribute] = requiredChildOutput ++ generatorOutput
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def producedAttributes: AttributeSet = AttributeSet(generatorOutput)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Suppose the following SQL:
```SQL
SELECT * FROM
    (SELECT xxx, explode(split(xxx)) FROM a JOIN b ON a.joinkey = b.joinkey)
GROUP BY joinkey
```
There may exist `FlushableAggregateTransformer` in the executed plan because `GenerateExecTransformer` doesn't override method `outputPartitioning`, which makes `FlushableHashAggregateRule` can't determine that the inputs have already been distributed by aggregation keys. So we need to override `outputPartitioning` in `GenerateExecTransformerBase`.
