### PR TITLE
[VL] tools/workload/tpch: Delete temporary files generated by dbgen

### DIFF
--- a/tools/workload/tpch/gen_data/parquet_dataset/tpch_datagen_parquet.scala
+++ b/tools/workload/tpch/gen_data/parquet_dataset/tpch_datagen_parquet.scala
@@ -16,6 +16,8 @@
  */
 import com.databricks.spark.sql.perf.tpch._
 
+import java.io.File
+
 
 val scaleFactor = "100" // scaleFactor defines the size of the dataset to generate (in GB).
 val numPartitions = 200  // how many dsdgen partitions to run - number of input tasks.
@@ -30,6 +32,20 @@ val tables = new TPCHTables(spark.sqlContext,
     useDoubleForDecimal = false, // true to replace DecimalType with DoubleType
     useStringForDate = false) // true to replace DateType with StringType
 
+object FileUtils {
+  def deleteFilesWithKeyword(path: String, keyword: String): Unit = {
+    val dir = new File(path)
+    if (dir.exists && dir.isDirectory) {
+      dir.listFiles()
+        .filter(f => f.isFile && f.getName.contains(keyword))
+        .foreach { f =>
+          f.delete()
+        }
+    }
+  }
+}
+
+FileUtils.deleteFilesWithKeyword(dbgenDir, "tbl")
 
 tables.genData(
     location = rootDir,


### PR DESCRIPTION


## What changes are proposed in this pull request?

When using TPCH shell script to generate test data, the script got stuck when execute it again.
The tool dbGen will generate a lots of temporary files and not be deleted after the first running. When running the tool again, it asks whether to overwrite the temporary files, which make the script stuck.

The patch adds a function to delete these temporary files before running the dbGen tool.

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
