### PR TITLE
[VL] Delta: Fix input file expressions not getting pushed to native scan when column mapping is applicable

### DIFF
--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -20,8 +20,6 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 
-import org.scalatest.Ignore
-
 // spotless:off
 class DeleteSQLSuite extends DeleteSuiteBase
   with DeltaExcludedTestMixin
@@ -95,9 +93,6 @@ class DeleteSQLSuite extends DeleteSuiteBase
   }
 }
 
-// FIXME: Enable the test.
-//  Skipping as function input_file_name doesn't get correctly resolved.
-@Ignore
 class DeleteSQLNameColumnMappingSuite extends DeleteSQLSuite
   with DeltaColumnMappingEnableNameMode {
 


### PR DESCRIPTION
Issue is because of the incorrect application order of `pushDownInputFileExprRule` and `columnMappingRule`, sometimes the input file expressions are not pushed to Velox scan, causing the input file expression columns to be returned with empty values incorrectly by Gluten.

The PR fixes the issue by adjusting the application order of `pushDownInputFileExprRule` and `columnMappingRule`.

This fixes the ignored Delta test suite `DeleteSQLNameColumnMappingSuite`.