### PR TITLE
[CORE] Fix iceberg version to 1.10.0 for Spark 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1161,10 +1161,11 @@
         <sparkbundle.version>4.0</sparkbundle.version>
         <sparkshim.artifactId>spark-sql-columnar-shims-spark40</sparkshim.artifactId>
         <spark.version>4.0.1</spark.version>
-        <iceberg.version>1.5.0</iceberg.version>
+        <iceberg.version>1.10.0</iceberg.version>
         <delta.package.name>delta-spark</delta.package.name>
         <delta.version>3.3.1</delta.version>
         <delta.binary.version>33</delta.binary.version>
+        <!-- TODO: This hudi version is invalid for Spark 4.0. -->
         <hudi.version>0.15.0</hudi.version>
         <fasterxml.version>2.15.1</fasterxml.version>
         <hadoop.version>3.3.4</hadoop.version>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Gluten depends on `iceberg-spark-runtime-${sparkbundle.version}_${scala.binary.version}` in its iceberg module. Only starting from Iceberg 1.10.0, spark 4.0 is supported.

Reference:
https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-spark-runtime-4.0_2.13

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Manually verified.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
