### PR TITLE
[VL] Following #10823, correct the config option key

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -868,7 +868,7 @@ object GlutenConfig {
       .createWithDefault(true)
 
   val COLUMNAR_OVERWRIET_PARTITIONS_DYNAMIC_ENABLED =
-    buildConf("spark.gluten.sql.columnar.overwriteOverwritePartitionsDynamic")
+    buildConf("spark.gluten.sql.columnar.overwritePartitionsDynamic")
       .doc("Enable or disable columnar v2 command overwrite partitions dynamic.")
       .booleanConf
       .createWithDefault(true)


### PR DESCRIPTION
#10823 

The configuration key `spark.gluten.sql.columnar.overwriteOverwritePartitionsDynamic` looks incorrect.