### PR TITLE
[CORE] Optimize the verboseString of ColumnarShuffleExchangeExec

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical._
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.CoalesceExec.EmptyPartition
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.metric.SQLShuffleWriteMetricsReporter
@@ -148,12 +149,16 @@ case class ColumnarShuffleExchangeExec(
     cachedShuffleRDD
   }
 
-  override def verboseString(maxFields: Int): String = toString(super.verboseString(maxFields))
+  override def verboseString(maxFields: Int): String =
+    toString(super.verboseString(maxFields), maxFields)
 
-  override def simpleString(maxFields: Int): String = toString(super.simpleString(maxFields))
-
-  private def toString(original: String): String = {
-    original + ", [OUTPUT] " + output.map(attr => attr.name + ":" + attr.dataType).toString()
+  private def toString(original: String, maxFields: Int): String = {
+    original + ", [output=" + truncatedString(
+      output.map(_.verboseString(maxFields)),
+      "[",
+      ", ",
+      "]",
+      maxFields) + "]"
   }
 
   override def output: Seq[Attribute] = if (projectOutputAttributes != null) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

```
before:
ColumnarExchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=744], [shuffle_writer_type=hash], [OUTPUT] List(sum:DoubleType, count:LongType), [OUTPUT] List(sum:DoubleType, count:LongType)


after:
ColumnarExchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=710], [shuffle_writer_type=hash], [output=[sum#133: double, count#134: bigint]]
```

The reason why the OUTPUT appeared twice previously is that verboseString internally calls simpleString. Moreover, simpleString generally does not include output information, so this PR simply removes it.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
